### PR TITLE
feat: カラムコンテナコンポーネント

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,36 @@
-import { useState } from "react";
-import { EmptyState, HeaderBar } from "./features/board";
-import type { Task } from "./types/task";
+import { useEffect, useState } from "react";
+import { Board, EmptyState, HeaderBar } from "./features/board";
+import { getColumns, getTasks } from "./lib/api";
+import type { Column, Task } from "./types/task";
 
 /**
  * @returns {JSX.Element} アプリケーションのルートレイアウトシェル
  */
 function App() {
 	const [projectPath, setProjectPath] = useState<string | null>(null);
-	const [tasks] = useState<Task[]>([]);
+	const [tasks, setTasks] = useState<Task[]>([]);
+	const [columns, setColumns] = useState<Column[]>([]);
 
 	const handleOpenProject = () => {
-		// 未実装の間は projectPath を更新しない。
-		void setProjectPath;
+		setProjectPath("mock-project");
 	};
+
+	useEffect(() => {
+		if (projectPath === null) return;
+		let cancelled = false;
+		(async () => {
+			const [loadedTasks, loadedColumns] = await Promise.all([
+				getTasks(),
+				getColumns(),
+			]);
+			if (cancelled) return;
+			setTasks(loadedTasks);
+			setColumns(loadedColumns);
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [projectPath]);
 
 	return (
 		<div className="flex h-screen w-screen flex-col overflow-hidden">
@@ -22,7 +40,9 @@ function App() {
 					<EmptyState type="no-project" onOpenProject={handleOpenProject} />
 				) : tasks.length === 0 ? (
 					<EmptyState type="empty-project" />
-				) : null}
+				) : (
+					<Board columns={columns} tasks={tasks} onAddTask={() => {}} />
+				)}
 			</main>
 		</div>
 	);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ function App() {
 	const [projectPath, setProjectPath] = useState<string | null>(null);
 	const [tasks, setTasks] = useState<Task[]>([]);
 	const [columns, setColumns] = useState<Column[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
 
 	const handleOpenProject = () => {
 		setProjectPath("mock-project");
@@ -18,6 +19,7 @@ function App() {
 	useEffect(() => {
 		if (projectPath === null) return;
 		let cancelled = false;
+		setIsLoading(true);
 		(async () => {
 			const [loadedTasks, loadedColumns] = await Promise.all([
 				getTasks(),
@@ -26,6 +28,7 @@ function App() {
 			if (cancelled) return;
 			setTasks(loadedTasks);
 			setColumns(loadedColumns);
+			setIsLoading(false);
 		})();
 		return () => {
 			cancelled = true;
@@ -38,6 +41,10 @@ function App() {
 			<main className="flex flex-1 overflow-hidden">
 				{projectPath === null ? (
 					<EmptyState type="no-project" onOpenProject={handleOpenProject} />
+				) : isLoading ? (
+					<div className="flex flex-1 items-center justify-center">
+						<p className="text-gray-500">読み込み中…</p>
+					</div>
 				) : (
 					<Board columns={columns} tasks={tasks} onAddTask={() => {}} />
 				)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,8 +38,6 @@ function App() {
 			<main className="flex flex-1 overflow-hidden">
 				{projectPath === null ? (
 					<EmptyState type="no-project" onOpenProject={handleOpenProject} />
-				) : tasks.length === 0 ? (
-					<EmptyState type="empty-project" />
 				) : (
 					<Board columns={columns} tasks={tasks} onAddTask={() => {}} />
 				)}

--- a/src/features/board/components/Board.rendering.test.tsx
+++ b/src/features/board/components/Board.rendering.test.tsx
@@ -1,0 +1,123 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Column as ColumnType, Task } from "../../../types/task";
+import { Board } from "./Board";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "task-1",
+		title: "テストタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "",
+		filePath: "tasks/test.md",
+		...overrides,
+	};
+}
+
+function render(props: Parameters<typeof Board>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(Board, props));
+	});
+}
+
+const defaultColumns: ColumnType[] = [
+	{ name: "Todo", order: 0 },
+	{ name: "In Progress", order: 1 },
+	{ name: "Done", order: 2 },
+];
+
+test("columns に応じたカラムが表示される", async () => {
+	render({ columns: defaultColumns, tasks: [], onAddTask: vi.fn() });
+	await vi.waitFor(() => {
+		const sections = container?.querySelectorAll("section") ?? [];
+		expect(sections.length).toBe(3);
+		const labels = Array.from(sections).map((s) =>
+			s.getAttribute("aria-label"),
+		);
+		expect(labels).toContain("Todo");
+		expect(labels).toContain("In Progress");
+		expect(labels).toContain("Done");
+	});
+});
+
+test("各カラムヘッダーにステータス名とタスク件数が表示される", async () => {
+	const tasks = [
+		createTask({ id: "task-1", title: "タスク1", status: "Todo" }),
+		createTask({ id: "task-2", title: "タスク2", status: "Todo" }),
+		createTask({ id: "task-3", title: "タスク3", status: "In Progress" }),
+	];
+	render({ columns: defaultColumns, tasks, onAddTask: vi.fn() });
+	await vi.waitFor(() => {
+		const todoSection = container?.querySelector('section[aria-label="Todo"]');
+		expect(todoSection?.textContent).toContain("Todo");
+		expect(todoSection?.textContent).toContain("2");
+
+		const inProgressSection = container?.querySelector(
+			'section[aria-label="In Progress"]',
+		);
+		expect(inProgressSection?.textContent).toContain("In Progress");
+		expect(inProgressSection?.textContent).toContain("1");
+
+		const doneSection = container?.querySelector('section[aria-label="Done"]');
+		expect(doneSection?.textContent).toContain("Done");
+		expect(doneSection?.textContent).toContain("0");
+	});
+});
+
+test("「+ 追加」ボタンが各カラムに表示される", async () => {
+	render({ columns: defaultColumns, tasks: [], onAddTask: vi.fn() });
+	await vi.waitFor(() => {
+		const buttons = Array.from(
+			container?.querySelectorAll("button") ?? [],
+		).filter((b) => b.textContent === "+ 追加");
+		expect(buttons.length).toBe(3);
+	});
+});
+
+test("カラムが 10 個以上ある場合でも表示される", async () => {
+	const manyColumns: ColumnType[] = Array.from({ length: 12 }, (_, i) => ({
+		name: `Status-${i}`,
+		order: i,
+	}));
+	render({ columns: manyColumns, tasks: [], onAddTask: vi.fn() });
+	await vi.waitFor(() => {
+		const sections = container?.querySelectorAll("section") ?? [];
+		expect(sections.length).toBe(12);
+	});
+});
+
+test("カラムが order 順に表示される", async () => {
+	const unorderedColumns: ColumnType[] = [
+		{ name: "Done", order: 2 },
+		{ name: "Todo", order: 0 },
+		{ name: "In Progress", order: 1 },
+	];
+	render({ columns: unorderedColumns, tasks: [], onAddTask: vi.fn() });
+	await vi.waitFor(() => {
+		const sections = container?.querySelectorAll("section") ?? [];
+		const labels = Array.from(sections).map((s) =>
+			s.getAttribute("aria-label"),
+		);
+		expect(labels).toEqual(["Todo", "In Progress", "Done"]);
+	});
+});

--- a/src/features/board/components/Board.tsx
+++ b/src/features/board/components/Board.tsx
@@ -1,0 +1,36 @@
+import type { Column as ColumnType, Task } from "../../../types/task";
+import { Column } from "./Column";
+
+/** ボードの Props */
+type BoardProps = {
+	/** カラム定義の配列 */
+	columns: ColumnType[];
+	/** タスクの配列 */
+	tasks: Task[];
+	/** カラムの「+ 追加」ボタンクリック時のコールバック
+	 * @param columnName - 追加対象のカラム名
+	 */
+	onAddTask: (columnName: string) => void;
+};
+
+/**
+ * カラム一覧を横並びで表示するボードコンテナ
+ * @param props - {@link BoardProps}
+ * @returns ボード要素
+ */
+export function Board({ columns, tasks, onAddTask }: BoardProps) {
+	const sorted = [...columns].sort((a, b) => a.order - b.order);
+
+	return (
+		<div className="flex h-full gap-4 overflow-x-auto p-4">
+			{sorted.map((col) => (
+				<Column
+					key={col.name}
+					name={col.name}
+					tasks={tasks.filter((t) => t.status === col.name)}
+					onAddClick={() => onAddTask(col.name)}
+				/>
+			))}
+		</div>
+	);
+}

--- a/src/features/board/components/Board.tsx
+++ b/src/features/board/components/Board.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { Column as ColumnType, Task } from "../../../types/task";
 import { Column } from "./Column";
 
@@ -19,7 +20,21 @@ type BoardProps = {
  * @returns ボード要素
  */
 export function Board({ columns, tasks, onAddTask }: BoardProps) {
-	const sorted = [...columns].sort((a, b) => a.order - b.order);
+	const sorted = useMemo(
+		() => [...columns].sort((a, b) => a.order - b.order),
+		[columns],
+	);
+
+	const tasksByStatus = useMemo(() => {
+		const grouped: Record<string, Task[]> = {};
+		for (const task of tasks) {
+			if (!grouped[task.status]) {
+				grouped[task.status] = [];
+			}
+			grouped[task.status].push(task);
+		}
+		return grouped;
+	}, [tasks]);
 
 	return (
 		<div className="flex h-full gap-4 overflow-x-auto p-4">
@@ -27,7 +42,7 @@ export function Board({ columns, tasks, onAddTask }: BoardProps) {
 				<Column
 					key={col.name}
 					name={col.name}
-					tasks={tasks.filter((t) => t.status === col.name)}
+					tasks={tasksByStatus[col.name] ?? []}
 					onAddClick={() => onAddTask(col.name)}
 				/>
 			))}

--- a/src/features/board/components/Column.rendering.test.tsx
+++ b/src/features/board/components/Column.rendering.test.tsx
@@ -1,0 +1,85 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Task } from "../../../types/task";
+import { Column } from "./Column";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "task-1",
+		title: "テストタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "",
+		filePath: "tasks/test.md",
+		...overrides,
+	};
+}
+
+function render(props: Parameters<typeof Column>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(Column, props));
+	});
+}
+
+test("カラム名がヘッダーに表示される", async () => {
+	render({ name: "In Progress", tasks: [], onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("In Progress");
+	});
+});
+
+test("タスク件数がヘッダーに表示される", async () => {
+	const tasks = [
+		createTask({ id: "task-1", title: "タスク1" }),
+		createTask({ id: "task-2", title: "タスク2" }),
+	];
+	render({ name: "Todo", tasks, onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("2");
+	});
+});
+
+test("タスクのタイトルが表示される", async () => {
+	const tasks = [createTask({ title: "ログイン修正" })];
+	render({ name: "Todo", tasks, onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("ログイン修正");
+	});
+});
+
+test("「+ 追加」ボタンが表示される", async () => {
+	render({ name: "Todo", tasks: [], onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
+			(b): b is HTMLButtonElement => b.textContent === "+ 追加",
+		);
+		expect(btn).toBeDefined();
+	});
+});
+
+test("aria-label にカラム名が設定される", async () => {
+	render({ name: "Done", tasks: [], onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		const section = container?.querySelector("section");
+		expect(section?.getAttribute("aria-label")).toBe("Done");
+	});
+});

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -1,0 +1,41 @@
+import type { Task } from "../../../types/task";
+import { ColumnHeader } from "./ColumnHeader";
+
+/** 個別カラムの Props */
+type ColumnProps = {
+	/** ステータス名 */
+	name: string;
+	/** カラムに属するタスクの配列 */
+	tasks: Task[];
+	/** 「+ 追加」ボタンクリック時のコールバック */
+	onAddClick: () => void;
+};
+
+/**
+ * ステータス別の個別カラムを表示する
+ * @param props - {@link ColumnProps}
+ * @returns カラム要素
+ */
+export function Column({ name, tasks, onAddClick }: ColumnProps) {
+	return (
+		<section
+			className="flex h-full w-72 min-w-72 flex-col rounded-lg bg-gray-50"
+			aria-label={name}
+		>
+			<ColumnHeader
+				name={name}
+				taskCount={tasks.length}
+				onAddClick={onAddClick}
+			/>
+			<ul className="flex-1 overflow-y-auto px-2 pb-2">
+				{tasks.map((task) => (
+					<li key={task.id} className="mb-2">
+						<div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+							<p className="text-sm text-gray-800">{task.title}</p>
+						</div>
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/src/features/board/components/ColumnHeader.rendering.test.tsx
+++ b/src/features/board/components/ColumnHeader.rendering.test.tsx
@@ -1,0 +1,63 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { ColumnHeader } from "./ColumnHeader";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function render(props: Parameters<typeof ColumnHeader>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(ColumnHeader, props));
+	});
+}
+
+test("ステータス名が表示される", async () => {
+	render({ name: "Todo", taskCount: 3, onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("Todo");
+	});
+});
+
+test("タスク件数が表示される", async () => {
+	render({ name: "Todo", taskCount: 5, onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("5");
+	});
+});
+
+test("「+ 追加」ボタンが表示される", async () => {
+	render({ name: "Todo", taskCount: 0, onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
+			(b): b is HTMLButtonElement => b.textContent === "+ 追加",
+		);
+		expect(btn).toBeDefined();
+	});
+});
+
+test("「+ 追加」ボタンクリックでコールバックが呼ばれる", async () => {
+	const onAddClick = vi.fn();
+	render({ name: "Todo", taskCount: 0, onAddClick });
+	let btn: HTMLButtonElement | undefined;
+	await vi.waitFor(() => {
+		btn = Array.from(container?.querySelectorAll("button") ?? []).find(
+			(b): b is HTMLButtonElement => b.textContent === "+ 追加",
+		);
+		expect(btn).toBeDefined();
+	});
+	btn?.click();
+	expect(onAddClick).toHaveBeenCalledTimes(1);
+});

--- a/src/features/board/components/ColumnHeader.tsx
+++ b/src/features/board/components/ColumnHeader.tsx
@@ -1,0 +1,39 @@
+/** カラムヘッダーの Props */
+type ColumnHeaderProps = {
+	/** ステータス名 */
+	name: string;
+	/** カラム内のタスク件数 */
+	taskCount: number;
+	/** 「+ 追加」ボタンクリック時のコールバック */
+	onAddClick: () => void;
+};
+
+/**
+ * カラムヘッダーを表示する
+ * @param props - {@link ColumnHeaderProps}
+ * @returns カラムヘッダー要素
+ */
+export function ColumnHeader({
+	name,
+	taskCount,
+	onAddClick,
+}: ColumnHeaderProps) {
+	return (
+		<div className="flex items-center justify-between px-2 py-2">
+			<div className="flex items-center gap-2">
+				<h2 className="text-sm font-semibold text-gray-700">{name}</h2>
+				<span className="rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600">
+					{taskCount}
+				</span>
+			</div>
+			<button
+				type="button"
+				onClick={onAddClick}
+				aria-label={`${name}に追加`}
+				className="rounded px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+			>
+				+ 追加
+			</button>
+		</div>
+	);
+}

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -1,2 +1,3 @@
+export { Board } from "./components/Board";
 export { EmptyState } from "./components/EmptyState";
 export { HeaderBar } from "./components/HeaderBar";


### PR DESCRIPTION
## 概要

ステータス別のカラムを横並びで表示するコンテナコンポーネントを実装。

## 変更内容

- `ColumnHeader` コンポーネント: ステータス名、タスク件数、「+ 追加」ボタンを表示
- `Column` コンポーネント: 個別カラム（ヘッダー + タスクリスト）
- `Board` コンポーネント: カラム一覧を横並びで表示（flexbox、水平スクロール対応）
- `App.tsx`: Board を配置し、モックデータの読み込みと接続
- アクセシビリティ: `section` + `aria-label`、セマンティックな `ul/li` 構造、ボタンの `aria-label`

## テスト

```bash
pnpm test:run
```

- ColumnHeader: ステータス名・件数表示、「+ 追加」ボタン表示・クリック
- Column: カラム名・件数・タスクタイトル表示、aria-label 設定
- Board: カラム数・order順表示、ヘッダー内容、10個以上のカラム対応

Automated by task-loop-run