### PR TITLE
feat: 詳細パネル - インライン編集とドロップダウン

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Board, EmptyState, HeaderBar } from "./features/board";
 import { DetailPanel } from "./features/detail";
-import { getColumns, getTasks } from "./lib/api";
+import { getColumns, getTasks, updateTask } from "./lib/api";
 import type { Column, Task } from "./types/task";
 
 /**
@@ -29,6 +29,14 @@ function App() {
 	const handleCloseDetail = useCallback(() => {
 		setSelectedTaskId(null);
 	}, []);
+
+	const handleTaskUpdate = useCallback(
+		async (id: string, updates: Partial<Omit<Task, "id">>) => {
+			const updated = await updateTask(id, updates);
+			setTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+		},
+		[],
+	);
 
 	useEffect(() => {
 		if (projectPath === null) return;
@@ -70,7 +78,12 @@ function App() {
 				)}
 			</main>
 			{selectedTask && (
-				<DetailPanel task={selectedTask} onClose={handleCloseDetail} />
+				<DetailPanel
+					task={selectedTask}
+					columns={columns}
+					onClose={handleCloseDetail}
+					onTaskUpdate={handleTaskUpdate}
+				/>
 			)}
 		</div>
 	);

--- a/src/features/detail/components/DetailPanel.rendering.test.tsx
+++ b/src/features/detail/components/DetailPanel.rendering.test.tsx
@@ -7,6 +7,13 @@ import { DetailPanel } from "./DetailPanel";
 let container: HTMLDivElement | null = null;
 let root: ReturnType<typeof createRoot> | null = null;
 
+/** テスト用カラム一覧 */
+const testColumns = [
+	{ name: "Todo", order: 0 },
+	{ name: "In Progress", order: 1 },
+	{ name: "Done", order: 2 },
+];
+
 afterEach(() => {
 	act(() => {
 		root?.unmount();
@@ -16,6 +23,11 @@ afterEach(() => {
 	container = null;
 });
 
+/**
+ * テスト用タスクを生成する
+ * @param overrides - 上書きするフィールド
+ * @returns テスト用タスク
+ */
 function createTask(overrides: Partial<Task> = {}): Task {
 	return {
 		id: "task-1",
@@ -31,6 +43,10 @@ function createTask(overrides: Partial<Task> = {}): Task {
 	};
 }
 
+/**
+ * DetailPanel をレンダリングするヘルパー
+ * @param props - DetailPanel に渡す props
+ */
 function render(props: Parameters<typeof DetailPanel>[0]) {
 	container = document.createElement("div");
 	document.body.appendChild(container);
@@ -41,7 +57,12 @@ function render(props: Parameters<typeof DetailPanel>[0]) {
 }
 
 test("タスク選択時にパネルが表示される", async () => {
-	render({ task: createTask(), onClose: vi.fn() });
+	render({
+		task: createTask(),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+	});
 	await vi.waitFor(() => {
 		const dialog = document.querySelector('[role="dialog"]');
 		expect(dialog).toBeTruthy();
@@ -49,7 +70,12 @@ test("タスク選択時にパネルが表示される", async () => {
 });
 
 test("タスクタイトルが表示される", async () => {
-	render({ task: createTask({ title: "ログイン修正" }), onClose: vi.fn() });
+	render({
+		task: createTask({ title: "ログイン修正" }),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+	});
 	await vi.waitFor(() => {
 		const dialog = document.querySelector('[role="dialog"]');
 		expect(dialog?.textContent).toContain("ログイン修正");
@@ -58,7 +84,12 @@ test("タスクタイトルが表示される", async () => {
 
 test("×ボタンクリックでonCloseが呼ばれる", async () => {
 	const onClose = vi.fn();
-	render({ task: createTask(), onClose });
+	render({
+		task: createTask(),
+		columns: testColumns,
+		onClose,
+		onTaskUpdate: vi.fn(),
+	});
 	await vi.waitFor(() => {
 		expect(document.querySelector('[aria-label="閉じる"]')).toBeTruthy();
 	});
@@ -71,7 +102,12 @@ test("×ボタンクリックでonCloseが呼ばれる", async () => {
 
 test("Escキーでパネルが閉じる", async () => {
 	const onClose = vi.fn();
-	render({ task: createTask(), onClose });
+	render({
+		task: createTask(),
+		columns: testColumns,
+		onClose,
+		onTaskUpdate: vi.fn(),
+	});
 	await vi.waitFor(() => {
 		expect(document.querySelector('[role="dialog"]')).toBeTruthy();
 	});
@@ -83,7 +119,12 @@ test("Escキーでパネルが閉じる", async () => {
 
 test("オーバーレイクリックでパネルが閉じる", async () => {
 	const onClose = vi.fn();
-	render({ task: createTask(), onClose });
+	render({
+		task: createTask(),
+		columns: testColumns,
+		onClose,
+		onTaskUpdate: vi.fn(),
+	});
 	await vi.waitFor(() => {
 		expect(
 			document.querySelector('[data-testid="detail-overlay"]'),

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -1,12 +1,23 @@
-import { useEffect, useRef } from "react";
-import type { Task } from "../../../types/task";
+import { useCallback, useEffect, useRef } from "react";
+import type { Column, Priority, Task } from "../../../types/task";
+import { InlineEdit } from "./InlineEdit";
+import { PrioritySelect } from "./PrioritySelect";
+import { StatusSelect } from "./StatusSelect";
 
 /** 詳細パネルの Props */
 type DetailPanelProps = {
 	/** 表示するタスク */
 	task: Task;
+	/** 選択肢となるカラム一覧 */
+	columns: Column[];
 	/** パネルを閉じるコールバック */
 	onClose: () => void;
+	/**
+	 * タスク更新時のコールバック
+	 * @param id - 更新対象のタスクID
+	 * @param updates - 更新するフィールド
+	 */
+	onTaskUpdate: (id: string, updates: Partial<Omit<Task, "id">>) => void;
 };
 
 /**
@@ -14,8 +25,34 @@ type DetailPanelProps = {
  * @param props - {@link DetailPanelProps}
  * @returns パネル要素
  */
-export function DetailPanel({ task, onClose }: DetailPanelProps) {
+export function DetailPanel({
+	task,
+	columns,
+	onClose,
+	onTaskUpdate,
+}: DetailPanelProps) {
 	const panelRef = useRef<HTMLElement>(null);
+
+	const handleTitleConfirm = useCallback(
+		(title: string) => {
+			onTaskUpdate(task.id, { title });
+		},
+		[task.id, onTaskUpdate],
+	);
+
+	const handleStatusChange = useCallback(
+		(status: string) => {
+			onTaskUpdate(task.id, { status });
+		},
+		[task.id, onTaskUpdate],
+	);
+
+	const handlePriorityChange = useCallback(
+		(priority: Priority | undefined) => {
+			onTaskUpdate(task.id, { priority });
+		},
+		[task.id, onTaskUpdate],
+	);
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -49,13 +86,16 @@ export function DetailPanel({ task, onClose }: DetailPanelProps) {
 				className="fixed top-0 right-0 z-50 flex h-full w-[480px] max-w-full animate-slide-in flex-col bg-white shadow-xl"
 			>
 				<div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-					<h2 className="truncate text-lg font-semibold text-gray-900">
-						{task.title || task.filePath}
-					</h2>
+					<div className="min-w-0 flex-1">
+						<InlineEdit
+							value={task.title || task.filePath}
+							onConfirm={handleTitleConfirm}
+						/>
+					</div>
 					<button
 						type="button"
 						aria-label="閉じる"
-						className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+						className="ml-2 shrink-0 rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
 						onClick={onClose}
 					>
 						<svg
@@ -74,7 +114,20 @@ export function DetailPanel({ task, onClose }: DetailPanelProps) {
 					</button>
 				</div>
 				<div className="flex-1 overflow-y-auto p-4">
-					<p className="text-sm text-gray-600">{task.body}</p>
+					<div className="flex flex-col gap-4">
+						<div className="flex gap-4">
+							<StatusSelect
+								value={task.status}
+								columns={columns}
+								onChange={handleStatusChange}
+							/>
+							<PrioritySelect
+								value={task.priority}
+								onChange={handlePriorityChange}
+							/>
+						</div>
+						<p className="text-sm text-gray-600">{task.body}</p>
+					</div>
 				</div>
 			</aside>
 		</>

--- a/src/features/detail/components/InlineEdit.interaction.test.tsx
+++ b/src/features/detail/components/InlineEdit.interaction.test.tsx
@@ -1,0 +1,142 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { InlineEdit } from "./InlineEdit";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * InlineEdit をレンダリングするヘルパー
+ * @param props - InlineEdit に渡す props
+ */
+function render(props: Parameters<typeof InlineEdit>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(InlineEdit, props));
+	});
+}
+
+test("初期表示でテキストが表示される", () => {
+	render({ value: "タスクタイトル", onConfirm: vi.fn() });
+	const display = document.querySelector('[data-testid="inline-edit-display"]');
+	expect(display?.textContent).toBe("タスクタイトル");
+});
+
+test("クリックで編集モードになる", () => {
+	render({ value: "タスクタイトル", onConfirm: vi.fn() });
+	const display = document.querySelector(
+		'[data-testid="inline-edit-display"]',
+	) as HTMLElement;
+	act(() => {
+		display.click();
+	});
+	const input = document.querySelector(
+		'[data-testid="inline-edit-input"]',
+	) as HTMLInputElement;
+	expect(input).toBeTruthy();
+	expect(input.value).toBe("タスクタイトル");
+});
+
+test("Enterで確定しonConfirmが呼ばれる", () => {
+	const onConfirm = vi.fn();
+	render({ value: "元の値", onConfirm });
+	const display = document.querySelector(
+		'[data-testid="inline-edit-display"]',
+	) as HTMLElement;
+	act(() => {
+		display.click();
+	});
+	const input = document.querySelector(
+		'[data-testid="inline-edit-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "新しい値");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onConfirm).toHaveBeenCalledWith("新しい値");
+});
+
+test("Escでキャンセルし元の値に戻る", () => {
+	const onConfirm = vi.fn();
+	render({ value: "元の値", onConfirm });
+	const display = document.querySelector(
+		'[data-testid="inline-edit-display"]',
+	) as HTMLElement;
+	act(() => {
+		display.click();
+	});
+	const input = document.querySelector(
+		'[data-testid="inline-edit-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "変更中");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+		);
+	});
+	expect(onConfirm).not.toHaveBeenCalled();
+	const displayAfter = document.querySelector(
+		'[data-testid="inline-edit-display"]',
+	);
+	expect(displayAfter?.textContent).toBe("元の値");
+});
+
+test("空文字で確定すると元に戻る", () => {
+	const onConfirm = vi.fn();
+	render({ value: "元の値", onConfirm });
+	const display = document.querySelector(
+		'[data-testid="inline-edit-display"]',
+	) as HTMLElement;
+	act(() => {
+		display.click();
+	});
+	const input = document.querySelector(
+		'[data-testid="inline-edit-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onConfirm).not.toHaveBeenCalled();
+	const displayAfter = document.querySelector(
+		'[data-testid="inline-edit-display"]',
+	);
+	expect(displayAfter?.textContent).toBe("元の値");
+});

--- a/src/features/detail/components/InlineEdit.interaction.test.tsx
+++ b/src/features/detail/components/InlineEdit.interaction.test.tsx
@@ -75,6 +75,7 @@ test("Enterで確定しonConfirmが呼ばれる", () => {
 		);
 	});
 	expect(onConfirm).toHaveBeenCalledWith("新しい値");
+	expect(onConfirm).toHaveBeenCalledTimes(1);
 });
 
 test("Escでキャンセルし元の値に戻る", () => {

--- a/src/features/detail/components/InlineEdit.tsx
+++ b/src/features/detail/components/InlineEdit.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from "react";
+
+/** InlineEdit の Props */
+type InlineEditProps = {
+	/** 表示・編集する値 */
+	value: string;
+	/**
+	 * 編集確定時のコールバック
+	 * @param value - 確定された値
+	 */
+	onConfirm: (value: string) => void;
+};
+
+/**
+ * クリックで編集モードに切り替わるインラインテキスト編集コンポーネント
+ * @param props - {@link InlineEditProps}
+ * @returns インライン編集要素
+ */
+export function InlineEdit({ value, onConfirm }: InlineEditProps) {
+	const [isEditing, setIsEditing] = useState(false);
+	const [editValue, setEditValue] = useState(value);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const isCancelledRef = useRef(false);
+
+	useEffect(() => {
+		setEditValue(value);
+	}, [value]);
+
+	useEffect(() => {
+		if (isEditing) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [isEditing]);
+
+	/** 編集内容を確定する。空文字の場合は元の値に戻す */
+	const confirm = () => {
+		const trimmed = editValue.trim();
+		if (trimmed.length === 0) {
+			setEditValue(value);
+		} else if (trimmed !== value) {
+			onConfirm(trimmed);
+		}
+		setIsEditing(false);
+	};
+
+	/** 編集をキャンセルし元の値に戻す */
+	const cancel = () => {
+		isCancelledRef.current = true;
+		setEditValue(value);
+		setIsEditing(false);
+	};
+
+	/** キーボードイベントを処理する（Enter: 確定、Escape: キャンセル） */
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			confirm();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			cancel();
+		}
+	};
+
+	if (isEditing) {
+		return (
+			<input
+				ref={inputRef}
+				type="text"
+				value={editValue}
+				onChange={(e) => setEditValue(e.target.value)}
+				onKeyDown={handleKeyDown}
+				onBlur={() => {
+					if (!isCancelledRef.current) confirm();
+					isCancelledRef.current = false;
+				}}
+				className="w-full rounded border border-blue-400 px-1 py-0.5 text-lg font-semibold text-gray-900 outline-none"
+				data-testid="inline-edit-input"
+			/>
+		);
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={() => setIsEditing(true)}
+			className="w-full cursor-pointer truncate rounded px-1 py-0.5 text-left text-lg font-semibold text-gray-900 hover:bg-gray-100"
+			data-testid="inline-edit-display"
+		>
+			{value}
+		</button>
+	);
+}

--- a/src/features/detail/components/InlineEdit.tsx
+++ b/src/features/detail/components/InlineEdit.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 
 /** InlineEdit の Props */
@@ -52,12 +53,15 @@ export function InlineEdit({ value, onConfirm }: InlineEditProps) {
 	};
 
 	/** キーボードイベントを処理する（Enter: 確定、Escape: キャンセル） */
-	const handleKeyDown = (e: React.KeyboardEvent) => {
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Enter") {
 			e.preventDefault();
+			e.stopPropagation();
+			isCancelledRef.current = true;
 			confirm();
 		} else if (e.key === "Escape") {
 			e.preventDefault();
+			e.stopPropagation();
 			cancel();
 		}
 	};

--- a/src/features/detail/components/PrioritySelect.interaction.test.tsx
+++ b/src/features/detail/components/PrioritySelect.interaction.test.tsx
@@ -1,0 +1,71 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { PrioritySelect } from "./PrioritySelect";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * PrioritySelect をレンダリングするヘルパー
+ * @param props - PrioritySelect に渡す props
+ */
+function render(props: Parameters<typeof PrioritySelect>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(PrioritySelect, props));
+	});
+}
+
+test("現在の優先度が選択状態で表示される", () => {
+	render({ value: "High", onChange: vi.fn() });
+	const select = document.querySelector(
+		'[data-testid="priority-select"]',
+	) as HTMLSelectElement;
+	expect(select.value).toBe("High");
+});
+
+test("優先度未設定時は「なし」が選択される", () => {
+	render({ value: undefined, onChange: vi.fn() });
+	const select = document.querySelector(
+		'[data-testid="priority-select"]',
+	) as HTMLSelectElement;
+	expect(select.value).toBe("");
+});
+
+test("優先度変更でonChangeが呼ばれる", () => {
+	const onChange = vi.fn();
+	render({ value: undefined, onChange });
+	const select = document.querySelector(
+		'[data-testid="priority-select"]',
+	) as HTMLSelectElement;
+	act(() => {
+		select.value = "Medium";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+	});
+	expect(onChange).toHaveBeenCalledWith("Medium");
+});
+
+test("「なし」を選択するとundefinedでonChangeが呼ばれる", () => {
+	const onChange = vi.fn();
+	render({ value: "High", onChange });
+	const select = document.querySelector(
+		'[data-testid="priority-select"]',
+	) as HTMLSelectElement;
+	act(() => {
+		select.value = "";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+	});
+	expect(onChange).toHaveBeenCalledWith(undefined);
+});

--- a/src/features/detail/components/PrioritySelect.tsx
+++ b/src/features/detail/components/PrioritySelect.tsx
@@ -20,20 +20,18 @@ const priorities: Priority[] = ["High", "Medium", "Low"];
  * @returns セレクト要素
  */
 export function PrioritySelect({ value, onChange }: PrioritySelectProps) {
-	/** セレクト変更ハンドラ */
-	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		const selected = e.target.value;
-		onChange(selected === "" ? undefined : (selected as Priority));
-	};
-
 	return (
 		<div className="flex items-center gap-2">
 			<span className="text-sm font-medium text-gray-500">優先度</span>
 			<select
 				value={value ?? ""}
-				onChange={handleChange}
+				onChange={(e) => {
+					const selected = e.target.value;
+					onChange(selected === "" ? undefined : (selected as Priority));
+				}}
 				className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-800 hover:border-blue-300 focus:border-blue-400 focus:outline-none"
 				data-testid="priority-select"
+				aria-label="優先度"
 			>
 				<option value="">なし</option>
 				{priorities.map((p) => (

--- a/src/features/detail/components/PrioritySelect.tsx
+++ b/src/features/detail/components/PrioritySelect.tsx
@@ -1,0 +1,47 @@
+import type { Priority } from "../../../types/task";
+
+/** PrioritySelect の Props */
+type PrioritySelectProps = {
+	/** 現在の優先度（未設定の場合は undefined） */
+	value: Priority | undefined;
+	/**
+	 * 優先度変更時のコールバック
+	 * @param priority - 選択された優先度（「なし」の場合は undefined）
+	 */
+	onChange: (priority: Priority | undefined) => void;
+};
+
+/** 選択可能な優先度一覧 */
+const priorities: Priority[] = ["High", "Medium", "Low"];
+
+/**
+ * 優先度を変更するドロップダウン
+ * @param props - {@link PrioritySelectProps}
+ * @returns セレクト要素
+ */
+export function PrioritySelect({ value, onChange }: PrioritySelectProps) {
+	/** セレクト変更ハンドラ */
+	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		const selected = e.target.value;
+		onChange(selected === "" ? undefined : (selected as Priority));
+	};
+
+	return (
+		<div className="flex items-center gap-2">
+			<span className="text-sm font-medium text-gray-500">優先度</span>
+			<select
+				value={value ?? ""}
+				onChange={handleChange}
+				className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-800 hover:border-blue-300 focus:border-blue-400 focus:outline-none"
+				data-testid="priority-select"
+			>
+				<option value="">なし</option>
+				{priorities.map((p) => (
+					<option key={p} value={p}>
+						{p}
+					</option>
+				))}
+			</select>
+		</div>
+	);
+}

--- a/src/features/detail/components/StatusSelect.interaction.test.tsx
+++ b/src/features/detail/components/StatusSelect.interaction.test.tsx
@@ -1,0 +1,67 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Column } from "../../../types/task";
+import { StatusSelect } from "./StatusSelect";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+/** テスト用カラム一覧 */
+const testColumns: Column[] = [
+	{ name: "Todo", order: 0 },
+	{ name: "In Progress", order: 1 },
+	{ name: "Done", order: 2 },
+];
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * StatusSelect をレンダリングするヘルパー
+ * @param props - StatusSelect に渡す props
+ */
+function render(props: Parameters<typeof StatusSelect>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(StatusSelect, props));
+	});
+}
+
+test("現在のステータスが選択状態で表示される", () => {
+	render({ value: "In Progress", columns: testColumns, onChange: vi.fn() });
+	const select = document.querySelector(
+		'[data-testid="status-select"]',
+	) as HTMLSelectElement;
+	expect(select.value).toBe("In Progress");
+});
+
+test("全カラムが選択肢として表示される", () => {
+	render({ value: "Todo", columns: testColumns, onChange: vi.fn() });
+	const select = document.querySelector(
+		'[data-testid="status-select"]',
+	) as HTMLSelectElement;
+	const options = Array.from(select.options).map((o) => o.value);
+	expect(options).toEqual(["Todo", "In Progress", "Done"]);
+});
+
+test("ステータス変更でonChangeが呼ばれる", () => {
+	const onChange = vi.fn();
+	render({ value: "Todo", columns: testColumns, onChange });
+	const select = document.querySelector(
+		'[data-testid="status-select"]',
+	) as HTMLSelectElement;
+	act(() => {
+		select.value = "Done";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+	});
+	expect(onChange).toHaveBeenCalledWith("Done");
+});

--- a/src/features/detail/components/StatusSelect.tsx
+++ b/src/features/detail/components/StatusSelect.tsx
@@ -1,0 +1,39 @@
+import type { Column } from "../../../types/task";
+
+/** StatusSelect の Props */
+type StatusSelectProps = {
+	/** 現在のステータス値 */
+	value: string;
+	/** 選択肢となるカラム一覧 */
+	columns: Column[];
+	/**
+	 * ステータス変更時のコールバック
+	 * @param status - 選択されたステータス
+	 */
+	onChange: (status: string) => void;
+};
+
+/**
+ * ステータスを変更するドロップダウン
+ * @param props - {@link StatusSelectProps}
+ * @returns セレクト要素
+ */
+export function StatusSelect({ value, columns, onChange }: StatusSelectProps) {
+	return (
+		<div className="flex items-center gap-2">
+			<span className="text-sm font-medium text-gray-500">ステータス</span>
+			<select
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-800 hover:border-blue-300 focus:border-blue-400 focus:outline-none"
+				data-testid="status-select"
+			>
+				{columns.map((col) => (
+					<option key={col.name} value={col.name}>
+						{col.name}
+					</option>
+				))}
+			</select>
+		</div>
+	);
+}

--- a/src/features/detail/components/StatusSelect.tsx
+++ b/src/features/detail/components/StatusSelect.tsx
@@ -27,6 +27,7 @@ export function StatusSelect({ value, columns, onChange }: StatusSelectProps) {
 				onChange={(e) => onChange(e.target.value)}
 				className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-800 hover:border-blue-300 focus:border-blue-400 focus:outline-none"
 				data-testid="status-select"
+				aria-label="ステータス"
 			>
 				{columns.map((col) => (
 					<option key={col.name} value={col.name}>


### PR DESCRIPTION
## Summary

詳細パネル内のタイトルインライン編集、ステータス変更ドロップダウン、優先度変更ドロップダウンを実装。

- **InlineEdit**: クリックで編集モード、Enter確定、Escキャンセル、空文字拒否、blur時の二重発火防止
- **StatusSelect**: カラム一覧からステータスを選択するドロップダウン
- **PrioritySelect**: High/Medium/Low/なし から優先度を選択するドロップダウン
- 各変更時に `updateTask` API を呼び出しローカルステートを同期

## Test Plan

- [x] `pnpm test --run` 全72テスト通過（14ファイル）
- [x] InlineEdit: 表示・編集モード切替・Enter確定・Escキャンセル・空文字拒否（5テスト）
- [x] StatusSelect: 初期値・全選択肢表示・onChange呼び出し（3テスト）
- [x] PrioritySelect: 初期値・未設定・onChange呼び出し・なし→undefined（4テスト）
- [x] DetailPanel既存テスト: 新props追加に対応して更新済み

Automated by task-loop-run