### PR TITLE
feat: トースト通知コンポーネント

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { ToastContainer, useToasts } from "./components/Toast";
 import { Board, EmptyState, HeaderBar } from "./features/board";
 import { DetailPanel } from "./features/detail";
 import { deleteTask, getColumns, getTasks, updateTask } from "./lib/api";
@@ -6,6 +7,7 @@ import type { Column, Task } from "./types/task";
 
 /**
  * @returns {JSX.Element} アプリケーションのルートレイアウトシェル
+ * @throws タスクの更新・削除 API が失敗したときに呼び出し側へエラーを再送出する
  */
 function App() {
 	const [projectPath, setProjectPath] = useState<string | null>(null);
@@ -13,6 +15,7 @@ function App() {
 	const [columns, setColumns] = useState<Column[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
 	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+	const { toasts, showToast, dismissToast } = useToasts();
 
 	const selectedTask = selectedTaskId
 		? (tasks.find((t) => t.id === selectedTaskId) ?? null)
@@ -32,17 +35,31 @@ function App() {
 
 	const handleTaskUpdate = useCallback(
 		async (id: string, updates: Partial<Omit<Task, "id">>) => {
-			const updated = await updateTask(id, updates);
-			setTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+			try {
+				const updated = await updateTask(id, updates);
+				setTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+			} catch {
+				showToast("タスクの更新に失敗しました", "error");
+				throw new Error("タスクの更新に失敗しました");
+			}
 		},
-		[],
+		[showToast],
 	);
 
-	const handleTaskDelete = useCallback(async (id: string) => {
-		await deleteTask(id);
-		setTasks((prev) => prev.filter((t) => t.id !== id));
-		setSelectedTaskId(null);
-	}, []);
+	const handleTaskDelete = useCallback(
+		async (id: string) => {
+			try {
+				await deleteTask(id);
+				setTasks((prev) => prev.filter((t) => t.id !== id));
+				setSelectedTaskId(null);
+				showToast("タスクを削除しました", "success");
+			} catch {
+				showToast("タスクの削除に失敗しました", "error");
+				throw new Error("タスクの削除に失敗しました");
+			}
+		},
+		[showToast],
+	);
 
 	useEffect(() => {
 		if (projectPath === null) return;
@@ -92,6 +109,7 @@ function App() {
 					onDelete={handleTaskDelete}
 				/>
 			)}
+			<ToastContainer toasts={toasts} onDismiss={dismissToast} />
 		</div>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import type { Column, Task } from "./types/task";
 
 /**
  * @returns {JSX.Element} アプリケーションのルートレイアウトシェル
- * @throws タスクの更新・削除 API が失敗したときに呼び出し側へエラーを再送出する
  */
 function App() {
 	const [projectPath, setProjectPath] = useState<string | null>(null);
@@ -38,9 +37,9 @@ function App() {
 			try {
 				const updated = await updateTask(id, updates);
 				setTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+				showToast("タスクを更新しました", "success");
 			} catch {
 				showToast("タスクの更新に失敗しました", "error");
-				throw new Error("タスクの更新に失敗しました");
 			}
 		},
 		[showToast],
@@ -55,7 +54,6 @@ function App() {
 				showToast("タスクを削除しました", "success");
 			} catch {
 				showToast("タスクの削除に失敗しました", "error");
-				throw new Error("タスクの削除に失敗しました");
 			}
 		},
 		[showToast],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,16 +46,18 @@ function App() {
 	);
 
 	const handleTaskDelete = useCallback(
-		async (id: string) => {
-			try {
-				await deleteTask(id);
-				setTasks((prev) => prev.filter((t) => t.id !== id));
-				setSelectedTaskId(null);
-				showToast("タスクを削除しました", "success");
-			} catch {
-				showToast("タスクの削除に失敗しました", "error");
-			}
-		},
+		(id: string): Promise<void> =>
+			deleteTask(id).then(
+				() => {
+					setTasks((prev) => prev.filter((t) => t.id !== id));
+					setSelectedTaskId(null);
+					showToast("タスクを削除しました", "success");
+				},
+				(error: unknown) => {
+					showToast("タスクの削除に失敗しました", "error");
+					return Promise.reject(error);
+				},
+			),
 		[showToast],
 	);
 

--- a/src/components/Toast.interaction.test.tsx
+++ b/src/components/Toast.interaction.test.tsx
@@ -1,4 +1,4 @@
-import { act, createElement } from "react";
+import { act, createElement, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import {
@@ -6,6 +6,9 @@ import {
 	Toast,
 	ToastContainer,
 	type ToastItem,
+	type ToastType,
+	type UseToastsResult,
+	useToasts,
 } from "./Toast";
 
 let container: HTMLDivElement | null = null;
@@ -154,4 +157,121 @@ test("複数のトーストがスタック表示される", () => {
 	expect(items[0].getAttribute("data-toast-id")).toBe("a");
 	expect(items[1].getAttribute("data-toast-id")).toBe("b");
 	expect(items[2].getAttribute("data-toast-id")).toBe("c");
+});
+
+/**
+ * useToasts フックの戻り値を外部に公開するテスト用コンポーネント。
+ * @param props - フック値を受け取るコールバック
+ * @returns null（描画は行わない）
+ */
+function UseToastsProbe({
+	onResult,
+}: {
+	onResult: (result: UseToastsResult) => void;
+}) {
+	const result = useToasts();
+	useEffect(() => {
+		onResult(result);
+	});
+	return null;
+}
+
+test("useToasts: showToast でトーストが追加され末尾に積まれる", () => {
+	let latest: UseToastsResult | null = null;
+	render(
+		createElement(UseToastsProbe, {
+			onResult: (r) => {
+				latest = r;
+			},
+		}),
+	);
+	expect(latest).not.toBeNull();
+	const probe = latest as unknown as UseToastsResult;
+
+	act(() => {
+		probe.showToast("1件目", "success" satisfies ToastType);
+	});
+	expect((latest as unknown as UseToastsResult).toasts.length).toBe(1);
+	expect((latest as unknown as UseToastsResult).toasts[0].message).toBe(
+		"1件目",
+	);
+	expect((latest as unknown as UseToastsResult).toasts[0].type).toBe("success");
+
+	act(() => {
+		(latest as unknown as UseToastsResult).showToast(
+			"2件目",
+			"error" satisfies ToastType,
+		);
+	});
+	const toasts = (latest as unknown as UseToastsResult).toasts;
+	expect(toasts.length).toBe(2);
+	expect(toasts[1].message).toBe("2件目");
+	expect(toasts[1].type).toBe("error");
+});
+
+test("useToasts: showToast は毎回ユニークな ID を生成する", () => {
+	let latest: UseToastsResult | null = null;
+	render(
+		createElement(UseToastsProbe, {
+			onResult: (r) => {
+				latest = r;
+			},
+		}),
+	);
+	const probe = latest as unknown as UseToastsResult;
+	act(() => {
+		probe.showToast("a", "success");
+		probe.showToast("b", "success");
+		probe.showToast("c", "success");
+	});
+	const ids = (latest as unknown as UseToastsResult).toasts.map((t) => t.id);
+	expect(new Set(ids).size).toBe(ids.length);
+});
+
+test("useToasts: dismissToast で指定 ID のみが取り除かれる", () => {
+	let latest: UseToastsResult | null = null;
+	render(
+		createElement(UseToastsProbe, {
+			onResult: (r) => {
+				latest = r;
+			},
+		}),
+	);
+	const probe = latest as unknown as UseToastsResult;
+	act(() => {
+		probe.showToast("a", "success");
+		probe.showToast("b", "success");
+		probe.showToast("c", "success");
+	});
+	const targetId = (latest as unknown as UseToastsResult).toasts[1].id;
+	act(() => {
+		(latest as unknown as UseToastsResult).dismissToast(targetId);
+	});
+	const remaining = (latest as unknown as UseToastsResult).toasts;
+	expect(remaining.length).toBe(2);
+	expect(remaining.some((t) => t.id === targetId)).toBe(false);
+	expect(remaining[0].message).toBe("a");
+	expect(remaining[1].message).toBe("c");
+});
+
+test("useToasts: 存在しない ID の dismissToast は配列に影響しない", () => {
+	let latest: UseToastsResult | null = null;
+	render(
+		createElement(UseToastsProbe, {
+			onResult: (r) => {
+				latest = r;
+			},
+		}),
+	);
+	const probe = latest as unknown as UseToastsResult;
+	act(() => {
+		probe.showToast("a", "success");
+	});
+	const before = (latest as unknown as UseToastsResult).toasts;
+	act(() => {
+		(latest as unknown as UseToastsResult).dismissToast("not-exist");
+	});
+	const after = (latest as unknown as UseToastsResult).toasts;
+	expect(after.length).toBe(before.length);
+	expect(after[0].id).toBe(before[0].id);
 });

--- a/src/components/Toast.interaction.test.tsx
+++ b/src/components/Toast.interaction.test.tsx
@@ -1,0 +1,157 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+	TOAST_DEFAULT_DURATION_MS,
+	Toast,
+	ToastContainer,
+	type ToastItem,
+} from "./Toast";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+	vi.useRealTimers();
+});
+
+/**
+ * コンポーネントをレンダリングするヘルパー
+ * @param element - レンダリング対象の React 要素
+ */
+function render(element: ReturnType<typeof createElement>) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(element);
+	});
+}
+
+/**
+ * テスト用の ToastItem を生成する
+ * @param overrides - 上書きするフィールド
+ * @returns テスト用 ToastItem
+ */
+function createToast(overrides: Partial<ToastItem> = {}): ToastItem {
+	return {
+		id: "toast-1",
+		message: "メッセージ",
+		type: "success",
+		...overrides,
+	};
+}
+
+test("successタイプのトーストが緑系で表示される", () => {
+	render(
+		createElement(Toast, {
+			toast: createToast({ type: "success", message: "保存しました" }),
+			onDismiss: vi.fn(),
+		}),
+	);
+	const el = document.querySelector('[data-testid="toast-success"]');
+	expect(el).toBeTruthy();
+	expect(el?.textContent).toBe("保存しました");
+	expect(el?.className).toContain("bg-green-600");
+});
+
+test("errorタイプのトーストが赤系で表示されaria-liveがassertive", () => {
+	render(
+		createElement(Toast, {
+			toast: createToast({ type: "error", message: "失敗しました" }),
+			onDismiss: vi.fn(),
+		}),
+	);
+	const el = document.querySelector('[data-testid="toast-error"]');
+	expect(el).toBeTruthy();
+	expect(el?.className).toContain("bg-red-600");
+	expect(el?.getAttribute("role")).toBe("alert");
+	expect(el?.getAttribute("aria-live")).toBe("assertive");
+});
+
+test("warningタイプのトーストが黄系で表示される", () => {
+	render(
+		createElement(Toast, {
+			toast: createToast({ type: "warning", message: "注意" }),
+			onDismiss: vi.fn(),
+		}),
+	);
+	const el = document.querySelector('[data-testid="toast-warning"]');
+	expect(el).toBeTruthy();
+	expect(el?.className).toContain("bg-yellow-500");
+});
+
+test("デフォルトで3秒後にonDismissが呼ばれる", () => {
+	const onDismiss = vi.fn();
+	render(
+		createElement(Toast, {
+			toast: createToast({ id: "t-auto" }),
+			onDismiss,
+		}),
+	);
+	expect(onDismiss).not.toHaveBeenCalled();
+	act(() => {
+		vi.advanceTimersByTime(TOAST_DEFAULT_DURATION_MS);
+	});
+	expect(onDismiss).toHaveBeenCalledWith("t-auto");
+});
+
+test("duration指定時はその時間経過後にonDismissが呼ばれる", () => {
+	const onDismiss = vi.fn();
+	render(
+		createElement(Toast, {
+			toast: createToast({ id: "t-custom" }),
+			onDismiss,
+			duration: 500,
+		}),
+	);
+	act(() => {
+		vi.advanceTimersByTime(499);
+	});
+	expect(onDismiss).not.toHaveBeenCalled();
+	act(() => {
+		vi.advanceTimersByTime(1);
+	});
+	expect(onDismiss).toHaveBeenCalledWith("t-custom");
+});
+
+test("ToastContainerは空配列のときは何も描画しない", () => {
+	render(
+		createElement(ToastContainer, {
+			toasts: [],
+			onDismiss: vi.fn(),
+		}),
+	);
+	expect(document.querySelector('[data-testid="toast-container"]')).toBeNull();
+});
+
+test("複数のトーストがスタック表示される", () => {
+	const toasts: ToastItem[] = [
+		{ id: "a", message: "1件目", type: "success" },
+		{ id: "b", message: "2件目", type: "error" },
+		{ id: "c", message: "3件目", type: "warning" },
+	];
+	render(
+		createElement(ToastContainer, {
+			toasts,
+			onDismiss: vi.fn(),
+		}),
+	);
+	const containerEl = document.querySelector('[data-testid="toast-container"]');
+	expect(containerEl).toBeTruthy();
+	const items = containerEl?.querySelectorAll("[data-toast-id]") ?? [];
+	expect(items.length).toBe(3);
+	expect(items[0].getAttribute("data-toast-id")).toBe("a");
+	expect(items[1].getAttribute("data-toast-id")).toBe("b");
+	expect(items[2].getAttribute("data-toast-id")).toBe("c");
+});

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type ToastType = "success" | "error" | "warning";
+
+export type ToastItem = {
+	id: string;
+	message: string;
+	type: ToastType;
+};
+
+export const TOAST_DEFAULT_DURATION_MS = 3000;
+
+const typeStyles: Record<ToastType, string> = {
+	success: "bg-green-600 text-white",
+	error: "bg-red-600 text-white",
+	warning: "bg-yellow-500 text-gray-900",
+};
+
+type ToastProps = {
+	/** 表示するトースト */
+	toast: ToastItem;
+	/**
+	 * 自動・手動クローズ時に呼ばれるコールバック
+	 * @param id - 閉じるトーストの ID
+	 */
+	onDismiss: (id: string) => void;
+	/** 自動で閉じるまでの時間（ミリ秒）。デフォルト {@link TOAST_DEFAULT_DURATION_MS} */
+	duration?: number;
+};
+
+/**
+ * 単一のトーストを描画するコンポーネント。
+ * duration 経過後に onDismiss を呼ぶ。
+ * @param props - {@link ToastProps}
+ * @returns トースト要素
+ */
+export function Toast({
+	toast,
+	onDismiss,
+	duration = TOAST_DEFAULT_DURATION_MS,
+}: ToastProps) {
+	useEffect(() => {
+		const timer = setTimeout(() => onDismiss(toast.id), duration);
+		return () => clearTimeout(timer);
+	}, [toast.id, onDismiss, duration]);
+
+	const isError = toast.type === "error";
+
+	return (
+		<div
+			role={isError ? "alert" : "status"}
+			aria-live={isError ? "assertive" : "polite"}
+			data-testid={`toast-${toast.type}`}
+			data-toast-id={toast.id}
+			className={`min-w-[240px] rounded-md px-4 py-2 text-sm shadow-lg ${typeStyles[toast.type]}`}
+		>
+			{toast.message}
+		</div>
+	);
+}
+
+type ToastContainerProps = {
+	/** 表示中のトースト一覧（配列順＝上から下に積まれる） */
+	toasts: ToastItem[];
+	/**
+	 * トーストを閉じるコールバック
+	 * @param id - 閉じるトーストの ID
+	 */
+	onDismiss: (id: string) => void;
+	/** 各トーストを閉じるまでの時間（ミリ秒） */
+	duration?: number;
+};
+
+/**
+ * 複数のトーストを画面右上に縦スタックで描画するコンテナ。
+ * toasts が空の場合は何も描画しない。
+ * @param props - {@link ToastContainerProps}
+ * @returns コンテナ要素、または null
+ */
+export function ToastContainer({
+	toasts,
+	onDismiss,
+	duration,
+}: ToastContainerProps) {
+	if (toasts.length === 0) return null;
+	return (
+		<div
+			className="pointer-events-none fixed top-4 right-4 z-[80] flex flex-col gap-2"
+			data-testid="toast-container"
+		>
+			{toasts.map((toast) => (
+				<div key={toast.id} className="pointer-events-auto">
+					<Toast toast={toast} onDismiss={onDismiss} duration={duration} />
+				</div>
+			))}
+		</div>
+	);
+}
+
+export type UseToastsResult = {
+	/** 現在表示中のトースト一覧 */
+	toasts: ToastItem[];
+	/**
+	 * 新しいトーストを表示する
+	 * @param message - 表示するメッセージ
+	 * @param type - トーストの種類
+	 */
+	showToast: (message: string, type: ToastType) => void;
+	/**
+	 * 指定した ID のトーストを閉じる
+	 * @param id - 閉じるトーストの ID
+	 */
+	dismissToast: (id: string) => void;
+};
+
+/**
+ * App レベルでトースト状態を管理するフック。
+ * @returns トースト配列と表示/クローズ関数
+ */
+export function useToasts(): UseToastsResult {
+	const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+	const showToast = useCallback((message: string, type: ToastType) => {
+		const id = crypto.randomUUID();
+		setToasts((prev) => [...prev, { id, message, type }]);
+	}, []);
+
+	const dismissToast = useCallback((id: string) => {
+		setToasts((prev) => prev.filter((t) => t.id !== id));
+	}, []);
+
+	return { toasts, showToast, dismissToast };
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -20,7 +20,7 @@ type ToastProps = {
 	/** 表示するトースト */
 	toast: ToastItem;
 	/**
-	 * 自動・手動クローズ時に呼ばれるコールバック
+	 * 自動クローズ時に呼ばれるコールバック
 	 * @param id - 閉じるトーストの ID
 	 */
 	onDismiss: (id: string) => void;

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -97,6 +97,26 @@ export function ToastContainer({
 	);
 }
 
+/**
+ * トースト ID を生成する。
+ * crypto.randomUUID が使える環境ではそれを使い、未対応環境では
+ * crypto.getRandomValues を使った簡易フォールバックを使う。
+ * @returns 衝突の可能性が極めて低い文字列 ID
+ */
+function generateToastId(): string {
+	const c: Crypto | undefined =
+		typeof crypto !== "undefined" ? crypto : undefined;
+	if (c?.randomUUID) {
+		return c.randomUUID();
+	}
+	if (c?.getRandomValues) {
+		const bytes = new Uint8Array(16);
+		c.getRandomValues(bytes);
+		return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+	}
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 export type UseToastsResult = {
 	/** 現在表示中のトースト一覧 */
 	toasts: ToastItem[];
@@ -121,7 +141,7 @@ export function useToasts(): UseToastsResult {
 	const [toasts, setToasts] = useState<ToastItem[]>([]);
 
 	const showToast = useCallback((message: string, type: ToastType) => {
-		const id = crypto.randomUUID();
+		const id = generateToastId();
 		setToasts((prev) => [...prev, { id, message, type }]);
 	}, []);
 


### PR DESCRIPTION
## 概要

操作結果やエラーを表示するトースト通知コンポーネントを追加し、App レベルで状態を管理する仕組みを整備した。

## 変更内容

- `src/components/Toast.tsx` を新規追加
  - `Toast`: 単一のトースト。`success` / `error` / `warning` の 3 種類で色分け。`role` と `aria-live` を種別に応じて付与し、デフォルト 3 秒で自動的に閉じる
  - `ToastContainer`: 画面右上に縦スタックでトーストを描画。空配列時は何も描画しない
  - `useToasts`: App レベルで表示中トースト配列・`showToast` / `dismissToast` を提供するフック
- `src/App.tsx` に `useToasts` を組み込み、`ToastContainer` をルートにマウント。タスク更新／削除の成功・失敗時にトーストを発火
- `src/components/Toast.interaction.test.tsx` で種別ごとの描画、自動クローズのタイマー挙動、スタック表示をカバー

## テスト

```bash
pnpm test:run
pnpm run build
```

Automated by task-loop-run
