### PR TITLE
feat: カラム削除（コンテキストメニュー）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,6 +162,15 @@ function App() {
 						showToast("最後のカラムは削除できません", "error");
 						return;
 					}
+					if (destColumn !== undefined) {
+						if (
+							destColumn === columnName ||
+							!current.some((c) => c.name === destColumn)
+						) {
+							showToast("移動先カラムが不正です", "error");
+							return;
+						}
+					}
 					const nextColumns: Column[] = current.filter(
 						(c) => c.name !== columnName,
 					);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,6 +145,51 @@ function App() {
 		[showToast],
 	);
 
+	/**
+	 * 既存カラムの削除。カラム追加・リネームと同じキューで直列化し、競合を防ぐ。
+	 * destColumn 指定時は削除対象カラムのタスクを移動先へ status 変更する。
+	 * カラムが 1 つしかない場合は何もしない。
+	 * @param columnName - 削除するカラム名
+	 * @param destColumn - 移動先のカラム名。タスクが 0 件の場合は undefined
+	 */
+	const handleDeleteColumn = useCallback(
+		(columnName: string, destColumn: string | undefined): Promise<void> => {
+			const next = columnsQueueRef.current.then(async () => {
+				try {
+					const current = columnsRef.current;
+					if (!current.some((c) => c.name === columnName)) return;
+					if (current.length <= 1) {
+						showToast("最後のカラムは削除できません", "error");
+						return;
+					}
+					const nextColumns: Column[] = current.filter(
+						(c) => c.name !== columnName,
+					);
+					const renames =
+						destColumn !== undefined
+							? [{ from: columnName, to: destColumn }]
+							: undefined;
+					const updated = await updateColumns(nextColumns, renames);
+					columnsRef.current = updated;
+					setColumns(updated);
+					if (destColumn !== undefined) {
+						setTasks((prev) =>
+							prev.map((t) =>
+								t.status === columnName ? { ...t, status: destColumn } : t,
+							),
+						);
+					}
+					showToast("カラムを削除しました", "success");
+				} catch {
+					showToast("カラムの削除に失敗しました", "error");
+				}
+			});
+			columnsQueueRef.current = next;
+			return next;
+		},
+		[showToast],
+	);
+
 	const handleCloseCreateModal = useCallback(() => {
 		setCreateModalStatus(null);
 		setCreateModalParent(undefined);
@@ -250,6 +295,7 @@ function App() {
 						onAddTask={handleAddTask}
 						onAddColumn={handleAddColumn}
 						onRenameColumn={handleRenameColumn}
+						onDeleteColumn={handleDeleteColumn}
 						onTaskClick={handleTaskClick}
 					/>
 				)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,10 +31,15 @@ function App() {
 	const { toasts, showToast, dismissToast } = useToasts();
 	const columnsRef = useRef<Column[]>(columns);
 	const columnsQueueRef = useRef<Promise<void>>(Promise.resolve());
+	const tasksRef = useRef<Task[]>(tasks);
 
 	useEffect(() => {
 		columnsRef.current = columns;
 	}, [columns]);
+
+	useEffect(() => {
+		tasksRef.current = tasks;
+	}, [tasks]);
 
 	const selectedTask = selectedTaskId
 		? (tasks.find((t) => t.id === selectedTaskId) ?? null)
@@ -170,6 +175,9 @@ function App() {
 							showToast("移動先カラムが不正です", "error");
 							return;
 						}
+					} else if (tasksRef.current.some((t) => t.status === columnName)) {
+						showToast("タスクが残っているため移動先カラムが必要です", "error");
+						return;
 					}
 					const nextColumns: Column[] = current.filter(
 						(c) => c.name !== columnName,

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useEffect, useId, useRef } from "react";
 
 type ConfirmDialogProps = {
@@ -17,6 +18,8 @@ type ConfirmDialogProps = {
 	onConfirm: () => void;
 	/** キャンセル時のコールバック */
 	onCancel: () => void;
+	/** メッセージとボタンの間に表示する追加コンテンツ（任意入力要素など） */
+	children?: ReactNode;
 };
 
 /**
@@ -33,6 +36,7 @@ export function ConfirmDialog({
 	cancelDisabled = false,
 	onConfirm,
 	onCancel,
+	children,
 }: ConfirmDialogProps) {
 	const dialogRef = useRef<HTMLDivElement>(null);
 	const id = useId();
@@ -78,6 +82,7 @@ export function ConfirmDialog({
 				<p id={messageId} className="mt-2 text-sm text-gray-600">
 					{message}
 				</p>
+				{children}
 				<div className="mt-6 flex justify-end gap-3">
 					<button
 						type="button"

--- a/src/features/board/components/Board.tsx
+++ b/src/features/board/components/Board.tsx
@@ -34,6 +34,14 @@ type BoardProps = {
 	 * @param newName - 新しいカラム名（trim 済み、既存と非重複）
 	 */
 	onRenameColumn?: (oldName: string, newName: string) => void;
+	/**
+	 * カラム削除確定時のコールバック。
+	 * 未指定の場合はカラム削除 UI を無効化する。
+	 * カラムが 1 つの場合は内部で削除操作を禁止する。
+	 * @param columnName - 削除するカラム名
+	 * @param destColumn - タスクの移動先カラム名。削除対象カラムにタスクが 0 件の場合は undefined
+	 */
+	onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
 };
 
 /**
@@ -49,6 +57,7 @@ export function Board({
 	onTaskClick,
 	onAddColumn,
 	onRenameColumn,
+	onDeleteColumn,
 }: BoardProps) {
 	const sorted = useMemo(
 		() => [...columns].sort((a, b) => a.order - b.order),
@@ -85,6 +94,12 @@ export function Board({
 							: undefined
 					}
 					existingColumnNames={columnNames.filter((n) => n !== col.name)}
+					onDelete={
+						onDeleteColumn
+							? (destColumn) => onDeleteColumn(col.name, destColumn)
+							: undefined
+					}
+					canDelete={columns.length > 1}
 				/>
 			))}
 			{onAddColumn && (

--- a/src/features/board/components/Column.interaction.test.tsx
+++ b/src/features/board/components/Column.interaction.test.tsx
@@ -212,6 +212,22 @@ test("タスクなしで確定すると onDelete が undefined で呼ばれる",
 	expect(onDelete).toHaveBeenCalledWith(undefined);
 });
 
+test("タスクがあるのに移動先カラムが無い場合、メニューの削除項目が無効化される", () => {
+	render({
+		name: "Todo",
+		tasks: [createTask({ status: "Todo" })],
+		onAddClick: vi.fn(),
+		onDelete: vi.fn(),
+		existingColumnNames: [],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	const deleteItem = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement | null;
+	expect(deleteItem?.disabled).toBe(true);
+});
+
 test("canDelete=false の場合、メニューの削除項目が無効化される", () => {
 	render({
 		name: "Todo",

--- a/src/features/board/components/Column.interaction.test.tsx
+++ b/src/features/board/components/Column.interaction.test.tsx
@@ -1,0 +1,260 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Task } from "../../../types/task";
+import { Column } from "./Column";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "task-1",
+		title: "テストタスク",
+		status: "Todo",
+		labels: [],
+		links: [],
+		children: [],
+		reverseLinks: [],
+		body: "",
+		filePath: "tasks/test.md",
+		...overrides,
+	};
+}
+
+function render(props: Parameters<typeof Column>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(Column, props));
+	});
+}
+
+function dispatchContextMenu(target: Element) {
+	act(() => {
+		target.dispatchEvent(
+			new MouseEvent("contextmenu", {
+				bubbles: true,
+				cancelable: true,
+				clientX: 50,
+				clientY: 80,
+			}),
+		);
+	});
+}
+
+test("ヘッダー右クリックでコンテキストメニューが表示される", () => {
+	render({
+		name: "Todo",
+		tasks: [],
+		onAddClick: vi.fn(),
+		onDelete: vi.fn(),
+		existingColumnNames: ["Done"],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	const menu = document.querySelector('[data-testid="column-context-menu"]');
+	expect(menu).toBeTruthy();
+});
+
+test("onDelete 未指定時は右クリックしてもメニューが表示されない", () => {
+	render({
+		name: "Todo",
+		tasks: [],
+		onAddClick: vi.fn(),
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	const menu = document.querySelector('[data-testid="column-context-menu"]');
+	expect(menu).toBeFalsy();
+});
+
+test("メニューの「削除」クリックで ConfirmDialog が表示される", () => {
+	render({
+		name: "Todo",
+		tasks: [],
+		onAddClick: vi.fn(),
+		onDelete: vi.fn(),
+		existingColumnNames: ["Done"],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	const deleteItem = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement;
+	act(() => {
+		deleteItem.click();
+	});
+	const dialog = document.querySelector('[data-testid="confirm-dialog"]');
+	expect(dialog).toBeTruthy();
+});
+
+test("タスクありの場合、移動先ドロップダウンが表示される", () => {
+	render({
+		name: "Todo",
+		tasks: [createTask({ status: "Todo" }), createTask({ id: "task-2" })],
+		onAddClick: vi.fn(),
+		onDelete: vi.fn(),
+		existingColumnNames: ["In Progress", "Done"],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	const deleteItem = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement;
+	act(() => {
+		deleteItem.click();
+	});
+	const dropdown = document.querySelector(
+		'[data-testid="column-delete-destination"]',
+	) as HTMLSelectElement | null;
+	expect(dropdown).toBeTruthy();
+	const options = Array.from(dropdown?.options ?? []).map((o) => o.value);
+	expect(options).toEqual(["In Progress", "Done"]);
+});
+
+test("タスクなしの場合、移動先ドロップダウンは表示されない", () => {
+	render({
+		name: "Todo",
+		tasks: [],
+		onAddClick: vi.fn(),
+		onDelete: vi.fn(),
+		existingColumnNames: ["Done"],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	const deleteItem = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement;
+	act(() => {
+		deleteItem.click();
+	});
+	const dropdown = document.querySelector(
+		'[data-testid="column-delete-destination"]',
+	);
+	expect(dropdown).toBeFalsy();
+});
+
+test("タスクありで確定すると onDelete が移動先と共に呼ばれる", () => {
+	const onDelete = vi.fn();
+	render({
+		name: "Todo",
+		tasks: [createTask({ status: "Todo" })],
+		onAddClick: vi.fn(),
+		onDelete,
+		existingColumnNames: ["In Progress", "Done"],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="column-context-menu-delete"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	const dropdown = document.querySelector(
+		'[data-testid="column-delete-destination"]',
+	) as HTMLSelectElement;
+	const nativeSetter = Object.getOwnPropertyDescriptor(
+		HTMLSelectElement.prototype,
+		"value",
+	)?.set;
+	act(() => {
+		nativeSetter?.call(dropdown, "Done");
+		dropdown.dispatchEvent(new Event("change", { bubbles: true }));
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="confirm-confirm-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	expect(onDelete).toHaveBeenCalledWith("Done");
+});
+
+test("タスクなしで確定すると onDelete が undefined で呼ばれる", () => {
+	const onDelete = vi.fn();
+	render({
+		name: "Todo",
+		tasks: [],
+		onAddClick: vi.fn(),
+		onDelete,
+		existingColumnNames: ["Done"],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="column-context-menu-delete"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="confirm-confirm-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	expect(onDelete).toHaveBeenCalledWith(undefined);
+});
+
+test("canDelete=false の場合、メニューの削除項目が無効化される", () => {
+	render({
+		name: "Todo",
+		tasks: [],
+		onAddClick: vi.fn(),
+		onDelete: vi.fn(),
+		existingColumnNames: [],
+		canDelete: false,
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	const deleteItem = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement | null;
+	expect(deleteItem?.disabled).toBe(true);
+});
+
+test("キャンセルで ConfirmDialog が閉じ、onDelete は呼ばれない", () => {
+	const onDelete = vi.fn();
+	render({
+		name: "Todo",
+		tasks: [],
+		onAddClick: vi.fn(),
+		onDelete,
+		existingColumnNames: ["Done"],
+	});
+	const header = container?.querySelector("section > div") as HTMLElement;
+	dispatchContextMenu(header);
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="column-context-menu-delete"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	act(() => {
+		(
+			document.querySelector(
+				'[data-testid="confirm-cancel-button"]',
+			) as HTMLButtonElement
+		).click();
+	});
+	expect(onDelete).not.toHaveBeenCalled();
+	const dialog = document.querySelector('[data-testid="confirm-dialog"]');
+	expect(dialog).toBeFalsy();
+});

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { ConfirmDialog } from "../../../components/ConfirmDialog";
 import type { Task } from "../../../types/task";
 import { ColumnContextMenu } from "./ColumnContextMenu";
@@ -67,13 +67,30 @@ export function Column({
 	const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
 	const [isConfirming, setIsConfirming] = useState(false);
 	const [destColumn, setDestColumn] = useState<string>("");
+	const triggerRef = useRef<HTMLElement | null>(null);
 
 	const handleContextMenu = onDelete
 		? (e: MouseEvent<HTMLElement>) => {
 				e.preventDefault();
-				setMenuPos({ x: e.clientX, y: e.clientY });
+				triggerRef.current = e.currentTarget;
+				// キーボード操作（Enter/Space）で発火したときは clientX/Y が 0 になる
+				// ため、トリガー要素の矩形を基準に配置して左上表示を避ける。
+				if (e.clientX !== 0 || e.clientY !== 0) {
+					setMenuPos({ x: e.clientX, y: e.clientY });
+					return;
+				}
+				const rect = e.currentTarget.getBoundingClientRect();
+				setMenuPos({ x: rect.left, y: rect.bottom });
 			}
 		: undefined;
+
+	const handleMenuClose = () => {
+		setMenuPos(null);
+		// キーボードでメニューを開いた場合にフォーカスが失われないよう、
+		// 開いた要素へフォーカスを戻す。
+		triggerRef.current?.focus();
+		triggerRef.current = null;
+	};
 
 	const handleDeleteClick = () => {
 		setDestColumn(otherColumnNames[0] ?? "");
@@ -133,7 +150,7 @@ export function Column({
 					y={menuPos.y}
 					canDelete={canDeleteEffective}
 					onDelete={handleDeleteClick}
-					onClose={() => setMenuPos(null)}
+					onClose={handleMenuClose}
 				/>
 			)}
 			{isConfirming && (

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -92,6 +92,10 @@ export function Column({
 
 	const hasTasks = tasks.length > 0;
 	const confirmDisabled = hasTasks && destColumn === "";
+	// タスクが残っているのに移動先が無いとダイアログが「確定不能」になるため、
+	// メニュー側で削除操作そのものを封じる。
+	const canDeleteEffective =
+		canDelete && !(hasTasks && otherColumnNames.length === 0);
 
 	return (
 		<section
@@ -127,7 +131,7 @@ export function Column({
 				<ColumnContextMenu
 					x={menuPos.x}
 					y={menuPos.y}
-					canDelete={canDelete}
+					canDelete={canDeleteEffective}
 					onDelete={handleDeleteClick}
 					onClose={() => setMenuPos(null)}
 				/>

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -1,5 +1,8 @@
-import { useMemo } from "react";
+import type { MouseEvent } from "react";
+import { useMemo, useState } from "react";
+import { ConfirmDialog } from "../../../components/ConfirmDialog";
 import type { Task } from "../../../types/task";
+import { ColumnContextMenu } from "./ColumnContextMenu";
 import { ColumnHeader } from "./ColumnHeader";
 import { TaskCard } from "./TaskCard";
 
@@ -28,6 +31,14 @@ type ColumnProps = {
 	onRename?: (newName: string) => void;
 	/** 他カラム名の一覧（重複チェック用。自身は含まない） */
 	existingColumnNames?: string[];
+	/**
+	 * カラム削除確定時のコールバック。
+	 * 未指定の場合は削除 UI を無効化する。
+	 * @param destColumn - タスクの移動先カラム名。タスクが 0 件の場合は undefined
+	 */
+	onDelete?: (destColumn: string | undefined) => void;
+	/** 削除操作を許可するか（false の場合は右クリックメニューの削除が無効化） */
+	canDelete?: boolean;
 };
 
 /**
@@ -44,11 +55,43 @@ export function Column({
 	onTaskClick,
 	onRename,
 	existingColumnNames,
+	onDelete,
+	canDelete = true,
 }: ColumnProps) {
 	const tasksByFilePath = useMemo(
 		() => new Map(allTasks.map((t) => [t.filePath, t])),
 		[allTasks],
 	);
+
+	const otherColumnNames = existingColumnNames ?? [];
+	const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+	const [isConfirming, setIsConfirming] = useState(false);
+	const [destColumn, setDestColumn] = useState<string>("");
+
+	const handleContextMenu = onDelete
+		? (e: MouseEvent<HTMLDivElement>) => {
+				e.preventDefault();
+				setMenuPos({ x: e.clientX, y: e.clientY });
+			}
+		: undefined;
+
+	const handleDeleteClick = () => {
+		setDestColumn(otherColumnNames[0] ?? "");
+		setIsConfirming(true);
+	};
+
+	const handleConfirm = () => {
+		const hasTasks = tasks.length > 0;
+		onDelete?.(hasTasks ? destColumn : undefined);
+		setIsConfirming(false);
+	};
+
+	const handleCancel = () => {
+		setIsConfirming(false);
+	};
+
+	const hasTasks = tasks.length > 0;
+	const confirmDisabled = hasTasks && destColumn === "";
 
 	return (
 		<section
@@ -61,6 +104,7 @@ export function Column({
 				onAddClick={onAddClick}
 				onRename={onRename}
 				existingColumnNames={existingColumnNames}
+				onContextMenu={handleContextMenu}
 			/>
 			<ul className="flex-1 overflow-y-auto px-2 pb-2">
 				{tasks.map((task) => {
@@ -79,6 +123,47 @@ export function Column({
 					);
 				})}
 			</ul>
+			{menuPos && (
+				<ColumnContextMenu
+					x={menuPos.x}
+					y={menuPos.y}
+					canDelete={canDelete}
+					onDelete={handleDeleteClick}
+					onClose={() => setMenuPos(null)}
+				/>
+			)}
+			{isConfirming && (
+				<ConfirmDialog
+					title="カラムを削除"
+					message={
+						hasTasks
+							? `「${name}」には ${tasks.length} 件のタスクがあります。移動先を選択してください。`
+							: `「${name}」を削除します。よろしいですか？`
+					}
+					confirmLabel="削除"
+					confirmDisabled={confirmDisabled}
+					onConfirm={handleConfirm}
+					onCancel={handleCancel}
+				>
+					{hasTasks && otherColumnNames.length > 0 && (
+						<label className="mt-4 block text-sm text-gray-700">
+							移動先カラム
+							<select
+								value={destColumn}
+								onChange={(e) => setDestColumn(e.target.value)}
+								className="mt-1 w-full rounded border border-gray-300 px-2 py-1 text-sm"
+								data-testid="column-delete-destination"
+							>
+								{otherColumnNames.map((n) => (
+									<option key={n} value={n}>
+										{n}
+									</option>
+								))}
+							</select>
+						</label>
+					)}
+				</ConfirmDialog>
+			)}
 		</section>
 	);
 }

--- a/src/features/board/components/Column.tsx
+++ b/src/features/board/components/Column.tsx
@@ -69,7 +69,7 @@ export function Column({
 	const [destColumn, setDestColumn] = useState<string>("");
 
 	const handleContextMenu = onDelete
-		? (e: MouseEvent<HTMLDivElement>) => {
+		? (e: MouseEvent<HTMLElement>) => {
 				e.preventDefault();
 				setMenuPos({ x: e.clientX, y: e.clientY });
 			}

--- a/src/features/board/components/ColumnContextMenu.interaction.test.tsx
+++ b/src/features/board/components/ColumnContextMenu.interaction.test.tsx
@@ -1,0 +1,87 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { ColumnContextMenu } from "./ColumnContextMenu";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function render(props: Parameters<typeof ColumnContextMenu>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(ColumnContextMenu, props));
+	});
+}
+
+test("削除項目クリックで onDelete と onClose が呼ばれる", () => {
+	const onDelete = vi.fn();
+	const onClose = vi.fn();
+	render({ x: 0, y: 0, canDelete: true, onDelete, onClose });
+	const item = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement;
+	act(() => {
+		item.click();
+	});
+	expect(onDelete).toHaveBeenCalledTimes(1);
+	expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("canDelete=false の場合、クリックしても onDelete は呼ばれない", () => {
+	const onDelete = vi.fn();
+	const onClose = vi.fn();
+	render({ x: 0, y: 0, canDelete: false, onDelete, onClose });
+	const item = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement;
+	act(() => {
+		item.click();
+	});
+	expect(onDelete).not.toHaveBeenCalled();
+});
+
+test("オーバーレイクリックで onClose が呼ばれる", () => {
+	const onClose = vi.fn();
+	render({
+		x: 0,
+		y: 0,
+		canDelete: true,
+		onDelete: vi.fn(),
+		onClose,
+	});
+	const overlay = document.querySelector(
+		'[data-testid="column-context-menu-overlay"]',
+	) as HTMLElement;
+	act(() => {
+		overlay.click();
+	});
+	expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("Esc キーで onClose が呼ばれる", () => {
+	const onClose = vi.fn();
+	render({
+		x: 0,
+		y: 0,
+		canDelete: true,
+		onDelete: vi.fn(),
+		onClose,
+	});
+	act(() => {
+		document.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+		);
+	});
+	expect(onClose).toHaveBeenCalled();
+});

--- a/src/features/board/components/ColumnContextMenu.rendering.test.tsx
+++ b/src/features/board/components/ColumnContextMenu.rendering.test.tsx
@@ -1,0 +1,80 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { ColumnContextMenu } from "./ColumnContextMenu";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+	act(() => {
+		root?.unmount();
+	});
+	root = null;
+	container?.remove();
+	container = null;
+});
+
+function render(props: Parameters<typeof ColumnContextMenu>[0]) {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	act(() => {
+		root?.render(createElement(ColumnContextMenu, props));
+	});
+}
+
+test("メニュー本体が表示される", () => {
+	render({
+		x: 10,
+		y: 20,
+		canDelete: true,
+		onDelete: vi.fn(),
+		onClose: vi.fn(),
+	});
+	const menu = document.querySelector('[data-testid="column-context-menu"]');
+	expect(menu).toBeTruthy();
+});
+
+test("「削除」メニュー項目が表示される", () => {
+	render({
+		x: 0,
+		y: 0,
+		canDelete: true,
+		onDelete: vi.fn(),
+		onClose: vi.fn(),
+	});
+	const item = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	);
+	expect(item?.textContent).toContain("削除");
+});
+
+test("canDelete=false の場合、削除項目は disabled になる", () => {
+	render({
+		x: 0,
+		y: 0,
+		canDelete: false,
+		onDelete: vi.fn(),
+		onClose: vi.fn(),
+	});
+	const item = document.querySelector(
+		'[data-testid="column-context-menu-delete"]',
+	) as HTMLButtonElement | null;
+	expect(item?.disabled).toBe(true);
+});
+
+test("指定座標にメニューが配置される", () => {
+	render({
+		x: 100,
+		y: 200,
+		canDelete: true,
+		onDelete: vi.fn(),
+		onClose: vi.fn(),
+	});
+	const menu = document.querySelector(
+		'[data-testid="column-context-menu"]',
+	) as HTMLElement | null;
+	expect(menu?.style.left).toBe("100px");
+	expect(menu?.style.top).toBe("200px");
+});

--- a/src/features/board/components/ColumnContextMenu.tsx
+++ b/src/features/board/components/ColumnContextMenu.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from "react";
+
+/** ColumnContextMenu の Props */
+type ColumnContextMenuProps = {
+	/** 表示位置 X 座標（clientX） */
+	x: number;
+	/** 表示位置 Y 座標（clientY） */
+	y: number;
+	/** 削除メニュー項目を有効化するか（false の場合はクリック不可） */
+	canDelete: boolean;
+	/** 「削除」項目クリック時のコールバック */
+	onDelete: () => void;
+	/** メニューを閉じるコールバック（外側クリック・Esc・項目選択後） */
+	onClose: () => void;
+};
+
+/**
+ * カラムヘッダーの右クリック時に表示されるコンテキストメニュー。
+ * 現時点では「削除」項目のみを提供する。
+ * @param props - {@link ColumnContextMenuProps}
+ * @returns コンテキストメニュー要素
+ */
+export function ColumnContextMenu({
+	x,
+	y,
+	canDelete,
+	onDelete,
+	onClose,
+}: ColumnContextMenuProps) {
+	const menuRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [onClose]);
+
+	return (
+		<>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: overlay dismisses menu on click; Escape handled separately */}
+			<div
+				role="presentation"
+				className="fixed inset-0 z-40"
+				data-testid="column-context-menu-overlay"
+				onClick={onClose}
+				onContextMenu={(e) => {
+					e.preventDefault();
+					onClose();
+				}}
+			/>
+			<div
+				ref={menuRef}
+				role="menu"
+				aria-label="カラム操作"
+				style={{ top: y, left: x }}
+				className="fixed z-50 min-w-32 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+				data-testid="column-context-menu"
+			>
+				<button
+					type="button"
+					role="menuitem"
+					disabled={!canDelete}
+					onClick={() => {
+						onDelete();
+						onClose();
+					}}
+					className="w-full px-3 py-1.5 text-left text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:bg-transparent"
+					data-testid="column-context-menu-delete"
+				>
+					削除
+				</button>
+			</div>
+		</>
+	);
+}

--- a/src/features/board/components/ColumnContextMenu.tsx
+++ b/src/features/board/components/ColumnContextMenu.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /** ColumnContextMenu の Props */
 type ColumnContextMenuProps = {
@@ -41,6 +41,7 @@ export function ColumnContextMenu({
 	onClose,
 }: ColumnContextMenuProps) {
 	const menuRef = useRef<HTMLDivElement>(null);
+	const [pos, setPos] = useState({ x, y });
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -54,6 +55,17 @@ export function ColumnContextMenu({
 		const [firstItem] = getFocusableMenuItems(menuRef.current);
 		firstItem?.focus();
 	}, []);
+
+	// メニューの実寸を測ってビューポート外にはみ出す場合は折り返す。
+	// useLayoutEffect で paint 前に補正するため表示直後のちらつきは出ない。
+	useLayoutEffect(() => {
+		const menu = menuRef.current;
+		if (!menu) return;
+		const rect = menu.getBoundingClientRect();
+		const maxX = Math.max(0, window.innerWidth - rect.width);
+		const maxY = Math.max(0, window.innerHeight - rect.height);
+		setPos({ x: Math.min(x, maxX), y: Math.min(y, maxY) });
+	}, [x, y]);
 
 	const handleMenuKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
 		if (
@@ -97,7 +109,7 @@ export function ColumnContextMenu({
 				ref={menuRef}
 				role="menu"
 				aria-label="カラム操作"
-				style={{ top: y, left: x }}
+				style={{ top: pos.y, left: pos.x }}
 				className="fixed z-50 min-w-32 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
 				data-testid="column-context-menu"
 				onKeyDown={handleMenuKeyDown}

--- a/src/features/board/components/ColumnContextMenu.tsx
+++ b/src/features/board/components/ColumnContextMenu.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useEffect, useRef } from "react";
 
 /** ColumnContextMenu の Props */
@@ -13,6 +14,18 @@ type ColumnContextMenuProps = {
 	/** メニューを閉じるコールバック（外側クリック・Esc・項目選択後） */
 	onClose: () => void;
 };
+
+/**
+ * メニュー内のフォーカス可能な menuitem 要素を取得する。
+ * @param menu - メニューのルート要素。`null` の場合は空配列を返す
+ * @returns disabled でない menuitem の配列（DOM 順）
+ */
+function getFocusableMenuItems(menu: HTMLDivElement | null): HTMLElement[] {
+	if (!menu) return [];
+	return Array.from(
+		menu.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])'),
+	);
+}
 
 /**
  * カラムヘッダーの右クリック時に表示されるコンテキストメニュー。
@@ -37,6 +50,36 @@ export function ColumnContextMenu({
 		return () => document.removeEventListener("keydown", handleKeyDown);
 	}, [onClose]);
 
+	useEffect(() => {
+		const [firstItem] = getFocusableMenuItems(menuRef.current);
+		firstItem?.focus();
+	}, []);
+
+	const handleMenuKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+		if (
+			e.key !== "ArrowDown" &&
+			e.key !== "ArrowUp" &&
+			e.key !== "Home" &&
+			e.key !== "End"
+		) {
+			return;
+		}
+		const items = getFocusableMenuItems(menuRef.current);
+		if (items.length === 0) return;
+		e.preventDefault();
+		const active = document.activeElement;
+		const currentIndex =
+			active instanceof HTMLElement ? items.indexOf(active) : -1;
+		const nextIndex =
+			e.key === "Home"
+				? 0
+				: e.key === "End"
+					? items.length - 1
+					: (currentIndex + (e.key === "ArrowDown" ? 1 : -1) + items.length) %
+						items.length;
+		items[nextIndex]?.focus();
+	};
+
 	return (
 		<>
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: overlay dismisses menu on click; Escape handled separately */}
@@ -57,6 +100,7 @@ export function ColumnContextMenu({
 				style={{ top: y, left: x }}
 				className="fixed z-50 min-w-32 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
 				data-testid="column-context-menu"
+				onKeyDown={handleMenuKeyDown}
 			>
 				<button
 					type="button"

--- a/src/features/board/components/ColumnHeader.tsx
+++ b/src/features/board/components/ColumnHeader.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
 import { useEffect, useId, useRef, useState } from "react";
 
 /** カラムヘッダーの Props */
@@ -18,6 +18,12 @@ type ColumnHeaderProps = {
 	onRename?: (newName: string) => void;
 	/** 他カラム名の一覧（重複チェック用。自身は含まない） */
 	existingColumnNames?: string[];
+	/**
+	 * ヘッダー上の右クリック（コンテキストメニュー）時のコールバック。
+	 * 未指定の場合はブラウザ既定動作のまま。
+	 * @param event - 発生した MouseEvent
+	 */
+	onContextMenu?: (event: MouseEvent<HTMLDivElement>) => void;
 };
 
 /**
@@ -32,6 +38,7 @@ export function ColumnHeader({
 	onAddClick,
 	onRename,
 	existingColumnNames = [],
+	onContextMenu,
 }: ColumnHeaderProps) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [inputValue, setInputValue] = useState(name);
@@ -97,7 +104,11 @@ export function ColumnHeader({
 		existingColumnNames.includes(trimmedInput);
 
 	return (
-		<div className="flex items-center justify-between px-2 py-2">
+		// biome-ignore lint/a11y/noStaticElementInteractions: onContextMenu is a non-primary interaction; inner controls provide keyboard/ARIA access
+		<div
+			className="flex items-center justify-between px-2 py-2"
+			onContextMenu={onContextMenu}
+		>
 			<div className="flex items-center gap-2">
 				{isEditing ? (
 					<div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/src/features/board/components/ColumnHeader.tsx
+++ b/src/features/board/components/ColumnHeader.tsx
@@ -19,11 +19,11 @@ type ColumnHeaderProps = {
 	/** 他カラム名の一覧（重複チェック用。自身は含まない） */
 	existingColumnNames?: string[];
 	/**
-	 * ヘッダー上の右クリック（コンテキストメニュー）時のコールバック。
-	 * 未指定の場合はブラウザ既定動作のまま。
+	 * ヘッダーのメニュー要求（右クリック、またはメニューボタン押下）時のコールバック。
+	 * 未指定の場合はメニューボタンも非表示になり、ブラウザ既定動作のまま。
 	 * @param event - 発生した MouseEvent
 	 */
-	onContextMenu?: (event: MouseEvent<HTMLDivElement>) => void;
+	onContextMenu?: (event: MouseEvent<HTMLElement>) => void;
 };
 
 /**
@@ -104,12 +104,12 @@ export function ColumnHeader({
 		existingColumnNames.includes(trimmedInput);
 
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: onContextMenu is a non-primary interaction; inner controls provide keyboard/ARIA access
+		// biome-ignore lint/a11y/noStaticElementInteractions: onContextMenu is a secondary trigger for mouse users; the inner menu button provides the keyboard-accessible path
 		<div
 			className="flex items-center justify-between px-2 py-2"
 			onContextMenu={onContextMenu}
 		>
-			<div className="flex items-center gap-2">
+			<div className="flex min-w-0 flex-1 items-center gap-2">
 				{isEditing ? (
 					<div className="flex min-w-0 flex-1 flex-col gap-1">
 						<input
@@ -153,14 +153,28 @@ export function ColumnHeader({
 					{taskCount}
 				</span>
 			</div>
-			<button
-				type="button"
-				onClick={onAddClick}
-				aria-label={`${name}に追加`}
-				className="rounded px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
-			>
-				+ 追加
-			</button>
+			<div className="flex items-center gap-1">
+				{onContextMenu && (
+					<button
+						type="button"
+						onClick={onContextMenu}
+						aria-label={`${name}のメニューを開く`}
+						aria-haspopup="menu"
+						className="rounded px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+						data-testid="column-menu-button"
+					>
+						⋯
+					</button>
+				)}
+				<button
+					type="button"
+					onClick={onAddClick}
+					aria-label={`${name}に追加`}
+					className="rounded px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+				>
+					+ 追加
+				</button>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## 概要

カラムヘッダーの右クリックメニューからカラムを削除する機能を実装する。

## 変更内容

- `ColumnContextMenu` コンポーネントを新規追加（右クリックで表示、「削除」項目、Esc / 外側クリックで閉じる）
- `ColumnHeader` に任意の `onContextMenu` prop を追加してヘッダー上の右クリックを検知
- `Column` で削除フローを統括
  - タスクがあるカラムは移動先ドロップダウンを表示
  - タスクが無いカラムは移動先選択なしでそのまま確認
  - `ConfirmDialog` での確認後に `onDelete` を呼び出す
- `Board` に `onDeleteColumn` prop を追加。`canDelete = columns.length > 1` を渡してカラムが 1 つの場合の削除を禁止
- `App` に `handleDeleteColumn` を追加。カラム追加・リネームと同じキューで直列化し、`updateColumns` を `ColumnRename` 付きで呼び出してタスクの status を一括移動
- `ConfirmDialog` に `children` prop を追加し、メッセージとボタンの間に移動先ドロップダウンを差し込めるようにリファクタ

## テスト

```bash
pnpm test:run
```

- `ColumnContextMenu` のレンダリング・インタラクションテスト
- `Column` の削除フロー（右クリック → メニュー → 確認 → 確定／キャンセル）

## 動作確認観点

- [x] 右クリックでコンテキストメニュー表示
- [x] 「削除」選択で確認ダイアログ表示
- [x] タスクありの場合、移動先選択が表示される
- [x] 確定で `updateColumns` が呼ばれる
- [x] カラムが 1 つの場合、削除メニューが無効
- [x] タスクなしカラムは移動先選択なしで直接削除

---
Automated by task-loop-run
