### PR TITLE
feat: 優先度バッジとラベルタグ

### DIFF
--- a/src/features/board/components/LabelTag.rendering.test.tsx
+++ b/src/features/board/components/LabelTag.rendering.test.tsx
@@ -1,0 +1,43 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { LabelTag } from "./LabelTag";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function render(props: Parameters<typeof LabelTag>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(LabelTag, props));
+	});
+}
+
+test("ラベル名が表示される", async () => {
+	render({ label: "bug" });
+	await vi.waitFor(() => {
+		const tag = container?.querySelector("span");
+		expect(tag).toBeTruthy();
+		expect(tag?.textContent).toBe("bug");
+	});
+});
+
+test("ラベルタグにスタイルが適用される", async () => {
+	render({ label: "frontend" });
+	await vi.waitFor(() => {
+		const tag = container?.querySelector("span");
+		expect(tag).toBeTruthy();
+		expect(tag?.className).toContain("bg-gray-100");
+	});
+});

--- a/src/features/board/components/LabelTag.tsx
+++ b/src/features/board/components/LabelTag.tsx
@@ -1,0 +1,16 @@
+type LabelTagProps = {
+	/** ラベル名 */
+	label: string;
+};
+
+/**
+ * @param props - {@link LabelTagProps}
+ * @returns ラベルタグ要素
+ */
+export function LabelTag({ label }: LabelTagProps) {
+	return (
+		<span className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
+			{label}
+		</span>
+	);
+}

--- a/src/features/board/components/PriorityBadge.rendering.test.tsx
+++ b/src/features/board/components/PriorityBadge.rendering.test.tsx
@@ -1,0 +1,64 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { PriorityBadge } from "./PriorityBadge";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function render(props: Parameters<typeof PriorityBadge>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(PriorityBadge, props));
+	});
+}
+
+test("priority が High の場合、赤いバッジが表示される", async () => {
+	render({ priority: "High" });
+	await vi.waitFor(() => {
+		const badge = container?.querySelector("span");
+		expect(badge).toBeTruthy();
+		expect(badge?.textContent).toBe("High");
+		expect(badge?.className).toContain("bg-red-100");
+		expect(badge?.className).toContain("text-red-800");
+	});
+});
+
+test("priority が Medium の場合、黄色いバッジが表示される", async () => {
+	render({ priority: "Medium" });
+	await vi.waitFor(() => {
+		const badge = container?.querySelector("span");
+		expect(badge).toBeTruthy();
+		expect(badge?.textContent).toBe("Medium");
+		expect(badge?.className).toContain("bg-yellow-100");
+	});
+});
+
+test("priority が Low の場合、青いバッジが表示される", async () => {
+	render({ priority: "Low" });
+	await vi.waitFor(() => {
+		const badge = container?.querySelector("span");
+		expect(badge).toBeTruthy();
+		expect(badge?.textContent).toBe("Low");
+		expect(badge?.className).toContain("bg-blue-100");
+	});
+});
+
+test("priority 未設定でバッジ非表示", async () => {
+	render({ priority: undefined });
+	await vi.waitFor(() => {
+		const badge = container?.querySelector("span");
+		expect(badge).toBeNull();
+	});
+});

--- a/src/features/board/components/PriorityBadge.tsx
+++ b/src/features/board/components/PriorityBadge.tsx
@@ -1,0 +1,29 @@
+import type { Priority } from "../../../types/task";
+
+type PriorityBadgeProps = {
+	priority: Priority | undefined;
+};
+
+const priorityStyles: Record<Priority, string> = {
+	High: "bg-red-100 text-red-800",
+	Medium: "bg-yellow-100 text-yellow-800",
+	Low: "bg-blue-100 text-blue-800",
+};
+
+/**
+ * @param props - {@link PriorityBadgeProps}
+ * @returns 優先度バッジ要素。未設定時は null
+ */
+export function PriorityBadge({ priority }: PriorityBadgeProps) {
+	if (!priority) {
+		return null;
+	}
+
+	return (
+		<span
+			className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${priorityStyles[priority]}`}
+		>
+			{priority}
+		</span>
+	);
+}

--- a/src/features/board/components/TaskCard.rendering.test.tsx
+++ b/src/features/board/components/TaskCard.rendering.test.tsx
@@ -78,3 +78,58 @@ test("titleが未設定の場合、filePathが表示される", async () => {
 		expect(container?.textContent).toContain("tasks/my-task.md");
 	});
 });
+
+test("priority が High の場合、赤いバッジが表示される", async () => {
+	render({ task: createTask({ priority: "High" }), onClick: vi.fn() });
+	await vi.waitFor(() => {
+		const badge = container?.querySelector("span.bg-red-100");
+		expect(badge).toBeTruthy();
+		expect(badge?.textContent).toBe("High");
+	});
+});
+
+test("labels が ['bug', 'frontend'] の場合、2つのタグが表示される", async () => {
+	render({
+		task: createTask({ labels: ["bug", "frontend"] }),
+		onClick: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const tags = container?.querySelectorAll(".bg-gray-100");
+		expect(tags?.length).toBe(2);
+		expect(tags?.[0]?.textContent).toBe("bug");
+		expect(tags?.[1]?.textContent).toBe("frontend");
+	});
+});
+
+test("priority 未設定でバッジ非表示", async () => {
+	render({ task: createTask({ priority: undefined }), onClick: vi.fn() });
+	await vi.waitFor(() => {
+		const badge = container?.querySelector(
+			".bg-red-100, .bg-yellow-100, .bg-blue-100",
+		);
+		expect(badge).toBeNull();
+	});
+});
+
+test("labels が空配列でタグ領域非表示", async () => {
+	render({ task: createTask({ labels: [] }), onClick: vi.fn() });
+	await vi.waitFor(() => {
+		const tagContainer = container?.querySelector(".flex-wrap");
+		expect(tagContainer).toBeNull();
+	});
+});
+
+test("ラベルが5個以上で折り返し表示", async () => {
+	render({
+		task: createTask({
+			labels: ["bug", "frontend", "urgent", "design", "refactor"],
+		}),
+		onClick: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const tags = container?.querySelectorAll(".bg-gray-100");
+		expect(tags?.length).toBe(5);
+		const wrapper = container?.querySelector(".flex-wrap");
+		expect(wrapper).toBeTruthy();
+	});
+});

--- a/src/features/board/components/TaskCard.tsx
+++ b/src/features/board/components/TaskCard.tsx
@@ -1,4 +1,6 @@
 import type { Task } from "../../../types/task";
+import { LabelTag } from "./LabelTag";
+import { PriorityBadge } from "./PriorityBadge";
 
 /** タスクカードの Props */
 type TaskCardProps = {
@@ -12,17 +14,39 @@ type TaskCardProps = {
 };
 
 /**
+ * @param props - {@link TaskCardProps}
+ * @returns カード要素
+ */
+function CardContent({ task }: { task: Task }) {
+	const displayTitle = task.title || task.filePath;
+
+	return (
+		<>
+			<div className="flex items-center gap-1.5">
+				<PriorityBadge priority={task.priority} />
+				<p className="text-sm text-gray-800">{displayTitle}</p>
+			</div>
+			{task.labels.length > 0 && (
+				<div className="mt-1.5 flex flex-wrap gap-1">
+					{task.labels.map((label) => (
+						<LabelTag key={label} label={label} />
+					))}
+				</div>
+			)}
+		</>
+	);
+}
+
+/**
  * タスクカードを表示する
  * @param props - {@link TaskCardProps}
  * @returns カード要素
  */
 export function TaskCard({ task, onClick }: TaskCardProps) {
-	const displayTitle = task.title || task.filePath;
-
 	if (!onClick) {
 		return (
 			<div className="w-full rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm">
-				<p className="text-sm text-gray-800">{displayTitle}</p>
+				<CardContent task={task} />
 			</div>
 		);
 	}
@@ -33,7 +57,7 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
 			className="w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md"
 			onClick={() => onClick(task.id)}
 		>
-			<p className="text-sm text-gray-800">{displayTitle}</p>
+			<CardContent task={task} />
 		</button>
 	);
 }


### PR DESCRIPTION
## 概要

タスクカードに優先度バッジとラベルタグを追加する。

## 変更内容

- `PriorityBadge` コンポーネントを新規作成（High=赤、Medium=黄、Low=青、未設定=非表示）
- `LabelTag` コンポーネントを新規作成（ラベルごとにタグ表示）
- `TaskCard` に PriorityBadge と LabelTag を組み込み（ラベルは横並び・折り返し対応）

## テスト

- `pnpm test:run` で全50テスト通過
- PriorityBadge: High/Medium/Low で対応する色のバッジ表示、未設定で非表示
- LabelTag: ラベル名の表示、スタイル適用
- TaskCard: バッジ・タグ統合、空ラベルでタグ領域非表示、5個以上で折り返し

Automated by task-loop-run
