### PR TITLE
feat: 簡易Markdownレンダラー

### DIFF
--- a/src/features/detail/components/DetailPanel.rendering.test.tsx
+++ b/src/features/detail/components/DetailPanel.rendering.test.tsx
@@ -95,3 +95,17 @@ test("オーバーレイクリックでパネルが閉じる", async () => {
 	overlay.click();
 	expect(onClose).toHaveBeenCalledOnce();
 });
+
+test("本文がMarkdownとしてレンダリングされる", async () => {
+	render({
+		task: createTask({ body: "# 見出し\n- リスト項目" }),
+		onClose: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const panel = document.querySelector('[role="dialog"]');
+		expect(panel?.querySelector("h1")).toBeTruthy();
+		expect(panel?.querySelector("h1")?.textContent).toBe("見出し");
+		expect(panel?.querySelector("li")).toBeTruthy();
+		expect(panel?.querySelector("li")?.textContent).toBe("リスト項目");
+	});
+});

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { Task } from "../../../types/task";
+import { MarkdownBody } from "./MarkdownBody";
 
 /** 詳細パネルの Props */
 type DetailPanelProps = {
@@ -74,7 +75,7 @@ export function DetailPanel({ task, onClose }: DetailPanelProps) {
 					</button>
 				</div>
 				<div className="flex-1 overflow-y-auto p-4">
-					<p className="text-sm text-gray-600">{task.body}</p>
+					<MarkdownBody body={task.body} />
 				</div>
 			</aside>
 		</>

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -75,7 +75,9 @@ export function DetailPanel({ task, onClose }: DetailPanelProps) {
 					</button>
 				</div>
 				<div className="flex-1 overflow-y-auto p-4">
-					<MarkdownBody body={task.body} />
+					<div className="text-sm text-gray-600">
+						<MarkdownBody body={task.body} />
+					</div>
 				</div>
 			</aside>
 		</>

--- a/src/features/detail/components/MarkdownBody.rendering.test.tsx
+++ b/src/features/detail/components/MarkdownBody.rendering.test.tsx
@@ -87,8 +87,8 @@ test("コードブロックがpre > codeでレンダリングされる", () => {
 
 test("<script>がエスケープされる", () => {
 	render('<script>alert("xss")</script>');
-	expect(document.querySelector("script")).toBeNull();
-	expect(document.body.textContent).toContain("alert");
+	expect(container?.querySelector("script")).toBeNull();
+	expect(container?.textContent).toContain("alert");
 });
 
 test("bodyが空文字の場合、何も表示されない", () => {

--- a/src/features/detail/components/MarkdownBody.rendering.test.tsx
+++ b/src/features/detail/components/MarkdownBody.rendering.test.tsx
@@ -1,0 +1,106 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test } from "vitest";
+import { MarkdownBody } from "./MarkdownBody";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * @param body - レンダリングする Markdown 文字列
+ */
+function render(body: string) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(MarkdownBody, { body }));
+	});
+}
+
+test("# 見出しがh1タグでレンダリングされる", () => {
+	render("# 見出し");
+	const h1 = document.querySelector("h1");
+	expect(h1).toBeTruthy();
+	expect(h1?.textContent).toBe("見出し");
+});
+
+test("## 見出しがh2タグでレンダリングされる", () => {
+	render("## 見出し2");
+	const h2 = document.querySelector("h2");
+	expect(h2).toBeTruthy();
+	expect(h2?.textContent).toBe("見出し2");
+});
+
+test("### 見出しがh3タグでレンダリングされる", () => {
+	render("### 見出し3");
+	const h3 = document.querySelector("h3");
+	expect(h3).toBeTruthy();
+	expect(h3?.textContent).toBe("見出し3");
+});
+
+test("- リスト項目がliタグでレンダリングされる", () => {
+	render("- リスト項目");
+	const li = document.querySelector("li");
+	expect(li).toBeTruthy();
+	expect(li?.textContent).toBe("リスト項目");
+});
+
+test("* リスト項目がliタグでレンダリングされる", () => {
+	render("* リスト項目");
+	const li = document.querySelector("li");
+	expect(li).toBeTruthy();
+	expect(li?.textContent).toBe("リスト項目");
+});
+
+test("**太字**がstrongタグでレンダリングされる", () => {
+	render("**太字**");
+	const strong = document.querySelector("strong");
+	expect(strong).toBeTruthy();
+	expect(strong?.textContent).toBe("太字");
+});
+
+test("`コード`がcodeタグでレンダリングされる", () => {
+	render("`コード`");
+	const code = document.querySelector("code");
+	expect(code).toBeTruthy();
+	expect(code?.textContent).toBe("コード");
+});
+
+test("コードブロックがpre > codeでレンダリングされる", () => {
+	render("```\nconst x = 1;\n```");
+	const pre = document.querySelector("pre");
+	const code = pre?.querySelector("code");
+	expect(pre).toBeTruthy();
+	expect(code).toBeTruthy();
+	expect(code?.textContent).toBe("const x = 1;");
+});
+
+test("<script>がエスケープされる", () => {
+	render('<script>alert("xss")</script>');
+	expect(document.querySelector("script")).toBeNull();
+	expect(document.body.textContent).toContain("alert");
+});
+
+test("bodyが空文字の場合、何も表示されない", () => {
+	render("");
+	const markdownBody = document.querySelector('[data-testid="markdown-body"]');
+	expect(markdownBody).toBeNull();
+});
+
+test("連続する空行が1つの段落区切りとして扱われる", () => {
+	render("段落1\n\n\n\n段落2");
+	const paragraphs = document.querySelectorAll("p");
+	expect(paragraphs.length).toBe(2);
+	expect(paragraphs[0]?.textContent).toBe("段落1");
+	expect(paragraphs[1]?.textContent).toBe("段落2");
+});

--- a/src/features/detail/components/MarkdownBody.tsx
+++ b/src/features/detail/components/MarkdownBody.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from "react";
+
+type MarkdownBodyProps = {
+	body: string;
+};
+
+/**
+ * @param text - インライン装飾を含むテキスト
+ * @returns ReactNode の配列
+ */
+function renderInline(text: string): ReactNode[] {
+	const result: ReactNode[] = [];
+	const regex = /(`[^`]+`|\*\*(.+?)\*\*)/g;
+	let lastIndex = 0;
+	let key = 0;
+
+	for (const match of text.matchAll(regex)) {
+		const idx = match.index;
+		if (idx > lastIndex) {
+			result.push(text.slice(lastIndex, idx));
+		}
+		if (match[0].startsWith("`")) {
+			result.push(<code key={key++}>{match[0].slice(1, -1)}</code>);
+		} else {
+			result.push(<strong key={key++}>{match[2]}</strong>);
+		}
+		lastIndex = idx + match[0].length;
+	}
+	if (lastIndex < text.length) {
+		result.push(text.slice(lastIndex));
+	}
+	return result;
+}
+
+/**
+ * @param props - {@link MarkdownBodyProps}
+ * @returns Markdown をレンダリングした要素、body が空なら null
+ */
+export function MarkdownBody({ body }: MarkdownBodyProps) {
+	if (!body) return null;
+
+	const lines = body.split("\n");
+	const elements: ReactNode[] = [];
+	let key = 0;
+	let i = 0;
+
+	while (i < lines.length) {
+		const line = lines[i];
+
+		if (line.startsWith("```")) {
+			const codeLines: string[] = [];
+			i++;
+			while (i < lines.length && !lines[i].startsWith("```")) {
+				codeLines.push(lines[i]);
+				i++;
+			}
+			if (i < lines.length) i++;
+			elements.push(
+				<pre key={key++}>
+					<code>{codeLines.join("\n")}</code>
+				</pre>,
+			);
+			continue;
+		}
+
+		if (line.trim() === "") {
+			i++;
+			continue;
+		}
+
+		const headingMatch = line.match(/^(#{1,3})\s+(.*)/);
+		if (headingMatch) {
+			const level = headingMatch[1].length;
+			const content = renderInline(headingMatch[2]);
+			if (level === 1) elements.push(<h1 key={key++}>{content}</h1>);
+			else if (level === 2) elements.push(<h2 key={key++}>{content}</h2>);
+			else elements.push(<h3 key={key++}>{content}</h3>);
+			i++;
+			continue;
+		}
+
+		if (/^[-*]\s+/.test(line)) {
+			const items: ReactNode[] = [];
+			while (i < lines.length && /^[-*]\s+/.test(lines[i])) {
+				const itemText = lines[i].replace(/^[-*]\s+/, "");
+				items.push(<li key={items.length}>{renderInline(itemText)}</li>);
+				i++;
+			}
+			elements.push(<ul key={key++}>{items}</ul>);
+			continue;
+		}
+
+		const paraLines: string[] = [];
+		while (
+			i < lines.length &&
+			lines[i].trim() !== "" &&
+			!lines[i].startsWith("```") &&
+			!/^#{1,3}\s+/.test(lines[i]) &&
+			!/^[-*]\s+/.test(lines[i])
+		) {
+			paraLines.push(lines[i]);
+			i++;
+		}
+		if (paraLines.length > 0) {
+			elements.push(<p key={key++}>{renderInline(paraLines.join(" "))}</p>);
+		}
+	}
+
+	return <div data-testid="markdown-body">{elements}</div>;
+}

--- a/src/features/detail/components/MarkdownBody.tsx
+++ b/src/features/detail/components/MarkdownBody.tsx
@@ -15,7 +15,7 @@ function renderInline(text: string): ReactNode[] {
 	let key = 0;
 
 	for (const match of text.matchAll(regex)) {
-		const idx = match.index;
+		const idx = match.index ?? 0;
 		if (idx > lastIndex) {
 			result.push(text.slice(lastIndex, idx));
 		}
@@ -37,9 +37,9 @@ function renderInline(text: string): ReactNode[] {
  * @returns Markdown をレンダリングした要素、body が空なら null
  */
 export function MarkdownBody({ body }: MarkdownBodyProps) {
-	if (!body) return null;
+	if (!body.trim()) return null;
 
-	const lines = body.split("\n");
+	const lines = body.replace(/\r\n?/g, "\n").split("\n");
 	const elements: ReactNode[] = [];
 	let key = 0;
 	let i = 0;

--- a/src/features/detail/components/MarkdownBody.tsx
+++ b/src/features/detail/components/MarkdownBody.tsx
@@ -56,7 +56,7 @@ export function MarkdownBody({ body }: MarkdownBodyProps) {
 			}
 			if (i < lines.length) i++;
 			elements.push(
-				<pre key={key++}>
+				<pre key={key++} className="overflow-x-auto">
 					<code>{codeLines.join("\n")}</code>
 				</pre>,
 			);
@@ -72,9 +72,34 @@ export function MarkdownBody({ body }: MarkdownBodyProps) {
 		if (headingMatch) {
 			const level = headingMatch[1].length;
 			const content = renderInline(headingMatch[2]);
-			if (level === 1) elements.push(<h1 key={key++}>{content}</h1>);
-			else if (level === 2) elements.push(<h2 key={key++}>{content}</h2>);
-			else elements.push(<h3 key={key++}>{content}</h3>);
+			if (level === 1) {
+				elements.push(
+					<h1
+						key={key++}
+						className="mt-8 mb-4 text-3xl font-bold leading-tight"
+					>
+						{content}
+					</h1>,
+				);
+			} else if (level === 2) {
+				elements.push(
+					<h2
+						key={key++}
+						className="mt-7 mb-3 text-2xl font-semibold leading-tight"
+					>
+						{content}
+					</h2>,
+				);
+			} else {
+				elements.push(
+					<h3
+						key={key++}
+						className="mt-6 mb-3 text-xl font-semibold leading-snug"
+					>
+						{content}
+					</h3>,
+				);
+			}
 			i++;
 			continue;
 		}
@@ -86,7 +111,11 @@ export function MarkdownBody({ body }: MarkdownBodyProps) {
 				items.push(<li key={items.length}>{renderInline(itemText)}</li>);
 				i++;
 			}
-			elements.push(<ul key={key++}>{items}</ul>);
+			elements.push(
+				<ul key={key++} className="list-disc pl-6">
+					{items}
+				</ul>,
+			);
 			continue;
 		}
 
@@ -106,5 +135,9 @@ export function MarkdownBody({ body }: MarkdownBodyProps) {
 		}
 	}
 
-	return <div data-testid="markdown-body">{elements}</div>;
+	return (
+		<div className="space-y-4" data-testid="markdown-body">
+			{elements}
+		</div>
+	);
 }


### PR DESCRIPTION
## Summary

外部ライブラリを使わず、タスク説明文の表示に必要な Markdown サブセットを自前でレンダリングする `MarkdownBody` コンポーネントを実装し、詳細パネルに組み込みました。

## Changes

- `MarkdownBody` コンポーネントを新規作成（`src/features/detail/components/MarkdownBody.tsx`）
  - 対応構文: 見出し（#〜###）、段落（空行区切り）、箇条書き（- / *）、太字（**）、インラインコード、コードブロック
  - XSS 対策: React の JSX エスケープにより HTML タグは自動エスケープ
  - body が空の場合は null を返し非表示
- `DetailPanel` の body 表示を `<p>` タグから `MarkdownBody` に置換
- レンダリングテスト（11ケース）を追加:
  1. `# 見出し` → h1 タグ
  2. `## 見出し` → h2 タグ
  3. `### 見出し` → h3 タグ
  4. `- リスト` → li タグ
  5. `* リスト` → li タグ
  6. `**太字**` → strong タグ
  7. `` `コード` `` → code タグ
  8. コードブロック → pre > code
  9. `<script>` タグのエスケープ
  10. 空文字 body → 非表示
  11. 連続空行 → 段落区切り

## Test

```bash
pnpm test:run
```

Automated by task-loop-run
