### PR TITLE
feat: カラム追加機能

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,6 @@ function App() {
 	/**
 	 * 新規カラムの追加。成功時はカラム一覧を更新しトーストを表示、失敗時はトースト表示のみ行う。
 	 * @param columnName - 追加するカラム名（trim 済み、既存と非重複）
-	 * @throws updateColumns API 呼び出しが失敗した場合のみ内部で捕捉する
 	 */
 	const handleAddColumn = useCallback(
 		async (columnName: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ToastContainer, useToasts } from "./components/Toast";
 import { Board, EmptyState, HeaderBar } from "./features/board";
 import { DetailPanel } from "./features/detail";
@@ -29,6 +29,12 @@ function App() {
 		string | undefined
 	>(undefined);
 	const { toasts, showToast, dismissToast } = useToasts();
+	const columnsRef = useRef<Column[]>(columns);
+	const addColumnQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+	useEffect(() => {
+		columnsRef.current = columns;
+	}, [columns]);
 
 	const selectedTask = selectedTaskId
 		? (tasks.find((t) => t.id === selectedTaskId) ?? null)
@@ -69,24 +75,30 @@ function App() {
 	 * @param columnName - 追加するカラム名（trim 済み、既存と非重複）
 	 */
 	const handleAddColumn = useCallback(
-		async (columnName: string) => {
-			try {
-				const maxOrder = columns.reduce(
-					(acc, c) => (c.order > acc ? c.order : acc),
-					-1,
-				);
-				const nextColumns: Column[] = [
-					...columns,
-					{ name: columnName, order: maxOrder + 1 },
-				];
-				const updated = await updateColumns(nextColumns);
-				setColumns(updated);
-				showToast("カラムを追加しました", "success");
-			} catch {
-				showToast("カラムの追加に失敗しました", "error");
-			}
+		(columnName: string): Promise<void> => {
+			const next = addColumnQueueRef.current.then(async () => {
+				try {
+					const current = columnsRef.current;
+					const maxOrder = current.reduce(
+						(acc, c) => (c.order > acc ? c.order : acc),
+						-1,
+					);
+					const nextColumns: Column[] = [
+						...current,
+						{ name: columnName, order: maxOrder + 1 },
+					];
+					const updated = await updateColumns(nextColumns);
+					columnsRef.current = updated;
+					setColumns(updated);
+					showToast("カラムを追加しました", "success");
+				} catch {
+					showToast("カラムの追加に失敗しました", "error");
+				}
+			});
+			addColumnQueueRef.current = next;
+			return next;
 		},
-		[columns, showToast],
+		[showToast],
 	);
 
 	const handleCloseCreateModal = useCallback(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,10 @@ function App() {
 			const next = addColumnQueueRef.current.then(async () => {
 				try {
 					const current = columnsRef.current;
+					if (current.some((c) => c.name === columnName)) {
+						showToast("同じ名前のカラムが既に存在します", "error");
+						return;
+					}
 					const maxOrder = current.reduce(
 						(acc, c) => (c.order > acc ? c.order : acc),
 						-1,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
 	deleteTask,
 	getColumns,
 	getTasks,
+	updateColumns,
 	updateTask,
 } from "./lib/api";
 import type { Column, Task } from "./types/task";
@@ -62,6 +63,32 @@ function App() {
 		setCreateModalStatus(columnName);
 		setCreateModalParent(undefined);
 	}, []);
+
+	/**
+	 * 新規カラムの追加。成功時はカラム一覧を更新しトーストを表示、失敗時はトースト表示のみ行う。
+	 * @param columnName - 追加するカラム名（trim 済み、既存と非重複）
+	 * @throws updateColumns API 呼び出しが失敗した場合のみ内部で捕捉する
+	 */
+	const handleAddColumn = useCallback(
+		async (columnName: string) => {
+			try {
+				const maxOrder = columns.reduce(
+					(acc, c) => (c.order > acc ? c.order : acc),
+					-1,
+				);
+				const nextColumns: Column[] = [
+					...columns,
+					{ name: columnName, order: maxOrder + 1 },
+				];
+				const updated = await updateColumns(nextColumns);
+				setColumns(updated);
+				showToast("カラムを追加しました", "success");
+			} catch {
+				showToast("カラムの追加に失敗しました", "error");
+			}
+		},
+		[columns, showToast],
+	);
 
 	const handleCloseCreateModal = useCallback(() => {
 		setCreateModalStatus(null);
@@ -166,6 +193,7 @@ function App() {
 						columns={columns}
 						tasks={tasks}
 						onAddTask={handleAddTask}
+						onAddColumn={handleAddColumn}
 						onTaskClick={handleTaskClick}
 					/>
 				)}

--- a/src/features/board/components/AddColumnButton.interaction.test.tsx
+++ b/src/features/board/components/AddColumnButton.interaction.test.tsx
@@ -1,0 +1,219 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { AddColumnButton } from "./AddColumnButton";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+/**
+ * AddColumnButton をレンダリングするヘルパー
+ * @param props - AddColumnButton に渡す props
+ */
+function render(props: Parameters<typeof AddColumnButton>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(AddColumnButton, props));
+	});
+}
+
+/**
+ * ネイティブ setter 経由で input に値を設定する
+ * @param input - 対象の input 要素
+ * @param value - 設定する値
+ */
+function setInputValue(input: HTMLInputElement, value: string) {
+	const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		"value",
+	)?.set;
+	nativeInputValueSetter?.call(input, value);
+	input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+test("初期表示で「+ カラムを追加」ボタンが表示される", () => {
+	render({ existingColumnNames: [], onAdd: vi.fn() });
+	const button = document.querySelector(
+		'[data-testid="add-column-button"]',
+	) as HTMLButtonElement | null;
+	expect(button?.textContent).toContain("+ カラムを追加");
+});
+
+test("ボタンクリックで入力フィールドが表示される", () => {
+	render({ existingColumnNames: [], onAdd: vi.fn() });
+	const button = document.querySelector(
+		'[data-testid="add-column-button"]',
+	) as HTMLButtonElement;
+	act(() => {
+		button.click();
+	});
+	const input = document.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement | null;
+	expect(input).toBeTruthy();
+});
+
+test("名前を入力して Enter で onAdd が呼ばれる", () => {
+	const onAdd = vi.fn();
+	render({ existingColumnNames: ["Todo"], onAdd });
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="add-column-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	const input = document.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		setInputValue(input, "Review");
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onAdd).toHaveBeenCalledWith("Review");
+	expect(onAdd).toHaveBeenCalledTimes(1);
+});
+
+test("入力前後の空白は trim されて onAdd に渡される", () => {
+	const onAdd = vi.fn();
+	render({ existingColumnNames: [], onAdd });
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="add-column-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	const input = document.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		setInputValue(input, "  Review  ");
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onAdd).toHaveBeenCalledWith("Review");
+});
+
+test("確定後はボタン表示に戻る", () => {
+	const onAdd = vi.fn();
+	render({ existingColumnNames: [], onAdd });
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="add-column-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	const input = document.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		setInputValue(input, "Review");
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	const button = document.querySelector('[data-testid="add-column-button"]');
+	expect(button).toBeTruthy();
+});
+
+test("空文字で Enter しても onAdd は呼ばれない", () => {
+	const onAdd = vi.fn();
+	render({ existingColumnNames: [], onAdd });
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="add-column-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	const input = document.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		setInputValue(input, "   ");
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onAdd).not.toHaveBeenCalled();
+});
+
+test("既存と同名の場合 onAdd は呼ばれず入力状態が維持される", () => {
+	const onAdd = vi.fn();
+	render({ existingColumnNames: ["Todo", "Done"], onAdd });
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="add-column-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	const input = document.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		setInputValue(input, "Todo");
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onAdd).not.toHaveBeenCalled();
+	const stillInput = document.querySelector('[data-testid="add-column-input"]');
+	expect(stillInput).toBeTruthy();
+	const alert = document.querySelector('[role="alert"]');
+	expect(alert?.textContent).toContain("同じ名前");
+});
+
+test("Esc でキャンセルされボタン表示に戻る", () => {
+	const onAdd = vi.fn();
+	render({ existingColumnNames: [], onAdd });
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="add-column-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	const input = document.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		setInputValue(input, "途中入力");
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+		);
+	});
+	expect(onAdd).not.toHaveBeenCalled();
+	const button = document.querySelector('[data-testid="add-column-button"]');
+	expect(button).toBeTruthy();
+	const stillInput = document.querySelector('[data-testid="add-column-input"]');
+	expect(stillInput).toBeFalsy();
+});

--- a/src/features/board/components/AddColumnButton.tsx
+++ b/src/features/board/components/AddColumnButton.tsx
@@ -68,6 +68,7 @@ export function AddColumnButton({
 
 	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Enter") {
+			if (e.nativeEvent.isComposing) return;
 			e.preventDefault();
 			e.stopPropagation();
 			confirm();

--- a/src/features/board/components/AddColumnButton.tsx
+++ b/src/features/board/components/AddColumnButton.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 /** AddColumnButton の Props */
 type AddColumnButtonProps = {
@@ -29,6 +29,8 @@ export function AddColumnButton({
 	const [inputValue, setInputValue] = useState("");
 	const inputRef = useRef<HTMLInputElement>(null);
 	const isCancelledRef = useRef(false);
+	const id = useId();
+	const errorId = `${id}-error`;
 
 	useEffect(() => {
 		if (isEditing) {
@@ -98,11 +100,13 @@ export function AddColumnButton({
 					}}
 					placeholder="カラム名"
 					aria-label="カラム名"
+					aria-invalid={isDuplicate}
+					aria-describedby={isDuplicate ? errorId : undefined}
 					className="w-full rounded border border-blue-400 px-2 py-1 text-sm text-gray-900 outline-none"
 					data-testid="add-column-input"
 				/>
 				{isDuplicate && (
-					<p className="text-xs text-red-500" role="alert">
+					<p id={errorId} className="text-xs text-red-500" role="alert">
 						同じ名前のカラムが既に存在します
 					</p>
 				)}

--- a/src/features/board/components/AddColumnButton.tsx
+++ b/src/features/board/components/AddColumnButton.tsx
@@ -1,0 +1,120 @@
+import type { KeyboardEvent } from "react";
+import { useEffect, useRef, useState } from "react";
+
+/** AddColumnButton の Props */
+type AddColumnButtonProps = {
+	/** 既存のカラム名一覧（重複チェック用） */
+	existingColumnNames: string[];
+	/**
+	 * 新規カラム追加時のコールバック。
+	 * 入力値の trim 後に空文字や既存と同名の場合は呼び出されない。
+	 * @param columnName - 追加するカラム名（trim 済み）
+	 */
+	onAdd: (columnName: string) => void;
+};
+
+/**
+ * ボード右端に表示される「+ カラムを追加」ボタン。
+ * クリックでカラム名入力フィールドに切り替わり、
+ * Enter で確定（onAdd 呼び出し）、Esc でキャンセルする。
+ *
+ * @param props - {@link AddColumnButtonProps}
+ * @returns カラム追加ボタン要素
+ */
+export function AddColumnButton({
+	existingColumnNames,
+	onAdd,
+}: AddColumnButtonProps) {
+	const [isEditing, setIsEditing] = useState(false);
+	const [inputValue, setInputValue] = useState("");
+	const inputRef = useRef<HTMLInputElement>(null);
+	const isCancelledRef = useRef(false);
+
+	useEffect(() => {
+		if (isEditing) {
+			inputRef.current?.focus();
+		}
+	}, [isEditing]);
+
+	const startEditing = () => {
+		setInputValue("");
+		setIsEditing(true);
+	};
+
+	const cancel = () => {
+		isCancelledRef.current = true;
+		setInputValue("");
+		setIsEditing(false);
+	};
+
+	const confirm = () => {
+		const trimmed = inputValue.trim();
+		if (trimmed.length === 0) {
+			setInputValue("");
+			setIsEditing(false);
+			return;
+		}
+		if (existingColumnNames.includes(trimmed)) {
+			return;
+		}
+		onAdd(trimmed);
+		setInputValue("");
+		setIsEditing(false);
+	};
+
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			e.stopPropagation();
+			isCancelledRef.current = true;
+			confirm();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			e.stopPropagation();
+			cancel();
+		}
+	};
+
+	const trimmedInput = inputValue.trim();
+	const isDuplicate =
+		trimmedInput.length > 0 && existingColumnNames.includes(trimmedInput);
+
+	if (isEditing) {
+		return (
+			<div className="flex h-fit w-72 min-w-72 flex-col gap-1 rounded-lg bg-gray-50 p-2">
+				<input
+					ref={inputRef}
+					type="text"
+					value={inputValue}
+					onChange={(e) => setInputValue(e.target.value)}
+					onKeyDown={handleKeyDown}
+					onBlur={() => {
+						if (!isCancelledRef.current) cancel();
+						isCancelledRef.current = false;
+					}}
+					placeholder="カラム名"
+					aria-label="カラム名"
+					className="w-full rounded border border-blue-400 px-2 py-1 text-sm text-gray-900 outline-none"
+					data-testid="add-column-input"
+				/>
+				{isDuplicate && (
+					<p className="text-xs text-red-500" role="alert">
+						同じ名前のカラムが既に存在します
+					</p>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={startEditing}
+			aria-label="カラムを追加"
+			className="h-fit w-72 min-w-72 rounded-lg border-2 border-dashed border-gray-300 px-4 py-2 text-sm text-gray-500 hover:border-gray-400 hover:text-gray-700"
+			data-testid="add-column-button"
+		>
+			+ カラムを追加
+		</button>
+	);
+}

--- a/src/features/board/components/AddColumnButton.tsx
+++ b/src/features/board/components/AddColumnButton.tsx
@@ -37,6 +37,7 @@ export function AddColumnButton({
 	}, [isEditing]);
 
 	const startEditing = () => {
+		isCancelledRef.current = false;
 		setInputValue("");
 		setIsEditing(true);
 	};
@@ -47,26 +48,28 @@ export function AddColumnButton({
 		setIsEditing(false);
 	};
 
-	const confirm = () => {
+	const confirm = (): boolean => {
 		const trimmed = inputValue.trim();
 		if (trimmed.length === 0) {
+			isCancelledRef.current = true;
 			setInputValue("");
 			setIsEditing(false);
-			return;
+			return true;
 		}
 		if (existingColumnNames.includes(trimmed)) {
-			return;
+			return false;
 		}
 		onAdd(trimmed);
+		isCancelledRef.current = true;
 		setInputValue("");
 		setIsEditing(false);
+		return true;
 	};
 
 	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Enter") {
 			e.preventDefault();
 			e.stopPropagation();
-			isCancelledRef.current = true;
 			confirm();
 		} else if (e.key === "Escape") {
 			e.preventDefault();

--- a/src/features/board/components/Board.rendering.test.tsx
+++ b/src/features/board/components/Board.rendering.test.tsx
@@ -121,3 +121,107 @@ test("カラムが order 順に表示される", async () => {
 		expect(labels).toEqual(["Todo", "In Progress", "Done"]);
 	});
 });
+
+test("onAddColumn 未指定の場合はカラム追加ボタンが表示されない", async () => {
+	render({ columns: defaultColumns, tasks: [], onAddTask: vi.fn() });
+	await vi.waitFor(() => {
+		const button = container?.querySelector(
+			'[data-testid="add-column-button"]',
+		);
+		expect(button).toBeFalsy();
+	});
+});
+
+test("onAddColumn 指定時はボード右端にカラム追加ボタンが表示される", async () => {
+	render({
+		columns: defaultColumns,
+		tasks: [],
+		onAddTask: vi.fn(),
+		onAddColumn: vi.fn(),
+	});
+	await vi.waitFor(() => {
+		const button = container?.querySelector(
+			'[data-testid="add-column-button"]',
+		);
+		expect(button).toBeTruthy();
+	});
+	const boardChildren = Array.from(
+		container?.firstElementChild?.children ?? [],
+	);
+	const lastChild = boardChildren[boardChildren.length - 1];
+	expect(lastChild?.getAttribute("data-testid")).toBe("add-column-button");
+});
+
+test("カラム追加ボタンから Enter で onAddColumn が呼ばれる", async () => {
+	const onAddColumn = vi.fn();
+	render({
+		columns: defaultColumns,
+		tasks: [],
+		onAddTask: vi.fn(),
+		onAddColumn,
+	});
+	let button: HTMLButtonElement | null = null;
+	await vi.waitFor(() => {
+		button = container?.querySelector(
+			'[data-testid="add-column-button"]',
+		) as HTMLButtonElement | null;
+		expect(button).toBeTruthy();
+	});
+	act(() => {
+		button?.click();
+	});
+	const input = container?.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "Review");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onAddColumn).toHaveBeenCalledWith("Review");
+});
+
+test("既存カラム名と同じ名前は onAddColumn に渡されない", async () => {
+	const onAddColumn = vi.fn();
+	render({
+		columns: defaultColumns,
+		tasks: [],
+		onAddTask: vi.fn(),
+		onAddColumn,
+	});
+	let button: HTMLButtonElement | null = null;
+	await vi.waitFor(() => {
+		button = container?.querySelector(
+			'[data-testid="add-column-button"]',
+		) as HTMLButtonElement | null;
+		expect(button).toBeTruthy();
+	});
+	act(() => {
+		button?.click();
+	});
+	const input = container?.querySelector(
+		'[data-testid="add-column-input"]',
+	) as HTMLInputElement;
+	act(() => {
+		const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+			HTMLInputElement.prototype,
+			"value",
+		)?.set;
+		nativeInputValueSetter?.call(input, "Todo");
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onAddColumn).not.toHaveBeenCalled();
+});

--- a/src/features/board/components/Board.tsx
+++ b/src/features/board/components/Board.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { Column as ColumnType, Task } from "../../../types/task";
+import { AddColumnButton } from "./AddColumnButton";
 import { Column } from "./Column";
 
 /** ボードの Props */
@@ -19,6 +20,13 @@ type BoardProps = {
 	 * @param taskId - クリックされたタスクのID
 	 */
 	onTaskClick?: (taskId: string) => void;
+	/**
+	 * 新規カラム追加時のコールバック。
+	 * ボード右端の AddColumnButton から呼び出される。
+	 * 未指定の場合はカラム追加 UI を非表示にする。
+	 * @param columnName - 追加するカラム名（trim 済み、既存と非重複）
+	 */
+	onAddColumn?: (columnName: string) => void;
 };
 
 /**
@@ -32,6 +40,7 @@ export function Board({
 	doneColumn,
 	onAddTask,
 	onTaskClick,
+	onAddColumn,
 }: BoardProps) {
 	const sorted = useMemo(
 		() => [...columns].sort((a, b) => a.order - b.order),
@@ -49,6 +58,8 @@ export function Board({
 		return grouped;
 	}, [tasks]);
 
+	const columnNames = useMemo(() => columns.map((c) => c.name), [columns]);
+
 	return (
 		<div className="flex h-full gap-4 overflow-x-auto p-4">
 			{sorted.map((col) => (
@@ -62,6 +73,12 @@ export function Board({
 					onTaskClick={onTaskClick}
 				/>
 			))}
+			{onAddColumn && (
+				<AddColumnButton
+					existingColumnNames={columnNames}
+					onAdd={onAddColumn}
+				/>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## 概要

ボード右端の「+ カラムを追加」ボタンを実装し、ユーザーが任意のカラムをボードに追加できるようにした。

## 変更内容

- `AddColumnButton` コンポーネント新規追加（クリックで入力フィールドに切替、Enter 確定 / Esc キャンセル、空文字・既存と同名は追加不可）
- `Board` に `onAddColumn` 任意プロップを追加し、ボード右端に `AddColumnButton` を配置（既存カラム名を渡して重複チェック）
- `App` に `handleAddColumn` を追加し、`updateColumns` API を呼び出してカラム一覧を更新（成功・失敗時にトースト通知）

## テスト

```bash
pnpm test:run
```

- `AddColumnButton.interaction.test.tsx`: 8 ケース（初期表示、入力切替、Enter で onAdd 呼び出し、trim、空文字・重複・Esc のキャンセル動作）
- `Board.rendering.test.tsx`: 4 ケース追加（onAddColumn 有無での表示切替、ボード右端配置、Enter 経由のコールバック呼び出し、重複時にコールバック未呼び出し）
- 全 171 テスト通過、`pnpm run build` 成功

---

Automated by task-loop-run
