### PR TITLE
feat: 詳細パネル - ラベル編集

### DIFF
--- a/src/features/detail/components/DetailPanel.rendering.test.tsx
+++ b/src/features/detail/components/DetailPanel.rendering.test.tsx
@@ -117,6 +117,73 @@ test("Escキーでパネルが閉じる", async () => {
 	expect(onClose).toHaveBeenCalledOnce();
 });
 
+test("ラベル追加でonTaskUpdateが呼ばれる", async () => {
+	const onTaskUpdate = vi.fn();
+	render({
+		task: createTask({ id: "t1", labels: ["existing"] }),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate,
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="label-add-button"]'),
+		).toBeTruthy();
+	});
+	const addButton = document.querySelector(
+		'[data-testid="label-add-button"]',
+	) as HTMLElement;
+	act(() => {
+		addButton.click();
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="label-input"]')).toBeTruthy();
+	});
+	const input = document.querySelector(
+		'[data-testid="label-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "new-label");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onTaskUpdate).toHaveBeenCalledWith("t1", {
+		labels: ["existing", "new-label"],
+	});
+});
+
+test("ラベル削除でonTaskUpdateが呼ばれる", async () => {
+	const onTaskUpdate = vi.fn();
+	render({
+		task: createTask({ id: "t1", labels: ["bug", "frontend"] }),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate,
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[aria-label="ラベル「bug」を削除"]'),
+		).toBeTruthy();
+	});
+	const removeButton = document.querySelector(
+		'[aria-label="ラベル「bug」を削除"]',
+	) as HTMLElement;
+	act(() => {
+		removeButton.click();
+	});
+	expect(onTaskUpdate).toHaveBeenCalledWith("t1", {
+		labels: ["frontend"],
+	});
+});
+
 test("オーバーレイクリックでパネルが閉じる", async () => {
 	const onClose = vi.fn();
 	render({

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -33,6 +33,8 @@ export function DetailPanel({
 	onTaskUpdate,
 }: DetailPanelProps) {
 	const panelRef = useRef<HTMLElement>(null);
+	const latestLabelsRef = useRef(task.labels);
+	latestLabelsRef.current = task.labels;
 
 	const handleTitleConfirm = useCallback(
 		(title: string) => {
@@ -55,22 +57,22 @@ export function DetailPanel({
 		[task.id, onTaskUpdate],
 	);
 
-	/** ラベルを追加してタスクを更新する */
 	const handleLabelAdd = useCallback(
 		(label: string) => {
-			onTaskUpdate(task.id, { labels: [...task.labels, label] });
+			const updated = [...latestLabelsRef.current, label];
+			latestLabelsRef.current = updated;
+			onTaskUpdate(task.id, { labels: updated });
 		},
-		[task.id, task.labels, onTaskUpdate],
+		[task.id, onTaskUpdate],
 	);
 
-	/** ラベルを削除してタスクを更新する */
 	const handleLabelRemove = useCallback(
 		(label: string) => {
-			onTaskUpdate(task.id, {
-				labels: task.labels.filter((l) => l !== label),
-			});
+			const updated = latestLabelsRef.current.filter((l) => l !== label);
+			latestLabelsRef.current = updated;
+			onTaskUpdate(task.id, { labels: updated });
 		},
-		[task.id, task.labels, onTaskUpdate],
+		[task.id, onTaskUpdate],
 	);
 
 	useEffect(() => {

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { Column, Priority, Task } from "../../../types/task";
 import { InlineEdit } from "./InlineEdit";
+import { LabelEditor } from "./LabelEditor";
 import { PrioritySelect } from "./PrioritySelect";
 import { StatusSelect } from "./StatusSelect";
 
@@ -52,6 +53,24 @@ export function DetailPanel({
 			onTaskUpdate(task.id, { priority });
 		},
 		[task.id, onTaskUpdate],
+	);
+
+	/** ラベルを追加してタスクを更新する */
+	const handleLabelAdd = useCallback(
+		(label: string) => {
+			onTaskUpdate(task.id, { labels: [...task.labels, label] });
+		},
+		[task.id, task.labels, onTaskUpdate],
+	);
+
+	/** ラベルを削除してタスクを更新する */
+	const handleLabelRemove = useCallback(
+		(label: string) => {
+			onTaskUpdate(task.id, {
+				labels: task.labels.filter((l) => l !== label),
+			});
+		},
+		[task.id, task.labels, onTaskUpdate],
 	);
 
 	useEffect(() => {
@@ -126,6 +145,11 @@ export function DetailPanel({
 								onChange={handlePriorityChange}
 							/>
 						</div>
+						<LabelEditor
+							labels={task.labels}
+							onAdd={handleLabelAdd}
+							onRemove={handleLabelRemove}
+						/>
 						<p className="text-sm text-gray-600">{task.body}</p>
 					</div>
 				</div>

--- a/src/features/detail/components/LabelEditor.interaction.test.tsx
+++ b/src/features/detail/components/LabelEditor.interaction.test.tsx
@@ -103,6 +103,114 @@ test("ラベル入力確定でonAddが呼ばれる", async () => {
 	expect(onAdd).toHaveBeenCalledWith("new-label");
 });
 
+test("Escapeキーでキャンセルされ、onAddが呼ばれない", async () => {
+	const onAdd = vi.fn();
+	render({
+		labels: [],
+		onAdd,
+		onRemove: vi.fn(),
+	});
+	const addButton = document.querySelector(
+		'[data-testid="label-add-button"]',
+	) as HTMLElement;
+	act(() => {
+		addButton.click();
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="label-input"]')).toBeTruthy();
+	});
+	const input = document.querySelector(
+		'[data-testid="label-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "cancelled-label");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+		);
+	});
+	expect(onAdd).not.toHaveBeenCalled();
+});
+
+test("blurで入力値が確定されonAddが1回だけ呼ばれる", async () => {
+	const onAdd = vi.fn();
+	render({
+		labels: [],
+		onAdd,
+		onRemove: vi.fn(),
+	});
+	const addButton = document.querySelector(
+		'[data-testid="label-add-button"]',
+	) as HTMLElement;
+	act(() => {
+		addButton.click();
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="label-input"]')).toBeTruthy();
+	});
+	const input = document.querySelector(
+		'[data-testid="label-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "blur-label");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.blur();
+	});
+	expect(onAdd).toHaveBeenCalledTimes(1);
+	expect(onAdd).toHaveBeenCalledWith("blur-label");
+});
+
+test("Enter後のblurでonAddが二重呼び出しされない", async () => {
+	const onAdd = vi.fn();
+	render({
+		labels: [],
+		onAdd,
+		onRemove: vi.fn(),
+	});
+	const addButton = document.querySelector(
+		'[data-testid="label-add-button"]',
+	) as HTMLElement;
+	act(() => {
+		addButton.click();
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="label-input"]')).toBeTruthy();
+	});
+	const input = document.querySelector(
+		'[data-testid="label-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "enter-label");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	act(() => {
+		input.blur();
+	});
+	expect(onAdd).toHaveBeenCalledTimes(1);
+	expect(onAdd).toHaveBeenCalledWith("enter-label");
+});
+
 test("タグ×ボタンで該当ラベルが削除される", async () => {
 	const onRemove = vi.fn();
 	render({

--- a/src/features/detail/components/LabelEditor.interaction.test.tsx
+++ b/src/features/detail/components/LabelEditor.interaction.test.tsx
@@ -1,0 +1,125 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { LabelEditor } from "./LabelEditor";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * LabelEditor をレンダリングするヘルパー
+ * @param props - LabelEditor に渡す props
+ */
+function render(props: Parameters<typeof LabelEditor>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(LabelEditor, props));
+	});
+}
+
+test("現在のラベルがタグ表示される", async () => {
+	render({
+		labels: ["bug", "frontend"],
+		onAdd: vi.fn(),
+		onRemove: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const editor = document.querySelector('[data-testid="label-editor"]');
+		expect(editor?.textContent).toContain("bug");
+		expect(editor?.textContent).toContain("frontend");
+	});
+});
+
+test("「+ 追加」クリックで入力フィールドが表示される", async () => {
+	render({
+		labels: [],
+		onAdd: vi.fn(),
+		onRemove: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="label-add-button"]'),
+		).toBeTruthy();
+	});
+	const addButton = document.querySelector(
+		'[data-testid="label-add-button"]',
+	) as HTMLElement;
+	act(() => {
+		addButton.click();
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="label-input"]')).toBeTruthy();
+	});
+});
+
+test("ラベル入力確定でonAddが呼ばれる", async () => {
+	const onAdd = vi.fn();
+	render({
+		labels: [],
+		onAdd,
+		onRemove: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="label-add-button"]'),
+		).toBeTruthy();
+	});
+	const addButton = document.querySelector(
+		'[data-testid="label-add-button"]',
+	) as HTMLElement;
+	act(() => {
+		addButton.click();
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="label-input"]')).toBeTruthy();
+	});
+	const input = document.querySelector(
+		'[data-testid="label-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "new-label");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onAdd).toHaveBeenCalledWith("new-label");
+});
+
+test("タグ×ボタンで該当ラベルが削除される", async () => {
+	const onRemove = vi.fn();
+	render({
+		labels: ["bug", "frontend"],
+		onAdd: vi.fn(),
+		onRemove,
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[aria-label="ラベル「bug」を削除"]'),
+		).toBeTruthy();
+	});
+	const removeButton = document.querySelector(
+		'[aria-label="ラベル「bug」を削除"]',
+	) as HTMLElement;
+	act(() => {
+		removeButton.click();
+	});
+	expect(onRemove).toHaveBeenCalledWith("bug");
+});

--- a/src/features/detail/components/LabelEditor.tsx
+++ b/src/features/detail/components/LabelEditor.tsx
@@ -1,0 +1,118 @@
+import type { KeyboardEvent } from "react";
+import { useRef, useState } from "react";
+
+/** LabelEditor の Props */
+type LabelEditorProps = {
+	/** 現在のラベル一覧 */
+	labels: string[];
+	/**
+	 * ラベル追加時のコールバック
+	 * @param label - 追加するラベル名
+	 */
+	onAdd: (label: string) => void;
+	/**
+	 * ラベル削除時のコールバック
+	 * @param label - 削除するラベル名
+	 */
+	onRemove: (label: string) => void;
+};
+
+/**
+ * ラベルの表示・追加・削除を行うエディタコンポーネント
+ * @param props - {@link LabelEditorProps}
+ * @returns ラベルエディタ要素
+ */
+export function LabelEditor({ labels, onAdd, onRemove }: LabelEditorProps) {
+	const [isAdding, setIsAdding] = useState(false);
+	const [inputValue, setInputValue] = useState("");
+	const inputRef = useRef<HTMLInputElement>(null);
+	const isCancelledRef = useRef(false);
+
+	/** 入力値を確定してラベルを追加する */
+	const confirmAdd = () => {
+		const trimmed = inputValue.trim();
+		if (trimmed.length > 0 && !labels.includes(trimmed)) {
+			onAdd(trimmed);
+		}
+		setInputValue("");
+		setIsAdding(false);
+	};
+
+	/** 追加をキャンセルして入力フィールドを閉じる */
+	const cancelAdd = () => {
+		isCancelledRef.current = true;
+		setInputValue("");
+		setIsAdding(false);
+	};
+
+	/** キーボードイベントを処理する（Enter: 確定、Escape: キャンセル） */
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			e.stopPropagation();
+			isCancelledRef.current = true;
+			confirmAdd();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			e.stopPropagation();
+			cancelAdd();
+		}
+	};
+
+	/** 追加ボタンクリックで入力フィールドを表示する */
+	const handleAddClick = () => {
+		setIsAdding(true);
+		requestAnimationFrame(() => {
+			inputRef.current?.focus();
+		});
+	};
+
+	return (
+		<div data-testid="label-editor">
+			<div className="mb-1 text-xs font-medium text-gray-500">ラベル</div>
+			<div className="flex flex-wrap gap-1.5">
+				{labels.map((label) => (
+					<span
+						key={label}
+						className="inline-flex items-center gap-0.5 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700"
+					>
+						{label}
+						<button
+							type="button"
+							aria-label={`ラベル「${label}」を削除`}
+							className="ml-0.5 rounded text-gray-400 hover:text-gray-700"
+							onClick={() => onRemove(label)}
+						>
+							×
+						</button>
+					</span>
+				))}
+				{isAdding ? (
+					<input
+						ref={inputRef}
+						type="text"
+						value={inputValue}
+						onChange={(e) => setInputValue(e.target.value)}
+						onKeyDown={handleKeyDown}
+						onBlur={() => {
+							if (!isCancelledRef.current) confirmAdd();
+							isCancelledRef.current = false;
+						}}
+						className="rounded border border-blue-400 px-1.5 py-0.5 text-xs outline-none"
+						data-testid="label-input"
+						placeholder="ラベル名"
+					/>
+				) : (
+					<button
+						type="button"
+						className="rounded border border-dashed border-gray-300 px-1.5 py-0.5 text-xs text-gray-500 hover:border-gray-400 hover:text-gray-700"
+						data-testid="label-add-button"
+						onClick={handleAddClick}
+					>
+						+ 追加
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/features/detail/components/LabelEditor.tsx
+++ b/src/features/detail/components/LabelEditor.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from "react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /** LabelEditor の Props */
 type LabelEditorProps = {
@@ -59,19 +59,21 @@ export function LabelEditor({ labels, onAdd, onRemove }: LabelEditorProps) {
 		}
 	};
 
-	/** 追加ボタンクリックで入力フィールドを表示する */
 	const handleAddClick = () => {
 		setIsAdding(true);
-		requestAnimationFrame(() => {
-			inputRef.current?.focus();
-		});
 	};
+
+	useEffect(() => {
+		if (isAdding) {
+			inputRef.current?.focus();
+		}
+	}, [isAdding]);
 
 	return (
 		<div data-testid="label-editor">
 			<div className="mb-1 text-xs font-medium text-gray-500">ラベル</div>
 			<div className="flex flex-wrap gap-1.5">
-				{labels.map((label) => (
+				{[...new Set(labels)].map((label) => (
 					<span
 						key={label}
 						className="inline-flex items-center gap-0.5 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700"


### PR DESCRIPTION
## 概要

詳細パネル内のラベル追加・削除機能を実装。

## 変更内容

- `LabelEditor` コンポーネントを新規作成（`src/features/detail/components/LabelEditor.tsx`）
  - 現在のラベルをタグ表示し、各タグに×ボタンで削除可能
  - 「+ 追加」ボタンでインライン入力フィールドを表示、Enter で確定
  - Escape でキャンセル、blur 時の二重発火防止（isCancelledRef パターン）
  - アクセシビリティ対応（aria-label 付き削除ボタン）
- `DetailPanel` に `LabelEditor` を組み込み、`onTaskUpdate` 経由で labels を更新
- `LabelEditor.interaction.test.tsx`（4件）を追加

## テスト方法

```bash
pnpm test:run
```

Automated by task-loop-run
