### PR TITLE
feat: TypeScript 型定義（Task, Column, ProjectConfig）

### DIFF
--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,48 @@
+/** 優先度 */
+export type Priority = "High" | "Medium" | "Low";
+
+/** タスク */
+export type Task = {
+	/** 一意な識別子 */
+	id: string;
+	/** タスクタイトル */
+	title: string;
+	/** ステータス（カラム名に対応） */
+	status: string;
+	/** 優先度（未設定の場合は undefined） */
+	priority: Priority | undefined;
+	/** ラベルの配列 */
+	labels: string[];
+	/** 親タスクのファイルパス */
+	parent: string | undefined;
+	/** 関連タスクのファイルパスの配列 */
+	links: string[];
+	/** 子タスクのファイルパスの配列（parent から逆引き） */
+	children: string[];
+	/** 逆方向リンクのファイルパスの配列（links から逆引き） */
+	reverseLinks: string[];
+	/** Markdown 本文 */
+	body: string;
+	/** タスクファイルのパス */
+	filePath: string;
+};
+
+/** カラム定義 */
+export type Column = {
+	/** カラム名 */
+	name: string;
+	/** 表示順序 */
+	order: number;
+};
+
+/** プロジェクト設定 */
+export type ProjectConfig = {
+	/** スキーマバージョン */
+	version: number;
+	/** カラム定義の配列 */
+	columns: Column[];
+	/** カラムごとのカード表示順（カラム名 → ファイルパスの配列） */
+	cardOrder: Record<string, string[]>;
+	/** 完了として扱うカラム名 */
+	doneColumn: string;
+};

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -9,12 +9,12 @@ export type Task = {
 	title: string;
 	/** ステータス（カラム名に対応） */
 	status: string;
-	/** 優先度（未設定の場合は undefined） */
-	priority: Priority | undefined;
+	/** 優先度（未設定可） */
+	priority?: Priority;
 	/** ラベルの配列 */
 	labels: string[];
-	/** 親タスクのファイルパス */
-	parent: string | undefined;
+	/** 親タスクのファイルパス（親がない場合は未設定） */
+	parent?: string;
 	/** 関連タスクのファイルパスの配列 */
 	links: string[];
 	/** 子タスクのファイルパスの配列（parent から逆引き） */


### PR DESCRIPTION
## Summary

spec-board フロントエンドで使用する TypeScript 型定義を追加。

- `Priority` 型: `"High" | "Medium" | "Low"` のユニオン型
- `Task` 型: id, title, status, priority, labels, parent, links, children, reverseLinks, body, filePath
- `Column` 型: name, order
- `ProjectConfig` 型: version, columns, cardOrder, doneColumn

## Files Changed

- `src/types/task.ts` (新規作成)

## Test Plan

- [x] `pnpm run build` で型エラーなくコンパイルされることを確認済み

Automated by task-loop-run
