### PR TITLE
🔧 oxlint に curly: ["error", "all"] を追加し既存 51 件 / 24 ファイルを一括修正

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "rules": {
+    "curly": ["error", "all"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,9 @@ export const App = () => {
       const next = columnsQueueRef.current.then(async () => {
         try {
           const current = columnsRef.current;
-          if (!current.some((c) => c.name === oldName)) return;
+          if (!current.some((c) => c.name === oldName)) {
+            return;
+          }
           if (current.some((c) => c.name === newName)) {
             showToast("同じ名前のカラムが既に存在します", "error");
             return;
@@ -163,7 +165,9 @@ export const App = () => {
       const next = columnsQueueRef.current.then(async () => {
         try {
           const current = columnsRef.current;
-          if (!current.some((c) => c.name === columnName)) return;
+          if (!current.some((c) => c.name === columnName)) {
+            return;
+          }
           if (current.length <= 1) {
             showToast("最後のカラムは削除できません", "error");
             return;
@@ -243,7 +247,9 @@ export const App = () => {
         const created = await createTask(values);
         setTasks((prev) => {
           const withCreated = [...prev, created];
-          if (created.parent === undefined) return withCreated;
+          if (created.parent === undefined) {
+            return withCreated;
+          }
           return withCreated.map((t) =>
             t.filePath === created.parent &&
             !t.children.includes(created.filePath)
@@ -277,7 +283,9 @@ export const App = () => {
   );
 
   useEffect(() => {
-    if (projectPath === null) return;
+    if (projectPath === null) {
+      return;
+    }
     let cancelled = false;
     setIsLoading(true);
     setSelectedTaskId(null);
@@ -286,7 +294,9 @@ export const App = () => {
         getTasks(),
         getColumns(),
       ]);
-      if (cancelled) return;
+      if (cancelled) {
+        return;
+      }
       setTasks(loadedTasks);
       setColumns(loadedColumns);
       setIsLoading(false);

--- a/src/components/EditableText/index.tsx
+++ b/src/components/EditableText/index.tsx
@@ -93,7 +93,9 @@ export const EditableText = ({
 
     if (e.key === "Enter") {
       // IME 変換確定の Enter は編集確定と区別する。
-      if (e.nativeEvent.isComposing) return;
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       commit();

--- a/src/components/ToastContainer/index.tsx
+++ b/src/components/ToastContainer/index.tsx
@@ -24,7 +24,9 @@ export const ToastContainer = ({
   onDismiss,
   duration,
 }: ToastContainerProps) => {
-  if (toasts.length === 0) return null;
+  if (toasts.length === 0) {
+    return null;
+  }
   return (
     <div
       className="pointer-events-none fixed top-4 right-4 z-[80] flex flex-col gap-2"

--- a/src/domains/priority/index.ts
+++ b/src/domains/priority/index.ts
@@ -12,7 +12,9 @@ export const Priority = {
    * @returns 正規化された Priority、または undefined
    */
   parse: (raw: string | undefined): Priority | undefined => {
-    if (raw === undefined) return undefined;
+    if (raw === undefined) {
+      return undefined;
+    }
     return (Priority.OPTIONS as readonly string[]).includes(raw)
       ? (raw as Priority)
       : undefined;

--- a/src/features/board/components/AddColumnButton/index.tsx
+++ b/src/features/board/components/AddColumnButton/index.tsx
@@ -70,7 +70,9 @@ export const AddColumnButton = ({
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      if (e.nativeEvent.isComposing) return;
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       confirm();
@@ -95,7 +97,9 @@ export const AddColumnButton = ({
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}
           onBlur={() => {
-            if (!isCancelledRef.current) cancel();
+            if (!isCancelledRef.current) {
+              cancel();
+            }
             isCancelledRef.current = false;
           }}
           placeholder="カラム名"

--- a/src/features/board/components/ColumnContextMenu/index.tsx
+++ b/src/features/board/components/ColumnContextMenu/index.tsx
@@ -21,7 +21,9 @@ type ColumnContextMenuProps = {
  * @returns disabled でない menuitem の配列（DOM 順）
  */
 const getFocusableMenuItems = (menu: HTMLDivElement | null): HTMLElement[] => {
-  if (!menu) return [];
+  if (!menu) {
+    return [];
+  }
   return Array.from(
     menu.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])'),
   );
@@ -45,7 +47,9 @@ export const ColumnContextMenu = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+      }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
@@ -60,7 +64,9 @@ export const ColumnContextMenu = ({
   // useLayoutEffect で paint 前に補正するため表示直後のちらつきは出ない。
   useLayoutEffect(() => {
     const menu = menuRef.current;
-    if (!menu) return;
+    if (!menu) {
+      return;
+    }
     const rect = menu.getBoundingClientRect();
     const maxX = Math.max(0, window.innerWidth - rect.width);
     const maxY = Math.max(0, window.innerHeight - rect.height);
@@ -77,7 +83,9 @@ export const ColumnContextMenu = ({
       return;
     }
     const items = getFocusableMenuItems(menuRef.current);
-    if (items.length === 0) return;
+    if (items.length === 0) {
+      return;
+    }
     e.preventDefault();
     const active = document.activeElement;
     const currentIndex =

--- a/src/features/board/components/ColumnHeader/index.tsx
+++ b/src/features/board/components/ColumnHeader/index.tsx
@@ -55,7 +55,9 @@ export const ColumnHeader = ({
   }, [isEditing]);
 
   const startEditing = () => {
-    if (!onRename) return;
+    if (!onRename) {
+      return;
+    }
     isCancelledRef.current = false;
     setInputValue(name);
     setIsEditing(true);
@@ -86,7 +88,9 @@ export const ColumnHeader = ({
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      if (e.nativeEvent.isComposing) return;
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       confirm();
@@ -119,7 +123,9 @@ export const ColumnHeader = ({
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
               onBlur={() => {
-                if (!isCancelledRef.current) cancel();
+                if (!isCancelledRef.current) {
+                  cancel();
+                }
                 isCancelledRef.current = false;
               }}
               aria-label="カラム名"

--- a/src/features/board/components/TaskCard/index.tsx
+++ b/src/features/board/components/TaskCard/index.tsx
@@ -82,7 +82,9 @@ export const TaskCard = ({
       className="w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md"
       onClick={() => onClick(task.id)}
       onKeyDown={(e) => {
-        if (e.currentTarget !== e.target) return;
+        if (e.currentTarget !== e.target) {
+          return;
+        }
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onClick(task.id);

--- a/src/features/detail/components/LabelEditor/index.tsx
+++ b/src/features/detail/components/LabelEditor/index.tsx
@@ -54,7 +54,9 @@ export const LabelEditor = ({ labels, onAdd, onRemove }: LabelEditorProps) => {
   const handleBlur = () => {
     const justClosedByKey = justClosedByKeyRef.current;
     justClosedByKeyRef.current = false;
-    if (justClosedByKey) return;
+    if (justClosedByKey) {
+      return;
+    }
     input.confirmAdding();
   };
 

--- a/src/features/detail/components/MarkdownBody/index.tsx
+++ b/src/features/detail/components/MarkdownBody/index.tsx
@@ -82,7 +82,9 @@ const renderBlock = (block: Block, key: number): ReactNode => {
  */
 export const MarkdownBody = ({ body }: MarkdownBodyProps) => {
   const blocks = Markdown.parse(body);
-  if (blocks.length === 0) return null;
+  if (blocks.length === 0) {
+    return null;
+  }
   return (
     <div className="space-y-4" data-testid="markdown-body">
       {blocks.map((block, i) => renderBlock(block, i))}

--- a/src/features/detail/domains/delete-flow/index.ts
+++ b/src/features/detail/domains/delete-flow/index.ts
@@ -76,7 +76,9 @@ export const DeleteFlow = {
    * @returns 新しい state
    */
   request: (current: DeleteFlowState): DeleteFlowState => {
-    if (!isIdle(current)) return invalidTransition("request", current);
+    if (!isIdle(current)) {
+      return invalidTransition("request", current);
+    }
     return { kind: "confirming" };
   },
 
@@ -87,8 +89,9 @@ export const DeleteFlow = {
    * @returns 新しい state
    */
   cancel: (current: DeleteFlowState): DeleteFlowState => {
-    if (!isConfirming(current) && !isError(current))
+    if (!isConfirming(current) && !isError(current)) {
       return invalidTransition("cancel", current);
+    }
     return { kind: "idle" };
   },
 
@@ -99,8 +102,9 @@ export const DeleteFlow = {
    * @returns 新しい state
    */
   confirm: (current: DeleteFlowState): DeleteFlowState => {
-    if (!isConfirming(current) && !isError(current))
+    if (!isConfirming(current) && !isError(current)) {
       return invalidTransition("confirm", current);
+    }
     return { kind: "deleting" };
   },
 
@@ -110,7 +114,9 @@ export const DeleteFlow = {
    * @returns 新しい state
    */
   succeed: (current: DeleteFlowState): DeleteFlowState => {
-    if (!isDeleting(current)) return invalidTransition("succeed", current);
+    if (!isDeleting(current)) {
+      return invalidTransition("succeed", current);
+    }
     return { kind: "idle" };
   },
 
@@ -124,7 +130,9 @@ export const DeleteFlow = {
     current: DeleteFlowState,
     payload: { reason: unknown },
   ): DeleteFlowState => {
-    if (!isDeleting(current)) return invalidTransition("fail", current);
+    if (!isDeleting(current)) {
+      return invalidTransition("fail", current);
+    }
     return { kind: "error", reason: payload.reason };
   },
 } as const;

--- a/src/features/detail/domains/label-input/index.ts
+++ b/src/features/detail/domains/label-input/index.ts
@@ -67,7 +67,9 @@ export const LabelInput = {
    * @returns 新しい state
    */
   startAdding: (current: LabelInputState): LabelInputState => {
-    if (!isIdle(current)) return invalidTransition("startAdding", current);
+    if (!isIdle(current)) {
+      return invalidTransition("startAdding", current);
+    }
     return { kind: "adding", input: "" };
   },
 
@@ -81,8 +83,12 @@ export const LabelInput = {
     current: LabelInputState,
     payload: { value: string },
   ): LabelInputState => {
-    if (!isAddingGuard(current)) return invalidTransition("setInput", current);
-    if (current.input === payload.value) return current;
+    if (!isAddingGuard(current)) {
+      return invalidTransition("setInput", current);
+    }
+    if (current.input === payload.value) {
+      return current;
+    }
     return { kind: "adding", input: payload.value };
   },
 
@@ -92,7 +98,9 @@ export const LabelInput = {
    * @returns 新しい state
    */
   cancel: (current: LabelInputState): LabelInputState => {
-    if (!isAddingGuard(current)) return invalidTransition("cancel", current);
+    if (!isAddingGuard(current)) {
+      return invalidTransition("cancel", current);
+    }
     return { kind: "idle" };
   },
 
@@ -102,7 +110,9 @@ export const LabelInput = {
    * @returns 新しい state
    */
   confirm: (current: LabelInputState): LabelInputState => {
-    if (!isAddingGuard(current)) return invalidTransition("confirm", current);
+    if (!isAddingGuard(current)) {
+      return invalidTransition("confirm", current);
+    }
     return { kind: "idle" };
   },
 } as const;

--- a/src/features/detail/domains/label/index.ts
+++ b/src/features/detail/domains/label/index.ts
@@ -14,8 +14,12 @@ export const Labels = {
    */
   tryAdd: (current: Labels, input: string): Labels | null => {
     const trimmed = input.trim();
-    if (trimmed.length === 0) return null;
-    if (current.includes(trimmed)) return null;
+    if (trimmed.length === 0) {
+      return null;
+    }
+    if (current.includes(trimmed)) {
+      return null;
+    }
     return [...current, trimmed];
   },
 

--- a/src/features/detail/domains/markdown/index.ts
+++ b/src/features/detail/domains/markdown/index.ts
@@ -36,7 +36,9 @@ const matchHeading = (
   line: string,
 ): { level: 1 | 2 | 3; text: string } | undefined => {
   const m = line.match(/^(#{1,3})\s+(.*)/);
-  if (m === null) return undefined;
+  if (m === null) {
+    return undefined;
+  }
   const level = m[1].length as 1 | 2 | 3;
   return { level, text: m[2] };
 };
@@ -96,7 +98,9 @@ export const Markdown = {
    * @returns Block の配列
    */
   parse: (source: string): readonly Block[] => {
-    if (source.trim() === "") return [];
+    if (source.trim() === "") {
+      return [];
+    }
     const normalized = source.replace(/\r\n?/g, "\n");
     const lines = normalized.split("\n");
     const blocks: Block[] = [];
@@ -111,7 +115,9 @@ export const Markdown = {
           codeLines.push(lines[i]);
           i++;
         }
-        if (i < lines.length) i++;
+        if (i < lines.length) {
+          i++;
+        }
         blocks.push({ type: "codeblock", code: codeLines.join("\n") });
         continue;
       }
@@ -133,7 +139,9 @@ export const Markdown = {
         const items: string[] = [];
         while (i < lines.length) {
           const item = matchListItem(lines[i]);
-          if (item === undefined) break;
+          if (item === undefined) {
+            break;
+          }
           items.push(item);
           i++;
         }
@@ -149,8 +157,9 @@ export const Markdown = {
           isFence(cur) ||
           matchHeading(cur) !== undefined ||
           matchListItem(cur) !== undefined
-        )
+        ) {
           break;
+        }
         paraLines.push(cur);
         i++;
       }

--- a/src/features/detail/domains/sub-issue/index.ts
+++ b/src/features/detail/domains/sub-issue/index.ts
@@ -25,7 +25,9 @@ export const SubIssue = {
     allTasks: readonly Task[] | undefined,
     parentFilePath: string,
   ): readonly Task[] => {
-    if (allTasks === undefined) return [];
+    if (allTasks === undefined) {
+      return [];
+    }
     return allTasks.filter((t) => t.parent === parentFilePath);
   },
 
@@ -40,7 +42,9 @@ export const SubIssue = {
     doneColumn: string,
   ): SubIssueProgress => {
     const total = childTasks.length;
-    if (total === 0) return { total: 0, doneCount: 0, percentage: 0 };
+    if (total === 0) {
+      return { total: 0, doneCount: 0, percentage: 0 };
+    }
     const doneCount = childTasks.filter((t) => t.status === doneColumn).length;
     const percentage = Math.round((doneCount / total) * 100);
     return { total, doneCount, percentage };
@@ -57,7 +61,9 @@ export const SubIssue = {
     columns: readonly Column[],
     override: string | undefined,
   ): string => {
-    if (override !== undefined) return override;
+    if (override !== undefined) {
+      return override;
+    }
     const maxOrderColumn = columns.reduce<Column | undefined>(
       (currentMax, column) =>
         currentMax === undefined || column.order > currentMax.order

--- a/src/features/detail/hooks/useDeleteFlow/__tests__/useDeleteFlow.interaction.test.tsx
+++ b/src/features/detail/hooks/useDeleteFlow/__tests__/useDeleteFlow.interaction.test.tsx
@@ -265,7 +265,9 @@ test("deleting 中の confirmDelete 再呼び出しは machine no-op で吸収",
   });
   expect(probe.latest.state).toEqual({ kind: "deleting" });
   await act(async () => {
-    for (const r of resolvers) r();
+    for (const r of resolvers) {
+      r();
+    }
     await pending;
     await pending2;
   });

--- a/src/features/detail/hooks/useDeleteFlow/index.ts
+++ b/src/features/detail/hooks/useDeleteFlow/index.ts
@@ -53,7 +53,9 @@ export const useDeleteFlow = (args: UseDeleteFlowArgs): UseDeleteFlowResult => {
   }, []);
 
   const confirmDelete = useCallback(async () => {
-    if (!DeleteFlow.canConfirm(state)) return;
+    if (!DeleteFlow.canConfirm(state)) {
+      return;
+    }
     setState((s) => DeleteFlow.confirm(s));
     try {
       await onDelete();

--- a/src/features/detail/hooks/useDetailLabels/index.ts
+++ b/src/features/detail/hooks/useDetailLabels/index.ts
@@ -52,7 +52,9 @@ export const useDetailLabels = (
   const add = useCallback(
     (label: string) => {
       const next = Labels.tryAdd(latestLabelsRef.current, label);
-      if (next === null) return;
+      if (next === null) {
+        return;
+      }
       latestLabelsRef.current = next;
       onTaskUpdate(task.id, { labels: [...next] });
     },

--- a/src/features/detail/hooks/useLabelInput/index.ts
+++ b/src/features/detail/hooks/useLabelInput/index.ts
@@ -69,7 +69,9 @@ export const useLabelInput = (args: UseLabelInputArgs): UseLabelInputResult => {
   }, []);
 
   const confirmAdding = useCallback(() => {
-    if (!LabelInput.isAdding(state)) return;
+    if (!LabelInput.isAdding(state)) {
+      return;
+    }
     const next = Labels.tryAdd(existingLabels, state.input);
     if (next !== null) {
       const added = next[next.length - 1];

--- a/src/features/task-form/components/ParentTaskSelect/index.tsx
+++ b/src/features/task-form/components/ParentTaskSelect/index.tsx
@@ -49,7 +49,9 @@ export const ParentTaskSelect = ({
 
   const candidates = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (q.length === 0) return tasks;
+    if (q.length === 0) {
+      return tasks;
+    }
     return tasks.filter((t) => {
       const title = (t.title || t.filePath).toLowerCase();
       return title.includes(q) || t.filePath.toLowerCase().includes(q);

--- a/src/features/task-form/components/TaskCreateModal/index.tsx
+++ b/src/features/task-form/components/TaskCreateModal/index.tsx
@@ -59,7 +59,9 @@ export const TaskCreateModal = ({
 
   const handleSubmit = useCallback(
     async (values: TaskFormValues) => {
-      if (submittingRef.current) return;
+      if (submittingRef.current) {
+        return;
+      }
       submittingRef.current = true;
       setIsSubmitting(true);
       try {
@@ -76,7 +78,9 @@ export const TaskCreateModal = ({
   );
 
   const handleOverlayClick = useCallback(() => {
-    if (submittingRef.current) return;
+    if (submittingRef.current) {
+      return;
+    }
     onClose();
   }, [onClose]);
 

--- a/src/features/task-form/hooks/useLabelsInput/index.ts
+++ b/src/features/task-form/hooks/useLabelsInput/index.ts
@@ -74,7 +74,9 @@ export const useLabelsInput = (
       // IME 変換確定の Enter であっても抑止しないとフォーム submit が発火する。
       e.preventDefault();
       // IME 変換確定の Enter はラベル確定と区別し、commit のみスキップする。
-      if (e.nativeEvent.isComposing) return;
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       dispatch({ type: "commit" });
     }
   }, []);

--- a/src/features/task-form/lib/fields/labels/index.ts
+++ b/src/features/task-form/lib/fields/labels/index.ts
@@ -40,8 +40,12 @@ export const LabelsField = {
    */
   commit: (field: LabelsField): LabelsField => {
     const trimmed = field.labelInput.trim();
-    if (trimmed.length === 0) return field;
-    if (field.labels.includes(trimmed)) return { ...field, labelInput: "" };
+    if (trimmed.length === 0) {
+      return field;
+    }
+    if (field.labels.includes(trimmed)) {
+      return { ...field, labelInput: "" };
+    }
     return { labels: [...field.labels, trimmed], labelInput: "" };
   },
 

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -145,7 +145,9 @@ export async function deleteTask(id: string): Promise<void> {
   const col = cardOrder[removed.status];
   if (col) {
     const pos = col.indexOf(removed.filePath);
-    if (pos !== -1) col.splice(pos, 1);
+    if (pos !== -1) {
+      col.splice(pos, 1);
+    }
   }
 }
 


### PR DESCRIPTION
## 概要

oxlint に `curly: ["error", "all"]` を新規追加し、既存違反 **51 件 / 24 ファイル** を同 PR で一括修正します。「if と同じ行に return を書かない」「if/else/for/while の波括弧必須化」を 1 ルールで実現し、コードスタイルを統一します。

## 変更内容

### 🎯 変更の種類

- [x] 🔧 設定変更 (Configuration) — `.oxlintrc.json` 新規 / `package.json` scripts 追加
- [x] 🚨 Lint 修正 (Lint) — curly 違反 51 件への波括弧追加

### 📝 詳細な変更内容

#### 追加された機能・修正

- `.oxlintrc.json` を新規作成し、`$schema` + `rules.curly = ["error", "all"]` の最小構成で導入
- `package.json` に `lint` (`oxlint`) / `lint:fix` (`oxlint --fix`) scripts を追加してローカル DX を向上
- `pnpm exec oxlint --fix` により 51 件すべての curly 違反を auto-fix（手動修正は発生せず）
- `pnpm exec biome check --write` で auto-fix 後のフォーマット差分を吸収

#### 変更されたファイル（コード変更）

`src/` 配下 24 ファイル（純粋なシンタックス修正・ロジック不変）:

- `src/App.tsx`（5 件）
- `src/components/EditableText/index.tsx`（1 件）
- `src/components/ToastContainer/index.tsx`（1 件）
- `src/domains/priority/index.ts`（1 件）
- `src/features/board/components/AddColumnButton/index.tsx`（2 件）
- `src/features/board/components/ColumnContextMenu/index.tsx`（4 件）
- `src/features/board/components/ColumnHeader/index.tsx`（3 件）
- `src/features/board/components/TaskCard/index.tsx`（1 件）
- `src/features/detail/components/LabelEditor/index.tsx`（1 件）
- `src/features/detail/components/MarkdownBody/index.tsx`（1 件）
- `src/features/detail/domains/delete-flow/index.ts`（5 件）
- `src/features/detail/domains/label-input/index.ts`（5 件）
- `src/features/detail/domains/label/index.ts`（2 件）
- `src/features/detail/domains/markdown/index.ts`（5 件）
- `src/features/detail/domains/sub-issue/index.ts`（3 件）
- `src/features/detail/hooks/useDeleteFlow/__tests__/useDeleteFlow.interaction.test.tsx`（1 件）
- `src/features/detail/hooks/useDeleteFlow/index.ts`（1 件）
- `src/features/detail/hooks/useDetailLabels/index.ts`（1 件）
- `src/features/detail/hooks/useLabelInput/index.ts`（1 件）
- `src/features/task-form/components/ParentTaskSelect/index.tsx`（1 件）
- `src/features/task-form/components/TaskCreateModal/index.tsx`（2 件）
- `src/features/task-form/hooks/useLabelsInput/index.ts`（1 件）
- `src/features/task-form/lib/fields/labels/index.ts`（2 件）
- `src/lib/api/index.ts`（1 件）

#### 削除されたファイル・機能

- なし

## 📊 システム図

### CI/lint パイプライン データフロー（[NEW] が今回追加）

```mermaid
flowchart TD
    Dev[ローカル開発者] -->|pnpm lint / lint:fix| Scripts["package.json:scripts<br/>lint / lint:fix [NEW]"]:::new
    Scripts --> Config[".oxlintrc.json [NEW]<br/>rules.curly = error,all"]:::new
    Config --> Oxlint["oxlint v1.58.0<br/>156 ファイル / 94 ルール"]
    Oxlint -->|違反検出 / auto-fix| Code["ソースコード<br/>24 ファイル更新"]
    Code --> Biome["biome formatter<br/>(既存・変更なし)"]
    Biome --> Verify{検証コマンド群}
    Verify --> TC[pnpm typecheck]
    Verify --> TR[pnpm test:run]
    Verify --> TCov[pnpm test:coverage]
    Verify --> BD[pnpm build]
    Verify --> BC[pnpm exec biome check]
    Verify --> OL[pnpm exec oxlint]
    TC --> CI[GitHub Actions<br/>frontend.yml]
    TR --> CI
    TCov --> CI
    BD --> CI
    BC --> CI
    OL --> CI
    CI -->|全て exit 0| Green([緑・マージ可])

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

要点:

- `.oxlintrc.json` は `pnpm exec oxlint` の引数なし呼び出し時に CWD から自動読込される。CI の YAML は変更不要
- `package.json:scripts` 経由のローカル DX は向上するが、CI は引き続き `pnpm exec oxlint` を直叩き（互換維持）

## 📋 関連 Issue

- なし（spec 007-oxlint-style-rules 内部タスクとして起票なし）

## 🧪 テスト

### テスト実行方法

```bash
pnpm exec oxlint        # exit 0 / Found 0 warnings and 0 errors
pnpm lint               # 同上（scripts 経由）
pnpm exec biome check   # No fixes applied
pnpm typecheck          # tsc -b 成功
pnpm test:run           # 55 ファイル / 415 tests pass
pnpm test:coverage      # CI 同等条件での再現
pnpm build              # vite build 成功
```

### テスト項目

- [x] 単体テスト (Unit tests) — 既存 415 件全件 pass（ロジック不変のため回帰テスト扱い）
- [ ] 統合テスト — 該当なし
- [ ] E2E テスト — 該当なし
- [x] 手動テスト (Manual testing) — 検証コマンド群で目視確認

### テスト結果

すべてのコマンドが exit 0 / diagnostics 0 で完了:

| コマンド | 結果 |
|:-|:-|
| `pnpm exec oxlint` | `Found 0 warnings and 0 errors. (156 files / 94 rules)` |
| `pnpm lint` | 同上 |
| `pnpm exec biome check` | `Checked 159 files. No fixes applied.` |
| `pnpm typecheck` | exit 0 |
| `pnpm test:run` | `Test Files 55 passed (55) / Tests 415 passed (415)` |
| `pnpm test:coverage` | 同上 + Statements 79.58% / Branches 75.23% |
| `pnpm build` | `built in 1.78s` |

## 🔍 レビューポイント

- 純粋なシンタックス修正のみで挙動変更がないことを `git diff` で確認してください（`if (cond) stmt;` → `if (cond) { stmt; }` 形式のみ）
- `.oxlintrc.json` を最小構成にした方針（`$schema` + `rules.curly` のみ、`categories` / `plugins` / `env` は既定値依存）
- テストファイル中の curly 違反 1 件（`useDeleteFlow.interaction.test.tsx:268`）も `overrides` を入れず同様に修正している点
- CI（`.github/workflows/frontend.yml`）は変更なし — `pnpm exec oxlint` の引数なし呼び出しが `.oxlintrc.json` を自動読込する

### 設計判断（インライン化）

- **なぜ `curly: ["error", "all"]` 一本にするのか**: ESLint の `nonblock-statement-body-position`（同一行 if-return 専用）相当は oxlint 1.58.0 に存在しないため、curly の副次効果（ボディに波括弧が無い状態を全て検出）で 2 要件を 1 ルールでカバーできる
- **なぜ `.oxlintrc.json` を最小構成にするのか**: 今後ルールを増やす際の集約地点として `$schema` + `rules.curly` のみで開始し、`categories` / `plugins` / `env` は既定値に委ねて見通しを優先
- **なぜテストファイルを `overrides` で除外しないのか**: テスト中の curly 違反は 1 件のみで、設定の複雑化に見合わない。テストにも本ルールを適用したほうが品質一貫性が保てる
- **なぜ TDD 適用外なのか**: ロジック変更ゼロの純粋なシンタックス修正であり、既存テスト 55 ファイル / 415 件が回帰テストの役割を果たす

### 違反全件のファイル別内訳

実装計画段階の調査値（`pnpm exec oxlint -D curly` 実測）:

| 違反件数 | ファイル |
|---:|---|
| 5 | `src/features/detail/domains/markdown/index.ts` |
| 5 | `src/features/detail/domains/label-input/index.ts` |
| 5 | `src/features/detail/domains/delete-flow/index.ts` |
| 5 | `src/App.tsx` |
| 4 | `src/features/board/components/ColumnContextMenu/index.tsx` |
| 3 | `src/features/detail/domains/sub-issue/index.ts` |
| 3 | `src/features/board/components/ColumnHeader/index.tsx` |
| 2 | `src/features/task-form/lib/fields/labels/index.ts` |
| 2 | `src/features/task-form/components/TaskCreateModal/index.tsx` |
| 2 | `src/features/detail/domains/label/index.ts` |
| 2 | `src/features/board/components/AddColumnButton/index.tsx` |
| 1 | `src/lib/api/index.ts` |
| 1 | `src/features/task-form/hooks/useLabelsInput/index.ts` |
| 1 | `src/features/task-form/components/ParentTaskSelect/index.tsx` |
| 1 | `src/features/detail/hooks/useLabelInput/index.ts` |
| 1 | `src/features/detail/hooks/useDetailLabels/index.ts` |
| 1 | `src/features/detail/hooks/useDeleteFlow/index.ts` |
| 1 | `src/features/detail/hooks/useDeleteFlow/__tests__/useDeleteFlow.interaction.test.tsx` |
| 1 | `src/features/detail/components/MarkdownBody/index.tsx` |
| 1 | `src/features/detail/components/LabelEditor/index.tsx` |
| 1 | `src/features/board/components/TaskCard/index.tsx` |
| 1 | `src/domains/priority/index.ts` |
| 1 | `src/components/ToastContainer/index.tsx` |
| 1 | `src/components/EditableText/index.tsx` |
| **51** | **24 ファイル合計** |

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

ランタイム挙動は完全に不変です（純粋な構文整形のみ）。

## 📚 追加情報

### 注意事項

- 今回の PR では oxlint の他ルールは追加していません（curly 一本でヒアリング 2 要件をカバー）
- ESLint の `nonblock-statement-body-position` 相当は oxlint 1.58.0 に存在しないため、curly で代替

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）— 該当なし
- [x] コミットメッセージが適切な形式で書かれている（2 コミット分割）
- [ ] 関連する Issue が PR の「Development」に Linked されている — Issue なし
- [x] PR 本文に Issue 番号が記載されている — 該当なし
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている — 破壊的変更なし

## 🤝 レビュアーへのお願い

- 変更ファイル数が多く見えますが内容は単純な波括弧追加のみです。`git diff` で速読してください
- `.oxlintrc.json` の `$schema` は IDE 補完用のため `node_modules` 配下を指していますが、CI でも問題なく動作します