### PR TITLE
feat: ヘッダーバーコンポーネント

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
+import { HeaderBar } from "./features/board";
+
 /**
  * @returns {JSX.Element} アプリケーションのルートレイアウトシェル
  */
 function App() {
 	return (
 		<div className="flex h-screen w-screen flex-col overflow-hidden">
+			<HeaderBar onSettingsClick={() => {}} onOpenClick={() => {}} />
 			<main className="flex-1" />
 		</div>
 	);

--- a/src/features/board/components/HeaderBar.rendering.test.tsx
+++ b/src/features/board/components/HeaderBar.rendering.test.tsx
@@ -3,16 +3,20 @@ import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import { HeaderBar } from "./HeaderBar";
 
-let container: HTMLDivElement;
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
 
 afterEach(() => {
-	container.remove();
+	root?.unmount();
+	root = null;
+	container?.remove();
+	container = null;
 });
 
 function renderHeaderBar(props: Partial<Parameters<typeof HeaderBar>[0]> = {}) {
 	container = document.createElement("div");
 	document.body.appendChild(container);
-	const root = createRoot(container);
+	root = createRoot(container);
 	root.render(
 		createElement(HeaderBar, {
 			onSettingsClick: vi.fn(),
@@ -26,21 +30,21 @@ function renderHeaderBar(props: Partial<Parameters<typeof HeaderBar>[0]> = {}) {
 test("プロジェクト名が表示される", async () => {
 	renderHeaderBar({ projectName: "My Project" });
 	await vi.waitFor(() => {
-		expect(container.textContent).toContain("My Project");
+		expect(container?.textContent).toContain("My Project");
 	});
 });
 
 test("未選択時はデフォルト名「spec-board」が表示される", async () => {
 	renderHeaderBar();
 	await vi.waitFor(() => {
-		expect(container.textContent).toContain("spec-board");
+		expect(container?.textContent).toContain("spec-board");
 	});
 });
 
 test("設定ボタンと「開く」ボタンが表示される", async () => {
 	renderHeaderBar();
 	await vi.waitFor(() => {
-		const buttons = container.querySelectorAll("button");
+		const buttons = container?.querySelectorAll("button") ?? [];
 		const texts = Array.from(buttons).map((b) => b.textContent);
 		expect(texts).toContain("設定");
 		expect(texts).toContain("開く");
@@ -51,7 +55,7 @@ test("設定ボタンクリックでコールバックが呼ばれる", async ()
 	const onSettingsClick = vi.fn();
 	renderHeaderBar({ onSettingsClick });
 	await vi.waitFor(() => {
-		const btn = Array.from(container.querySelectorAll("button")).find(
+		const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
 			(b) => b.textContent === "設定",
 		);
 		expect(btn).toBeDefined();
@@ -64,7 +68,7 @@ test("「開く」ボタンクリックでコールバックが呼ばれる", as
 	const onOpenClick = vi.fn();
 	renderHeaderBar({ onOpenClick });
 	await vi.waitFor(() => {
-		const btn = Array.from(container.querySelectorAll("button")).find(
+		const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
 			(b) => b.textContent === "開く",
 		);
 		expect(btn).toBeDefined();

--- a/src/features/board/components/HeaderBar.rendering.test.tsx
+++ b/src/features/board/components/HeaderBar.rendering.test.tsx
@@ -1,0 +1,74 @@
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { HeaderBar } from "./HeaderBar";
+
+let container: HTMLDivElement;
+
+afterEach(() => {
+	container.remove();
+});
+
+function renderHeaderBar(props: Partial<Parameters<typeof HeaderBar>[0]> = {}) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	const root = createRoot(container);
+	root.render(
+		createElement(HeaderBar, {
+			onSettingsClick: vi.fn(),
+			onOpenClick: vi.fn(),
+			...props,
+		}),
+	);
+	return root;
+}
+
+test("プロジェクト名が表示される", async () => {
+	renderHeaderBar({ projectName: "My Project" });
+	await vi.waitFor(() => {
+		expect(container.textContent).toContain("My Project");
+	});
+});
+
+test("未選択時はデフォルト名「spec-board」が表示される", async () => {
+	renderHeaderBar();
+	await vi.waitFor(() => {
+		expect(container.textContent).toContain("spec-board");
+	});
+});
+
+test("設定ボタンと「開く」ボタンが表示される", async () => {
+	renderHeaderBar();
+	await vi.waitFor(() => {
+		const buttons = container.querySelectorAll("button");
+		const texts = Array.from(buttons).map((b) => b.textContent);
+		expect(texts).toContain("設定");
+		expect(texts).toContain("開く");
+	});
+});
+
+test("設定ボタンクリックでコールバックが呼ばれる", async () => {
+	const onSettingsClick = vi.fn();
+	renderHeaderBar({ onSettingsClick });
+	await vi.waitFor(() => {
+		const btn = Array.from(container.querySelectorAll("button")).find(
+			(b) => b.textContent === "設定",
+		);
+		expect(btn).toBeDefined();
+		btn?.click();
+		expect(onSettingsClick).toHaveBeenCalledTimes(1);
+	});
+});
+
+test("「開く」ボタンクリックでコールバックが呼ばれる", async () => {
+	const onOpenClick = vi.fn();
+	renderHeaderBar({ onOpenClick });
+	await vi.waitFor(() => {
+		const btn = Array.from(container.querySelectorAll("button")).find(
+			(b) => b.textContent === "開く",
+		);
+		expect(btn).toBeDefined();
+		btn?.click();
+		expect(onOpenClick).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/features/board/components/HeaderBar.rendering.test.tsx
+++ b/src/features/board/components/HeaderBar.rendering.test.tsx
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import { HeaderBar } from "./HeaderBar";
@@ -7,7 +7,9 @@ let container: HTMLDivElement | null = null;
 let root: ReturnType<typeof createRoot> | null = null;
 
 afterEach(() => {
-	root?.unmount();
+	act(() => {
+		root?.unmount();
+	});
 	root = null;
 	container?.remove();
 	container = null;
@@ -17,13 +19,15 @@ function renderHeaderBar(props: Partial<Parameters<typeof HeaderBar>[0]> = {}) {
 	container = document.createElement("div");
 	document.body.appendChild(container);
 	root = createRoot(container);
-	root.render(
-		createElement(HeaderBar, {
-			onSettingsClick: vi.fn(),
-			onOpenClick: vi.fn(),
-			...props,
-		}),
-	);
+	act(() => {
+		root?.render(
+			createElement(HeaderBar, {
+				onSettingsClick: vi.fn(),
+				onOpenClick: vi.fn(),
+				...props,
+			}),
+		);
+	});
 	return root;
 }
 

--- a/src/features/board/components/HeaderBar.rendering.test.tsx
+++ b/src/features/board/components/HeaderBar.rendering.test.tsx
@@ -54,25 +54,27 @@ test("設定ボタンと「開く」ボタンが表示される", async () => {
 test("設定ボタンクリックでコールバックが呼ばれる", async () => {
 	const onSettingsClick = vi.fn();
 	renderHeaderBar({ onSettingsClick });
+	let btn: HTMLButtonElement | undefined;
 	await vi.waitFor(() => {
-		const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
-			(b) => b.textContent === "設定",
+		btn = Array.from(container?.querySelectorAll("button") ?? []).find(
+			(b): b is HTMLButtonElement => b.textContent === "設定",
 		);
 		expect(btn).toBeDefined();
-		btn?.click();
-		expect(onSettingsClick).toHaveBeenCalledTimes(1);
 	});
+	btn?.click();
+	expect(onSettingsClick).toHaveBeenCalledTimes(1);
 });
 
 test("「開く」ボタンクリックでコールバックが呼ばれる", async () => {
 	const onOpenClick = vi.fn();
 	renderHeaderBar({ onOpenClick });
+	let btn: HTMLButtonElement | undefined;
 	await vi.waitFor(() => {
-		const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
-			(b) => b.textContent === "開く",
+		btn = Array.from(container?.querySelectorAll("button") ?? []).find(
+			(b): b is HTMLButtonElement => b.textContent === "開く",
 		);
 		expect(btn).toBeDefined();
-		btn?.click();
-		expect(onOpenClick).toHaveBeenCalledTimes(1);
 	});
+	btn?.click();
+	expect(onOpenClick).toHaveBeenCalledTimes(1);
 });

--- a/src/features/board/components/HeaderBar.tsx
+++ b/src/features/board/components/HeaderBar.tsx
@@ -1,0 +1,44 @@
+/** ヘッダーバーの Props */
+type HeaderBarProps = {
+	/** プロジェクト名（未指定時は「spec-board」を表示） */
+	projectName?: string;
+	/** 設定ボタンのクリックハンドラ */
+	onSettingsClick: () => void;
+	/** 「開く」ボタンのクリックハンドラ */
+	onOpenClick: () => void;
+};
+
+/**
+ * ボード上部のヘッダーバー
+ * @param props - {@link HeaderBarProps}
+ * @returns ヘッダーバー要素
+ */
+export function HeaderBar({
+	projectName,
+	onSettingsClick,
+	onOpenClick,
+}: HeaderBarProps) {
+	return (
+		<header className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2">
+			<h1 className="text-lg font-semibold text-gray-800">
+				{projectName ?? "spec-board"}
+			</h1>
+			<div className="flex items-center gap-2">
+				<button
+					type="button"
+					onClick={onSettingsClick}
+					className="rounded px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100"
+				>
+					設定
+				</button>
+				<button
+					type="button"
+					onClick={onOpenClick}
+					className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+				>
+					開く
+				</button>
+			</div>
+		</header>
+	);
+}

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -1,0 +1,1 @@
+export { HeaderBar } from "./components/HeaderBar";


### PR DESCRIPTION
## Summary
- ボード上部のヘッダーバーコンポーネント（`HeaderBar`）を追加
- プロジェクト名表示（未選択時は「spec-board」）、設定ボタン、「開く」ボタンを配置
- `App.tsx` にHeaderBarを組み込み

## Test plan
- [x] プロジェクト名が正しく表示される
- [x] 未選択時にデフォルト名「spec-board」が表示される
- [x] 設定ボタンと「開く」ボタンが表示される
- [x] 各ボタンクリックでコールバックが呼ばれる
- [x] `pnpm test:run` 全テスト通過

## Test command
```bash
pnpm test:run
```

Automated by task-loop-run
