### PR TITLE
🐛 [Bug Fix]: run-loop.shのレビュー修正後に再レビュー依頼を追加

### DIFF
--- a/run-loop.sh
+++ b/run-loop.sh
@@ -303,6 +303,9 @@ PR #${PR_NUMBER} のレビュー修正が上限（${MAX_FIX_ITERATIONS}回）に
           clean_pr_number
           break
         fi
+        # 修正push後、再レビューを依頼
+        echo "再レビューを依頼: ${REVIEWER}"
+        gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER"
         ;;
 
       TIMEOUT)


### PR DESCRIPTION
## 概要

run-loop.sh でレビュー指摘修正後に Copilot への再レビュー依頼が行われず、修正確認なしでマージされる問題を修正。

## 変更の種類

🐛 バグ修正

## 追加した内容

- 修正 push 後の再ポーリング前に `gh pr edit --add-reviewer` を実行する処理を追加

## 変更した内容

- `run-loop.sh`: REVIEWED ケースの修正後フロー（306行目付近）に再レビュー依頼を挿入

## 削除した内容

なし

## テスト

- スクリプトの構文チェック（bash -n）で問題なし

## チェックリスト

- [x] セルフレビューを実施した
- [x] 必要なテストを実施した（該当する場合）
- [x] 破壊的変更がある場合は明記した
