### PR TITLE
feat: カラム名のインライン編集

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
 	>(undefined);
 	const { toasts, showToast, dismissToast } = useToasts();
 	const columnsRef = useRef<Column[]>(columns);
-	const addColumnQueueRef = useRef<Promise<void>>(Promise.resolve());
+	const columnsQueueRef = useRef<Promise<void>>(Promise.resolve());
 
 	useEffect(() => {
 		columnsRef.current = columns;
@@ -76,7 +76,7 @@ function App() {
 	 */
 	const handleAddColumn = useCallback(
 		(columnName: string): Promise<void> => {
-			const next = addColumnQueueRef.current.then(async () => {
+			const next = columnsQueueRef.current.then(async () => {
 				try {
 					const current = columnsRef.current;
 					if (current.some((c) => c.name === columnName)) {
@@ -99,7 +99,47 @@ function App() {
 					showToast("カラムの追加に失敗しました", "error");
 				}
 			});
-			addColumnQueueRef.current = next;
+			columnsQueueRef.current = next;
+			return next;
+		},
+		[showToast],
+	);
+
+	/**
+	 * 既存カラムの名前変更。カラム追加と同じキューで直列化し、競合を防ぐ。
+	 * 成功時はカラムとタスクの status を更新、失敗時はトースト表示のみ行う。
+	 * @param oldName - 元のカラム名
+	 * @param newName - 新しいカラム名（trim 済み、既存と非重複）
+	 */
+	const handleRenameColumn = useCallback(
+		(oldName: string, newName: string): Promise<void> => {
+			const next = columnsQueueRef.current.then(async () => {
+				try {
+					const current = columnsRef.current;
+					if (!current.some((c) => c.name === oldName)) return;
+					if (current.some((c) => c.name === newName)) {
+						showToast("同じ名前のカラムが既に存在します", "error");
+						return;
+					}
+					const nextColumns: Column[] = current.map((c) =>
+						c.name === oldName ? { ...c, name: newName } : c,
+					);
+					const updated = await updateColumns(nextColumns, [
+						{ from: oldName, to: newName },
+					]);
+					columnsRef.current = updated;
+					setColumns(updated);
+					setTasks((prev) =>
+						prev.map((t) =>
+							t.status === oldName ? { ...t, status: newName } : t,
+						),
+					);
+					showToast("カラム名を変更しました", "success");
+				} catch {
+					showToast("カラム名の変更に失敗しました", "error");
+				}
+			});
+			columnsQueueRef.current = next;
 			return next;
 		},
 		[showToast],
@@ -209,6 +249,7 @@ function App() {
 						tasks={tasks}
 						onAddTask={handleAddTask}
 						onAddColumn={handleAddColumn}
+						onRenameColumn={handleRenameColumn}
 						onTaskClick={handleTaskClick}
 					/>
 				)}

--- a/src/features/board/components/Board.tsx
+++ b/src/features/board/components/Board.tsx
@@ -27,6 +27,13 @@ type BoardProps = {
 	 * @param columnName - 追加するカラム名（trim 済み、既存と非重複）
 	 */
 	onAddColumn?: (columnName: string) => void;
+	/**
+	 * カラム名リネーム確定時のコールバック。
+	 * 未指定の場合はカラム名編集 UI を無効化する。
+	 * @param oldName - 元のカラム名
+	 * @param newName - 新しいカラム名（trim 済み、既存と非重複）
+	 */
+	onRenameColumn?: (oldName: string, newName: string) => void;
 };
 
 /**
@@ -41,6 +48,7 @@ export function Board({
 	onAddTask,
 	onTaskClick,
 	onAddColumn,
+	onRenameColumn,
 }: BoardProps) {
 	const sorted = useMemo(
 		() => [...columns].sort((a, b) => a.order - b.order),
@@ -71,6 +79,12 @@ export function Board({
 					doneColumn={doneColumn}
 					onAddClick={() => onAddTask(col.name)}
 					onTaskClick={onTaskClick}
+					onRename={
+						onRenameColumn
+							? (newName) => onRenameColumn(col.name, newName)
+							: undefined
+					}
+					existingColumnNames={columnNames.filter((n) => n !== col.name)}
 				/>
 			))}
 			{onAddColumn && (

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -20,6 +20,14 @@ type ColumnProps = {
 	 * @param taskId - クリックされたタスクのID
 	 */
 	onTaskClick?: (taskId: string) => void;
+	/**
+	 * カラム名リネーム確定時のコールバック。
+	 * 未指定の場合はヘッダー名編集 UI を無効化する。
+	 * @param newName - 新しいカラム名（trim 済み、既存と非重複）
+	 */
+	onRename?: (newName: string) => void;
+	/** 他カラム名の一覧（重複チェック用。自身は含まない） */
+	existingColumnNames?: string[];
 };
 
 /**
@@ -34,6 +42,8 @@ export function Column({
 	doneColumn,
 	onAddClick,
 	onTaskClick,
+	onRename,
+	existingColumnNames,
 }: ColumnProps) {
 	const tasksByFilePath = useMemo(
 		() => new Map(allTasks.map((t) => [t.filePath, t])),
@@ -49,6 +59,8 @@ export function Column({
 				name={name}
 				taskCount={tasks.length}
 				onAddClick={onAddClick}
+				onRename={onRename}
+				existingColumnNames={existingColumnNames}
 			/>
 			<ul className="flex-1 overflow-y-auto px-2 pb-2">
 				{tasks.map((task) => {

--- a/src/features/board/components/ColumnHeader.interaction.test.tsx
+++ b/src/features/board/components/ColumnHeader.interaction.test.tsx
@@ -1,0 +1,199 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { ColumnHeader } from "./ColumnHeader";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function render(props: Parameters<typeof ColumnHeader>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(ColumnHeader, props));
+	});
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+	const nativeSetter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		"value",
+	)?.set;
+	act(() => {
+		nativeSetter?.call(input, value);
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+}
+
+test("onRename 指定時にステータス名クリックで編集モードになる", async () => {
+	render({
+		name: "Todo",
+		taskCount: 0,
+		onAddClick: vi.fn(),
+		onRename: vi.fn(),
+		existingColumnNames: ["In Progress", "Done"],
+	});
+	const nameButton = container?.querySelector(
+		'[data-testid="column-name-button"]',
+	) as HTMLButtonElement | null;
+	expect(nameButton).toBeTruthy();
+	act(() => {
+		nameButton?.click();
+	});
+	const input = container?.querySelector(
+		'[data-testid="column-rename-input"]',
+	) as HTMLInputElement | null;
+	expect(input).toBeTruthy();
+	expect(input?.value).toBe("Todo");
+});
+
+test("新しい名前を入力して Enter で onRename が呼ばれる", async () => {
+	const onRename = vi.fn();
+	render({
+		name: "Todo",
+		taskCount: 0,
+		onAddClick: vi.fn(),
+		onRename,
+		existingColumnNames: ["In Progress", "Done"],
+	});
+	act(() => {
+		(
+			container?.querySelector(
+				'[data-testid="column-name-button"]',
+			) as HTMLButtonElement | null
+		)?.click();
+	});
+	const input = container?.querySelector(
+		'[data-testid="column-rename-input"]',
+	) as HTMLInputElement;
+	setInputValue(input, "Backlog");
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onRename).toHaveBeenCalledWith("Backlog");
+});
+
+test("空文字で確定すると onRename は呼ばれず元に戻る", async () => {
+	const onRename = vi.fn();
+	render({
+		name: "Todo",
+		taskCount: 0,
+		onAddClick: vi.fn(),
+		onRename,
+		existingColumnNames: ["Done"],
+	});
+	act(() => {
+		(
+			container?.querySelector(
+				'[data-testid="column-name-button"]',
+			) as HTMLButtonElement | null
+		)?.click();
+	});
+	const input = container?.querySelector(
+		'[data-testid="column-rename-input"]',
+	) as HTMLInputElement;
+	setInputValue(input, "   ");
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onRename).not.toHaveBeenCalled();
+	await vi.waitFor(() => {
+		const button = container?.querySelector(
+			'[data-testid="column-name-button"]',
+		);
+		expect(button?.textContent).toBe("Todo");
+	});
+});
+
+test("既存カラム名と同じ名前で確定すると onRename は呼ばれずエラーが表示される", async () => {
+	const onRename = vi.fn();
+	render({
+		name: "Todo",
+		taskCount: 0,
+		onAddClick: vi.fn(),
+		onRename,
+		existingColumnNames: ["In Progress", "Done"],
+	});
+	act(() => {
+		(
+			container?.querySelector(
+				'[data-testid="column-name-button"]',
+			) as HTMLButtonElement | null
+		)?.click();
+	});
+	const input = container?.querySelector(
+		'[data-testid="column-rename-input"]',
+	) as HTMLInputElement;
+	setInputValue(input, "Done");
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+	});
+	expect(onRename).not.toHaveBeenCalled();
+	const error = container?.querySelector('[role="alert"]');
+	expect(error?.textContent).toContain("同じ名前");
+	const stillEditing = container?.querySelector(
+		'[data-testid="column-rename-input"]',
+	);
+	expect(stillEditing).toBeTruthy();
+});
+
+test("Esc で編集がキャンセルされ元の名前に戻る", async () => {
+	const onRename = vi.fn();
+	render({
+		name: "Todo",
+		taskCount: 0,
+		onAddClick: vi.fn(),
+		onRename,
+		existingColumnNames: ["Done"],
+	});
+	act(() => {
+		(
+			container?.querySelector(
+				'[data-testid="column-name-button"]',
+			) as HTMLButtonElement | null
+		)?.click();
+	});
+	const input = container?.querySelector(
+		'[data-testid="column-rename-input"]',
+	) as HTMLInputElement;
+	setInputValue(input, "Changed");
+	act(() => {
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+		);
+	});
+	expect(onRename).not.toHaveBeenCalled();
+	await vi.waitFor(() => {
+		const button = container?.querySelector(
+			'[data-testid="column-name-button"]',
+		);
+		expect(button?.textContent).toBe("Todo");
+	});
+});
+
+test("onRename 未指定時は編集用ボタンが表示されない", async () => {
+	render({ name: "Todo", taskCount: 0, onAddClick: vi.fn() });
+	await vi.waitFor(() => {
+		expect(container?.textContent).toContain("Todo");
+	});
+	const nameButton = container?.querySelector(
+		'[data-testid="column-name-button"]',
+	);
+	expect(nameButton).toBeFalsy();
+});

--- a/src/features/board/components/ColumnHeader.tsx
+++ b/src/features/board/components/ColumnHeader.tsx
@@ -1,3 +1,6 @@
+import type { KeyboardEvent } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+
 /** カラムヘッダーの Props */
 type ColumnHeaderProps = {
 	/** ステータス名 */
@@ -6,10 +9,20 @@ type ColumnHeaderProps = {
 	taskCount: number;
 	/** 「+ 追加」ボタンクリック時のコールバック */
 	onAddClick: () => void;
+	/**
+	 * カラム名リネーム確定時のコールバック。
+	 * 未指定の場合は名前クリックでの編集モードを無効化する。
+	 * 呼び出されるのは trim 後に空でなく、現在名と異なり、重複もしない場合のみ。
+	 * @param newName - 新しいカラム名（trim 済み）
+	 */
+	onRename?: (newName: string) => void;
+	/** 他カラム名の一覧（重複チェック用。自身は含まない） */
+	existingColumnNames?: string[];
 };
 
 /**
- * カラムヘッダーを表示する
+ * カラムヘッダーを表示する。
+ * onRename 指定時はステータス名クリックでインライン編集に切り替わる。
  * @param props - {@link ColumnHeaderProps}
  * @returns カラムヘッダー要素
  */
@@ -17,11 +30,112 @@ export function ColumnHeader({
 	name,
 	taskCount,
 	onAddClick,
+	onRename,
+	existingColumnNames = [],
 }: ColumnHeaderProps) {
+	const [isEditing, setIsEditing] = useState(false);
+	const [inputValue, setInputValue] = useState(name);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const isCancelledRef = useRef(false);
+	const reactId = useId();
+	const errorId = `${reactId}-error`;
+
+	useEffect(() => {
+		if (isEditing) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [isEditing]);
+
+	const startEditing = () => {
+		if (!onRename) return;
+		isCancelledRef.current = false;
+		setInputValue(name);
+		setIsEditing(true);
+	};
+
+	const cancel = () => {
+		isCancelledRef.current = true;
+		setInputValue(name);
+		setIsEditing(false);
+	};
+
+	const confirm = (): boolean => {
+		const trimmed = inputValue.trim();
+		if (trimmed.length === 0 || trimmed === name) {
+			isCancelledRef.current = true;
+			setInputValue(name);
+			setIsEditing(false);
+			return true;
+		}
+		if (existingColumnNames.includes(trimmed)) {
+			return false;
+		}
+		onRename?.(trimmed);
+		isCancelledRef.current = true;
+		setIsEditing(false);
+		return true;
+	};
+
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			if (e.nativeEvent.isComposing) return;
+			e.preventDefault();
+			e.stopPropagation();
+			confirm();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			e.stopPropagation();
+			cancel();
+		}
+	};
+
+	const trimmedInput = inputValue.trim();
+	const isDuplicate =
+		trimmedInput.length > 0 &&
+		trimmedInput !== name &&
+		existingColumnNames.includes(trimmedInput);
+
 	return (
 		<div className="flex items-center justify-between px-2 py-2">
 			<div className="flex items-center gap-2">
-				<h2 className="text-sm font-semibold text-gray-700">{name}</h2>
+				{isEditing ? (
+					<div className="flex flex-col gap-1">
+						<input
+							ref={inputRef}
+							type="text"
+							value={inputValue}
+							onChange={(e) => setInputValue(e.target.value)}
+							onKeyDown={handleKeyDown}
+							onBlur={() => {
+								if (!isCancelledRef.current) cancel();
+								isCancelledRef.current = false;
+							}}
+							aria-label="カラム名"
+							aria-invalid={isDuplicate}
+							aria-describedby={isDuplicate ? errorId : undefined}
+							className="w-32 rounded border border-blue-400 px-1 py-0.5 text-sm font-semibold text-gray-900 outline-none"
+							data-testid="column-rename-input"
+						/>
+						{isDuplicate && (
+							<p id={errorId} className="text-xs text-red-500" role="alert">
+								同じ名前のカラムが既に存在します
+							</p>
+						)}
+					</div>
+				) : onRename ? (
+					<button
+						type="button"
+						onClick={startEditing}
+						aria-label={`${name}の名前を変更`}
+						className="rounded px-1 py-0.5 text-sm font-semibold text-gray-700 hover:bg-gray-100"
+						data-testid="column-name-button"
+					>
+						{name}
+					</button>
+				) : (
+					<h2 className="text-sm font-semibold text-gray-700">{name}</h2>
+				)}
 				<span className="rounded-full bg-gray-200 px-2 py-0.5 text-xs text-gray-600">
 					{taskCount}
 				</span>

--- a/src/features/board/components/ColumnHeader.tsx
+++ b/src/features/board/components/ColumnHeader.tsx
@@ -100,7 +100,7 @@ export function ColumnHeader({
 		<div className="flex items-center justify-between px-2 py-2">
 			<div className="flex items-center gap-2">
 				{isEditing ? (
-					<div className="flex flex-col gap-1">
+					<div className="flex min-w-0 flex-1 flex-col gap-1">
 						<input
 							ref={inputRef}
 							type="text"
@@ -114,7 +114,7 @@ export function ColumnHeader({
 							aria-label="カラム名"
 							aria-invalid={isDuplicate}
 							aria-describedby={isDuplicate ? errorId : undefined}
-							className="w-32 rounded border border-blue-400 px-1 py-0.5 text-sm font-semibold text-gray-900 outline-none"
+							className="w-full min-w-32 rounded border border-blue-400 px-1 py-0.5 text-sm font-semibold text-gray-900 outline-none"
 							data-testid="column-rename-input"
 						/>
 						{isDuplicate && (

--- a/src/features/board/components/ColumnHeader.tsx
+++ b/src/features/board/components/ColumnHeader.tsx
@@ -124,15 +124,17 @@ export function ColumnHeader({
 						)}
 					</div>
 				) : onRename ? (
-					<button
-						type="button"
-						onClick={startEditing}
-						aria-label={`${name}の名前を変更`}
-						className="rounded px-1 py-0.5 text-sm font-semibold text-gray-700 hover:bg-gray-100"
-						data-testid="column-name-button"
-					>
-						{name}
-					</button>
+					<h2 className="text-sm font-semibold text-gray-700">
+						<button
+							type="button"
+							onClick={startEditing}
+							aria-label={`${name}の名前を変更`}
+							className="rounded px-1 py-0.5 hover:bg-gray-100"
+							data-testid="column-name-button"
+						>
+							{name}
+						</button>
+					</h2>
 				) : (
 					<h2 className="text-sm font-semibold text-gray-700">{name}</h2>
 				)}

--- a/src/lib/api.integration.test.ts
+++ b/src/lib/api.integration.test.ts
@@ -159,6 +159,27 @@ test("updateColumns でカラム定義を更新できる", async () => {
 	expect(columns).toHaveLength(4);
 });
 
+test("updateColumns で renames を渡すと該当タスクの status が一括更新される", async () => {
+	const before = await getTasks();
+	const todoTaskIds = before
+		.filter((t) => t.status === "Todo")
+		.map((t) => t.id);
+	expect(todoTaskIds.length).toBeGreaterThan(0);
+
+	const newColumns = [
+		{ name: "Backlog", order: 0 },
+		{ name: "In Progress", order: 1 },
+		{ name: "Done", order: 2 },
+	];
+	await updateColumns(newColumns, [{ from: "Todo", to: "Backlog" }]);
+
+	const after = await getTasks();
+	for (const id of todoTaskIds) {
+		expect(after.find((t) => t.id === id)?.status).toBe("Backlog");
+	}
+	expect(after.some((t) => t.status === "Todo")).toBe(false);
+});
+
 test("updateCardOrder でカード表示順を更新できる", async () => {
 	const newOrder = {
 		Todo: ["tasks/fix-login-bug.md"],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -149,12 +149,33 @@ export async function deleteTask(id: string): Promise<void> {
 	}
 }
 
+/** カラム名変更の指定 */
+export type ColumnRename = {
+	/** 元のカラム名 */
+	from: string;
+	/** 新しいカラム名 */
+	to: string;
+};
+
 /**
  * カラム定義を更新する
  * @param newColumns - 新しいカラム定義の配列
+ * @param renames - カラム名変更の配列。指定時は該当タスクの status を一括更新する
  * @returns 更新後のカラム配列
  */
-export async function updateColumns(newColumns: Column[]): Promise<Column[]> {
+export async function updateColumns(
+	newColumns: Column[],
+	renames?: ColumnRename[],
+): Promise<Column[]> {
+	if (renames && renames.length > 0) {
+		const renameMap = new Map(renames.map((r) => [r.from, r.to]));
+		for (const task of tasks) {
+			const next = renameMap.get(task.status);
+			if (next !== undefined) {
+				task.status = next;
+			}
+		}
+	}
 	columns = structuredClone(newColumns);
 	cardOrder = buildCardOrder(tasks, columns);
 	return structuredClone(columns);


### PR DESCRIPTION
## 概要

カラムヘッダーのステータス名クリックでインライン編集できるようにする (task 021)。

- `ColumnHeader` に名前クリックで切替わる編集 UI を追加（Enter 確定・Esc キャンセル）
- `updateColumns` API に `renames` パラメータを追加し、確定時に呼び出す
- `App` で該当タスクの `status` を新名へ一括更新
- カラム追加/名前変更を同じキューで直列化して競合を防止

## 変更ファイル

- `src/lib/api.ts` — `ColumnRename` 型と `updateColumns(columns, renames?)` オーバーロード
- `src/lib/api.integration.test.ts` — `renames` 指定で task.status が更新されるテスト
- `src/features/board/components/ColumnHeader.tsx` — インライン編集実装
- `src/features/board/components/ColumnHeader.interaction.test.tsx` — 編集挙動のテスト（正常/空文字/重複/Esc/未指定）
- `src/features/board/components/Column.tsx` — `onRename` / `existingColumnNames` パススルー
- `src/features/board/components/Board.tsx` — `onRenameColumn` 受け取り、各カラムへ配線
- `src/App.tsx` — `handleRenameColumn` 実装、`columnsQueueRef` で add/rename を直列化

## テスト方法

- [x] `pnpm test:run` — 178 tests passed
- [x] `pnpm run build` — tsc + vite ビルド成功

## 受け入れ基準

- [x] ステータス名クリックで編集モードになる
- [x] Enter で updateColumns が renames 付きで呼ばれる
- [x] 空文字で確定すると元に戻る
- [x] 既存と同名で確定するとエラー表示
- [x] Esc でキャンセルされ元に戻る

---
Automated by task-loop-run
