### PR TITLE
feat: サブIssue 進捗表示

### DIFF
--- a/src/features/board/components/Board.tsx
+++ b/src/features/board/components/Board.tsx
@@ -8,6 +8,8 @@ type BoardProps = {
 	columns: ColumnType[];
 	/** タスクの配列 */
 	tasks: Task[];
+	/** 完了カラム名 */
+	doneColumn?: string;
 	/** カラムの「+ 追加」ボタンクリック時のコールバック
 	 * @param columnName - 追加対象のカラム名
 	 */
@@ -19,7 +21,7 @@ type BoardProps = {
  * @param props - {@link BoardProps}
  * @returns ボード要素
  */
-export function Board({ columns, tasks, onAddTask }: BoardProps) {
+export function Board({ columns, tasks, doneColumn, onAddTask }: BoardProps) {
 	const sorted = useMemo(
 		() => [...columns].sort((a, b) => a.order - b.order),
 		[columns],
@@ -43,6 +45,8 @@ export function Board({ columns, tasks, onAddTask }: BoardProps) {
 					key={col.name}
 					name={col.name}
 					tasks={tasksByStatus[col.name] ?? []}
+					allTasks={tasks}
+					doneColumn={doneColumn}
 					onAddClick={() => onAddTask(col.name)}
 				/>
 			))}

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { Task } from "../../../types/task";
 import { ColumnHeader } from "./ColumnHeader";
 import { TaskCard } from "./TaskCard";
@@ -34,7 +35,10 @@ export function Column({
 	onAddClick,
 	onTaskClick,
 }: ColumnProps) {
-	const tasksByFilePath = new Map(allTasks.map((t) => [t.filePath, t]));
+	const tasksByFilePath = useMemo(
+		() => new Map(allTasks.map((t) => [t.filePath, t])),
+		[allTasks],
+	);
 
 	return (
 		<section

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -8,6 +8,10 @@ type ColumnProps = {
 	name: string;
 	/** カラムに属するタスクの配列 */
 	tasks: Task[];
+	/** 全タスクの配列（子タスク解決用） */
+	allTasks?: Task[];
+	/** 完了カラム名 */
+	doneColumn?: string;
 	/** 「+ 追加」ボタンクリック時のコールバック */
 	onAddClick: () => void;
 	/**
@@ -22,7 +26,16 @@ type ColumnProps = {
  * @param props - {@link ColumnProps}
  * @returns カラム要素
  */
-export function Column({ name, tasks, onAddClick, onTaskClick }: ColumnProps) {
+export function Column({
+	name,
+	tasks,
+	allTasks = [],
+	doneColumn,
+	onAddClick,
+	onTaskClick,
+}: ColumnProps) {
+	const tasksByFilePath = new Map(allTasks.map((t) => [t.filePath, t]));
+
 	return (
 		<section
 			className="flex h-full w-72 min-w-72 flex-col rounded-lg bg-gray-50"
@@ -34,11 +47,21 @@ export function Column({ name, tasks, onAddClick, onTaskClick }: ColumnProps) {
 				onAddClick={onAddClick}
 			/>
 			<ul className="flex-1 overflow-y-auto px-2 pb-2">
-				{tasks.map((task) => (
-					<li key={task.id} className="mb-2">
-						<TaskCard task={task} onClick={onTaskClick} />
-					</li>
-				))}
+				{tasks.map((task) => {
+					const childTasks = task.children
+						.map((fp) => tasksByFilePath.get(fp))
+						.filter((t): t is Task => t !== undefined);
+					return (
+						<li key={task.id} className="mb-2">
+							<TaskCard
+								task={task}
+								childTasks={childTasks}
+								doneColumn={doneColumn}
+								onClick={onTaskClick}
+							/>
+						</li>
+					);
+				})}
 			</ul>
 		</section>
 	);

--- a/src/features/board/components/SubIssueProgress.rendering.test.tsx
+++ b/src/features/board/components/SubIssueProgress.rendering.test.tsx
@@ -1,0 +1,104 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test } from "vitest";
+import type { Task } from "../../../types/task";
+import { SubIssueProgress } from "./SubIssueProgress";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "child-1",
+		title: "子タスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "",
+		filePath: "tasks/child.md",
+		...overrides,
+	};
+}
+
+function render(props: Parameters<typeof SubIssueProgress>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(SubIssueProgress, props));
+	});
+}
+
+test("children が存在する場合、進捗バーが表示される", () => {
+	render({
+		childTasks: [createTask({ id: "c1", status: "Todo" })],
+		doneColumn: "Done",
+	});
+	const progressBar = container?.querySelector("[role='progressbar']");
+	expect(progressBar).toBeTruthy();
+});
+
+test("完了数/全数が正しい割合で表示される", () => {
+	render({
+		childTasks: [
+			createTask({ id: "c1", status: "Done" }),
+			createTask({ id: "c2", status: "Todo" }),
+			createTask({ id: "c3", status: "Done" }),
+			createTask({ id: "c4", status: "In Progress" }),
+			createTask({ id: "c5", status: "Todo" }),
+		],
+		doneColumn: "Done",
+	});
+	expect(container?.textContent).toContain("2/5");
+});
+
+test("▶ クリックで子タスクリストが展開される", () => {
+	render({
+		childTasks: [
+			createTask({ id: "c1", title: "タスクA", status: "Todo" }),
+			createTask({ id: "c2", title: "タスクB", status: "Done" }),
+		],
+		doneColumn: "Done",
+	});
+	expect(container?.textContent).not.toContain("タスクA");
+
+	const toggleButton = container?.querySelector("button") as HTMLButtonElement;
+	act(() => {
+		toggleButton.click();
+	});
+
+	expect(container?.textContent).toContain("タスクA");
+	expect(container?.textContent).toContain("タスクB");
+});
+
+test("children が空配列で非表示", () => {
+	render({ childTasks: [], doneColumn: "Done" });
+	expect(container?.innerHTML).toBe("");
+});
+
+test("全子タスクが完了の場合、バーが 100% になる", () => {
+	render({
+		childTasks: [
+			createTask({ id: "c1", status: "Done" }),
+			createTask({ id: "c2", status: "Done" }),
+			createTask({ id: "c3", status: "Done" }),
+		],
+		doneColumn: "Done",
+	});
+	const progressBar = container?.querySelector(
+		"[role='progressbar']",
+	) as HTMLElement;
+	expect(progressBar.getAttribute("aria-valuenow")).toBe("100");
+	expect(container?.textContent).toContain("3/3");
+});

--- a/src/features/board/components/SubIssueProgress.rendering.test.tsx
+++ b/src/features/board/components/SubIssueProgress.rendering.test.tsx
@@ -71,13 +71,15 @@ test("▶ クリックで子タスクリストが展開される", () => {
 		],
 		doneColumn: "Done",
 	});
-	expect(container?.textContent).not.toContain("タスクA");
+	const details = container?.querySelector("details") as HTMLDetailsElement;
+	expect(details.open).toBe(false);
 
-	const toggleButton = container?.querySelector("button") as HTMLButtonElement;
+	const summary = details.querySelector("summary") as HTMLElement;
 	act(() => {
-		toggleButton.click();
+		summary.click();
 	});
 
+	expect(details.open).toBe(true);
 	expect(container?.textContent).toContain("タスクA");
 	expect(container?.textContent).toContain("タスクB");
 });

--- a/src/features/board/components/SubIssueProgress.tsx
+++ b/src/features/board/components/SubIssueProgress.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import type { Task } from "../../../types/task";
+
+type SubIssueProgressProps = {
+	childTasks: Task[];
+	doneColumn: string;
+};
+
+/**
+ * @param props - isDone: 完了かどうか
+ * @returns ステータスアイコン要素
+ */
+function StatusIcon({ isDone }: { isDone: boolean }) {
+	if (isDone) {
+		return <span className="text-green-600">✓</span>;
+	}
+	return <span className="text-gray-400">○</span>;
+}
+
+/**
+ * @param props - {@link SubIssueProgressProps}
+ * @returns サブIssue進捗バーと子タスクリスト。子タスクが空の場合は null
+ */
+export function SubIssueProgress({
+	childTasks,
+	doneColumn,
+}: SubIssueProgressProps) {
+	const [expanded, setExpanded] = useState(false);
+
+	if (childTasks.length === 0) {
+		return null;
+	}
+
+	const total = childTasks.length;
+	const doneCount = childTasks.filter((t) => t.status === doneColumn).length;
+	const percentage = Math.round((doneCount / total) * 100);
+
+	return (
+		<div className="mt-2">
+			<button
+				type="button"
+				className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-800"
+				onClick={(e) => {
+					e.stopPropagation();
+					setExpanded((prev) => !prev);
+				}}
+				aria-expanded={expanded}
+				aria-label={`サブIssue ${doneCount}/${total}`}
+			>
+				<span
+					className={`inline-block transition-transform ${expanded ? "rotate-90" : ""}`}
+				>
+					▶
+				</span>
+				<span>
+					サブIssue ({doneCount}/{total})
+				</span>
+			</button>
+			{expanded && (
+				<ul className="mt-1 ml-4 space-y-0.5 text-xs text-gray-700">
+					{childTasks.map((child) => (
+						<li key={child.id} className="flex items-center gap-1.5">
+							<StatusIcon isDone={child.status === doneColumn} />
+							<span>{child.title || child.filePath}</span>
+						</li>
+					))}
+				</ul>
+			)}
+			<div className="mt-1 flex items-center gap-2">
+				<div
+					className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200"
+					role="progressbar"
+					aria-valuenow={percentage}
+					aria-valuemin={0}
+					aria-valuemax={100}
+					aria-label={`進捗 ${doneCount}/${total}`}
+				>
+					<div
+						className="h-full rounded-full bg-green-500 transition-all"
+						style={{ width: `${percentage}%` }}
+					/>
+				</div>
+				<span className="text-xs text-gray-500">
+					{doneCount}/{total}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/src/features/board/components/SubIssueProgress.tsx
+++ b/src/features/board/components/SubIssueProgress.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import type { Task } from "../../../types/task";
 
 type SubIssueProgressProps = {
@@ -11,10 +10,20 @@ type SubIssueProgressProps = {
  * @returns ステータスアイコン要素
  */
 function StatusIcon({ isDone }: { isDone: boolean }) {
+	const label = isDone ? "完了" : "未完了";
+
 	if (isDone) {
-		return <span className="text-green-600">✓</span>;
+		return (
+			<span className="text-green-600" role="img" aria-label={label}>
+				✓
+			</span>
+		);
 	}
-	return <span className="text-gray-400">○</span>;
+	return (
+		<span className="text-gray-400" role="img" aria-label={label}>
+			○
+		</span>
+	);
 }
 
 /**
@@ -25,8 +34,6 @@ export function SubIssueProgress({
 	childTasks,
 	doneColumn,
 }: SubIssueProgressProps) {
-	const [expanded, setExpanded] = useState(false);
-
 	if (childTasks.length === 0) {
 		return null;
 	}
@@ -37,26 +44,16 @@ export function SubIssueProgress({
 
 	return (
 		<div className="mt-2">
-			<button
-				type="button"
-				className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-800"
-				onClick={(e) => {
-					e.stopPropagation();
-					setExpanded((prev) => !prev);
-				}}
-				aria-expanded={expanded}
-				aria-label={`サブIssue ${doneCount}/${total}`}
+			<details
+				onClick={(e) => e.stopPropagation()}
+				onKeyDown={(e) => e.stopPropagation()}
 			>
-				<span
-					className={`inline-block transition-transform ${expanded ? "rotate-90" : ""}`}
-				>
-					▶
-				</span>
-				<span>
-					サブIssue ({doneCount}/{total})
-				</span>
-			</button>
-			{expanded && (
+				<summary className="flex cursor-pointer list-none items-center gap-1 text-xs text-gray-600 hover:text-gray-800 [&::-webkit-details-marker]:hidden">
+					<span aria-hidden="true">▶</span>
+					<span>
+						サブIssue ({doneCount}/{total})
+					</span>
+				</summary>
 				<ul className="mt-1 ml-4 space-y-0.5 text-xs text-gray-700">
 					{childTasks.map((child) => (
 						<li key={child.id} className="flex items-center gap-1.5">
@@ -65,7 +62,7 @@ export function SubIssueProgress({
 						</li>
 					))}
 				</ul>
-			)}
+			</details>
 			<div className="mt-1 flex items-center gap-2">
 				<div
 					className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200"

--- a/src/features/board/components/TaskCard.rendering.test.tsx
+++ b/src/features/board/components/TaskCard.rendering.test.tsx
@@ -51,10 +51,10 @@ test("カードクリックでonClickが呼ばれる", async () => {
 	const onClick = vi.fn();
 	render({ task: createTask({ id: "task-42" }), onClick });
 	await vi.waitFor(() => {
-		expect(container?.querySelector("button")).toBeTruthy();
+		expect(container?.querySelector('[role="button"]')).toBeTruthy();
 	});
-	const button = container?.querySelector("button") as HTMLButtonElement;
-	button.click();
+	const card = container?.querySelector('[role="button"]') as HTMLElement;
+	card.click();
 	expect(onClick).toHaveBeenCalledWith("task-42");
 });
 

--- a/src/features/board/components/TaskCard.tsx
+++ b/src/features/board/components/TaskCard.tsx
@@ -1,11 +1,16 @@
 import type { Task } from "../../../types/task";
 import { LabelTag } from "./LabelTag";
 import { PriorityBadge } from "./PriorityBadge";
+import { SubIssueProgress } from "./SubIssueProgress";
 
 /** タスクカードの Props */
 type TaskCardProps = {
 	/** 表示するタスク */
 	task: Task;
+	/** 子タスクの配列（children を解決済み） */
+	childTasks?: Task[];
+	/** 完了カラム名 */
+	doneColumn?: string;
 	/**
 	 * カードクリック時のコールバック
 	 * @param taskId - クリックされたタスクのID
@@ -17,7 +22,15 @@ type TaskCardProps = {
  * @param props - {@link TaskCardProps}
  * @returns カード要素
  */
-function CardContent({ task }: { task: Task }) {
+function CardContent({
+	task,
+	childTasks = [],
+	doneColumn = "Done",
+}: {
+	task: Task;
+	childTasks?: Task[];
+	doneColumn?: string;
+}) {
 	const displayTitle = task.title || task.filePath;
 
 	return (
@@ -33,6 +46,7 @@ function CardContent({ task }: { task: Task }) {
 					))}
 				</div>
 			)}
+			<SubIssueProgress childTasks={childTasks} doneColumn={doneColumn} />
 		</>
 	);
 }
@@ -42,11 +56,20 @@ function CardContent({ task }: { task: Task }) {
  * @param props - {@link TaskCardProps}
  * @returns カード要素
  */
-export function TaskCard({ task, onClick }: TaskCardProps) {
+export function TaskCard({
+	task,
+	childTasks,
+	doneColumn,
+	onClick,
+}: TaskCardProps) {
 	if (!onClick) {
 		return (
 			<div className="w-full rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm">
-				<CardContent task={task} />
+				<CardContent
+					task={task}
+					childTasks={childTasks}
+					doneColumn={doneColumn}
+				/>
 			</div>
 		);
 	}
@@ -57,7 +80,11 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
 			className="w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md"
 			onClick={() => onClick(task.id)}
 		>
-			<CardContent task={task} />
+			<CardContent
+				task={task}
+				childTasks={childTasks}
+				doneColumn={doneColumn}
+			/>
 		</button>
 	);
 }

--- a/src/features/board/components/TaskCard.tsx
+++ b/src/features/board/components/TaskCard.tsx
@@ -75,13 +75,14 @@ export function TaskCard({
 	}
 
 	return (
-		// biome-ignore lint/a11y/useSemanticElements: avoid nesting interactive elements (details/summary) inside button
+		// biome-ignore lint/a11y/useSemanticElements: CardContent may include interactive descendants such as details/summary, so a semantic <button> cannot be used as the card container
 		<div
 			role="button"
 			tabIndex={0}
 			className="w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md"
 			onClick={() => onClick(task.id)}
 			onKeyDown={(e) => {
+				if (e.currentTarget !== e.target) return;
 				if (e.key === "Enter" || e.key === " ") {
 					e.preventDefault();
 					onClick(task.id);

--- a/src/features/board/components/TaskCard.tsx
+++ b/src/features/board/components/TaskCard.tsx
@@ -75,16 +75,24 @@ export function TaskCard({
 	}
 
 	return (
-		<button
-			type="button"
+		// biome-ignore lint/a11y/useSemanticElements: avoid nesting interactive elements (details/summary) inside button
+		<div
+			role="button"
+			tabIndex={0}
 			className="w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md"
 			onClick={() => onClick(task.id)}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					onClick(task.id);
+				}
+			}}
 		>
 			<CardContent
 				task={task}
 				childTasks={childTasks}
 				doneColumn={doneColumn}
 			/>
-		</button>
+		</div>
 	);
 }


### PR DESCRIPTION
## 概要

タスクカードにサブIssueの進捗バーと折りたたみ可能な子タスクリストを追加。

## 変更内容

- `SubIssueProgress` コンポーネントを新規作成
  - 進捗バー: 完了数/全数を色付きバーで表示
  - 子タスクリスト: デフォルト折りたたみ、▶クリックで展開
  - 展開時は直接の子タスクのみ表示（タイトル + ステータスアイコン）
  - children が空の場合は非表示
- `TaskCard` に `childTasks` / `doneColumn` props を追加し `SubIssueProgress` を組み込み
- `Column` で子タスクをファイルパスから解決して `TaskCard` に渡す
- `Board` に `doneColumn` prop を追加し `Column` へ伝搬

## テスト

```bash
pnpm test:run
```

- 5件のテストケースを追加（正常系3件、エッジケース2件）

Automated by task-loop-run
