### PR TITLE
✨ Storybook 10 を導入し全コンポーネントに見た目確認用 story を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,7 @@ Task.md
 .pr_number
 session-logs/
 tasks*
+.specs
+
+# Storybook
+storybook-static/

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import type { StorybookConfig } from "@storybook/react-vite";
+import { mergeConfig } from "vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
+  addons: ["@storybook/addon-a11y", "@storybook/addon-themes"],
+  framework: { name: "@storybook/react-vite", options: {} },
+  typescript: { reactDocgen: "react-docgen-typescript" },
+  async viteFinal(baseConfig) {
+    return mergeConfig(baseConfig, {
+      resolve: {
+        alias: {
+          "@": fileURLToPath(new URL("../src", import.meta.url)),
+        },
+      },
+    });
+  },
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,20 @@
+import type { Preview } from "@storybook/react-vite";
+import "../src/index.css";
+
+const preview: Preview = {
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "app",
+      values: [{ name: "app", value: "#ffffff" }],
+    },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
+    "@storybook/addon-a11y": "^10.3.5",
+    "@storybook/addon-themes": "^10.3.5",
+    "@storybook/react-vite": "^10.3.5",
     "@tauri-apps/cli": "^2",
     "@types/node": "^25.5.2",
     "@types/react": "^19.1.8",
@@ -33,6 +36,7 @@
     "happy-dom": "^20.8.9",
     "oxlint": "^1.58.0",
     "oxlint-tsgolint": "^0.20.0",
+    "storybook": "^10.3.5",
     "typescript": "~5.8.3",
     "vite": "^8.0.5",
     "vitest": "^4.1.4"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test:run": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,15 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.10
         version: 2.4.10
+      '@storybook/addon-a11y':
+        specifier: ^10.3.5
+        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/addon-themes':
+        specifier: ^10.3.5
+        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-vite':
+        specifier: ^10.3.5
+        version: 10.3.5(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
@@ -57,6 +66,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.20.0
         version: 0.20.0
+      storybook:
+        specifier: ^10.3.5
+        version: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -69,6 +81,43 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -77,10 +126,30 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -311,6 +380,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -590,8 +668,86 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-a11y@10.3.5':
+    resolution: {integrity: sha512-5k6lpgfIeLxvNhE8v3wEzdiu73ONKjF4gmH1AHvfqYd8kIVzQJai0KCDxgvqNncXHQhIWkaf1fg6+9hKaYJyaw==}
+    peerDependencies:
+      storybook: ^10.3.5
+
+  '@storybook/addon-themes@10.3.5':
+    resolution: {integrity: sha512-Mv+C7GuZ0MhGRx5C+rv8sCEjgYsDTLBvq68101V0s8Vwh3gKd6W9cbS31HoOeLAiIMiPPZ8C1iWudA3Oumdtlw==}
+    peerDependencies:
+      storybook: ^10.3.5
+
+  '@storybook/builder-vite@10.3.5':
+    resolution: {integrity: sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==}
+    peerDependencies:
+      storybook: ^10.3.5
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.3.5':
+    resolution: {integrity: sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.5
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.0.1':
+    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.3.5':
+    resolution: {integrity: sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
+
+  '@storybook/react-vite@10.3.5':
+    resolution: {integrity: sha512-UB5sJHeh26bfd8sNMx2YPGYRYmErIdTRaLOT28m4bykQIa1l9IgVktsYg/geW7KsJU0lXd3oTbnUjLD+enpi3w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/react@10.3.5':
+    resolution: {integrity: sha512-tpLTLaVGoA6fLK3ReyGzZUricq7lyPaV2hLPpj5wqdXLV/LpRtAHClUpNoPDYSBjlnSjL81hMZijbkGC3mA+gw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -769,14 +925,46 @@ packages:
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -791,6 +979,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -820,6 +1011,9 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
@@ -834,6 +1028,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.4':
     resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
@@ -843,32 +1040,151 @@ packages:
   '@vitest/snapshot@4.1.4':
     resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.4':
     resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.20:
+    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  electron-to-chromium@1.5.340:
+    resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -878,6 +1194,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -886,8 +1206,24 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -907,6 +1243,17 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -918,8 +1265,34 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -939,6 +1312,19 @@ packages:
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1014,6 +1400,20 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1024,13 +1424,38 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   oxlint-tsgolint@0.20.0:
     resolution: {integrity: sha512-/Uc9TQyN1l8w9QNvXtVHYtz+SzDJHKpb5X0UnHodl0BVzijUPk0LPlDOHAvogd1UI+iy9ZSF6gQxEqfzUxCULQ==}
@@ -1046,8 +1471,19 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1060,22 +1496,59 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1089,15 +1562,44 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
+  storybook@10.3.5:
+    resolution: {integrity: sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -1105,6 +1607,9 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1117,9 +1622,25 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1131,6 +1652,21 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite@8.0.5:
     resolution: {integrity: sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==}
@@ -1216,6 +1752,9 @@ packages:
       jsdom:
         optional: true
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
@@ -1237,15 +1776,113 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -1382,6 +2019,14 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.8.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@5.8.3)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)
+    optionalDependencies:
+      typescript: 5.8.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1540,7 +2185,92 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@rollup/pluginutils@5.3.0':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-a11y@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      axe-core: 4.11.3
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  '@storybook/addon-themes@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ts-dedent: 2.2.0
+
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ts-dedent: 2.2.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@storybook/react-dom-shim@10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  '@storybook/react-vite@10.3.5(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.8.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))
+      '@rollup/pluginutils': 5.3.0
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))
+      '@storybook/react': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)
+      empathic: 2.0.0
+      magic-string: 0.30.21
+      react: 19.2.4
+      react-docgen: 8.0.3
+      react-dom: 19.2.4(react@19.2.4)
+      resolve: 1.22.12
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tsconfig-paths: 4.2.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react@10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      react: 19.2.4
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0(typescript@5.8.3)
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@tailwindcss/node@4.2.2':
     dependencies:
@@ -1663,10 +2393,57 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.10.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1674,6 +2451,8 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/doctrine@0.0.9': {}
 
   '@types/estree@1.0.8': {}
 
@@ -1688,6 +2467,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/resolve@1.20.6': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -1714,6 +2495,14 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.4(@types/node@25.5.2)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1))
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1731,6 +2520,10 @@ snapshots:
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
@@ -1747,7 +2540,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -1755,7 +2558,25 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@webcontainer/env@1.1.1': {}
+
+  acorn@8.16.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   assertion-error@2.0.1: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
 
   ast-v8-to-istanbul@1.0.0:
     dependencies:
@@ -1763,13 +2584,78 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  axe-core@4.11.3: {}
+
+  balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.20: {}
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.20
+      caniuse-lite: 1.0.30001788
+      electron-to-chromium: 1.5.340
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  caniuse-lite@1.0.30001788: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
+
+  check-error@2.1.3: {}
 
   convert-source-map@2.0.0: {}
 
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  electron-to-chromium@1.5.340: {}
+
+  empathic@2.0.0: {}
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -1777,6 +2663,8 @@ snapshots:
       tapable: 2.3.2
 
   entities@7.0.1: {}
+
+  es-errors@1.3.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -1808,11 +2696,18 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
-    optional: true
+
+  escalade@3.2.0: {}
+
+  esprima@4.0.1: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -1822,6 +2717,16 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   graceful-fs@4.2.11: {}
 
@@ -1839,7 +2744,27 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
   html-escaper@2.0.2: {}
+
+  indent-string@4.0.0: {}
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.3
+
+  is-docker@3.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -1857,6 +2782,12 @@ snapshots:
   jiti@2.6.1: {}
 
   js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1907,6 +2838,16 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@11.3.5: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1921,9 +2862,30 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  min-indent@1.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
 
+  node-releases@2.0.37: {}
+
   obug@2.1.1: {}
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   oxlint-tsgolint@0.20.0:
     optionalDependencies:
@@ -1957,7 +2919,16 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.58.0
       oxlint-tsgolint: 0.20.0
 
+  path-parse@1.0.7: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -1969,12 +2940,59 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  react-docgen-typescript@2.4.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-is@17.0.2: {}
+
   react@19.2.4: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     dependencies:
@@ -2000,7 +3018,11 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  run-applescript@7.1.0: {}
+
   scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -2008,17 +3030,53 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.7
+      open: 10.2.0
+      recast: 0.23.11
+      semver: 7.7.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
+  strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-indent@4.1.1: {}
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -2029,14 +3087,42 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  tinyspy@4.0.4: {}
+
+  ts-dedent@2.2.0: {}
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tslib@2.8.1: {}
 
   typescript@5.8.3: {}
 
   undici-types@7.18.2: {}
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1):
     dependencies:
@@ -2083,6 +3169,8 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  webpack-virtual-modules@0.6.2: {}
+
   whatwg-mimetype@3.0.0: {}
 
   why-is-node-running@2.3.0:
@@ -2091,3 +3179,9 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.20.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
+  yallist@3.1.1: {}

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from ".";
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  args: {
+    variant: "primary",
+    children: "Button",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary"],
+    },
+    disabled: { control: "boolean" },
+    type: {
+      control: "select",
+      options: ["button", "submit", "reset"],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {};
+
+export const Primary: Story = {
+  args: { variant: "primary", children: "Primary" },
+};
+
+export const Secondary: Story = {
+  args: { variant: "secondary", children: "Secondary" },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, children: "Disabled" },
+};
+
+export const WithDataAttribute: Story = {
+  args: {
+    children: "With data-testid",
+    "data-testid": "button-sample",
+  },
+};

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -1,3 +1,4 @@
+// @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Button } from ".";
 

--- a/src/components/ConfirmDialog/index.stories.tsx
+++ b/src/components/ConfirmDialog/index.stories.tsx
@@ -1,0 +1,42 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ConfirmDialog } from ".";
+
+const meta: Meta<typeof ConfirmDialog> = {
+  component: ConfirmDialog,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    title: "削除しますか？",
+    message: "この操作は取り消せません。",
+    confirmLabel: "削除",
+    cancelLabel: "キャンセル",
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ConfirmDialog>;
+
+export const Default: Story = {};
+
+export const WithExtraChildren: Story = {
+  args: {
+    children: (
+      <div className="mt-3 rounded bg-gray-50 p-3 text-sm text-gray-700">
+        補足: 削除した項目は復元できません。
+      </div>
+    ),
+  },
+};
+
+export const ConfirmDisabled: Story = {
+  args: { confirmDisabled: true },
+};
+
+export const CancelDisabled: Story = {
+  args: { cancelDisabled: true },
+};

--- a/src/components/EditableText/index.stories.tsx
+++ b/src/components/EditableText/index.stories.tsx
@@ -1,0 +1,39 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EditableText } from ".";
+
+const meta: Meta<typeof EditableText> = {
+  component: EditableText,
+  args: {
+    value: "編集可能なテキスト",
+    onConfirm: () => {},
+  },
+  argTypes: {
+    value: { control: "text" },
+    ariaLabel: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EditableText>;
+
+export const Default: Story = {};
+
+export const LongText: Story = {
+  args: {
+    value:
+      "とても長いテキストの例。Storybook の Canvas 上で truncate（省略表示）が効くかどうかを確認するために、敢えて長めの文字列を投入している。",
+  },
+};
+
+export const Empty: Story = {
+  args: { value: "" },
+};
+
+export const WithAriaLabel: Story = {
+  args: {
+    value: "見出し",
+    ariaLabel: "ボード名",
+  },
+};

--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -1,0 +1,46 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ToastItem } from "@/types/toast";
+import { Toast } from ".";
+
+const baseToast: ToastItem = {
+  id: "toast-1",
+  message: "保存しました",
+  type: "success",
+};
+
+const meta: Meta<typeof Toast> = {
+  component: Toast,
+  args: {
+    toast: baseToast,
+    onDismiss: () => {},
+    duration: 1000 * 60 * 60,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Toast>;
+
+export const Success: Story = {
+  args: {
+    toast: { id: "t-success", message: "保存しました", type: "success" },
+  },
+};
+
+export const ErrorVariant: Story = {
+  name: "Error",
+  args: {
+    toast: { id: "t-error", message: "通信に失敗しました", type: "error" },
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    toast: {
+      id: "t-warning",
+      message: "下書きが残っています",
+      type: "warning",
+    },
+  },
+};

--- a/src/components/ToastContainer/index.stories.tsx
+++ b/src/components/ToastContainer/index.stories.tsx
@@ -1,0 +1,48 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ToastItem } from "@/types/toast";
+import { ToastContainer } from ".";
+
+const longDuration = 1000 * 60 * 60;
+
+const meta: Meta<typeof ToastContainer> = {
+  component: ToastContainer,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    toasts: [],
+    onDismiss: () => {},
+    duration: longDuration,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ToastContainer>;
+
+export const Empty: Story = {
+  args: { toasts: [] },
+};
+
+export const Single: Story = {
+  args: {
+    toasts: [
+      {
+        id: "t-1",
+        message: "保存しました",
+        type: "success",
+      } satisfies ToastItem,
+    ],
+  },
+};
+
+export const Multiple: Story = {
+  args: {
+    toasts: [
+      { id: "t-1", message: "保存しました", type: "success" },
+      { id: "t-2", message: "通信に失敗しました", type: "error" },
+      { id: "t-3", message: "下書きが残っています", type: "warning" },
+    ] satisfies ToastItem[],
+  },
+};

--- a/src/features/board/components/AddColumnButton/index.stories.tsx
+++ b/src/features/board/components/AddColumnButton/index.stories.tsx
@@ -1,0 +1,17 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AddColumnButton } from ".";
+
+const meta: Meta<typeof AddColumnButton> = {
+  component: AddColumnButton,
+  args: {
+    existingColumnNames: ["Todo", "In Progress", "Done"],
+    onAdd: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AddColumnButton>;
+
+export const Default: Story = {};

--- a/src/features/board/components/Board/index.stories.tsx
+++ b/src/features/board/components/Board/index.stories.tsx
@@ -1,0 +1,38 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialColumns, initialTasks } from "@/lib/mock-data";
+import { Board } from ".";
+
+const meta: Meta<typeof Board> = {
+  component: Board,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    columns: initialColumns,
+    tasks: initialTasks,
+    doneColumn: "Done",
+    onAddTask: () => {},
+    onTaskClick: () => {},
+    onAddColumn: () => {},
+    onRenameColumn: () => {},
+    onDeleteColumn: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Board>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { tasks: [] },
+};
+
+export const SingleColumn: Story = {
+  args: {
+    columns: [{ name: "Todo", order: 0 }],
+    tasks: initialTasks.filter((t) => t.status === "Todo"),
+  },
+};

--- a/src/features/board/components/Column/index.stories.tsx
+++ b/src/features/board/components/Column/index.stories.tsx
@@ -1,0 +1,58 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialTasks } from "@/lib/mock-data";
+import type { Task } from "@/types/task";
+import { Column } from ".";
+
+const todoTasks = initialTasks.filter((t) => t.status === "Todo");
+
+const meta: Meta<typeof Column> = {
+  component: Column,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    name: "Todo",
+    tasks: todoTasks,
+    allTasks: initialTasks,
+    doneColumn: "Done",
+    existingColumnNames: ["In Progress", "Done"],
+    canDelete: true,
+    onAddClick: () => {},
+    onTaskClick: () => {},
+    onRename: () => {},
+    onDelete: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Column>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { tasks: [] },
+};
+
+const manyTasks: Task[] = Array.from({ length: 12 }, (_, i) => ({
+  id: `many-${i}`,
+  title: `タスク ${i + 1}`,
+  status: "Todo",
+  priority: i % 3 === 0 ? "High" : i % 3 === 1 ? "Medium" : "Low",
+  labels: i % 2 === 0 ? ["sample"] : [],
+  parent: undefined,
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: `tasks/many-${i}.md`,
+}));
+
+export const ManyTasks: Story = {
+  args: { tasks: manyTasks },
+};
+
+export const WithoutMenu: Story = {
+  args: { onDelete: undefined, onRename: undefined },
+};

--- a/src/features/board/components/ColumnContextMenu/index.stories.tsx
+++ b/src/features/board/components/ColumnContextMenu/index.stories.tsx
@@ -1,0 +1,23 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ColumnContextMenu } from ".";
+
+const meta: Meta<typeof ColumnContextMenu> = {
+  component: ColumnContextMenu,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    x: 120,
+    y: 120,
+    canDelete: true,
+    onDelete: () => {},
+    onClose: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ColumnContextMenu>;
+
+export const Default: Story = {};

--- a/src/features/board/components/ColumnHeader/index.stories.tsx
+++ b/src/features/board/components/ColumnHeader/index.stories.tsx
@@ -1,0 +1,32 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ColumnHeader } from ".";
+
+const meta: Meta<typeof ColumnHeader> = {
+  component: ColumnHeader,
+  args: {
+    name: "Todo",
+    taskCount: 5,
+    onAddClick: () => {},
+    onRename: () => {},
+    existingColumnNames: ["In Progress", "Done"],
+    onContextMenu: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ColumnHeader>;
+
+export const Default: Story = {};
+
+export const WithoutActions: Story = {
+  args: { onRename: undefined, onContextMenu: undefined },
+};
+
+export const LongName: Story = {
+  args: {
+    name: "とても長いカラム名のサンプル例 - 表示の折り返しを確認",
+    taskCount: 99,
+  },
+};

--- a/src/features/board/components/EmptyState/index.stories.tsx
+++ b/src/features/board/components/EmptyState/index.stories.tsx
@@ -1,0 +1,22 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EmptyState } from ".";
+
+const meta: Meta<typeof EmptyState> = {
+  component: EmptyState,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EmptyState>;
+
+export const NoProject: Story = {
+  args: { type: "no-project", onOpenProject: () => {} },
+};
+
+export const EmptyProject: Story = {
+  args: { type: "empty-project" },
+};

--- a/src/features/board/components/HeaderBar/index.stories.tsx
+++ b/src/features/board/components/HeaderBar/index.stories.tsx
@@ -1,0 +1,26 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { HeaderBar } from ".";
+
+const meta: Meta<typeof HeaderBar> = {
+  component: HeaderBar,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    onSettingsClick: () => {},
+    onOpenClick: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HeaderBar>;
+
+export const WithProject: Story = {
+  args: { projectName: "my-board-project" },
+};
+
+export const NoProject: Story = {
+  args: { projectName: undefined },
+};

--- a/src/features/board/components/LabelTag/index.stories.tsx
+++ b/src/features/board/components/LabelTag/index.stories.tsx
@@ -1,0 +1,20 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LabelTag } from ".";
+
+const meta: Meta<typeof LabelTag> = {
+  component: LabelTag,
+  args: {
+    label: "bug",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LabelTag>;
+
+export const Short: Story = { args: { label: "bug" } };
+
+export const Long: Story = {
+  args: { label: "long-label-name-for-overflow-test" },
+};

--- a/src/features/board/components/PriorityBadge/index.stories.tsx
+++ b/src/features/board/components/PriorityBadge/index.stories.tsx
@@ -1,0 +1,25 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PriorityBadge } from ".";
+
+const meta: Meta<typeof PriorityBadge> = {
+  component: PriorityBadge,
+  args: {
+    priority: "High",
+  },
+  argTypes: {
+    priority: {
+      control: "select",
+      options: ["High", "Medium", "Low", undefined],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PriorityBadge>;
+
+export const High: Story = { args: { priority: "High" } };
+export const Medium: Story = { args: { priority: "Medium" } };
+export const Low: Story = { args: { priority: "Low" } };
+export const Undefined: Story = { args: { priority: undefined } };

--- a/src/features/board/components/SubIssueProgress/index.stories.tsx
+++ b/src/features/board/components/SubIssueProgress/index.stories.tsx
@@ -1,0 +1,54 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Task } from "@/types/task";
+import { SubIssueProgress } from ".";
+
+const makeChild = (id: string, status: string, title: string): Task => ({
+  id,
+  title,
+  status,
+  labels: [],
+  parent: "tasks/parent.md",
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: `tasks/${id}.md`,
+});
+
+const meta: Meta<typeof SubIssueProgress> = {
+  component: SubIssueProgress,
+  args: {
+    childTasks: [],
+    doneColumn: "Done",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SubIssueProgress>;
+
+export const Empty: Story = {
+  args: { childTasks: [] },
+};
+
+export const InProgress: Story = {
+  args: {
+    childTasks: [
+      makeChild("c1", "Done", "完了済み 1"),
+      makeChild("c2", "Done", "完了済み 2"),
+      makeChild("c3", "Todo", "未完了 1"),
+      makeChild("c4", "Todo", "未完了 2"),
+    ],
+  },
+};
+
+export const AllDone: Story = {
+  args: {
+    childTasks: [
+      makeChild("c1", "Done", "完了 1"),
+      makeChild("c2", "Done", "完了 2"),
+      makeChild("c3", "Done", "完了 3"),
+    ],
+  },
+};

--- a/src/features/board/components/TaskCard/index.stories.tsx
+++ b/src/features/board/components/TaskCard/index.stories.tsx
@@ -1,0 +1,63 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialTasks } from "@/lib/mock-data";
+import type { Task } from "@/types/task";
+import { TaskCard } from ".";
+
+const baseTask: Task = initialTasks[0];
+
+const meta: Meta<typeof TaskCard> = {
+  component: TaskCard,
+  args: {
+    task: baseTask,
+    childTasks: [],
+    doneColumn: "Done",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskCard>;
+
+export const Default: Story = {};
+
+export const Clickable: Story = {
+  args: { onClick: () => {} },
+};
+
+export const HighPriority: Story = {
+  args: {
+    task: { ...baseTask, priority: "High", title: "高優先度のタスク" },
+  },
+};
+
+export const WithLabels: Story = {
+  args: {
+    task: {
+      ...baseTask,
+      labels: ["bug", "frontend", "urgent"],
+    },
+  },
+};
+
+const childTasks = initialTasks.filter((t) => t.parent === baseTask.filePath);
+
+export const WithChildren: Story = {
+  args: {
+    task: { ...baseTask },
+    childTasks,
+  },
+};
+
+export const Minimal: Story = {
+  args: {
+    task: {
+      ...baseTask,
+      priority: undefined,
+      labels: [],
+      children: [],
+      title: "最小構成のタスク",
+    },
+    childTasks: [],
+  },
+};

--- a/src/features/detail/components/DetailPanel/index.stories.tsx
+++ b/src/features/detail/components/DetailPanel/index.stories.tsx
@@ -1,0 +1,50 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialColumns, initialTasks } from "@/lib/mock-data";
+import { DetailPanel } from ".";
+
+const baseTask = initialTasks[1];
+
+const meta: Meta<typeof DetailPanel> = {
+  component: DetailPanel,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    task: baseTask,
+    columns: initialColumns,
+    allTasks: initialTasks,
+    doneColumn: "Done",
+    onClose: () => {},
+    onTaskUpdate: () => {},
+    onDelete: () => {},
+    onAddSubIssue: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DetailPanel>;
+
+export const Default: Story = {};
+
+export const WithChildren: Story = {
+  args: { task: initialTasks[0] },
+};
+
+export const WithParent: Story = {
+  args: { task: initialTasks[2] },
+};
+
+export const Minimal: Story = {
+  args: {
+    task: {
+      ...baseTask,
+      title: "",
+      body: "",
+      labels: [],
+      priority: undefined,
+    },
+    onAddSubIssue: undefined,
+  },
+};

--- a/src/features/detail/components/LabelEditor/index.stories.tsx
+++ b/src/features/detail/components/LabelEditor/index.stories.tsx
@@ -1,0 +1,38 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LabelEditor } from ".";
+
+const meta: Meta<typeof LabelEditor> = {
+  component: LabelEditor,
+  args: {
+    labels: [],
+    onAdd: () => {},
+    onRemove: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LabelEditor>;
+
+export const Empty: Story = { args: { labels: [] } };
+
+export const WithLabels: Story = {
+  args: { labels: ["bug", "frontend"] },
+};
+
+export const Many: Story = {
+  args: {
+    labels: [
+      "bug",
+      "frontend",
+      "backend",
+      "design",
+      "docs",
+      "performance",
+      "security",
+      "urgent",
+      "review-needed",
+    ],
+  },
+};

--- a/src/features/detail/components/MarkdownBody/index.stories.tsx
+++ b/src/features/detail/components/MarkdownBody/index.stories.tsx
@@ -1,0 +1,45 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MarkdownBody } from ".";
+
+const meta: Meta<typeof MarkdownBody> = {
+  component: MarkdownBody,
+  args: {
+    body: "",
+  },
+  argTypes: {
+    body: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MarkdownBody>;
+
+export const Empty: Story = {
+  args: { body: "" },
+};
+
+export const Heading: Story = {
+  args: {
+    body: "# 見出し 1\n\n## 見出し 2\n\n### 見出し 3\n\n本文の段落",
+  },
+};
+
+export const List: Story = {
+  args: {
+    body: "TODO リスト:\n\n- 一つ目の項目\n- 二つ目の項目\n- 三つ目の項目",
+  },
+};
+
+export const CodeBlock: Story = {
+  args: {
+    body: "サンプルコード:\n\n```\nconst foo = 'bar';\nconsole.log(foo);\n```",
+  },
+};
+
+export const Inline: Story = {
+  args: {
+    body: "テキストには **強調** や `inline code` が含まれることがあります。",
+  },
+};

--- a/src/features/detail/components/PrioritySelect/index.stories.tsx
+++ b/src/features/detail/components/PrioritySelect/index.stories.tsx
@@ -1,0 +1,18 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PrioritySelect } from ".";
+
+const meta: Meta<typeof PrioritySelect> = {
+  component: PrioritySelect,
+  args: {
+    value: "High",
+    onChange: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PrioritySelect>;
+
+export const WithValue: Story = { args: { value: "Medium" } };
+export const Undefined: Story = { args: { value: undefined } };

--- a/src/features/detail/components/StatusSelect/index.stories.tsx
+++ b/src/features/detail/components/StatusSelect/index.stories.tsx
@@ -1,0 +1,33 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialColumns } from "@/lib/mock-data";
+import { StatusSelect } from ".";
+
+const meta: Meta<typeof StatusSelect> = {
+  component: StatusSelect,
+  args: {
+    value: "Todo",
+    columns: initialColumns,
+    onChange: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatusSelect>;
+
+export const Default: Story = {};
+
+export const ManyColumns: Story = {
+  args: {
+    value: "Review",
+    columns: [
+      { name: "Backlog", order: 0 },
+      { name: "Todo", order: 1 },
+      { name: "In Progress", order: 2 },
+      { name: "Review", order: 3 },
+      { name: "QA", order: 4 },
+      { name: "Done", order: 5 },
+    ],
+  },
+};

--- a/src/features/detail/components/SubIssueSection/index.stories.tsx
+++ b/src/features/detail/components/SubIssueSection/index.stories.tsx
@@ -1,0 +1,33 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialTasks } from "@/lib/mock-data";
+import { SubIssueSection } from ".";
+
+const parentTask = initialTasks[0];
+const childTasks = initialTasks.filter((t) => t.parent === parentTask.filePath);
+
+const meta: Meta<typeof SubIssueSection> = {
+  component: SubIssueSection,
+  args: {
+    parentTask,
+    childTasks: [],
+    doneColumn: "Done",
+    onAddSubIssue: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SubIssueSection>;
+
+export const Empty: Story = {
+  args: { childTasks: [] },
+};
+
+export const WithChildren: Story = {
+  args: { childTasks },
+};
+
+export const Clickable: Story = {
+  args: { childTasks, onChildClick: () => {} },
+};

--- a/src/features/task-form/components/ParentTaskSelect/index.stories.tsx
+++ b/src/features/task-form/components/ParentTaskSelect/index.stories.tsx
@@ -1,0 +1,29 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialTasks } from "@/lib/mock-data";
+import { ParentTaskSelect } from ".";
+
+const meta: Meta<typeof ParentTaskSelect> = {
+  component: ParentTaskSelect,
+  args: {
+    tasks: initialTasks,
+    value: undefined,
+    onChange: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ParentTaskSelect>;
+
+export const Unselected: Story = {
+  args: { value: undefined },
+};
+
+export const Selected: Story = {
+  args: { value: initialTasks[0].filePath },
+};
+
+export const Disabled: Story = {
+  args: { value: initialTasks[0].filePath, disabled: true },
+};

--- a/src/features/task-form/components/TaskCreateModal/index.stories.tsx
+++ b/src/features/task-form/components/TaskCreateModal/index.stories.tsx
@@ -23,12 +23,6 @@ type Story = StoryObj<typeof TaskCreateModal>;
 
 export const Default: Story = {};
 
-export const Submitting: Story = {
-  args: {
-    onSubmit: () => new Promise(() => {}),
-  },
-};
-
 export const WithInitialParent: Story = {
   args: {
     initialParent: initialTasks[0].filePath,

--- a/src/features/task-form/components/TaskCreateModal/index.stories.tsx
+++ b/src/features/task-form/components/TaskCreateModal/index.stories.tsx
@@ -1,0 +1,36 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialColumns, initialTasks } from "@/lib/mock-data";
+import { TaskCreateModal } from ".";
+
+const meta: Meta<typeof TaskCreateModal> = {
+  component: TaskCreateModal,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    columns: initialColumns,
+    initialStatus: "Todo",
+    parentCandidates: initialTasks,
+    onSubmit: async () => {},
+    onClose: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskCreateModal>;
+
+export const Default: Story = {};
+
+export const Submitting: Story = {
+  args: {
+    onSubmit: () => new Promise(() => {}),
+  },
+};
+
+export const WithInitialParent: Story = {
+  args: {
+    initialParent: initialTasks[0].filePath,
+  },
+};

--- a/src/features/task-form/components/TaskForm/TaskFormActions/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormActions/index.stories.tsx
@@ -1,0 +1,24 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "@/components/Button";
+import { TaskFormActions } from ".";
+
+const meta: Meta<typeof TaskFormActions> = {
+  component: TaskFormActions,
+  args: {
+    children: (
+      <>
+        <Button variant="secondary">キャンセル</Button>
+        <Button variant="primary" type="submit">
+          作成
+        </Button>
+      </>
+    ),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskFormActions>;
+
+export const Default: Story = {};

--- a/src/features/task-form/components/TaskForm/TaskFormBody/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormBody/index.stories.tsx
@@ -1,0 +1,22 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TaskFormBody } from ".";
+
+const meta: Meta<typeof TaskFormBody> = {
+  component: TaskFormBody,
+  args: {
+    value: "## 概要\n\nタスクの説明文をここに記述する",
+    disabled: false,
+    onChange: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskFormBody>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/src/features/task-form/components/TaskForm/TaskFormLabels/LabelChip/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormLabels/LabelChip/index.stories.tsx
@@ -1,0 +1,22 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LabelChip } from ".";
+
+const meta: Meta<typeof LabelChip> = {
+  component: LabelChip,
+  args: {
+    label: "bug",
+    onRemove: () => {},
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LabelChip>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/src/features/task-form/components/TaskForm/TaskFormLabels/LabelInput/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormLabels/LabelInput/index.stories.tsx
@@ -1,0 +1,27 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LabelInput } from ".";
+
+const meta: Meta<typeof LabelInput> = {
+  component: LabelInput,
+  args: {
+    id: "label-input-story",
+    value: "",
+    onChange: () => {},
+    onKeyDown: () => {},
+    onBlur: () => {},
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LabelInput>;
+
+export const Empty: Story = { args: { value: "" } };
+
+export const WithValue: Story = { args: { value: "frontend" } };
+
+export const Disabled: Story = {
+  args: { value: "frontend", disabled: true },
+};

--- a/src/features/task-form/components/TaskForm/TaskFormLabels/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormLabels/index.stories.tsx
@@ -1,0 +1,31 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TaskFormLabels } from ".";
+import { LabelChip } from "./LabelChip";
+import { LabelInput } from "./LabelInput";
+
+const meta: Meta<typeof TaskFormLabels> = {
+  component: TaskFormLabels,
+  args: {
+    htmlFor: "task-form-labels-input",
+    children: (
+      <>
+        <LabelChip label="bug" onRemove={() => {}} />
+        <LabelChip label="frontend" onRemove={() => {}} />
+        <LabelInput
+          id="task-form-labels-input"
+          value=""
+          onChange={() => {}}
+          onKeyDown={() => {}}
+          onBlur={() => {}}
+        />
+      </>
+    ),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskFormLabels>;
+
+export const Default: Story = {};

--- a/src/features/task-form/components/TaskForm/TaskFormParent/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormParent/index.stories.tsx
@@ -1,0 +1,20 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialTasks } from "@/lib/mock-data";
+import { TaskFormParent } from ".";
+
+const meta: Meta<typeof TaskFormParent> = {
+  component: TaskFormParent,
+  args: {
+    tasks: initialTasks,
+    value: undefined,
+    disabled: false,
+    onChange: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskFormParent>;
+
+export const Default: Story = {};

--- a/src/features/task-form/components/TaskForm/TaskFormPriority/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormPriority/index.stories.tsx
@@ -1,0 +1,28 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TaskFormPriority } from ".";
+
+const meta: Meta<typeof TaskFormPriority> = {
+  component: TaskFormPriority,
+  args: {
+    value: "Medium",
+    disabled: false,
+    onChange: () => {},
+  },
+  argTypes: {
+    value: {
+      control: "select",
+      options: ["", "High", "Medium", "Low"],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskFormPriority>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/src/features/task-form/components/TaskForm/TaskFormStatus/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormStatus/index.stories.tsx
@@ -1,0 +1,24 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialColumns } from "@/lib/mock-data";
+import { TaskFormStatus } from ".";
+
+const meta: Meta<typeof TaskFormStatus> = {
+  component: TaskFormStatus,
+  args: {
+    columns: initialColumns,
+    value: "Todo",
+    disabled: false,
+    onChange: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskFormStatus>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/index.stories.tsx
@@ -1,0 +1,22 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TaskFormTitle } from ".";
+
+const meta: Meta<typeof TaskFormTitle> = {
+  component: TaskFormTitle,
+  args: {
+    value: "ログイン画面のバグ修正",
+    disabled: false,
+    onChange: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskFormTitle>;
+
+export const Default: Story = {};
+
+export const WithError: Story = {
+  args: { value: "", error: "タイトルを入力してください" },
+};

--- a/src/features/task-form/components/TaskForm/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/index.stories.tsx
@@ -1,0 +1,28 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { initialColumns, initialTasks } from "@/lib/mock-data";
+import { TaskForm } from ".";
+
+const meta: Meta<typeof TaskForm> = {
+  component: TaskForm,
+  args: {
+    columns: initialColumns,
+    initialStatus: "Todo",
+    onSubmit: () => {},
+    onCancel: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TaskForm>;
+
+export const Default: Story = {};
+
+export const Submitting: Story = {
+  args: { isSubmitting: true },
+};
+
+export const WithParentCandidates: Story = {
+  args: { parentCandidates: initialTasks },
+};

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", ".storybook/**/*.ts"]
+  "include": ["vite.config.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", ".storybook/**/*.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,12 @@ export default defineConfig(() => ({
       reporter: ["text", "json-summary", "json"],
       reportOnFailure: true,
       include: ["src/**/*.{ts,tsx}"],
-      exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.d.ts", "src/main.tsx"],
+      exclude: [
+        "src/**/*.test.{ts,tsx}",
+        "src/**/*.stories.{ts,tsx}",
+        "src/**/*.d.ts",
+        "src/main.tsx",
+      ],
     },
   },
 }));


### PR DESCRIPTION
## 概要

Storybook 10（`@storybook/react-vite`）をプロジェクトに導入し、`src/App.tsx` を除く全 34 コンポーネントに「見た目確認のみ」を目的とした CSF3 形式の story を追加した。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🔧 設定変更 (Configuration)

### 📝 詳細な変更内容

#### 追加された機能・修正

- **Storybook 10 の導入**
  - `storybook` / `@storybook/react-vite` / `@storybook/addon-a11y` / `@storybook/addon-themes` を devDependencies に追加（v10.3.5）
  - `.storybook/main.ts` を新規作成（`framework: "@storybook/react-vite"`, `viteFinal` で `@` alias を mergeConfig 経由で注入）
  - `.storybook/preview.ts` を新規作成（`src/index.css` を import して Tailwind v4 を Story Canvas に適用、`layout: "centered"` / `backgrounds` を設定）
- **package.json scripts の追加**
  - `pnpm storybook`（dev サーバー起動 / port 6006）
  - `pnpm build-storybook`（静的ビルド）
- **34 件の story ファイル追加**
  - `src/components/*` × 5（Button / ConfirmDialog / EditableText / Toast / ToastContainer）
  - `src/features/board/components/*` × 11（Board / Column / ColumnHeader / ColumnContextMenu / TaskCard / PriorityBadge / LabelTag / SubIssueProgress / AddColumnButton / HeaderBar / EmptyState）
  - `src/features/detail/components/*` × 6（DetailPanel / MarkdownBody / PrioritySelect / StatusSelect / SubIssueSection / LabelEditor）
  - `src/features/task-form/components/**` × 12（TaskCreateModal / TaskForm / ParentTaskSelect / TaskFormActions / TaskFormBody / TaskFormLabels + LabelChip / LabelInput / TaskFormParent / TaskFormPriority / TaskFormStatus / TaskFormTitle）
- **fixed / portal 系コンポーネント対応**
  - ConfirmDialog / ToastContainer / ColumnContextMenu / DetailPanel / TaskCreateModal の story には `parameters: { layout: "fullscreen" }` を指定し、Canvas 全体を viewport として確保
- **規約整備**
  - `vite.config.ts` の `coverage.exclude` に `src/**/*.stories.{ts,tsx}` を追加（カバレッジ分母から除外）
  - `.gitignore` に `storybook-static/` を追加
  - story ファイルは `// @jsdoc-rules-disable` を付与し、TypeScript の JSDoc ルールから除外（Storybook 慣習の args 内アロー関数を許容）

#### 変更されたファイル

- `package.json` — devDependencies + scripts 追加
- `vite.config.ts` — coverage.exclude に story を追加
- `.gitignore` — `storybook-static/` 追加
- `pnpm-lock.yaml` — Storybook 関連パッケージ

#### 削除されたファイル・機能

- なし

## 📊 システム図

### Storybook 起動時のデータフロー

```mermaid
flowchart TD
    User([開発者]) -->|pnpm storybook| CLI[Storybook CLI v10]:::new
    CLI --> Builder[Vite Builder]
    Builder -->|viteFinal で alias @ を注入| Resolve[Module Resolution]:::new
    Resolve --> Preview[.storybook/preview.ts]:::new
    Preview -->|src/index.css import| Tailwind[Tailwind v4 適用]
    Preview --> Story["{Name}/index.stories.tsx (×34)"]:::new
    Story --> Render[Component Canvas]
    Render --> UI[Storybook UI<br/>Sidebar / Canvas / Controls]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### story 配置とプロジェクト規約

```
src/
├── components/{Name}/
│   ├── index.tsx
│   └── index.stories.tsx          [NEW] CSF3 + export default meta（story 例外）
└── features/<feature>/components/{Name}/
    ├── index.tsx
    └── index.stories.tsx          [NEW]

.storybook/
├── main.ts                        [NEW] viteFinal で @ alias を明示注入
└── preview.ts                     [NEW] src/index.css を import
```

## 📋 関連 Issue

なし（implementation-plan.md に記載なし）

仕様: `.specs/005-storybook-introduction/`（hearing-notes / exploration-report / implementation-plan / tasks）

## 🧪 テスト

### テスト実行方法

```bash
pnpm typecheck       # tsc -b
pnpm test:run        # vitest run
pnpm build           # tsc -b + vite build
pnpm build-storybook # storybook build
pnpm exec biome check src
pnpm exec oxlint
```

### テスト項目

- [x] 単体テスト (Unit tests) — 既存 279 テスト pass（Storybook 追加によるテスト破壊なし）
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing) — `pnpm build-storybook` 成功確認

### テスト結果

| 項目 | 結果 |
|---|---|
| `pnpm typecheck` | ✅ エラー 0 |
| `pnpm test:run` | ✅ 46 ファイル / 279 テスト pass |
| `pnpm build` | ✅ 既存通り成功 |
| `pnpm build-storybook` | ✅ `storybook-static/` 生成 |
| `pnpm exec biome check src` | ✅ エラー 0 |
| `pnpm exec oxlint` | ✅ 0 warning / 0 error |
| Copilot review (refined prompt) | ✅ 問題なし |

## 🔍 レビューポイント

- **CLAUDE.md からの逸脱**: story ファイルは慣習に合わせて `__tests__/` ではなく `{Name}/index.stories.tsx` に配置し、`export default meta` を story ファイルに限り許可している（implementation-plan.md セクション 3-1 に明記）
- **Tailwind v4 連携**: `@tailwindcss/vite` プラグインは `vite.config.ts` 経由で Storybook の Vite ビルダーに継承される。`viteFinal` への明示的な再注入は不要だった
- **fixed/portal 系の表示**: `parameters: { layout: "fullscreen" }` のみで対応し、preview.ts への共通 OverlayFrame decorator 追加は見送った（追加抽象化が冗長と判断）
- **JSDoc rule の story 例外**: 各 story 先頭に `// @jsdoc-rules-disable` を付与し、args 内の `() => {}` などをルール対象外とした

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（implementation-plan.md / tasks.md）
- [x] コミットメッセージが適切な形式で書かれている
- [x] セルフレビューを実施した（Copilot review 2 ラウンド）
- [x] 破壊的変更なし

## 📚 追加情報

### 参考資料

- `.specs/005-storybook-introduction/implementation-plan.md`（設計）
- `.specs/005-storybook-introduction/tasks.md`（タスク分割）
- Storybook 10 公式: https://storybook.js.org/docs/

### 注意事項

- 本 PR では VRT / play function / a11y 自動検証 / Vitest 統合 addon / CI 統合は対象外（ヒアリング指定）
- `pnpm storybook` での目視確認は CI 環境で未実施（`pnpm build-storybook` 成功で代替）