### PR TITLE
feat: タスクカード基本表示

### DIFF
--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -1,5 +1,6 @@
 import type { Task } from "../../../types/task";
 import { ColumnHeader } from "./ColumnHeader";
+import { TaskCard } from "./TaskCard";
 
 /** 個別カラムの Props */
 type ColumnProps = {
@@ -9,6 +10,11 @@ type ColumnProps = {
 	tasks: Task[];
 	/** 「+ 追加」ボタンクリック時のコールバック */
 	onAddClick: () => void;
+	/**
+	 * タスクカードクリック時のコールバック
+	 * @param taskId - クリックされたタスクのID
+	 */
+	onTaskClick?: (taskId: string) => void;
 };
 
 /**
@@ -16,7 +22,7 @@ type ColumnProps = {
  * @param props - {@link ColumnProps}
  * @returns カラム要素
  */
-export function Column({ name, tasks, onAddClick }: ColumnProps) {
+export function Column({ name, tasks, onAddClick, onTaskClick }: ColumnProps) {
 	return (
 		<section
 			className="flex h-full w-72 min-w-72 flex-col rounded-lg bg-gray-50"
@@ -30,9 +36,7 @@ export function Column({ name, tasks, onAddClick }: ColumnProps) {
 			<ul className="flex-1 overflow-y-auto px-2 pb-2">
 				{tasks.map((task) => (
 					<li key={task.id} className="mb-2">
-						<div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-							<p className="text-sm text-gray-800">{task.title}</p>
-						</div>
+						<TaskCard task={task} onClick={onTaskClick ?? (() => {})} />
 					</li>
 				))}
 			</ul>

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -36,7 +36,7 @@ export function Column({ name, tasks, onAddClick, onTaskClick }: ColumnProps) {
 			<ul className="flex-1 overflow-y-auto px-2 pb-2">
 				{tasks.map((task) => (
 					<li key={task.id} className="mb-2">
-						<TaskCard task={task} onClick={onTaskClick ?? (() => {})} />
+						<TaskCard task={task} onClick={onTaskClick} />
 					</li>
 				))}
 			</ul>

--- a/src/features/board/components/TaskCard.rendering.test.tsx
+++ b/src/features/board/components/TaskCard.rendering.test.tsx
@@ -50,12 +50,11 @@ test("タイトルが表示される", async () => {
 test("カードクリックでonClickが呼ばれる", async () => {
 	const onClick = vi.fn();
 	render({ task: createTask({ id: "task-42" }), onClick });
-	let button: HTMLButtonElement | null = null;
 	await vi.waitFor(() => {
-		button = container?.querySelector("button") as HTMLButtonElement | null;
-		expect(button).toBeTruthy();
+		expect(container?.querySelector("button")).toBeTruthy();
 	});
-	button?.click();
+	const button = container?.querySelector("button") as HTMLButtonElement;
+	button.click();
 	expect(onClick).toHaveBeenCalledWith("task-42");
 });
 

--- a/src/features/board/components/TaskCard.rendering.test.tsx
+++ b/src/features/board/components/TaskCard.rendering.test.tsx
@@ -50,12 +50,24 @@ test("タイトルが表示される", async () => {
 test("カードクリックでonClickが呼ばれる", async () => {
 	const onClick = vi.fn();
 	render({ task: createTask({ id: "task-42" }), onClick });
+	let button: HTMLButtonElement | null = null;
 	await vi.waitFor(() => {
-		const button = container?.querySelector("button");
-		expect(button).toBeDefined();
-		button?.click();
-		expect(onClick).toHaveBeenCalledWith("task-42");
+		button = container?.querySelector("button") as HTMLButtonElement | null;
+		expect(button).toBeTruthy();
 	});
+	button?.click();
+	expect(onClick).toHaveBeenCalledWith("task-42");
+});
+
+test("onClick未指定の場合、divで描画されボタンにならない", async () => {
+	render({ task: createTask({ title: "非インタラクティブ" }) });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("非インタラクティブ");
+	});
+	const button = container?.querySelector("button");
+	expect(button).toBeNull();
+	const div = container?.querySelector("div");
+	expect(div).toBeTruthy();
 });
 
 test("titleが未設定の場合、filePathが表示される", async () => {

--- a/src/features/board/components/TaskCard.rendering.test.tsx
+++ b/src/features/board/components/TaskCard.rendering.test.tsx
@@ -1,0 +1,69 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Task } from "../../../types/task";
+import { TaskCard } from "./TaskCard";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "task-1",
+		title: "テストタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "",
+		filePath: "tasks/test.md",
+		...overrides,
+	};
+}
+
+function render(props: Parameters<typeof TaskCard>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(TaskCard, props));
+	});
+}
+
+test("タイトルが表示される", async () => {
+	render({ task: createTask({ title: "ログイン修正" }), onClick: vi.fn() });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("ログイン修正");
+	});
+});
+
+test("カードクリックでonClickが呼ばれる", async () => {
+	const onClick = vi.fn();
+	render({ task: createTask({ id: "task-42" }), onClick });
+	await vi.waitFor(() => {
+		const button = container?.querySelector("button");
+		expect(button).toBeDefined();
+		button?.click();
+		expect(onClick).toHaveBeenCalledWith("task-42");
+	});
+});
+
+test("titleが未設定の場合、filePathが表示される", async () => {
+	render({
+		task: createTask({ title: "", filePath: "tasks/my-task.md" }),
+		onClick: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("tasks/my-task.md");
+	});
+});

--- a/src/features/board/components/TaskCard.tsx
+++ b/src/features/board/components/TaskCard.tsx
@@ -8,7 +8,7 @@ type TaskCardProps = {
 	 * カードクリック時のコールバック
 	 * @param taskId - クリックされたタスクのID
 	 */
-	onClick: (taskId: string) => void;
+	onClick?: (taskId: string) => void;
 };
 
 /**
@@ -18,6 +18,14 @@ type TaskCardProps = {
  */
 export function TaskCard({ task, onClick }: TaskCardProps) {
 	const displayTitle = task.title || task.filePath;
+
+	if (!onClick) {
+		return (
+			<div className="w-full rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm">
+				<p className="text-sm text-gray-800">{displayTitle}</p>
+			</div>
+		);
+	}
 
 	return (
 		<button

--- a/src/features/board/components/TaskCard.tsx
+++ b/src/features/board/components/TaskCard.tsx
@@ -1,0 +1,31 @@
+import type { Task } from "../../../types/task";
+
+/** タスクカードの Props */
+type TaskCardProps = {
+	/** 表示するタスク */
+	task: Task;
+	/**
+	 * カードクリック時のコールバック
+	 * @param taskId - クリックされたタスクのID
+	 */
+	onClick: (taskId: string) => void;
+};
+
+/**
+ * タスクカードを表示する
+ * @param props - {@link TaskCardProps}
+ * @returns カード要素
+ */
+export function TaskCard({ task, onClick }: TaskCardProps) {
+	const displayTitle = task.title || task.filePath;
+
+	return (
+		<button
+			type="button"
+			className="w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md"
+			onClick={() => onClick(task.id)}
+		>
+			<p className="text-sm text-gray-800">{displayTitle}</p>
+		</button>
+	);
+}


### PR DESCRIPTION
## 概要

カラム内に表示するタスクカードの基本コンポーネントを実装。

## 変更内容

- `TaskCard` コンポーネントを新規作成（タイトル表示 + クリックハンドラ）
- `title` が未設定の場合は `filePath` をフォールバック表示
- `Column` コンポーネントに `TaskCard` を統合し、`onTaskClick` コールバックを追加

## テスト

- `pnpm test --run` で全38テスト通過
- TaskCard のレンダリングテスト3件を追加（タイトル表示、クリック、filePathフォールバック）

Automated by task-loop-run
