### PR TITLE
feat: 詳細パネル - サブIssue セクションと関連リンクセクション

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,9 +80,12 @@ function App() {
 			{selectedTask && (
 				<DetailPanel
 					task={selectedTask}
+					allTasks={tasks}
 					columns={columns}
+					doneColumn="Done"
 					onClose={handleCloseDetail}
 					onTaskUpdate={handleTaskUpdate}
+					onTaskSelect={handleTaskClick}
 				/>
 			)}
 		</div>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,36 @@
+/** ProgressBar の Props */
+type ProgressBarProps = {
+	/** 完了数 */
+	doneCount: number;
+	/** 合計数 */
+	total: number;
+};
+
+/**
+ * @param props - {@link ProgressBarProps}
+ * @returns 進捗バー要素
+ */
+export function ProgressBar({ doneCount, total }: ProgressBarProps) {
+	const percentage = total > 0 ? Math.round((doneCount / total) * 100) : 0;
+
+	return (
+		<div className="flex items-center gap-2">
+			<div
+				className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200"
+				role="progressbar"
+				aria-valuenow={percentage}
+				aria-valuemin={0}
+				aria-valuemax={100}
+				aria-label={`進捗 ${doneCount}/${total}`}
+			>
+				<div
+					className="h-full rounded-full bg-green-500 transition-all"
+					style={{ width: `${percentage}%` }}
+				/>
+			</div>
+			<span className="text-xs text-gray-500">
+				{doneCount}/{total}
+			</span>
+		</div>
+	);
+}

--- a/src/components/StatusIcon.tsx
+++ b/src/components/StatusIcon.tsx
@@ -1,0 +1,26 @@
+/** ステータスアイコンの Props */
+type StatusIconProps = {
+	/** 完了かどうか */
+	isDone: boolean;
+};
+
+/**
+ * @param props - {@link StatusIconProps}
+ * @returns ステータスアイコン要素
+ */
+export function StatusIcon({ isDone }: StatusIconProps) {
+	const label = isDone ? "完了" : "未完了";
+
+	if (isDone) {
+		return (
+			<span className="text-green-600" role="img" aria-label={label}>
+				✓
+			</span>
+		);
+	}
+	return (
+		<span className="text-gray-400" role="img" aria-label={label}>
+			○
+		</span>
+	);
+}

--- a/src/features/board/components/SubIssueProgress.tsx
+++ b/src/features/board/components/SubIssueProgress.tsx
@@ -1,30 +1,11 @@
+import { ProgressBar } from "../../../components/ProgressBar";
+import { StatusIcon } from "../../../components/StatusIcon";
 import type { Task } from "../../../types/task";
 
 type SubIssueProgressProps = {
 	childTasks: Task[];
 	doneColumn: string;
 };
-
-/**
- * @param props - isDone: 完了かどうか
- * @returns ステータスアイコン要素
- */
-function StatusIcon({ isDone }: { isDone: boolean }) {
-	const label = isDone ? "完了" : "未完了";
-
-	if (isDone) {
-		return (
-			<span className="text-green-600" role="img" aria-label={label}>
-				✓
-			</span>
-		);
-	}
-	return (
-		<span className="text-gray-400" role="img" aria-label={label}>
-			○
-		</span>
-	);
-}
 
 /**
  * @param props - {@link SubIssueProgressProps}
@@ -40,7 +21,6 @@ export function SubIssueProgress({
 
 	const total = childTasks.length;
 	const doneCount = childTasks.filter((t) => t.status === doneColumn).length;
-	const percentage = Math.round((doneCount / total) * 100);
 
 	return (
 		<div className="mt-2">
@@ -63,23 +43,8 @@ export function SubIssueProgress({
 					))}
 				</ul>
 			</details>
-			<div className="mt-1 flex items-center gap-2">
-				<div
-					className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200"
-					role="progressbar"
-					aria-valuenow={percentage}
-					aria-valuemin={0}
-					aria-valuemax={100}
-					aria-label={`進捗 ${doneCount}/${total}`}
-				>
-					<div
-						className="h-full rounded-full bg-green-500 transition-all"
-						style={{ width: `${percentage}%` }}
-					/>
-				</div>
-				<span className="text-xs text-gray-500">
-					{doneCount}/{total}
-				</span>
+			<div className="mt-1">
+				<ProgressBar doneCount={doneCount} total={total} />
 			</div>
 		</div>
 	);

--- a/src/features/detail/components/DetailPanel.rendering.test.tsx
+++ b/src/features/detail/components/DetailPanel.rendering.test.tsx
@@ -14,6 +14,21 @@ const testColumns = [
 	{ name: "Done", order: 2 },
 ];
 
+/** テスト用の全タスク一覧 */
+const allTestTasks: Task[] = [
+	{
+		id: "task-1",
+		title: "テストタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "タスクの本文",
+		filePath: "tasks/test.md",
+	},
+];
+
 afterEach(() => {
 	act(() => {
 		root?.unmount();
@@ -59,9 +74,12 @@ function render(props: Parameters<typeof DetailPanel>[0]) {
 test("タスク選択時にパネルが表示される", async () => {
 	render({
 		task: createTask(),
+		allTasks: allTestTasks,
 		columns: testColumns,
+		doneColumn: "Done",
 		onClose: vi.fn(),
 		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		const dialog = document.querySelector('[role="dialog"]');
@@ -72,9 +90,12 @@ test("タスク選択時にパネルが表示される", async () => {
 test("タスクタイトルが表示される", async () => {
 	render({
 		task: createTask({ title: "ログイン修正" }),
+		allTasks: allTestTasks,
 		columns: testColumns,
+		doneColumn: "Done",
 		onClose: vi.fn(),
 		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		const dialog = document.querySelector('[role="dialog"]');
@@ -86,9 +107,12 @@ test("×ボタンクリックでonCloseが呼ばれる", async () => {
 	const onClose = vi.fn();
 	render({
 		task: createTask(),
+		allTasks: allTestTasks,
 		columns: testColumns,
+		doneColumn: "Done",
 		onClose,
 		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(document.querySelector('[aria-label="閉じる"]')).toBeTruthy();
@@ -104,9 +128,12 @@ test("Escキーでパネルが閉じる", async () => {
 	const onClose = vi.fn();
 	render({
 		task: createTask(),
+		allTasks: allTestTasks,
 		columns: testColumns,
+		doneColumn: "Done",
 		onClose,
 		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(document.querySelector('[role="dialog"]')).toBeTruthy();
@@ -121,9 +148,12 @@ test("ラベル追加でonTaskUpdateが呼ばれる", async () => {
 	const onTaskUpdate = vi.fn();
 	render({
 		task: createTask({ id: "t1", labels: ["existing"] }),
+		allTasks: allTestTasks,
 		columns: testColumns,
+		doneColumn: "Done",
 		onClose: vi.fn(),
 		onTaskUpdate,
+		onTaskSelect: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(
@@ -164,9 +194,12 @@ test("ラベル削除でonTaskUpdateが呼ばれる", async () => {
 	const onTaskUpdate = vi.fn();
 	render({
 		task: createTask({ id: "t1", labels: ["bug", "frontend"] }),
+		allTasks: allTestTasks,
 		columns: testColumns,
+		doneColumn: "Done",
 		onClose: vi.fn(),
 		onTaskUpdate,
+		onTaskSelect: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(
@@ -188,9 +221,12 @@ test("オーバーレイクリックでパネルが閉じる", async () => {
 	const onClose = vi.fn();
 	render({
 		task: createTask(),
+		allTasks: allTestTasks,
 		columns: testColumns,
+		doneColumn: "Done",
 		onClose,
 		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(
@@ -202,4 +238,127 @@ test("オーバーレイクリックでパネルが閉じる", async () => {
 	) as HTMLElement;
 	overlay.click();
 	expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("親タスクがある場合、親タスク名が表示されクリックで遷移する", async () => {
+	const parentTask = createTask({
+		id: "parent-1",
+		title: "親タスク",
+		filePath: "tasks/parent.md",
+	});
+	const onTaskSelect = vi.fn();
+	render({
+		task: createTask({ parent: "tasks/parent.md" }),
+		allTasks: [parentTask],
+		columns: testColumns,
+		doneColumn: "Done",
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onTaskSelect,
+	});
+	await vi.waitFor(() => {
+		const parentSection = document.querySelector('[data-testid="parent-task"]');
+		expect(parentSection).toBeTruthy();
+		expect(parentSection?.textContent).toContain("親タスク");
+	});
+	const parentButton = document
+		.querySelector('[data-testid="parent-task"]')
+		?.querySelector("button") as HTMLElement;
+	act(() => {
+		parentButton.click();
+	});
+	expect(onTaskSelect).toHaveBeenCalledWith("parent-1");
+});
+
+test("parentが未設定で親タスク表示なし", async () => {
+	render({
+		task: createTask({ parent: undefined }),
+		allTasks: allTestTasks,
+		columns: testColumns,
+		doneColumn: "Done",
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[role="dialog"]')).toBeTruthy();
+	});
+	expect(document.querySelector('[data-testid="parent-task"]')).toBeNull();
+});
+
+test("childrenがある場合、サブIssueセクションが表示される", async () => {
+	const childTask = createTask({
+		id: "child-1",
+		title: "子タスク",
+		filePath: "tasks/child.md",
+		status: "Done",
+	});
+	render({
+		task: createTask({ children: ["tasks/child.md"] }),
+		allTasks: [childTask],
+		columns: testColumns,
+		doneColumn: "Done",
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="sub-issue-section"]'),
+		).toBeTruthy();
+	});
+});
+
+test("childrenが空でサブIssueセクション非表示", async () => {
+	render({
+		task: createTask({ children: [] }),
+		allTasks: allTestTasks,
+		columns: testColumns,
+		doneColumn: "Done",
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[role="dialog"]')).toBeTruthy();
+	});
+	expect(
+		document.querySelector('[data-testid="sub-issue-section"]'),
+	).toBeNull();
+});
+
+test("linksがある場合、関連リンクセクションが表示される", async () => {
+	const linkedTask = createTask({
+		id: "linked-1",
+		title: "リンクタスク",
+		filePath: "tasks/linked.md",
+	});
+	render({
+		task: createTask({ links: ["tasks/linked.md"] }),
+		allTasks: [linkedTask],
+		columns: testColumns,
+		doneColumn: "Done",
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="link-section"]')).toBeTruthy();
+	});
+});
+
+test("linksとreverseLinksが共に空で関連リンクセクション非表示", async () => {
+	render({
+		task: createTask({ links: [], reverseLinks: [] }),
+		allTasks: allTestTasks,
+		columns: testColumns,
+		doneColumn: "Done",
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onTaskSelect: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[role="dialog"]')).toBeTruthy();
+	});
+	expect(document.querySelector('[data-testid="link-section"]')).toBeNull();
 });

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -1,16 +1,23 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { Column, Priority, Task } from "../../../types/task";
 import { InlineEdit } from "./InlineEdit";
 import { LabelEditor } from "./LabelEditor";
+import type { ResolvedLink } from "./LinkSection";
+import { LinkSection } from "./LinkSection";
 import { PrioritySelect } from "./PrioritySelect";
 import { StatusSelect } from "./StatusSelect";
+import { SubIssueSection } from "./SubIssueSection";
 
 /** 詳細パネルの Props */
 type DetailPanelProps = {
 	/** 表示するタスク */
 	task: Task;
+	/** 全タスク一覧（ファイルパスからタスクを解決するため） */
+	allTasks: Task[];
 	/** 選択肢となるカラム一覧 */
 	columns: Column[];
+	/** 完了カラム名 */
+	doneColumn: string;
 	/** パネルを閉じるコールバック */
 	onClose: () => void;
 	/**
@@ -19,6 +26,11 @@ type DetailPanelProps = {
 	 * @param updates - 更新するフィールド
 	 */
 	onTaskUpdate: (id: string, updates: Partial<Omit<Task, "id">>) => void;
+	/**
+	 * 別タスクの詳細に切り替えるコールバック
+	 * @param taskId - 切り替え先のタスクID
+	 */
+	onTaskSelect: (taskId: string) => void;
 };
 
 /**
@@ -28,13 +40,58 @@ type DetailPanelProps = {
  */
 export function DetailPanel({
 	task,
+	allTasks,
 	columns,
+	doneColumn,
 	onClose,
 	onTaskUpdate,
+	onTaskSelect,
 }: DetailPanelProps) {
 	const panelRef = useRef<HTMLElement>(null);
 	const latestLabelsRef = useRef(task.labels);
 	latestLabelsRef.current = task.labels;
+
+	const parentTask = useMemo(
+		() =>
+			task.parent
+				? allTasks.find((t) => t.filePath === task.parent)
+				: undefined,
+		[task.parent, allTasks],
+	);
+
+	const childTasks = useMemo(
+		() =>
+			task.children
+				.map((fp) => allTasks.find((t) => t.filePath === fp))
+				.filter((t): t is Task => t !== undefined),
+		[task.children, allTasks],
+	);
+
+	const resolvedLinks: ResolvedLink[] = useMemo(
+		() =>
+			task.links.map((fp) => ({
+				filePath: fp,
+				task: allTasks.find((t) => t.filePath === fp),
+			})),
+		[task.links, allTasks],
+	);
+
+	const resolvedReverseLinks: ResolvedLink[] = useMemo(
+		() =>
+			task.reverseLinks.map((fp) => ({
+				filePath: fp,
+				task: allTasks.find((t) => t.filePath === fp),
+			})),
+		[task.reverseLinks, allTasks],
+	);
+
+	const handleRemoveLink = useCallback(
+		(filePath: string) => {
+			const updated = task.links.filter((l) => l !== filePath);
+			onTaskUpdate(task.id, { links: updated });
+		},
+		[task.id, task.links, onTaskUpdate],
+	);
 
 	const handleTitleConfirm = useCallback(
 		(title: string) => {
@@ -151,6 +208,33 @@ export function DetailPanel({
 							labels={task.labels}
 							onAdd={handleLabelAdd}
 							onRemove={handleLabelRemove}
+						/>
+						{parentTask && (
+							<div data-testid="parent-task">
+								<span className="text-xs font-medium text-gray-500">
+									親タスク:
+								</span>
+								<button
+									type="button"
+									className="ml-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+									onClick={() => onTaskSelect(parentTask.id)}
+								>
+									{parentTask.title || parentTask.filePath}
+								</button>
+							</div>
+						)}
+						<SubIssueSection
+							childTasks={childTasks}
+							doneColumn={doneColumn}
+							onTaskSelect={onTaskSelect}
+							onAddSubIssue={() => {}}
+						/>
+						<LinkSection
+							links={resolvedLinks}
+							reverseLinks={resolvedReverseLinks}
+							onTaskSelect={onTaskSelect}
+							onRemoveLink={handleRemoveLink}
+							onAddLink={() => {}}
 						/>
 						<p className="text-sm text-gray-600">{task.body}</p>
 					</div>

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -51,38 +51,40 @@ export function DetailPanel({
 	const latestLabelsRef = useRef(task.labels);
 	latestLabelsRef.current = task.labels;
 
+	const tasksByFilePath = useMemo(
+		() => new Map(allTasks.map((t) => [t.filePath, t])),
+		[allTasks],
+	);
+
 	const parentTask = useMemo(
-		() =>
-			task.parent
-				? allTasks.find((t) => t.filePath === task.parent)
-				: undefined,
-		[task.parent, allTasks],
+		() => (task.parent ? tasksByFilePath.get(task.parent) : undefined),
+		[task.parent, tasksByFilePath],
 	);
 
 	const childTasks = useMemo(
 		() =>
 			task.children
-				.map((fp) => allTasks.find((t) => t.filePath === fp))
+				.map((fp) => tasksByFilePath.get(fp))
 				.filter((t): t is Task => t !== undefined),
-		[task.children, allTasks],
+		[task.children, tasksByFilePath],
 	);
 
 	const resolvedLinks: ResolvedLink[] = useMemo(
 		() =>
 			task.links.map((fp) => ({
 				filePath: fp,
-				task: allTasks.find((t) => t.filePath === fp),
+				task: tasksByFilePath.get(fp),
 			})),
-		[task.links, allTasks],
+		[task.links, tasksByFilePath],
 	);
 
 	const resolvedReverseLinks: ResolvedLink[] = useMemo(
 		() =>
 			task.reverseLinks.map((fp) => ({
 				filePath: fp,
-				task: allTasks.find((t) => t.filePath === fp),
+				task: tasksByFilePath.get(fp),
 			})),
-		[task.reverseLinks, allTasks],
+		[task.reverseLinks, tasksByFilePath],
 	);
 
 	const handleRemoveLink = useCallback(
@@ -227,14 +229,12 @@ export function DetailPanel({
 							childTasks={childTasks}
 							doneColumn={doneColumn}
 							onTaskSelect={onTaskSelect}
-							onAddSubIssue={() => {}}
 						/>
 						<LinkSection
 							links={resolvedLinks}
 							reverseLinks={resolvedReverseLinks}
 							onTaskSelect={onTaskSelect}
 							onRemoveLink={handleRemoveLink}
-							onAddLink={() => {}}
 						/>
 						<p className="text-sm text-gray-600">{task.body}</p>
 					</div>

--- a/src/features/detail/components/LinkSection.rendering.test.tsx
+++ b/src/features/detail/components/LinkSection.rendering.test.tsx
@@ -1,0 +1,174 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Task } from "../../../types/task";
+import type { ResolvedLink } from "./LinkSection";
+import { LinkSection } from "./LinkSection";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * テスト用タスクを生成する
+ * @param overrides - 上書きするフィールド
+ * @returns テスト用タスク
+ */
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "linked-1",
+		title: "リンクタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "",
+		filePath: "tasks/linked.md",
+		...overrides,
+	};
+}
+
+/**
+ * LinkSection をレンダリングするヘルパー
+ * @param props - LinkSection に渡す props
+ */
+function render(props: Parameters<typeof LinkSection>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(LinkSection, props));
+	});
+}
+
+test("linksがある場合、関連リンクが表示される", async () => {
+	const links: ResolvedLink[] = [
+		{ filePath: "tasks/a.md", task: createTask({ id: "a", title: "タスクA" }) },
+	];
+	render({
+		links,
+		reverseLinks: [],
+		onTaskSelect: vi.fn(),
+		onRemoveLink: vi.fn(),
+		onAddLink: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const section = document.querySelector('[data-testid="link-section"]');
+		expect(section).toBeTruthy();
+		expect(section?.textContent).toContain("タスクA");
+	});
+});
+
+test("reverseLinksがある場合、関連リンクが表示される", async () => {
+	const reverseLinks: ResolvedLink[] = [
+		{ filePath: "tasks/b.md", task: createTask({ id: "b", title: "タスクB" }) },
+	];
+	render({
+		links: [],
+		reverseLinks,
+		onTaskSelect: vi.fn(),
+		onRemoveLink: vi.fn(),
+		onAddLink: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const section = document.querySelector('[data-testid="link-section"]');
+		expect(section).toBeTruthy();
+		expect(section?.textContent).toContain("タスクB");
+	});
+});
+
+test("リンククリックでonTaskSelectが呼ばれる", async () => {
+	const onTaskSelect = vi.fn();
+	const links: ResolvedLink[] = [
+		{
+			filePath: "tasks/a.md",
+			task: createTask({ id: "link-a", title: "タスクA" }),
+		},
+	];
+	render({
+		links,
+		reverseLinks: [],
+		onTaskSelect,
+		onRemoveLink: vi.fn(),
+		onAddLink: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="link-section"]')).toBeTruthy();
+	});
+	const button = document
+		.querySelector('[data-testid="link-section"] ul')
+		?.querySelector("button") as HTMLElement;
+	act(() => {
+		button.click();
+	});
+	expect(onTaskSelect).toHaveBeenCalledWith("link-a");
+});
+
+test("linksとreverseLinksが共に空で関連リンクセクション非表示", () => {
+	render({
+		links: [],
+		reverseLinks: [],
+		onTaskSelect: vi.fn(),
+		onRemoveLink: vi.fn(),
+		onAddLink: vi.fn(),
+	});
+	expect(document.querySelector('[data-testid="link-section"]')).toBeNull();
+});
+
+test("リンク切れの場合は警告アイコンが表示される", async () => {
+	const links: ResolvedLink[] = [
+		{ filePath: "tasks/broken.md", task: undefined },
+	];
+	render({
+		links,
+		reverseLinks: [],
+		onTaskSelect: vi.fn(),
+		onRemoveLink: vi.fn(),
+		onAddLink: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const section = document.querySelector('[data-testid="link-section"]');
+		expect(section).toBeTruthy();
+		const warning = section?.querySelector('[aria-label="リンク切れ"]');
+		expect(warning).toBeTruthy();
+		expect(section?.textContent).toContain("tasks/broken.md");
+	});
+});
+
+test("リンク削除ボタンでonRemoveLinkが呼ばれる", async () => {
+	const onRemoveLink = vi.fn();
+	const links: ResolvedLink[] = [
+		{
+			filePath: "tasks/a.md",
+			task: createTask({ id: "a", title: "タスクA" }),
+		},
+	];
+	render({
+		links,
+		reverseLinks: [],
+		onTaskSelect: vi.fn(),
+		onRemoveLink,
+		onAddLink: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[aria-label="リンク「タスクA」を削除"]'),
+		).toBeTruthy();
+	});
+	const removeButton = document.querySelector(
+		'[aria-label="リンク「タスクA」を削除"]',
+	) as HTMLElement;
+	act(() => {
+		removeButton.click();
+	});
+	expect(onRemoveLink).toHaveBeenCalledWith("tasks/a.md");
+});

--- a/src/features/detail/components/LinkSection.tsx
+++ b/src/features/detail/components/LinkSection.tsx
@@ -1,0 +1,136 @@
+import type { Task } from "../../../types/task";
+
+/** 解決済みリンク（タスクが見つからない場合は task が undefined） */
+export type ResolvedLink = {
+	/** リンク先のファイルパス */
+	filePath: string;
+	/** 解決されたタスク（リンク切れの場合は undefined） */
+	task: Task | undefined;
+};
+
+/** LinkSection の Props */
+type LinkSectionProps = {
+	/** 順方向リンクの配列 */
+	links: ResolvedLink[];
+	/** 逆方向リンクの配列 */
+	reverseLinks: ResolvedLink[];
+	/**
+	 * タスク選択時のコールバック
+	 * @param taskId - 選択されたタスクのID
+	 */
+	onTaskSelect: (taskId: string) => void;
+	/**
+	 * リンク削除時のコールバック
+	 * @param filePath - 削除するリンクのファイルパス
+	 */
+	onRemoveLink: (filePath: string) => void;
+	/** リンク追加ボタン押下時のコールバック */
+	onAddLink: () => void;
+};
+
+/**
+ * @param props - link: 解決済みリンク, onTaskSelect, onRemoveLink
+ * @returns リンク行要素
+ */
+function LinkItem({
+	link,
+	onTaskSelect,
+	onRemoveLink,
+}: {
+	link: ResolvedLink;
+	onTaskSelect: (taskId: string) => void;
+	onRemoveLink?: (filePath: string) => void;
+}) {
+	if (!link.task) {
+		return (
+			<li className="flex items-center gap-2 rounded px-2 py-1 text-sm text-gray-400">
+				<span role="img" aria-label="リンク切れ">
+					⚠
+				</span>
+				<span>{link.filePath}</span>
+				{onRemoveLink && (
+					<button
+						type="button"
+						aria-label={`リンク「${link.filePath}」を削除`}
+						className="ml-auto text-gray-400 hover:text-red-500"
+						onClick={() => onRemoveLink(link.filePath)}
+					>
+						×
+					</button>
+				)}
+			</li>
+		);
+	}
+
+	return (
+		<li className="flex items-center gap-2">
+			<button
+				type="button"
+				className="flex flex-1 items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-gray-100"
+				onClick={() => link.task && onTaskSelect(link.task.id)}
+			>
+				<span>{link.task.title || link.task.filePath}</span>
+			</button>
+			{onRemoveLink && (
+				<button
+					type="button"
+					aria-label={`リンク「${link.task.title || link.filePath}」を削除`}
+					className="shrink-0 px-1 text-gray-400 hover:text-red-500"
+					onClick={() => onRemoveLink(link.filePath)}
+				>
+					×
+				</button>
+			)}
+		</li>
+	);
+}
+
+/**
+ * 関連リンクセクション（リンク一覧 + 追加・削除）
+ * @param props - {@link LinkSectionProps}
+ * @returns セクション要素。リンクが空の場合は null
+ */
+export function LinkSection({
+	links,
+	reverseLinks,
+	onTaskSelect,
+	onRemoveLink,
+	onAddLink,
+}: LinkSectionProps) {
+	if (links.length === 0 && reverseLinks.length === 0) {
+		return null;
+	}
+
+	return (
+		<section data-testid="link-section" aria-label="関連リンク">
+			<div className="mb-2 flex items-center justify-between">
+				<h3 className="text-sm font-medium text-gray-700">関連リンク</h3>
+				<button
+					type="button"
+					className="text-xs text-blue-600 hover:text-blue-800"
+					data-testid="add-link-button"
+					onClick={onAddLink}
+				>
+					+ リンク追加
+				</button>
+			</div>
+			<ul className="space-y-1">
+				{links.map((link) => (
+					<LinkItem
+						key={link.filePath}
+						link={link}
+						onTaskSelect={onTaskSelect}
+						onRemoveLink={onRemoveLink}
+					/>
+				))}
+				{reverseLinks.map((link) => (
+					<LinkItem
+						key={`reverse-${link.filePath}`}
+						link={link}
+						onTaskSelect={onTaskSelect}
+					/>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/src/features/detail/components/LinkSection.tsx
+++ b/src/features/detail/components/LinkSection.tsx
@@ -24,8 +24,8 @@ type LinkSectionProps = {
 	 * @param filePath - 削除するリンクのファイルパス
 	 */
 	onRemoveLink: (filePath: string) => void;
-	/** リンク追加ボタン押下時のコールバック */
-	onAddLink: () => void;
+	/** リンク追加ボタン押下時のコールバック（未指定時はボタン非表示） */
+	onAddLink?: () => void;
 };
 
 /**
@@ -105,14 +105,16 @@ export function LinkSection({
 		<section data-testid="link-section" aria-label="関連リンク">
 			<div className="mb-2 flex items-center justify-between">
 				<h3 className="text-sm font-medium text-gray-700">関連リンク</h3>
-				<button
-					type="button"
-					className="text-xs text-blue-600 hover:text-blue-800"
-					data-testid="add-link-button"
-					onClick={onAddLink}
-				>
-					+ リンク追加
-				</button>
+				{onAddLink && (
+					<button
+						type="button"
+						className="text-xs text-blue-600 hover:text-blue-800"
+						data-testid="add-link-button"
+						onClick={onAddLink}
+					>
+						+ リンク追加
+					</button>
+				)}
 			</div>
 			<ul className="space-y-1">
 				{links.map((link) => (

--- a/src/features/detail/components/SubIssueSection.rendering.test.tsx
+++ b/src/features/detail/components/SubIssueSection.rendering.test.tsx
@@ -1,0 +1,106 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Task } from "../../../types/task";
+import { SubIssueSection } from "./SubIssueSection";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * テスト用タスクを生成する
+ * @param overrides - 上書きするフィールド
+ * @returns テスト用タスク
+ */
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "child-1",
+		title: "子タスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "",
+		filePath: "tasks/child.md",
+		...overrides,
+	};
+}
+
+/**
+ * SubIssueSection をレンダリングするヘルパー
+ * @param props - SubIssueSection に渡す props
+ */
+function render(props: Parameters<typeof SubIssueSection>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(SubIssueSection, props));
+	});
+}
+
+test("childrenがある場合、進捗バーと子タスク一覧が表示される", async () => {
+	const children = [
+		createTask({ id: "c1", title: "子タスク1", status: "Todo" }),
+		createTask({ id: "c2", title: "子タスク2", status: "Done" }),
+	];
+	render({
+		childTasks: children,
+		doneColumn: "Done",
+		onTaskSelect: vi.fn(),
+		onAddSubIssue: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const section = document.querySelector('[data-testid="sub-issue-section"]');
+		expect(section).toBeTruthy();
+		expect(section?.textContent).toContain("子タスク1");
+		expect(section?.textContent).toContain("子タスク2");
+		const progressbar = section?.querySelector('[role="progressbar"]');
+		expect(progressbar).toBeTruthy();
+		expect(progressbar?.getAttribute("aria-valuenow")).toBe("50");
+	});
+});
+
+test("子タスククリックでonTaskSelectが呼ばれる", async () => {
+	const onTaskSelect = vi.fn();
+	render({
+		childTasks: [createTask({ id: "c1", title: "子タスク1" })],
+		doneColumn: "Done",
+		onTaskSelect,
+		onAddSubIssue: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="sub-issue-section"]'),
+		).toBeTruthy();
+	});
+	const button = document
+		.querySelector('[data-testid="sub-issue-section"]')
+		?.querySelector("button:not([data-testid])") as HTMLElement;
+	act(() => {
+		button.click();
+	});
+	expect(onTaskSelect).toHaveBeenCalledWith("c1");
+});
+
+test("childrenが空でサブIssueセクション非表示", () => {
+	render({
+		childTasks: [],
+		doneColumn: "Done",
+		onTaskSelect: vi.fn(),
+		onAddSubIssue: vi.fn(),
+	});
+	expect(
+		document.querySelector('[data-testid="sub-issue-section"]'),
+	).toBeNull();
+});

--- a/src/features/detail/components/SubIssueSection.tsx
+++ b/src/features/detail/components/SubIssueSection.tsx
@@ -1,0 +1,105 @@
+import type { Task } from "../../../types/task";
+
+/** SubIssueSection の Props */
+type SubIssueSectionProps = {
+	/** 子タスクの配列 */
+	childTasks: Task[];
+	/** 完了カラム名 */
+	doneColumn: string;
+	/**
+	 * タスク選択時のコールバック
+	 * @param taskId - 選択されたタスクのID
+	 */
+	onTaskSelect: (taskId: string) => void;
+	/** サブIssue追加ボタン押下時のコールバック */
+	onAddSubIssue: () => void;
+};
+
+/**
+ * @param props - isDone: 完了かどうか
+ * @returns ステータスアイコン要素
+ */
+function StatusIcon({ isDone }: { isDone: boolean }) {
+	const label = isDone ? "完了" : "未完了";
+
+	if (isDone) {
+		return (
+			<span className="text-green-600" role="img" aria-label={label}>
+				✓
+			</span>
+		);
+	}
+	return (
+		<span className="text-gray-400" role="img" aria-label={label}>
+			○
+		</span>
+	);
+}
+
+/**
+ * サブIssueセクション（進捗バー + 子タスク一覧）
+ * @param props - {@link SubIssueSectionProps}
+ * @returns セクション要素。子タスクが空の場合は null
+ */
+export function SubIssueSection({
+	childTasks,
+	doneColumn,
+	onTaskSelect,
+	onAddSubIssue,
+}: SubIssueSectionProps) {
+	if (childTasks.length === 0) {
+		return null;
+	}
+
+	const total = childTasks.length;
+	const doneCount = childTasks.filter((t) => t.status === doneColumn).length;
+	const percentage = Math.round((doneCount / total) * 100);
+
+	return (
+		<section data-testid="sub-issue-section" aria-label="サブIssue">
+			<div className="mb-2 flex items-center justify-between">
+				<h3 className="text-sm font-medium text-gray-700">サブIssue</h3>
+				<button
+					type="button"
+					className="text-xs text-blue-600 hover:text-blue-800"
+					data-testid="add-sub-issue-button"
+					onClick={onAddSubIssue}
+				>
+					+ サブIssue 追加
+				</button>
+			</div>
+			<div className="mb-2 flex items-center gap-2">
+				<div
+					className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200"
+					role="progressbar"
+					aria-valuenow={percentage}
+					aria-valuemin={0}
+					aria-valuemax={100}
+					aria-label={`進捗 ${doneCount}/${total}`}
+				>
+					<div
+						className="h-full rounded-full bg-green-500 transition-all"
+						style={{ width: `${percentage}%` }}
+					/>
+				</div>
+				<span className="text-xs text-gray-500">
+					{doneCount}/{total}
+				</span>
+			</div>
+			<ul className="space-y-1">
+				{childTasks.map((child) => (
+					<li key={child.id}>
+						<button
+							type="button"
+							className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-gray-100"
+							onClick={() => onTaskSelect(child.id)}
+						>
+							<StatusIcon isDone={child.status === doneColumn} />
+							<span>{child.title || child.filePath}</span>
+						</button>
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/src/features/detail/components/SubIssueSection.tsx
+++ b/src/features/detail/components/SubIssueSection.tsx
@@ -1,3 +1,5 @@
+import { ProgressBar } from "../../../components/ProgressBar";
+import { StatusIcon } from "../../../components/StatusIcon";
 import type { Task } from "../../../types/task";
 
 /** SubIssueSection の Props */
@@ -11,30 +13,9 @@ type SubIssueSectionProps = {
 	 * @param taskId - 選択されたタスクのID
 	 */
 	onTaskSelect: (taskId: string) => void;
-	/** サブIssue追加ボタン押下時のコールバック */
-	onAddSubIssue: () => void;
+	/** サブIssue追加ボタン押下時のコールバック（未指定時はボタン非表示） */
+	onAddSubIssue?: () => void;
 };
-
-/**
- * @param props - isDone: 完了かどうか
- * @returns ステータスアイコン要素
- */
-function StatusIcon({ isDone }: { isDone: boolean }) {
-	const label = isDone ? "完了" : "未完了";
-
-	if (isDone) {
-		return (
-			<span className="text-green-600" role="img" aria-label={label}>
-				✓
-			</span>
-		);
-	}
-	return (
-		<span className="text-gray-400" role="img" aria-label={label}>
-			○
-		</span>
-	);
-}
 
 /**
  * サブIssueセクション（進捗バー + 子タスク一覧）
@@ -53,38 +34,24 @@ export function SubIssueSection({
 
 	const total = childTasks.length;
 	const doneCount = childTasks.filter((t) => t.status === doneColumn).length;
-	const percentage = Math.round((doneCount / total) * 100);
 
 	return (
 		<section data-testid="sub-issue-section" aria-label="サブIssue">
 			<div className="mb-2 flex items-center justify-between">
 				<h3 className="text-sm font-medium text-gray-700">サブIssue</h3>
-				<button
-					type="button"
-					className="text-xs text-blue-600 hover:text-blue-800"
-					data-testid="add-sub-issue-button"
-					onClick={onAddSubIssue}
-				>
-					+ サブIssue 追加
-				</button>
+				{onAddSubIssue && (
+					<button
+						type="button"
+						className="text-xs text-blue-600 hover:text-blue-800"
+						data-testid="add-sub-issue-button"
+						onClick={onAddSubIssue}
+					>
+						+ サブIssue 追加
+					</button>
+				)}
 			</div>
-			<div className="mb-2 flex items-center gap-2">
-				<div
-					className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200"
-					role="progressbar"
-					aria-valuenow={percentage}
-					aria-valuemin={0}
-					aria-valuemax={100}
-					aria-label={`進捗 ${doneCount}/${total}`}
-				>
-					<div
-						className="h-full rounded-full bg-green-500 transition-all"
-						style={{ width: `${percentage}%` }}
-					/>
-				</div>
-				<span className="text-xs text-gray-500">
-					{doneCount}/{total}
-				</span>
+			<div className="mb-2">
+				<ProgressBar doneCount={doneCount} total={total} />
 			</div>
 			<ul className="space-y-1">
 				{childTasks.map((child) => (

--- a/src/features/detail/index.ts
+++ b/src/features/detail/index.ts
@@ -1,1 +1,4 @@
 export { DetailPanel } from "./components/DetailPanel";
+export type { ResolvedLink } from "./components/LinkSection";
+export { LinkSection } from "./components/LinkSection";
+export { SubIssueSection } from "./components/SubIssueSection";


### PR DESCRIPTION
## Summary

- 詳細パネルに **SubIssueSection** を追加（進捗バー + 子タスク一覧、クリックで子タスク詳細に切り替え、サブIssue追加ボタン）
- 詳細パネルに **LinkSection** を追加（関連タスク一覧、リンク削除ボタン、リンク追加ボタン、リンク切れ警告アイコン）
- 詳細パネルに **親タスク表示** を追加（クリックで親タスク詳細に切り替え）
- children/links/reverseLinks が空の場合は各セクション非表示

## Test plan

- [x] children がある場合、進捗バーと子タスク一覧が表示される
- [x] 子タスククリックで詳細パネルが切り替わる
- [x] links/reverseLinks がある場合、関連リンクが表示される
- [x] 親タスクがある場合、親タスク名が表示されクリックで遷移する
- [x] children が空でサブIssue セクション非表示
- [x] links と reverseLinks が共に空で関連リンクセクション非表示
- [x] parent が未設定で親タスク表示なし
- [x] リンク切れの場合は警告アイコン表示
- [x] 全96テスト通過

Automated by task-loop-run
