### PR TITLE
feat: 詳細パネル - 削除ボタンと確認ダイアログ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,13 +39,9 @@ function App() {
 	);
 
 	const handleTaskDelete = useCallback(async (id: string) => {
-		try {
-			await deleteTask(id);
-			setTasks((prev) => prev.filter((t) => t.id !== id));
-			setSelectedTaskId(null);
-		} catch {
-			// deleteTask の失敗時は UI を維持する
-		}
+		await deleteTask(id);
+		setTasks((prev) => prev.filter((t) => t.id !== id));
+		setSelectedTaskId(null);
 	}, []);
 
 	useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,9 +39,13 @@ function App() {
 	);
 
 	const handleTaskDelete = useCallback(async (id: string) => {
-		await deleteTask(id);
-		setTasks((prev) => prev.filter((t) => t.id !== id));
-		setSelectedTaskId(null);
+		try {
+			await deleteTask(id);
+			setTasks((prev) => prev.filter((t) => t.id !== id));
+			setSelectedTaskId(null);
+		} catch {
+			// deleteTask の失敗時は UI を維持する
+		}
 	}, []);
 
 	useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Board, EmptyState, HeaderBar } from "./features/board";
 import { DetailPanel } from "./features/detail";
-import { getColumns, getTasks, updateTask } from "./lib/api";
+import { deleteTask, getColumns, getTasks, updateTask } from "./lib/api";
 import type { Column, Task } from "./types/task";
 
 /**
@@ -37,6 +37,12 @@ function App() {
 		},
 		[],
 	);
+
+	const handleTaskDelete = useCallback(async (id: string) => {
+		await deleteTask(id);
+		setTasks((prev) => prev.filter((t) => t.id !== id));
+		setSelectedTaskId(null);
+	}, []);
 
 	useEffect(() => {
 		if (projectPath === null) return;
@@ -83,6 +89,7 @@ function App() {
 					columns={columns}
 					onClose={handleCloseDetail}
 					onTaskUpdate={handleTaskUpdate}
+					onDelete={handleTaskDelete}
 				/>
 			)}
 		</div>

--- a/src/components/ConfirmDialog.interaction.test.tsx
+++ b/src/components/ConfirmDialog.interaction.test.tsx
@@ -1,0 +1,119 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * ConfirmDialog をレンダリングするヘルパー
+ * @param props - ConfirmDialog に渡す props
+ */
+function render(props: Parameters<typeof ConfirmDialog>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(ConfirmDialog, props));
+	});
+}
+
+test("タイトルとメッセージが表示される", () => {
+	render({
+		title: "削除確認",
+		message: "本当に削除しますか？",
+		onConfirm: vi.fn(),
+		onCancel: vi.fn(),
+	});
+	const dialog = document.querySelector('[data-testid="confirm-dialog"]');
+	expect(dialog?.textContent).toContain("削除確認");
+	expect(dialog?.textContent).toContain("本当に削除しますか？");
+});
+
+test("確定ボタンクリックでonConfirmが呼ばれる", () => {
+	const onConfirm = vi.fn();
+	render({
+		title: "確認",
+		message: "実行しますか？",
+		onConfirm,
+		onCancel: vi.fn(),
+	});
+	const button = document.querySelector(
+		'[data-testid="confirm-confirm-button"]',
+	) as HTMLElement;
+	button.click();
+	expect(onConfirm).toHaveBeenCalledOnce();
+});
+
+test("キャンセルボタンクリックでonCancelが呼ばれる", () => {
+	const onCancel = vi.fn();
+	render({
+		title: "確認",
+		message: "実行しますか？",
+		onConfirm: vi.fn(),
+		onCancel,
+	});
+	const button = document.querySelector(
+		'[data-testid="confirm-cancel-button"]',
+	) as HTMLElement;
+	button.click();
+	expect(onCancel).toHaveBeenCalledOnce();
+});
+
+test("オーバーレイクリックでonCancelが呼ばれる", () => {
+	const onCancel = vi.fn();
+	render({
+		title: "確認",
+		message: "実行しますか？",
+		onConfirm: vi.fn(),
+		onCancel,
+	});
+	const overlay = document.querySelector(
+		'[data-testid="confirm-overlay"]',
+	) as HTMLElement;
+	overlay.click();
+	expect(onCancel).toHaveBeenCalledOnce();
+});
+
+test("EscキーでonCancelが呼ばれる", () => {
+	const onCancel = vi.fn();
+	render({
+		title: "確認",
+		message: "実行しますか？",
+		onConfirm: vi.fn(),
+		onCancel,
+	});
+	act(() => {
+		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+	});
+	expect(onCancel).toHaveBeenCalledOnce();
+});
+
+test("カスタムラベルが表示される", () => {
+	render({
+		title: "確認",
+		message: "メッセージ",
+		confirmLabel: "はい",
+		cancelLabel: "いいえ",
+		onConfirm: vi.fn(),
+		onCancel: vi.fn(),
+	});
+	const confirmBtn = document.querySelector(
+		'[data-testid="confirm-confirm-button"]',
+	);
+	const cancelBtn = document.querySelector(
+		'[data-testid="confirm-cancel-button"]',
+	);
+	expect(confirmBtn?.textContent).toBe("はい");
+	expect(cancelBtn?.textContent).toBe("いいえ");
+});

--- a/src/components/ConfirmDialog.interaction.test.tsx
+++ b/src/components/ConfirmDialog.interaction.test.tsx
@@ -99,6 +99,37 @@ test("EscキーでonCancelが呼ばれる", () => {
 	expect(onCancel).toHaveBeenCalledOnce();
 });
 
+test("cancelDisabled時にEscキーでonCancelが呼ばれない", () => {
+	const onCancel = vi.fn();
+	render({
+		title: "確認",
+		message: "実行しますか？",
+		onConfirm: vi.fn(),
+		onCancel,
+		cancelDisabled: true,
+	});
+	act(() => {
+		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+	});
+	expect(onCancel).not.toHaveBeenCalled();
+});
+
+test("cancelDisabled時にオーバーレイクリックでonCancelが呼ばれない", () => {
+	const onCancel = vi.fn();
+	render({
+		title: "確認",
+		message: "実行しますか？",
+		onConfirm: vi.fn(),
+		onCancel,
+		cancelDisabled: true,
+	});
+	const overlay = document.querySelector(
+		'[data-testid="confirm-overlay"]',
+	) as HTMLElement;
+	overlay.click();
+	expect(onCancel).not.toHaveBeenCalled();
+});
+
 test("カスタムラベルが表示される", () => {
 	render({
 		title: "確認",

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -49,10 +49,10 @@ export function ConfirmDialog({
 
 	return (
 		<>
-			<button
-				type="button"
-				aria-label="ダイアログを閉じる"
-				className="fixed inset-0 z-[60] border-0 bg-black/40 p-0"
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: overlay dismisses dialog on click, Escape key handled separately */}
+			<div
+				role="presentation"
+				className="fixed inset-0 z-[60] bg-black/40"
 				data-testid="confirm-overlay"
 				onClick={onCancel}
 			/>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -9,6 +9,10 @@ type ConfirmDialogProps = {
 	confirmLabel?: string;
 	/** キャンセルボタンのラベル（デフォルト: "キャンセル"） */
 	cancelLabel?: string;
+	/** 確定ボタンを無効化するか */
+	confirmDisabled?: boolean;
+	/** キャンセルボタンを無効化するか */
+	cancelDisabled?: boolean;
 	/** 確定時のコールバック */
 	onConfirm: () => void;
 	/** キャンセル時のコールバック */
@@ -25,6 +29,8 @@ export function ConfirmDialog({
 	message,
 	confirmLabel = "確定",
 	cancelLabel = "キャンセル",
+	confirmDisabled = false,
+	cancelDisabled = false,
 	onConfirm,
 	onCancel,
 }: ConfirmDialogProps) {
@@ -75,16 +81,18 @@ export function ConfirmDialog({
 				<div className="mt-6 flex justify-end gap-3">
 					<button
 						type="button"
-						className="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+						className="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
 						data-testid="confirm-cancel-button"
+						disabled={cancelDisabled}
 						onClick={onCancel}
 					>
 						{cancelLabel}
 					</button>
 					<button
 						type="button"
-						className="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
+						className="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50"
 						data-testid="confirm-confirm-button"
+						disabled={confirmDisabled}
 						onClick={onConfirm}
 					>
 						{confirmLabel}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from "react";
+
+type ConfirmDialogProps = {
+	/** ダイアログのタイトル */
+	title: string;
+	/** 確認メッセージ */
+	message: string;
+	/** 確定ボタンのラベル（デフォルト: "確定"） */
+	confirmLabel?: string;
+	/** キャンセルボタンのラベル（デフォルト: "キャンセル"） */
+	cancelLabel?: string;
+	/** 確定時のコールバック */
+	onConfirm: () => void;
+	/** キャンセル時のコールバック */
+	onCancel: () => void;
+};
+
+/**
+ * 確認ダイアログコンポーネント
+ * @param props - {@link ConfirmDialogProps}
+ * @returns ダイアログ要素
+ */
+export function ConfirmDialog({
+	title,
+	message,
+	confirmLabel = "確定",
+	cancelLabel = "キャンセル",
+	onConfirm,
+	onCancel,
+}: ConfirmDialogProps) {
+	const dialogRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		dialogRef.current?.focus();
+	}, []);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				onCancel();
+			}
+		};
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [onCancel]);
+
+	return (
+		<>
+			<button
+				type="button"
+				aria-label="ダイアログを閉じる"
+				className="fixed inset-0 z-60 border-0 bg-black/40 p-0"
+				data-testid="confirm-overlay"
+				onClick={onCancel}
+			/>
+			<div
+				ref={dialogRef}
+				role="alertdialog"
+				aria-modal="true"
+				aria-labelledby="confirm-dialog-title"
+				aria-describedby="confirm-dialog-message"
+				tabIndex={-1}
+				className="fixed top-1/2 left-1/2 z-70 w-[400px] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-2xl"
+				data-testid="confirm-dialog"
+			>
+				<h2
+					id="confirm-dialog-title"
+					className="text-lg font-semibold text-gray-900"
+				>
+					{title}
+				</h2>
+				<p id="confirm-dialog-message" className="mt-2 text-sm text-gray-600">
+					{message}
+				</p>
+				<div className="mt-6 flex justify-end gap-3">
+					<button
+						type="button"
+						className="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+						data-testid="confirm-cancel-button"
+						onClick={onCancel}
+					>
+						{cancelLabel}
+					</button>
+					<button
+						type="button"
+						className="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
+						data-testid="confirm-confirm-button"
+						onClick={onConfirm}
+					>
+						{confirmLabel}
+					</button>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -45,13 +45,13 @@ export function ConfirmDialog({
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
+			if (e.key === "Escape" && !cancelDisabled) {
 				onCancel();
 			}
 		};
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [onCancel]);
+	}, [onCancel, cancelDisabled]);
 
 	return (
 		<>
@@ -60,7 +60,7 @@ export function ConfirmDialog({
 				role="presentation"
 				className="fixed inset-0 z-[60] bg-black/40"
 				data-testid="confirm-overlay"
-				onClick={onCancel}
+				onClick={cancelDisabled ? undefined : onCancel}
 			/>
 			<div
 				ref={dialogRef}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useRef } from "react";
 
 type ConfirmDialogProps = {
 	/** ダイアログのタイトル */
@@ -29,6 +29,9 @@ export function ConfirmDialog({
 	onCancel,
 }: ConfirmDialogProps) {
 	const dialogRef = useRef<HTMLDivElement>(null);
+	const id = useId();
+	const titleId = `${id}-title`;
+	const messageId = `${id}-message`;
 
 	useEffect(() => {
 		dialogRef.current?.focus();
@@ -49,7 +52,7 @@ export function ConfirmDialog({
 			<button
 				type="button"
 				aria-label="ダイアログを閉じる"
-				className="fixed inset-0 z-60 border-0 bg-black/40 p-0"
+				className="fixed inset-0 z-[60] border-0 bg-black/40 p-0"
 				data-testid="confirm-overlay"
 				onClick={onCancel}
 			/>
@@ -57,19 +60,16 @@ export function ConfirmDialog({
 				ref={dialogRef}
 				role="alertdialog"
 				aria-modal="true"
-				aria-labelledby="confirm-dialog-title"
-				aria-describedby="confirm-dialog-message"
+				aria-labelledby={titleId}
+				aria-describedby={messageId}
 				tabIndex={-1}
-				className="fixed top-1/2 left-1/2 z-70 w-[400px] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-2xl"
+				className="fixed top-1/2 left-1/2 z-[70] w-[400px] max-w-[90vw] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-2xl"
 				data-testid="confirm-dialog"
 			>
-				<h2
-					id="confirm-dialog-title"
-					className="text-lg font-semibold text-gray-900"
-				>
+				<h2 id={titleId} className="text-lg font-semibold text-gray-900">
 					{title}
 				</h2>
-				<p id="confirm-dialog-message" className="mt-2 text-sm text-gray-600">
+				<p id={messageId} className="mt-2 text-sm text-gray-600">
 					{message}
 				</p>
 				<div className="mt-6 flex justify-end gap-3">

--- a/src/features/detail/components/DetailPanel.delete.test.tsx
+++ b/src/features/detail/components/DetailPanel.delete.test.tsx
@@ -1,0 +1,172 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Task } from "../../../types/task";
+import { DetailPanel } from "./DetailPanel";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+const testColumns = [
+	{ name: "Todo", order: 0 },
+	{ name: "In Progress", order: 1 },
+	{ name: "Done", order: 2 },
+];
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * テスト用タスクを生成する
+ * @param overrides - 上書きするフィールド
+ * @returns テスト用タスク
+ */
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "task-1",
+		title: "テストタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "タスクの本文",
+		filePath: "tasks/test.md",
+		...overrides,
+	};
+}
+
+/**
+ * DetailPanel をレンダリングするヘルパー
+ * @param props - DetailPanel に渡す props
+ */
+function render(props: Parameters<typeof DetailPanel>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(DetailPanel, props));
+	});
+}
+
+test("「削除」ボタンクリックで確認ダイアログが表示される", async () => {
+	render({
+		task: createTask(),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="detail-delete-button"]'),
+		).toBeTruthy();
+	});
+	const deleteButton = document.querySelector(
+		'[data-testid="detail-delete-button"]',
+	) as HTMLElement;
+	act(() => {
+		deleteButton.click();
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="confirm-dialog"]'),
+		).toBeTruthy();
+	});
+});
+
+test("確定でonDeleteが呼ばれる", async () => {
+	const onDelete = vi.fn();
+	render({
+		task: createTask({ id: "task-42" }),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onDelete,
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="detail-delete-button"]'),
+		).toBeTruthy();
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="detail-delete-button"]',
+			) as HTMLElement
+		).click();
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="confirm-confirm-button"]'),
+		).toBeTruthy();
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="confirm-confirm-button"]',
+			) as HTMLElement
+		).click();
+	});
+	expect(onDelete).toHaveBeenCalledWith("task-42");
+});
+
+test("キャンセルでダイアログが閉じ削除されない", async () => {
+	const onDelete = vi.fn();
+	render({
+		task: createTask(),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onDelete,
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="detail-delete-button"]'),
+		).toBeTruthy();
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="detail-delete-button"]',
+			) as HTMLElement
+		).click();
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="confirm-dialog"]'),
+		).toBeTruthy();
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="confirm-cancel-button"]',
+			) as HTMLElement
+		).click();
+	});
+	await vi.waitFor(() => {
+		expect(document.querySelector('[data-testid="confirm-dialog"]')).toBeNull();
+	});
+	expect(onDelete).not.toHaveBeenCalled();
+});
+
+test("ファイルパスがパネル下部に表示される", async () => {
+	render({
+		task: createTask({ filePath: "projects/my-task.md" }),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const filePath = document.querySelector('[data-testid="detail-file-path"]');
+		expect(filePath).toBeTruthy();
+		expect(filePath?.textContent).toBe("projects/my-task.md");
+	});
+});

--- a/src/features/detail/components/DetailPanel.delete.test.tsx
+++ b/src/features/detail/components/DetailPanel.delete.test.tsx
@@ -156,6 +156,52 @@ test("キャンセルでダイアログが閉じ削除されない", async () =>
 	expect(onDelete).not.toHaveBeenCalled();
 });
 
+test("onDeleteが失敗した場合、ダイアログが開いたままでisDeleteが解除される", async () => {
+	const onDelete = vi.fn().mockRejectedValue(new Error("削除失敗"));
+	render({
+		task: createTask({ id: "task-fail" }),
+		columns: testColumns,
+		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onDelete,
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="detail-delete-button"]'),
+		).toBeTruthy();
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="detail-delete-button"]',
+			) as HTMLElement
+		).click();
+	});
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="confirm-confirm-button"]'),
+		).toBeTruthy();
+	});
+	await act(async () => {
+		(
+			document.querySelector(
+				'[data-testid="confirm-confirm-button"]',
+			) as HTMLElement
+		).click();
+	});
+	expect(onDelete).toHaveBeenCalledWith("task-fail");
+	await vi.waitFor(() => {
+		expect(
+			document.querySelector('[data-testid="confirm-dialog"]'),
+		).toBeTruthy();
+		const confirmBtn = document.querySelector(
+			'[data-testid="confirm-confirm-button"]',
+		) as HTMLButtonElement;
+		expect(confirmBtn.disabled).toBe(false);
+		expect(confirmBtn.textContent).toBe("削除");
+	});
+});
+
 test("ファイルパスがパネル下部に表示される", async () => {
 	render({
 		task: createTask({ filePath: "projects/my-task.md" }),

--- a/src/features/detail/components/DetailPanel.rendering.test.tsx
+++ b/src/features/detail/components/DetailPanel.rendering.test.tsx
@@ -62,6 +62,7 @@ test("タスク選択時にパネルが表示される", async () => {
 		columns: testColumns,
 		onClose: vi.fn(),
 		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		const dialog = document.querySelector('[role="dialog"]');
@@ -75,6 +76,7 @@ test("タスクタイトルが表示される", async () => {
 		columns: testColumns,
 		onClose: vi.fn(),
 		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		const dialog = document.querySelector('[role="dialog"]');
@@ -89,6 +91,7 @@ test("×ボタンクリックでonCloseが呼ばれる", async () => {
 		columns: testColumns,
 		onClose,
 		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(document.querySelector('[aria-label="閉じる"]')).toBeTruthy();
@@ -107,6 +110,7 @@ test("Escキーでパネルが閉じる", async () => {
 		columns: testColumns,
 		onClose,
 		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(document.querySelector('[role="dialog"]')).toBeTruthy();
@@ -124,6 +128,7 @@ test("ラベル追加でonTaskUpdateが呼ばれる", async () => {
 		columns: testColumns,
 		onClose: vi.fn(),
 		onTaskUpdate,
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(
@@ -167,6 +172,7 @@ test("ラベル削除でonTaskUpdateが呼ばれる", async () => {
 		columns: testColumns,
 		onClose: vi.fn(),
 		onTaskUpdate,
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(
@@ -191,6 +197,7 @@ test("オーバーレイクリックでパネルが閉じる", async () => {
 		columns: testColumns,
 		onClose,
 		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		expect(
@@ -207,7 +214,10 @@ test("オーバーレイクリックでパネルが閉じる", async () => {
 test("本文がMarkdownとしてレンダリングされる", async () => {
 	render({
 		task: createTask({ body: "# 見出し\n- リスト項目" }),
+		columns: testColumns,
 		onClose: vi.fn(),
+		onTaskUpdate: vi.fn(),
+		onDelete: vi.fn(),
 	});
 	await vi.waitFor(() => {
 		const panel = document.querySelector('[role="dialog"]');

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ConfirmDialog } from "../../../components/ConfirmDialog";
 import type { Column, Priority, Task } from "../../../types/task";
 import { InlineEdit } from "./InlineEdit";
 import { LabelEditor } from "./LabelEditor";
@@ -7,18 +8,23 @@ import { StatusSelect } from "./StatusSelect";
 
 /** 詳細パネルの Props */
 type DetailPanelProps = {
-  /** 表示するタスク */
-  task: Task;
-  /** 選択肢となるカラム一覧 */
-  columns: Column[];
-  /** パネルを閉じるコールバック */
-  onClose: () => void;
-  /**
-   * タスク更新時のコールバック
-   * @param id - 更新対象のタスクID
-   * @param updates - 更新するフィールド
-   */
-  onTaskUpdate: (id: string, updates: Partial<Omit<Task, "id">>) => void;
+	/** 表示するタスク */
+	task: Task;
+	/** 選択肢となるカラム一覧 */
+	columns: Column[];
+	/** パネルを閉じるコールバック */
+	onClose: () => void;
+	/**
+	 * タスク更新時のコールバック
+	 * @param id - 更新対象のタスクID
+	 * @param updates - 更新するフィールド
+	 */
+	onTaskUpdate: (id: string, updates: Partial<Omit<Task, "id">>) => void;
+	/**
+	 * タスク削除時のコールバック
+	 * @param id - 削除対象のタスクID
+	 */
+	onDelete: (id: string) => void;
 };
 
 /**
@@ -27,135 +33,164 @@ type DetailPanelProps = {
  * @returns パネル要素
  */
 export function DetailPanel({
-  task,
-  columns,
-  onClose,
-  onTaskUpdate,
+	task,
+	columns,
+	onClose,
+	onTaskUpdate,
+	onDelete,
 }: DetailPanelProps) {
-  const panelRef = useRef<HTMLElement>(null);
-  const latestLabelsRef = useRef(task.labels);
-  latestLabelsRef.current = task.labels;
+	const panelRef = useRef<HTMLElement>(null);
+	const latestLabelsRef = useRef(task.labels);
+	latestLabelsRef.current = task.labels;
+	const [showConfirm, setShowConfirm] = useState(false);
 
-  const handleTitleConfirm = useCallback(
-    (title: string) => {
-      onTaskUpdate(task.id, { title });
-    },
-    [task.id, onTaskUpdate],
-  );
+	const handleTitleConfirm = useCallback(
+		(title: string) => {
+			onTaskUpdate(task.id, { title });
+		},
+		[task.id, onTaskUpdate],
+	);
 
-  const handleStatusChange = useCallback(
-    (status: string) => {
-      onTaskUpdate(task.id, { status });
-    },
-    [task.id, onTaskUpdate],
-  );
+	const handleStatusChange = useCallback(
+		(status: string) => {
+			onTaskUpdate(task.id, { status });
+		},
+		[task.id, onTaskUpdate],
+	);
 
-  const handlePriorityChange = useCallback(
-    (priority: Priority | undefined) => {
-      onTaskUpdate(task.id, { priority });
-    },
-    [task.id, onTaskUpdate],
-  );
+	const handlePriorityChange = useCallback(
+		(priority: Priority | undefined) => {
+			onTaskUpdate(task.id, { priority });
+		},
+		[task.id, onTaskUpdate],
+	);
 
-  const handleLabelAdd = useCallback(
-    (label: string) => {
-      const updated = [...latestLabelsRef.current, label];
-      latestLabelsRef.current = updated;
-      onTaskUpdate(task.id, { labels: updated });
-    },
-    [task.id, onTaskUpdate],
-  );
+	const handleLabelAdd = useCallback(
+		(label: string) => {
+			const updated = [...latestLabelsRef.current, label];
+			latestLabelsRef.current = updated;
+			onTaskUpdate(task.id, { labels: updated });
+		},
+		[task.id, onTaskUpdate],
+	);
 
-  const handleLabelRemove = useCallback(
-    (label: string) => {
-      const updated = latestLabelsRef.current.filter((l) => l !== label);
-      latestLabelsRef.current = updated;
-      onTaskUpdate(task.id, { labels: updated });
-    },
-    [task.id, onTaskUpdate],
-  );
+	const handleLabelRemove = useCallback(
+		(label: string) => {
+			const updated = latestLabelsRef.current.filter((l) => l !== label);
+			latestLabelsRef.current = updated;
+			onTaskUpdate(task.id, { labels: updated });
+		},
+		[task.id, onTaskUpdate],
+	);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && !showConfirm) {
+				onClose();
+			}
+		};
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [onClose, showConfirm]);
 
-  useEffect(() => {
-    panelRef.current?.focus();
-  }, []);
+	useEffect(() => {
+		panelRef.current?.focus();
+	}, []);
 
-  return (
-    <>
-      <button
-        type="button"
-        aria-label="詳細パネルを閉じる"
-        className="fixed inset-0 z-40 border-0 bg-black/30 p-0"
-        data-testid="detail-overlay"
-        onClick={onClose}
-      />
-      <aside
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label="タスク詳細"
-        tabIndex={-1}
-        className="fixed top-0 right-0 z-50 flex h-full w-[480px] max-w-full animate-slide-in flex-col bg-white shadow-xl"
-      >
-        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-          <div className="min-w-0 flex-1">
-            <InlineEdit
-              value={task.title || task.filePath}
-              onConfirm={handleTitleConfirm}
-            />
-          </div>
-          <button
-            type="button"
-            aria-label="閉じる"
-            className="ml-2 shrink-0 rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
-            onClick={onClose}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
-        </div>
-        <div className="flex-1 overflow-y-auto p-4">
-          <div className="flex flex-col gap-4">
-            <div className="flex gap-4">
-              <StatusSelect
-                value={task.status}
-                columns={columns}
-                onChange={handleStatusChange}
-              />
-              <PrioritySelect
-                value={task.priority}
-                onChange={handlePriorityChange}
-              />
-            </div>
-            <LabelEditor
-              labels={task.labels}
-              onAdd={handleLabelAdd}
-              onRemove={handleLabelRemove}
-            />
-            <p className="text-sm text-gray-600">{task.body}</p>
-          </div>
-        </div>
-      </aside>
-    </>
-  );
+	return (
+		<>
+			<button
+				type="button"
+				aria-label="詳細パネルを閉じる"
+				className="fixed inset-0 z-40 border-0 bg-black/30 p-0"
+				data-testid="detail-overlay"
+				onClick={onClose}
+			/>
+			<aside
+				ref={panelRef}
+				role="dialog"
+				aria-modal="true"
+				aria-label="タスク詳細"
+				tabIndex={-1}
+				className="fixed top-0 right-0 z-50 flex h-full w-[480px] max-w-full animate-slide-in flex-col bg-white shadow-xl"
+			>
+				<div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+					<div className="min-w-0 flex-1">
+						<InlineEdit
+							value={task.title || task.filePath}
+							onConfirm={handleTitleConfirm}
+						/>
+					</div>
+					<button
+						type="button"
+						aria-label="閉じる"
+						className="ml-2 shrink-0 rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+						onClick={onClose}
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							className="h-5 w-5"
+							viewBox="0 0 20 20"
+							fill="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								fillRule="evenodd"
+								d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+								clipRule="evenodd"
+							/>
+						</svg>
+					</button>
+				</div>
+				<div className="flex-1 overflow-y-auto p-4">
+					<div className="flex flex-col gap-4">
+						<div className="flex gap-4">
+							<StatusSelect
+								value={task.status}
+								columns={columns}
+								onChange={handleStatusChange}
+							/>
+							<PrioritySelect
+								value={task.priority}
+								onChange={handlePriorityChange}
+							/>
+						</div>
+						<LabelEditor
+							labels={task.labels}
+							onAdd={handleLabelAdd}
+							onRemove={handleLabelRemove}
+						/>
+						<p className="text-sm text-gray-600">{task.body}</p>
+					</div>
+				</div>
+				<div className="border-t border-gray-200 px-4 py-3">
+					<p
+						className="mb-3 truncate text-xs text-gray-400"
+						data-testid="detail-file-path"
+					>
+						{task.filePath}
+					</p>
+					<button
+						type="button"
+						className="w-full rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
+						data-testid="detail-delete-button"
+						onClick={() => setShowConfirm(true)}
+					>
+						削除
+					</button>
+				</div>
+			</aside>
+			{showConfirm && (
+				<ConfirmDialog
+					title="タスクの削除"
+					message={`「${task.title || task.filePath}」を削除しますか？この操作は取り消せません。`}
+					confirmLabel="削除"
+					onConfirm={() => {
+						onDelete(task.id);
+					}}
+					onCancel={() => setShowConfirm(false)}
+				/>
+			)}
+		</>
+	);
 }

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -194,11 +194,11 @@ export function DetailPanel({
 						setIsDeleting(true);
 						try {
 							await onDelete(task.id);
+							setShowConfirm(false);
 						} catch {
-							// エラー時のみ削除中状態を解除（再試行可能にする）
+							// エラー時はダイアログを開いたまま再試行可能にする
 						} finally {
 							setIsDeleting(false);
-							setShowConfirm(false);
 						}
 					}}
 					onCancel={() => {

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -187,14 +187,18 @@ export function DetailPanel({
 					title="タスクの削除"
 					message={`「${task.title || task.filePath}」を削除しますか？この操作は取り消せません。`}
 					confirmLabel={isDeleting ? "削除中…" : "削除"}
+					confirmDisabled={isDeleting}
+					cancelDisabled={isDeleting}
 					onConfirm={async () => {
 						if (isDeleting) return;
 						setIsDeleting(true);
 						try {
 							await onDelete(task.id);
-							setShowConfirm(false);
 						} catch {
+							// エラー時のみ削除中状態を解除（再試行可能にする）
+						} finally {
 							setIsDeleting(false);
+							setShowConfirm(false);
 						}
 					}}
 					onCancel={() => {

--- a/src/features/detail/components/DetailPanel.tsx
+++ b/src/features/detail/components/DetailPanel.tsx
@@ -3,6 +3,7 @@ import { ConfirmDialog } from "../../../components/ConfirmDialog";
 import type { Column, Priority, Task } from "../../../types/task";
 import { InlineEdit } from "./InlineEdit";
 import { LabelEditor } from "./LabelEditor";
+import { MarkdownBody } from "./MarkdownBody";
 import { PrioritySelect } from "./PrioritySelect";
 import { StatusSelect } from "./StatusSelect";
 
@@ -24,7 +25,7 @@ type DetailPanelProps = {
 	 * タスク削除時のコールバック
 	 * @param id - 削除対象のタスクID
 	 */
-	onDelete: (id: string) => void;
+	onDelete: (id: string) => void | Promise<void>;
 };
 
 /**
@@ -43,6 +44,7 @@ export function DetailPanel({
 	const latestLabelsRef = useRef(task.labels);
 	latestLabelsRef.current = task.labels;
 	const [showConfirm, setShowConfirm] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
 
 	const handleTitleConfirm = useCallback(
 		(title: string) => {
@@ -160,7 +162,7 @@ export function DetailPanel({
 							onAdd={handleLabelAdd}
 							onRemove={handleLabelRemove}
 						/>
-						<p className="text-sm text-gray-600">{task.body}</p>
+						<MarkdownBody body={task.body} />
 					</div>
 				</div>
 				<div className="border-t border-gray-200 px-4 py-3">
@@ -184,11 +186,20 @@ export function DetailPanel({
 				<ConfirmDialog
 					title="タスクの削除"
 					message={`「${task.title || task.filePath}」を削除しますか？この操作は取り消せません。`}
-					confirmLabel="削除"
-					onConfirm={() => {
-						onDelete(task.id);
+					confirmLabel={isDeleting ? "削除中…" : "削除"}
+					onConfirm={async () => {
+						if (isDeleting) return;
+						setIsDeleting(true);
+						try {
+							await onDelete(task.id);
+							setShowConfirm(false);
+						} catch {
+							setIsDeleting(false);
+						}
 					}}
-					onCancel={() => setShowConfirm(false)}
+					onCancel={() => {
+						if (!isDeleting) setShowConfirm(false);
+					}}
 				/>
 			)}
 		</>


### PR DESCRIPTION
## Summary
- 共通UIコンポーネント `ConfirmDialog` を `src/components/` に追加（タイトル・メッセージ・確定/キャンセルボタン、Esc/オーバーレイで閉じる）
- 詳細パネル下部に「削除」ボタンとファイルパス表示を追加
- 削除ボタンクリックで ConfirmDialog を表示し、確定で `deleteTask` API を呼び出してパネルを閉じる

## Changes
- `src/components/ConfirmDialog.tsx` — 新規: 確認ダイアログ共通コンポーネント
- `src/features/detail/components/DetailPanel.tsx` — 削除ボタン・ファイルパス表示・ConfirmDialog統合
- `src/App.tsx` — `handleTaskDelete` コールバック追加、`onDelete` prop接続

## Test
```bash
pnpm test:run
```
- ConfirmDialog: 6テスト（表示、確定、キャンセル、オーバーレイ、Esc、カスタムラベル）
- DetailPanel削除: 4テスト（ダイアログ表示、確定で削除、キャンセルで閉じ、ファイルパス表示）
- 既存テスト: onDelete prop追加で全テスト通過

Automated by task-loop-run
