### PR TITLE
feat: 詳細パネルシェル（スライドイン、×/Esc/オーバーレイで閉じる）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Board, EmptyState, HeaderBar } from "./features/board";
+import { DetailPanel } from "./features/detail";
 import { getColumns, getTasks } from "./lib/api";
 import type { Column, Task } from "./types/task";
 
@@ -11,15 +12,29 @@ function App() {
 	const [tasks, setTasks] = useState<Task[]>([]);
 	const [columns, setColumns] = useState<Column[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
+	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+	const selectedTask = selectedTaskId
+		? (tasks.find((t) => t.id === selectedTaskId) ?? null)
+		: null;
 
 	const handleOpenProject = () => {
 		setProjectPath("mock-project");
 	};
 
+	const handleTaskClick = useCallback((taskId: string) => {
+		setSelectedTaskId(taskId);
+	}, []);
+
+	const handleCloseDetail = useCallback(() => {
+		setSelectedTaskId(null);
+	}, []);
+
 	useEffect(() => {
 		if (projectPath === null) return;
 		let cancelled = false;
 		setIsLoading(true);
+		setSelectedTaskId(null);
 		(async () => {
 			const [loadedTasks, loadedColumns] = await Promise.all([
 				getTasks(),
@@ -46,9 +61,17 @@ function App() {
 						<p className="text-gray-500">読み込み中…</p>
 					</div>
 				) : (
-					<Board columns={columns} tasks={tasks} onAddTask={() => {}} />
+					<Board
+						columns={columns}
+						tasks={tasks}
+						onAddTask={() => {}}
+						onTaskClick={handleTaskClick}
+					/>
 				)}
 			</main>
+			{selectedTask && (
+				<DetailPanel task={selectedTask} onClose={handleCloseDetail} />
+			)}
 		</div>
 	);
 }

--- a/src/features/board/components/Board.tsx
+++ b/src/features/board/components/Board.tsx
@@ -14,6 +14,11 @@ type BoardProps = {
 	 * @param columnName - 追加対象のカラム名
 	 */
 	onAddTask: (columnName: string) => void;
+	/**
+	 * タスクカードクリック時のコールバック
+	 * @param taskId - クリックされたタスクのID
+	 */
+	onTaskClick?: (taskId: string) => void;
 };
 
 /**
@@ -21,7 +26,13 @@ type BoardProps = {
  * @param props - {@link BoardProps}
  * @returns ボード要素
  */
-export function Board({ columns, tasks, doneColumn, onAddTask }: BoardProps) {
+export function Board({
+	columns,
+	tasks,
+	doneColumn,
+	onAddTask,
+	onTaskClick,
+}: BoardProps) {
 	const sorted = useMemo(
 		() => [...columns].sort((a, b) => a.order - b.order),
 		[columns],
@@ -48,6 +59,7 @@ export function Board({ columns, tasks, doneColumn, onAddTask }: BoardProps) {
 					allTasks={tasks}
 					doneColumn={doneColumn}
 					onAddClick={() => onAddTask(col.name)}
+					onTaskClick={onTaskClick}
 				/>
 			))}
 		</div>

--- a/src/features/detail/components/DetailPanel.rendering.test.tsx
+++ b/src/features/detail/components/DetailPanel.rendering.test.tsx
@@ -60,12 +60,12 @@ test("×ボタンクリックでonCloseが呼ばれる", async () => {
 	const onClose = vi.fn();
 	render({ task: createTask(), onClose });
 	await vi.waitFor(() => {
-		const closeButton = document.querySelector(
-			'[aria-label="閉じる"]',
-		) as HTMLElement;
-		expect(closeButton).toBeTruthy();
-		closeButton.click();
+		expect(document.querySelector('[aria-label="閉じる"]')).toBeTruthy();
 	});
+	const closeButton = document.querySelector(
+		'[aria-label="閉じる"]',
+	) as HTMLElement;
+	closeButton.click();
 	expect(onClose).toHaveBeenCalledOnce();
 });
 
@@ -85,11 +85,13 @@ test("オーバーレイクリックでパネルが閉じる", async () => {
 	const onClose = vi.fn();
 	render({ task: createTask(), onClose });
 	await vi.waitFor(() => {
-		const overlay = document.querySelector(
-			'[data-testid="detail-overlay"]',
-		) as HTMLElement;
-		expect(overlay).toBeTruthy();
-		overlay.click();
+		expect(
+			document.querySelector('[data-testid="detail-overlay"]'),
+		).toBeTruthy();
 	});
+	const overlay = document.querySelector(
+		'[data-testid="detail-overlay"]',
+	) as HTMLElement;
+	overlay.click();
 	expect(onClose).toHaveBeenCalledOnce();
 });

--- a/src/features/detail/components/DetailPanel.rendering.test.tsx
+++ b/src/features/detail/components/DetailPanel.rendering.test.tsx
@@ -1,0 +1,95 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Task } from "../../../types/task";
+import { DetailPanel } from "./DetailPanel";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "task-1",
+		title: "テストタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "タスクの本文",
+		filePath: "tasks/test.md",
+		...overrides,
+	};
+}
+
+function render(props: Parameters<typeof DetailPanel>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(DetailPanel, props));
+	});
+}
+
+test("タスク選択時にパネルが表示される", async () => {
+	render({ task: createTask(), onClose: vi.fn() });
+	await vi.waitFor(() => {
+		const dialog = document.querySelector('[role="dialog"]');
+		expect(dialog).toBeTruthy();
+	});
+});
+
+test("タスクタイトルが表示される", async () => {
+	render({ task: createTask({ title: "ログイン修正" }), onClose: vi.fn() });
+	await vi.waitFor(() => {
+		const dialog = document.querySelector('[role="dialog"]');
+		expect(dialog?.textContent).toContain("ログイン修正");
+	});
+});
+
+test("×ボタンクリックでonCloseが呼ばれる", async () => {
+	const onClose = vi.fn();
+	render({ task: createTask(), onClose });
+	await vi.waitFor(() => {
+		const closeButton = document.querySelector(
+			'[aria-label="閉じる"]',
+		) as HTMLElement;
+		expect(closeButton).toBeTruthy();
+		closeButton.click();
+	});
+	expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("Escキーでパネルが閉じる", async () => {
+	const onClose = vi.fn();
+	render({ task: createTask(), onClose });
+	await vi.waitFor(() => {
+		expect(document.querySelector('[role="dialog"]')).toBeTruthy();
+	});
+	act(() => {
+		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+	});
+	expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("オーバーレイクリックでパネルが閉じる", async () => {
+	const onClose = vi.fn();
+	render({ task: createTask(), onClose });
+	await vi.waitFor(() => {
+		const overlay = document.querySelector(
+			'[data-testid="detail-overlay"]',
+		) as HTMLElement;
+		expect(overlay).toBeTruthy();
+		overlay.click();
+	});
+	expect(onClose).toHaveBeenCalledOnce();
+});

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+import type { Task } from "../../../types/task";
+
+/** 詳細パネルの Props */
+type DetailPanelProps = {
+	/** 表示するタスク */
+	task: Task;
+	/** パネルを閉じるコールバック */
+	onClose: () => void;
+};
+
+/**
+ * 右側からスライドインするタスク詳細パネル
+ * @param props - {@link DetailPanelProps}
+ * @returns パネル要素
+ */
+export function DetailPanel({ task, onClose }: DetailPanelProps) {
+	const panelRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				onClose();
+			}
+		};
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [onClose]);
+
+	useEffect(() => {
+		panelRef.current?.focus();
+	}, []);
+
+	return (
+		<>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses panel on click, no semantic role needed */}
+			<div
+				className="fixed inset-0 z-40 bg-black/30"
+				data-testid="detail-overlay"
+				onClick={onClose}
+				onKeyDown={() => {}}
+				role="presentation"
+			/>
+			<aside
+				ref={panelRef}
+				role="dialog"
+				aria-modal="true"
+				aria-label="タスク詳細"
+				tabIndex={-1}
+				className="fixed top-0 right-0 z-50 flex h-full w-[480px] max-w-full animate-slide-in flex-col bg-white shadow-xl"
+			>
+				<div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+					<h2 className="truncate text-lg font-semibold text-gray-900">
+						{task.title || task.filePath}
+					</h2>
+					<button
+						type="button"
+						aria-label="閉じる"
+						className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+						onClick={onClose}
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							className="h-5 w-5"
+							viewBox="0 0 20 20"
+							fill="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								fillRule="evenodd"
+								d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+								clipRule="evenodd"
+							/>
+						</svg>
+					</button>
+				</div>
+				<div className="flex-1 overflow-y-auto p-4">
+					<p className="text-sm text-gray-600">{task.body}</p>
+				</div>
+			</aside>
+		</>
+	);
+}

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -15,7 +15,7 @@ type DetailPanelProps = {
  * @returns パネル要素
  */
 export function DetailPanel({ task, onClose }: DetailPanelProps) {
-	const panelRef = useRef<HTMLDivElement>(null);
+	const panelRef = useRef<HTMLElement>(null);
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -33,13 +33,12 @@ export function DetailPanel({ task, onClose }: DetailPanelProps) {
 
 	return (
 		<>
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop dismisses panel on click, no semantic role needed */}
-			<div
-				className="fixed inset-0 z-40 bg-black/30"
+			<button
+				type="button"
+				aria-label="詳細パネルを閉じる"
+				className="fixed inset-0 z-40 border-0 bg-black/30 p-0"
 				data-testid="detail-overlay"
 				onClick={onClose}
-				onKeyDown={() => {}}
-				role="presentation"
 			/>
 			<aside
 				ref={panelRef}

--- a/src/features/detail/index.ts
+++ b/src/features/detail/index.ts
@@ -1,0 +1,1 @@
+export { DetailPanel } from "./components/DetailPanel";

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,14 @@
 @import "tailwindcss";
+
+@theme {
+	--animate-slide-in: slide-in 0.2s ease-out;
+}
+
+@keyframes slide-in {
+	from {
+		transform: translateX(100%);
+	}
+	to {
+		transform: translateX(0);
+	}
+}


### PR DESCRIPTION
## 概要

タスクカードクリック時に右側からスライドインする詳細パネルのシェル（外枠）を実装。

## 変更内容

- `DetailPanel` コンポーネントを新規作成（`src/features/detail/components/DetailPanel.tsx`）
  - 右からスライドインするサイドパネル（CSS animation）
  - ×ボタン、Escキー、オーバーレイクリックで閉じる
  - `role="dialog"` + `aria-modal="true"` によるアクセシビリティ対応
- `Board` コンポーネントに `onTaskClick` prop を追加
- `App.tsx` に `selectedTaskId` 状態管理を追加し、パネル開閉を制御
- `src/index.css` にスライドインアニメーション（`animate-slide-in`）を定義
- DetailPanel のレンダリングテスト（5件）を追加

## テスト方法

```bash
pnpm test:run
```

Automated by task-loop-run
