### PR TITLE
feat: タスク作成モーダル

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 import { ToastContainer, useToasts } from "./components/Toast";
 import { Board, EmptyState, HeaderBar } from "./features/board";
 import { DetailPanel } from "./features/detail";
-import { deleteTask, getColumns, getTasks, updateTask } from "./lib/api";
+import { TaskCreateModal, type TaskFormValues } from "./features/task-form";
+import {
+	createTask,
+	deleteTask,
+	getColumns,
+	getTasks,
+	updateTask,
+} from "./lib/api";
 import type { Column, Task } from "./types/task";
 
 /**
@@ -14,6 +21,9 @@ function App() {
 	const [columns, setColumns] = useState<Column[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
 	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+	const [createModalStatus, setCreateModalStatus] = useState<string | null>(
+		null,
+	);
 	const { toasts, showToast, dismissToast } = useToasts();
 
 	const selectedTask = selectedTaskId
@@ -40,6 +50,33 @@ function App() {
 				showToast("タスクを更新しました", "success");
 			} catch {
 				showToast("タスクの更新に失敗しました", "error");
+			}
+		},
+		[showToast],
+	);
+
+	const handleAddTask = useCallback((columnName: string) => {
+		setCreateModalStatus(columnName);
+	}, []);
+
+	const handleCloseCreateModal = useCallback(() => {
+		setCreateModalStatus(null);
+	}, []);
+
+	/**
+	 * 新規タスクの作成。成功時は一覧を更新しトーストを表示、失敗時はトースト表示のうえ呼び出し元へ再 throw する。
+	 * @param values - タスク作成フォームの入力値
+	 * @throws createTask API 呼び出しが失敗した場合
+	 */
+	const handleCreateTask = useCallback(
+		async (values: TaskFormValues) => {
+			try {
+				const created = await createTask(values);
+				setTasks((prev) => [...prev, created]);
+				showToast("タスクを作成しました", "success");
+			} catch (error) {
+				showToast("タスクの作成に失敗しました", "error");
+				throw error;
 			}
 		},
 		[showToast],
@@ -95,7 +132,7 @@ function App() {
 					<Board
 						columns={columns}
 						tasks={tasks}
-						onAddTask={() => {}}
+						onAddTask={handleAddTask}
 						onTaskClick={handleTaskClick}
 					/>
 				)}
@@ -107,6 +144,14 @@ function App() {
 					onClose={handleCloseDetail}
 					onTaskUpdate={handleTaskUpdate}
 					onDelete={handleTaskDelete}
+				/>
+			)}
+			{createModalStatus !== null && (
+				<TaskCreateModal
+					columns={columns}
+					initialStatus={createModalStatus}
+					onSubmit={handleCreateTask}
+					onClose={handleCloseCreateModal}
 				/>
 			)}
 			<ToastContainer toasts={toasts} onDismiss={dismissToast} />

--- a/src/features/task-form/components/TaskCreateModal.interaction.test.tsx
+++ b/src/features/task-form/components/TaskCreateModal.interaction.test.tsx
@@ -1,0 +1,218 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Column } from "../../../types/task";
+import { TaskCreateModal } from "./TaskCreateModal";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+const COLUMNS: Column[] = [
+	{ name: "Todo", order: 0 },
+	{ name: "In Progress", order: 1 },
+	{ name: "Done", order: 2 },
+];
+
+/**
+ * TaskCreateModal をレンダリングするヘルパー
+ * @param props - TaskCreateModal に渡す props
+ */
+function render(props: Parameters<typeof TaskCreateModal>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(TaskCreateModal, props));
+	});
+}
+
+/**
+ * 指定した input の value を変更して change イベントを発火する
+ * @param el - 対象要素
+ * @param value - 設定する値
+ */
+function changeValue(el: HTMLInputElement, value: string) {
+	const setter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		"value",
+	)?.set;
+	setter?.call(el, value);
+	el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/**
+ * マイクロタスクキューを flush するユーティリティ
+ */
+async function flush() {
+	await act(async () => {
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+}
+
+test("モーダルが開きダイアログが表示される", () => {
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit: vi.fn(),
+		onClose: vi.fn(),
+	});
+	expect(
+		document.querySelector('[data-testid="task-create-dialog"]'),
+	).toBeTruthy();
+	expect(
+		document.querySelector('[data-testid="task-create-overlay"]'),
+	).toBeTruthy();
+});
+
+test("ステータス初期値が作成元カラムのステータスになる", () => {
+	render({
+		columns: COLUMNS,
+		initialStatus: "In Progress",
+		onSubmit: vi.fn(),
+		onClose: vi.fn(),
+	});
+	const status = document.querySelector(
+		'[data-testid="task-form-status"]',
+	) as HTMLSelectElement;
+	expect(status.value).toBe("In Progress");
+});
+
+test("タイトル入力して送信すると onSubmit が呼ばれ成功でモーダルが閉じる", async () => {
+	const onSubmit = vi.fn().mockResolvedValue(undefined);
+	const onClose = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onClose,
+	});
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(title, "新しいタスク");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	await flush();
+	expect(onSubmit).toHaveBeenCalledOnce();
+	expect(onSubmit.mock.calls[0][0].title).toBe("新しいタスク");
+	expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("onSubmit が reject するとモーダルは閉じない", async () => {
+	const onSubmit = vi.fn().mockRejectedValue(new Error("fail"));
+	const onClose = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onClose,
+	});
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(title, "T");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	await flush();
+	expect(onSubmit).toHaveBeenCalledOnce();
+	expect(onClose).not.toHaveBeenCalled();
+	expect(
+		document.querySelector('[data-testid="task-create-dialog"]'),
+	).toBeTruthy();
+});
+
+test("Esc キーで onClose が呼ばれる", () => {
+	const onClose = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit: vi.fn(),
+		onClose,
+	});
+	act(() => {
+		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+	});
+	expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("オーバーレイクリックで onClose が呼ばれる", () => {
+	const onClose = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit: vi.fn(),
+		onClose,
+	});
+	const overlay = document.querySelector(
+		'[data-testid="task-create-overlay"]',
+	) as HTMLElement;
+	act(() => {
+		overlay.click();
+	});
+	expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("キャンセルボタンで onClose が呼ばれる", () => {
+	const onClose = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit: vi.fn(),
+		onClose,
+	});
+	const cancel = document.querySelector(
+		'[data-testid="task-form-cancel"]',
+	) as HTMLButtonElement;
+	act(() => {
+		cancel.click();
+	});
+	expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("タイトル空で送信するとバリデーションエラー表示で onSubmit は呼ばれない", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onClose: vi.fn(),
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	expect(
+		document.querySelector('[data-testid="task-form-title-error"]'),
+	).toBeTruthy();
+	expect(onSubmit).not.toHaveBeenCalled();
+});

--- a/src/features/task-form/components/TaskCreateModal.interaction.test.tsx
+++ b/src/features/task-form/components/TaskCreateModal.interaction.test.tsx
@@ -36,7 +36,8 @@ function render(props: Parameters<typeof TaskCreateModal>[0]) {
 }
 
 /**
- * 指定した input の value を変更して change イベントを発火する
+ * 指定した input の value を変更して input イベントを発火する
+ * （React の onChange は text input の input イベントで発火するため）
  * @param el - 対象要素
  * @param value - 設定する値
  */

--- a/src/features/task-form/components/TaskCreateModal.tsx
+++ b/src/features/task-form/components/TaskCreateModal.tsx
@@ -32,6 +32,7 @@ export function TaskCreateModal({
 }: TaskCreateModalProps) {
 	const dialogRef = useRef<HTMLDivElement>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const submittingRef = useRef(false);
 	const id = useId();
 	const titleId = `${id}-title`;
 
@@ -41,17 +42,18 @@ export function TaskCreateModal({
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape" && !isSubmitting) {
+			if (e.key === "Escape" && !submittingRef.current) {
 				onClose();
 			}
 		};
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [onClose, isSubmitting]);
+	}, [onClose]);
 
 	const handleSubmit = useCallback(
 		async (values: TaskFormValues) => {
-			if (isSubmitting) return;
+			if (submittingRef.current) return;
+			submittingRef.current = true;
 			setIsSubmitting(true);
 			try {
 				await onSubmit(values);
@@ -59,16 +61,17 @@ export function TaskCreateModal({
 			} catch {
 				// 親側で通知済み。モーダルは開いたままにする。
 			} finally {
+				submittingRef.current = false;
 				setIsSubmitting(false);
 			}
 		},
-		[isSubmitting, onSubmit, onClose],
+		[onSubmit, onClose],
 	);
 
 	const handleOverlayClick = useCallback(() => {
-		if (isSubmitting) return;
+		if (submittingRef.current) return;
 		onClose();
-	}, [isSubmitting, onClose]);
+	}, [onClose]);
 
 	return (
 		<>

--- a/src/features/task-form/components/TaskCreateModal.tsx
+++ b/src/features/task-form/components/TaskCreateModal.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import type { Column } from "../../../types/task";
+import { TaskForm, type TaskFormValues } from "./TaskForm";
+
+type TaskCreateModalProps = {
+	/** 選択肢となるカラム一覧 */
+	columns: Column[];
+	/** 初期ステータス（作成元カラム） */
+	initialStatus: string;
+	/**
+	 * 送信時のコールバック。reject した場合モーダルは閉じない。
+	 * 親側でトースト通知などのエラーハンドリングを行う想定。
+	 * @param values - フォームの入力値
+	 */
+	onSubmit: (values: TaskFormValues) => Promise<void>;
+	/** モーダルを閉じるコールバック（キャンセル・Esc・オーバーレイクリック） */
+	onClose: () => void;
+};
+
+/**
+ * タスク作成用モーダルダイアログ。
+ * TaskForm を内包し、送信成功時に自動で閉じる。
+ *
+ * @param props - {@link TaskCreateModalProps}
+ * @returns モーダル要素
+ */
+export function TaskCreateModal({
+	columns,
+	initialStatus,
+	onSubmit,
+	onClose,
+}: TaskCreateModalProps) {
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const id = useId();
+	const titleId = `${id}-title`;
+
+	useEffect(() => {
+		dialogRef.current?.focus();
+	}, []);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && !isSubmitting) {
+				onClose();
+			}
+		};
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [onClose, isSubmitting]);
+
+	const handleSubmit = useCallback(
+		async (values: TaskFormValues) => {
+			if (isSubmitting) return;
+			setIsSubmitting(true);
+			try {
+				await onSubmit(values);
+				onClose();
+			} catch {
+				// 親側で通知済み。モーダルは開いたままにする。
+			} finally {
+				setIsSubmitting(false);
+			}
+		},
+		[isSubmitting, onSubmit, onClose],
+	);
+
+	const handleOverlayClick = useCallback(() => {
+		if (isSubmitting) return;
+		onClose();
+	}, [isSubmitting, onClose]);
+
+	return (
+		<>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: overlay dismisses modal on click, Escape key handled separately */}
+			<div
+				role="presentation"
+				className="fixed inset-0 z-[60] bg-black/40"
+				data-testid="task-create-overlay"
+				onClick={handleOverlayClick}
+			/>
+			<div
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				tabIndex={-1}
+				className="fixed top-1/2 left-1/2 z-[70] w-[480px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-2xl"
+				data-testid="task-create-dialog"
+			>
+				<h2 id={titleId} className="mb-4 text-lg font-semibold text-gray-900">
+					新規タスクを作成
+				</h2>
+				<TaskForm
+					columns={columns}
+					initialStatus={initialStatus}
+					isSubmitting={isSubmitting}
+					onSubmit={handleSubmit}
+					onCancel={onClose}
+				/>
+			</div>
+		</>
+	);
+}

--- a/src/features/task-form/components/TaskForm.interaction.test.tsx
+++ b/src/features/task-form/components/TaskForm.interaction.test.tsx
@@ -1,0 +1,348 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Column } from "../../../types/task";
+import { TaskForm } from "./TaskForm";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+const COLUMNS: Column[] = [
+	{ name: "Todo", order: 0 },
+	{ name: "In Progress", order: 1 },
+	{ name: "Done", order: 2 },
+];
+
+/**
+ * TaskForm をレンダリングするヘルパー
+ * @param props - TaskForm に渡す props
+ */
+function render(props: Parameters<typeof TaskForm>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(TaskForm, props));
+	});
+}
+
+/**
+ * 指定した input/textarea の value を変更して change イベントを発火する
+ * @param el - 対象要素
+ * @param value - 設定する値
+ */
+function changeValue(
+	el: HTMLInputElement | HTMLTextAreaElement,
+	value: string,
+) {
+	const setter =
+		el instanceof HTMLTextAreaElement
+			? Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")
+					?.set
+			: Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")
+					?.set;
+	setter?.call(el, value);
+	el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/**
+ * 指定した select の value を変更して change イベントを発火する
+ * @param el - 対象要素
+ * @param value - 設定する値
+ */
+function changeSelect(el: HTMLSelectElement, value: string) {
+	const setter = Object.getOwnPropertyDescriptor(
+		HTMLSelectElement.prototype,
+		"value",
+	)?.set;
+	setter?.call(el, value);
+	el.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+test("全フィールドが表示される", () => {
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit: vi.fn(),
+		onCancel: vi.fn(),
+	});
+	expect(
+		document.querySelector('[data-testid="task-form-title"]'),
+	).toBeTruthy();
+	expect(
+		document.querySelector('[data-testid="task-form-status"]'),
+	).toBeTruthy();
+	expect(
+		document.querySelector('[data-testid="task-form-priority"]'),
+	).toBeTruthy();
+	expect(
+		document.querySelector('[data-testid="task-form-label-input"]'),
+	).toBeTruthy();
+	expect(document.querySelector('[data-testid="task-form-body"]')).toBeTruthy();
+});
+
+test("ステータスの初期値が initialStatus に設定される", () => {
+	render({
+		columns: COLUMNS,
+		initialStatus: "In Progress",
+		onSubmit: vi.fn(),
+		onCancel: vi.fn(),
+	});
+	const select = document.querySelector(
+		'[data-testid="task-form-status"]',
+	) as HTMLSelectElement;
+	expect(select.value).toBe("In Progress");
+});
+
+test("タイトル入力して送信すると onSubmit が呼ばれる", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onCancel: vi.fn(),
+	});
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(title, "新しいタスク");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	expect(onSubmit).toHaveBeenCalledOnce();
+	expect(onSubmit.mock.calls[0][0]).toMatchObject({
+		title: "新しいタスク",
+		status: "Todo",
+		priority: undefined,
+		labels: [],
+		body: "",
+	});
+});
+
+test("タイトル空で送信するとバリデーションエラーが表示され onSubmit は呼ばれない", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onCancel: vi.fn(),
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	const error = document.querySelector('[data-testid="task-form-title-error"]');
+	expect(error).toBeTruthy();
+	expect(error?.textContent).toContain("タイトル");
+	expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test("タイトルが空白のみの場合もバリデーションエラー", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onCancel: vi.fn(),
+	});
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(title, "   ");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	expect(
+		document.querySelector('[data-testid="task-form-title-error"]'),
+	).toBeTruthy();
+	expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test("優先度なしのまま送信で priority が undefined", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onCancel: vi.fn(),
+	});
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(title, "T");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	expect(onSubmit.mock.calls[0][0].priority).toBeUndefined();
+});
+
+test("優先度を選択すると送信値に反映される", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onCancel: vi.fn(),
+	});
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	const priority = document.querySelector(
+		'[data-testid="task-form-priority"]',
+	) as HTMLSelectElement;
+	act(() => {
+		changeValue(title, "T");
+		changeSelect(priority, "High");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	expect(onSubmit.mock.calls[0][0].priority).toBe("High");
+});
+
+test("ラベルを Enter で追加・×で削除できる", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onCancel: vi.fn(),
+	});
+	const labelInput = document.querySelector(
+		'[data-testid="task-form-label-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(labelInput, "bug");
+	});
+	act(() => {
+		labelInput.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(document.body.textContent).toContain("bug");
+
+	act(() => {
+		changeValue(labelInput, "urgent");
+	});
+	act(() => {
+		labelInput.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(title, "T");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	expect(onSubmit.mock.calls[0][0].labels).toEqual(["bug", "urgent"]);
+});
+
+test("説明を空のまま送信できる", () => {
+	const onSubmit = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit,
+		onCancel: vi.fn(),
+	});
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	act(() => {
+		changeValue(title, "T");
+	});
+	const form = document.querySelector(
+		'[data-testid="task-form"]',
+	) as HTMLFormElement;
+	act(() => {
+		form.dispatchEvent(
+			new Event("submit", { bubbles: true, cancelable: true }),
+		);
+	});
+	expect(onSubmit).toHaveBeenCalledOnce();
+	expect(onSubmit.mock.calls[0][0].body).toBe("");
+});
+
+test("キャンセルボタンで onCancel が呼ばれる", () => {
+	const onCancel = vi.fn();
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		onSubmit: vi.fn(),
+		onCancel,
+	});
+	const cancel = document.querySelector(
+		'[data-testid="task-form-cancel"]',
+	) as HTMLButtonElement;
+	act(() => {
+		cancel.click();
+	});
+	expect(onCancel).toHaveBeenCalledOnce();
+});
+
+test("isSubmitting 中は送信ボタンと入力欄が無効化される", () => {
+	render({
+		columns: COLUMNS,
+		initialStatus: "Todo",
+		isSubmitting: true,
+		onSubmit: vi.fn(),
+		onCancel: vi.fn(),
+	});
+	const submit = document.querySelector(
+		'[data-testid="task-form-submit"]',
+	) as HTMLButtonElement;
+	const title = document.querySelector(
+		'[data-testid="task-form-title"]',
+	) as HTMLInputElement;
+	expect(submit.disabled).toBe(true);
+	expect(title.disabled).toBe(true);
+});

--- a/src/features/task-form/components/TaskForm.interaction.test.tsx
+++ b/src/features/task-form/components/TaskForm.interaction.test.tsx
@@ -36,7 +36,8 @@ function render(props: Parameters<typeof TaskForm>[0]) {
 }
 
 /**
- * 指定した input/textarea の value を変更して change イベントを発火する
+ * 指定した input/textarea の value を変更して input イベントを発火する
+ * （React の onChange は text input/textarea の input イベントで発火するため）
  * @param el - 対象要素
  * @param value - 設定する値
  */

--- a/src/features/task-form/components/TaskForm.tsx
+++ b/src/features/task-form/components/TaskForm.tsx
@@ -1,0 +1,316 @@
+import {
+	type FormEvent,
+	type KeyboardEvent,
+	useCallback,
+	useId,
+	useState,
+} from "react";
+import type { Column, Priority } from "../../../types/task";
+
+/** TaskForm から送信される値 */
+export type TaskFormValues = {
+	/** タイトル（必須、空文字不可） */
+	title: string;
+	/** ステータス（必須） */
+	status: string;
+	/** 優先度（任意） */
+	priority?: Priority;
+	/** ラベル一覧 */
+	labels: string[];
+	/** 本文（Markdown） */
+	body: string;
+};
+
+type TaskFormProps = {
+	/** 選択肢となるカラム一覧 */
+	columns: Column[];
+	/** ステータスの初期値 */
+	initialStatus: string;
+	/** 送信中かどうか（true の間は送信ボタンと入力欄が無効化される） */
+	isSubmitting?: boolean;
+	/** 送信ボタンのラベル（デフォルト: "作成"） */
+	submitLabel?: string;
+	/** キャンセルボタンのラベル（デフォルト: "キャンセル"） */
+	cancelLabel?: string;
+	/**
+	 * 送信時のコールバック。バリデーション通過後に呼ばれる。
+	 * @param values - フォームの入力値
+	 */
+	onSubmit: (values: TaskFormValues) => void;
+	/** キャンセル時のコールバック */
+	onCancel: () => void;
+};
+
+const PRIORITY_OPTIONS: readonly Priority[] = ["High", "Medium", "Low"];
+
+/**
+ * 各フィールドの生値を TaskFormValues に正規化する。
+ * タイトルは前後空白を trim し、空文字の優先度は undefined に変換する。
+ * @param title - タイトル
+ * @param status - ステータス
+ * @param priority - 優先度（空文字はなし扱い）
+ * @param labels - ラベル一覧
+ * @param body - 本文
+ * @returns 正規化済みのフォーム送信値
+ */
+function normalizeSubmission(
+	title: string,
+	status: string,
+	priority: Priority | "",
+	labels: string[],
+	body: string,
+): TaskFormValues {
+	return {
+		title: title.trim(),
+		status,
+		priority: priority === "" ? undefined : priority,
+		labels,
+		body,
+	};
+}
+
+/**
+ * タスク作成フォーム。
+ * タイトル・ステータス・優先度・ラベル・本文を入力し、バリデーションを通過した値を `onSubmit` に渡す。
+ *
+ * @param props - {@link TaskFormProps}
+ * @returns フォーム要素
+ */
+export function TaskForm({
+	columns,
+	initialStatus,
+	isSubmitting = false,
+	submitLabel = "作成",
+	cancelLabel = "キャンセル",
+	onSubmit,
+	onCancel,
+}: TaskFormProps) {
+	const [title, setTitle] = useState("");
+	const [status, setStatus] = useState(initialStatus);
+	const [priority, setPriority] = useState<Priority | "">("");
+	const [labels, setLabels] = useState<string[]>([]);
+	const [labelInput, setLabelInput] = useState("");
+	const [body, setBody] = useState("");
+	const [titleError, setTitleError] = useState<string | null>(null);
+
+	const id = useId();
+	const titleId = `${id}-title`;
+	const statusId = `${id}-status`;
+	const priorityId = `${id}-priority`;
+	const labelsId = `${id}-labels`;
+	const bodyId = `${id}-body`;
+	const titleErrorId = `${id}-title-error`;
+
+	const commitLabel = useCallback(() => {
+		const trimmed = labelInput.trim();
+		if (trimmed.length === 0) return;
+		setLabels((prev) => (prev.includes(trimmed) ? prev : [...prev, trimmed]));
+		setLabelInput("");
+	}, [labelInput]);
+
+	const removeLabel = useCallback((target: string) => {
+		setLabels((prev) => prev.filter((l) => l !== target));
+	}, []);
+
+	const handleLabelKeyDown = useCallback(
+		(e: KeyboardEvent<HTMLInputElement>) => {
+			if (e.key === "Enter") {
+				e.preventDefault();
+				commitLabel();
+			}
+		},
+		[commitLabel],
+	);
+
+	const handleSubmit = useCallback(
+		(e: FormEvent<HTMLFormElement>) => {
+			e.preventDefault();
+			if (isSubmitting) return;
+			if (title.trim().length === 0) {
+				setTitleError("タイトルを入力してください");
+				return;
+			}
+			setTitleError(null);
+			const pending = labelInput.trim();
+			const finalLabels =
+				pending.length > 0 && !labels.includes(pending)
+					? [...labels, pending]
+					: labels;
+			const values = normalizeSubmission(
+				title,
+				status,
+				priority,
+				finalLabels,
+				body,
+			);
+			onSubmit(values);
+		},
+		[isSubmitting, title, status, priority, labels, labelInput, body, onSubmit],
+	);
+
+	return (
+		<form
+			className="flex flex-col gap-4"
+			data-testid="task-form"
+			noValidate
+			onSubmit={handleSubmit}
+		>
+			<div>
+				<label
+					htmlFor={titleId}
+					className="mb-1 block text-xs font-medium text-gray-700"
+				>
+					タイトル <span className="text-red-600">*</span>
+				</label>
+				<input
+					id={titleId}
+					type="text"
+					value={title}
+					onChange={(e) => {
+						setTitle(e.target.value);
+						if (titleError) setTitleError(null);
+					}}
+					disabled={isSubmitting}
+					aria-invalid={titleError !== null}
+					aria-describedby={titleError ? titleErrorId : undefined}
+					className="w-full rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:border-blue-500 disabled:bg-gray-100"
+					data-testid="task-form-title"
+				/>
+				{titleError && (
+					<p
+						id={titleErrorId}
+						className="mt-1 text-xs text-red-600"
+						data-testid="task-form-title-error"
+					>
+						{titleError}
+					</p>
+				)}
+			</div>
+
+			<div>
+				<label
+					htmlFor={statusId}
+					className="mb-1 block text-xs font-medium text-gray-700"
+				>
+					ステータス <span className="text-red-600">*</span>
+				</label>
+				<select
+					id={statusId}
+					value={status}
+					onChange={(e) => setStatus(e.target.value)}
+					disabled={isSubmitting}
+					className="w-full rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:border-blue-500 disabled:bg-gray-100"
+					data-testid="task-form-status"
+				>
+					{columns.map((col) => (
+						<option key={col.name} value={col.name}>
+							{col.name}
+						</option>
+					))}
+				</select>
+			</div>
+
+			<div>
+				<label
+					htmlFor={priorityId}
+					className="mb-1 block text-xs font-medium text-gray-700"
+				>
+					優先度
+				</label>
+				<select
+					id={priorityId}
+					value={priority}
+					onChange={(e) => setPriority(e.target.value as Priority | "")}
+					disabled={isSubmitting}
+					className="w-full rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:border-blue-500 disabled:bg-gray-100"
+					data-testid="task-form-priority"
+				>
+					<option value="">なし</option>
+					{PRIORITY_OPTIONS.map((p) => (
+						<option key={p} value={p}>
+							{p}
+						</option>
+					))}
+				</select>
+			</div>
+
+			<div>
+				<label
+					htmlFor={labelsId}
+					className="mb-1 block text-xs font-medium text-gray-700"
+				>
+					ラベル
+				</label>
+				<div className="flex flex-wrap items-center gap-1.5">
+					{labels.map((label) => (
+						<span
+							key={label}
+							className="inline-flex items-center gap-0.5 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700"
+						>
+							{label}
+							<button
+								type="button"
+								aria-label={`ラベル「${label}」を削除`}
+								className="ml-0.5 rounded text-gray-400 hover:text-gray-700"
+								disabled={isSubmitting}
+								onClick={() => removeLabel(label)}
+							>
+								×
+							</button>
+						</span>
+					))}
+					<input
+						id={labelsId}
+						type="text"
+						value={labelInput}
+						onChange={(e) => setLabelInput(e.target.value)}
+						onKeyDown={handleLabelKeyDown}
+						onBlur={commitLabel}
+						disabled={isSubmitting}
+						placeholder="Enter で追加"
+						className="flex-1 min-w-[100px] rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:border-blue-500 disabled:bg-gray-100"
+						data-testid="task-form-label-input"
+					/>
+				</div>
+			</div>
+
+			<div>
+				<label
+					htmlFor={bodyId}
+					className="mb-1 block text-xs font-medium text-gray-700"
+				>
+					説明
+				</label>
+				<textarea
+					id={bodyId}
+					value={body}
+					onChange={(e) => setBody(e.target.value)}
+					disabled={isSubmitting}
+					rows={4}
+					className="w-full rounded border border-gray-300 px-2 py-1 text-sm outline-none focus:border-blue-500 disabled:bg-gray-100"
+					data-testid="task-form-body"
+				/>
+			</div>
+
+			<div className="mt-2 flex justify-end gap-3">
+				<button
+					type="button"
+					className="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+					disabled={isSubmitting}
+					onClick={onCancel}
+					data-testid="task-form-cancel"
+				>
+					{cancelLabel}
+				</button>
+				<button
+					type="submit"
+					className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+					disabled={isSubmitting}
+					data-testid="task-form-submit"
+				>
+					{submitLabel}
+				</button>
+			</div>
+		</form>
+	);
+}

--- a/src/features/task-form/components/TaskForm.tsx
+++ b/src/features/task-form/components/TaskForm.tsx
@@ -136,6 +136,10 @@ export function TaskForm({
 				pending.length > 0 && !labels.includes(pending)
 					? [...labels, pending]
 					: labels;
+			if (pending.length > 0) {
+				setLabels(finalLabels);
+				setLabelInput("");
+			}
 			const values = normalizeSubmission(
 				title,
 				status,

--- a/src/features/task-form/index.ts
+++ b/src/features/task-form/index.ts
@@ -1,0 +1,2 @@
+export { TaskCreateModal } from "./components/TaskCreateModal";
+export type { TaskFormValues } from "./components/TaskForm";


### PR DESCRIPTION
## 概要

新規タスクを作成するためのモーダルフォームを追加。カラムヘッダーの「+ 追加」ボタンから開き、作成成功時はボードに即時反映、失敗時はトーストで通知する。

## 変更内容

- `src/features/task-form/components/TaskForm.tsx` を新規追加
  - タイトル（必須・trim後の空文字はバリデーションエラー）、ステータス（作成元カラムを初期値）、優先度（なし / High / Medium / Low）、ラベル（Enter/blur で追加・× で削除）、本文（Markdown）を入力する再利用可能な form コンポーネント
  - `isSubmitting` 中は全フィールドと送信/キャンセルボタンを無効化
  - 送信時に未確定のラベル入力も自動的に確定してから `onSubmit` を呼ぶ
- `src/features/task-form/components/TaskCreateModal.tsx` を新規追加
  - `ConfirmDialog` と同じモーダルパターン（`role="dialog"` / `aria-modal` / Escape・オーバーレイクリックで閉じる / マウント時フォーカス）
  - `onSubmit` が resolve したら自動で `onClose`、reject したら開いたまま（親側でトースト通知する想定）
  - 送信中は Escape/オーバーレイクリックを抑止
- `src/features/task-form/index.ts` で `TaskCreateModal` と `TaskFormValues` を公開 API として export
- `src/App.tsx`
  - `createModalStatus` state を追加し、`Board` の `onAddTask(columnName)` でモーダルを開く
  - `handleCreateTask` で `createTask` API 呼び出し → 成功時は tasks 更新 + 成功トースト、失敗時は失敗トースト + re-throw（モーダル側で開いたままにするため）
  - `TaskCreateModal` をルート直下にマウント

## テスト

```bash
pnpm test --run
pnpm run build
```

- TaskForm: 全フィールド表示 / 初期ステータス / 送信で onSubmit 呼び出し / タイトル空バリデーション / 優先度なしで undefined / 優先度選択反映 / ラベル Enter 追加・× 削除 / 説明空送信 / キャンセル / isSubmitting 無効化（11 ケース）
- TaskCreateModal: モーダル表示 / 初期ステータス / 成功で閉じる / 失敗で閉じない / Esc / オーバーレイ / キャンセル / バリデーションエラー（8 ケース）
- 全 136 テスト通過、ビルド成功

Automated by task-loop-run
