### PR TITLE
✨ [New Feature]: #45 file_scanner に 1MB 超 / バイナリ (.md) 除外フィルタを追加

### DIFF
--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -197,6 +197,8 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | BL-002a | ドット始まりのmdファイル | `.hidden.md` / `.DS_Store` などファイル名先頭がドット | `.md` 拡張子であっても除外 |
 | BL-002b | 非 UTF-8 のパス | ファイル名・パス component に非 UTF-8 バイト列を含む | 後続の Tauri / JSON 境界（UTF-8 文字列前提）と整合させるため保守的に除外 |
 | BL-002c | 除外パターンの適用範囲 | 利用者が `~/.spec-board/` や `node_modules` という名前のディレクトリを root として渡した場合 | 除外パターンは **root 配下の子孫エントリにのみ適用** し、root 自身がドット始まりや `node_modules` 名でもスキャン自体は実行する |
+| BL-002d | 巨大ファイル | サイズが 1MB（1,048,576 byte）を超える `.md` ファイル | スキャン結果から除外（1MB ちょうどは含める） |
+| BL-002e | バイナリファイル | 先頭 8KB（8,192 byte）に NUL byte (`0x00`) を含む `.md` ファイル | スキャン結果から除外（プローブ範囲外の NUL byte は判定しない） |
 | BL-003 | フロントマターなしのmd | フロントマターが存在しないmdファイル | タスクとして認識しない（スキップ） |
 
 ### ファイル名の生成
@@ -317,7 +319,7 @@ pub enum ScanError {
 | 配置 | `src-tauri/crates/fs/src/file_scanner.rs`（サブクレート `spec-board-fs`、`walkdir` の集約先）。呼び出しは `spec_board_fs::file_scanner::scan_md_files` |
 | 戻り値 | `root` からの **相対 `PathBuf`** の `Vec`。順序は OS 依存のため呼び出し側でソートする |
 | 走査ライブラリ | `walkdir` crate（`follow_links(false)` 設定でシンボリックリンクは辿らない） |
-| 除外パターン | BL-002 / BL-002a / BL-002b / BL-002c の各ルールを内部で適用 |
+| 除外パターン | BL-002 / BL-002a / BL-002b / BL-002c / BL-002d / BL-002e の各ルールを内部で適用 |
 | 個別 I/O エラー | per-entry の `Err` は黙って skip し走査を継続（上記「エラーハンドリング」の挙動） |
 | 致命的エラー | `Err(ScanError::Io { path, source })` を返す。`path` には呼び出し時に渡された root が保持され、エラー文脈を残す |
 | `Display` 形式 | `failed to scan directory \`{path}\`: {source}`（root のパスを必ず含める） |

--- a/src-tauri/crates/fs/src/file_scanner.rs
+++ b/src-tauri/crates/fs/src/file_scanner.rs
@@ -144,6 +144,7 @@ fn is_text_by_probe(path: &Path) -> bool {
         match file.read(&mut buf[filled..]) {
             Ok(0) => break,
             Ok(n) => filled += n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(_) => return false,
         }
     }

--- a/src-tauri/crates/fs/src/file_scanner.rs
+++ b/src-tauri/crates/fs/src/file_scanner.rs
@@ -114,7 +114,7 @@ fn should_include(entry: &walkdir::DirEntry) -> bool {
     if !is_size_within_limit(entry) {
         return false;
     }
-    if !is_text_by_probe(path) {
+    if !is_text(path) {
         return false;
     }
     true
@@ -146,7 +146,7 @@ fn is_size_within_limit(entry: &walkdir::DirEntry) -> bool {
 /// open / read に失敗した場合は false（除外側）を返す。
 /// プローブ範囲を超えた位置の NUL byte は判定対象外（仕様として固定）。
 /// 空ファイルは NUL byte なし扱いで true。
-fn is_text_by_probe(path: &Path) -> bool {
+fn is_text(path: &Path) -> bool {
     let mut file = match File::open(path) {
         Ok(f) => f,
         Err(_) => return false,

--- a/src-tauri/crates/fs/src/file_scanner.rs
+++ b/src-tauri/crates/fs/src/file_scanner.rs
@@ -1,5 +1,17 @@
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+/// このサイズを超える `.md` ファイルは scan 結果から除外する（バイト単位）。
+/// 巨大ファイルはタスクとして扱わないという仕様に基づく一次フィルタ。
+/// `> MAX_FILE_SIZE` で除外するため、1,048,576 byte ちょうどは含める。
+const MAX_FILE_SIZE: u64 = 1024 * 1024;
+
+/// バイナリ判定のために先頭からプローブするバイト数。
+/// この範囲内に NUL byte (0x00) が含まれていればバイナリと判定し除外する。
+/// プローブ範囲を超えた位置の NUL byte は判定対象外。
+const BINARY_PROBE_LEN: usize = 8 * 1024;
 
 /// 指定ディレクトリ配下の `.md` ファイルを再帰的に列挙する。
 ///
@@ -8,7 +20,9 @@ use thiserror::Error;
 /// - ディレクトリ名が `node_modules` のものは深さを問わず除外
 /// - シンボリックリンクは辿らない（リンク先は走査しない）
 /// - 非 UTF-8 のパスを含むエントリは保守的に除外（後続の Tauri / JSON 境界で扱えないため）
-/// - ファイル単位の I/O エラー（権限不足等）は黙って skip し、走査を継続する
+/// - サイズが 1MB（1,048,576 byte）を超えるファイルは除外（1MB ちょうどは含める）
+/// - 先頭 8KB に NUL byte (0x00) を含むバイナリ判定ファイルは除外
+/// - ファイル単位の I/O エラー（権限不足 / metadata 取得失敗 / read 失敗等）は黙って skip し、走査を継続する
 /// - 返却される `PathBuf` は `root` からの相対パス
 ///
 /// 除外パターン（先頭ドット / `node_modules`）は **root 配下の子孫エントリにのみ適用** する。
@@ -52,35 +66,88 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
             Ok(e) => e,
             Err(_) => continue,
         };
-        if entry.depth() == 0 {
-            continue;
+        if let Some(rel) = accept_entry(&entry, root) {
+            results.push(rel);
         }
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if !is_md_extension(path) {
-            continue;
-        }
-        let file_name_starts_with_dot = path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .map(|name| name.starts_with('.'))
-            .unwrap_or(true);
-        if file_name_starts_with_dot {
-            continue;
-        }
-        let rel = match path.strip_prefix(root) {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-        if rel.to_str().is_none() {
-            continue;
-        }
-        results.push(rel.to_path_buf());
     }
 
     Ok(results)
+}
+
+/// 単一の `WalkDir` エントリを採用するかを判定し、採用するなら root からの相対パスを返す。
+///
+/// 採用条件は早期 return で並べ、軽い判定を先に行う:
+/// 1. root 自身ではない（`depth() > 0`）
+/// 2. 通常ファイル
+/// 3. 拡張子 `.md`（大文字小文字非区別）
+/// 4. ファイル名がドットで始まらない
+/// 5. root からの相対パスが算出でき、UTF-8 として表現可能
+/// 6. サイズが [`MAX_FILE_SIZE`] byte 以下
+/// 7. 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
+///
+/// I/O 失敗（metadata 取得失敗 / open 失敗 / read 失敗）は `None` を返し、呼び出し側で skip される。
+fn accept_entry(entry: &walkdir::DirEntry, root: &Path) -> Option<PathBuf> {
+    if entry.depth() == 0 {
+        return None;
+    }
+    if !entry.file_type().is_file() {
+        return None;
+    }
+    let path = entry.path();
+    if !is_md_extension(path) {
+        return None;
+    }
+    let starts_with_dot = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|name| name.starts_with('.'))
+        .unwrap_or(true);
+    if starts_with_dot {
+        return None;
+    }
+    let rel = path.strip_prefix(root).ok()?;
+    rel.to_str()?;
+    if !is_size_within_limit(entry) {
+        return None;
+    }
+    if !is_text_by_probe(path) {
+        return None;
+    }
+    Some(rel.to_path_buf())
+}
+
+/// エントリのサイズが上限以内（[`MAX_FILE_SIZE`] byte 以下）かを判定する。
+///
+/// `> MAX_FILE_SIZE` で除外するため 1,048,576 byte ちょうどは含める。
+/// metadata 取得に失敗した場合は false（除外側）を返す。
+/// `entry.metadata()` を使うことで walkdir 内部キャッシュを活用できる。
+fn is_size_within_limit(entry: &walkdir::DirEntry) -> bool {
+    match entry.metadata() {
+        Ok(m) => m.len() <= MAX_FILE_SIZE,
+        Err(_) => false,
+    }
+}
+
+/// 先頭 [`BINARY_PROBE_LEN`] byte をプローブし、NUL byte を含まなければテキストと判定する。
+///
+/// open / read に失敗した場合は false（除外側）を返す。
+/// プローブ範囲を超えた位置の NUL byte は判定対象外（仕様として固定）。
+/// 空ファイルは NUL byte なし扱いで true。
+fn is_text_by_probe(path: &Path) -> bool {
+    let mut file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let mut buf = [0u8; BINARY_PROBE_LEN];
+    let mut filled = 0usize;
+    while filled < BINARY_PROBE_LEN {
+        match file.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(_) => return false,
+        }
+    }
+    !buf[..filled].contains(&0u8)
 }
 
 /// [`scan_md_files`] 実行時に発生し得る致命的エラー。
@@ -155,6 +222,30 @@ mod tests {
             }
             std::fs::write(&path, "").unwrap();
         }
+    }
+
+    /// 指定したバイト列を実体としてファイルに書き込む。
+    ///
+    /// バイナリ判定（先頭 8KB の NUL byte 検査）が走るテストでは、内容が NUL byte を
+    /// 含むかどうかでテスト結果が変わるため、必ずこの関数で実体を制御する。
+    fn make_file_with_bytes(root: &Path, rel: &str, contents: &[u8]) {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, contents).unwrap();
+    }
+
+    /// 指定サイズの sparse ファイルを作る。`set_len` の確保領域は NUL byte 埋めになるため、
+    /// **サイズチェックで先に除外されるケース専用**。バイナリチェック通過を期待するテストには
+    /// `make_file_with_bytes` を使い、明示的に NUL byte を含まない内容を書き込むこと。
+    fn make_file_with_size(root: &Path, rel: &str, len: u64) {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let f = std::fs::File::create(&path).unwrap();
+        f.set_len(len).unwrap();
     }
 
     fn collect_sorted_relative(result: &[PathBuf]) -> Vec<String> {
@@ -406,5 +497,159 @@ mod tests {
 
         let result = scan_md_files(dir.path()).unwrap();
         assert_eq!(collect_sorted_relative(&result), vec!["real/x.md"]);
+    }
+
+    // ── サイズフィルタ（1MB 上限） ─────────────────────────────────
+
+    #[test]
+    fn scan_md_files_includes_small_text_md_file() {
+        let dir = TempDir::new().unwrap();
+        make_file_with_bytes(dir.path(), "small.md", &b"a".repeat(1024));
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert_eq!(collect_sorted_relative(&result), vec!["small.md"]);
+    }
+
+    #[test]
+    fn scan_md_files_includes_file_at_exactly_max_size() {
+        let dir = TempDir::new().unwrap();
+        // ちょうど 1,048,576 byte（NUL byte なし）。サイズ境界 + バイナリ判定通過の両方を検証。
+        make_file_with_bytes(dir.path(), "max.md", &b"a".repeat(1024 * 1024));
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert_eq!(collect_sorted_relative(&result), vec!["max.md"]);
+    }
+
+    #[test]
+    fn scan_md_files_excludes_file_over_max_size() {
+        let dir = TempDir::new().unwrap();
+        // 1,048,577 byte (1MB + 1 byte)。sparse file で OK（サイズチェックで先に弾かれる）。
+        make_file_with_size(dir.path(), "over.md", 1024 * 1024 + 1);
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "1MB+1 byte file should be excluded, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn scan_md_files_excludes_multi_megabyte_file() {
+        let dir = TempDir::new().unwrap();
+        make_file_with_size(dir.path(), "huge.md", 5 * 1024 * 1024);
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "5MB file should be excluded, got {result:?}"
+        );
+    }
+
+    // ── バイナリフィルタ（先頭 8KB に NUL byte） ──────────────────
+
+    #[test]
+    fn scan_md_files_includes_text_without_nul_byte() {
+        let dir = TempDir::new().unwrap();
+        make_file_with_bytes(dir.path(), "plain.md", b"hello world");
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert_eq!(collect_sorted_relative(&result), vec!["plain.md"]);
+    }
+
+    #[test]
+    fn scan_md_files_excludes_binary_with_nul_in_probe_range() {
+        let dir = TempDir::new().unwrap();
+        make_file_with_bytes(dir.path(), "binary.md", b"hello\x00world");
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "binary file with NUL byte should be excluded, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn scan_md_files_excludes_binary_with_nul_at_probe_boundary() {
+        let dir = TempDir::new().unwrap();
+        // 先頭 8,191 byte 'a' + 8,192 byte 目に NUL → プローブ範囲の最終バイト。
+        let mut bytes = vec![b'a'; 8 * 1024 - 1];
+        bytes.push(0);
+        make_file_with_bytes(dir.path(), "boundary.md", &bytes);
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "NUL byte at probe boundary should still be detected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn scan_md_files_includes_file_with_nul_after_probe_range() {
+        let dir = TempDir::new().unwrap();
+        // 先頭 8,192 byte 'a' + 8,193 byte 目以降にのみ NUL → プローブ範囲外。仕様として含める。
+        let mut bytes = vec![b'a'; 8 * 1024];
+        bytes.push(0);
+        bytes.extend_from_slice(b"trailing\x00bytes");
+        make_file_with_bytes(dir.path(), "tail-nul.md", &bytes);
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert_eq!(collect_sorted_relative(&result), vec!["tail-nul.md"]);
+    }
+
+    #[test]
+    fn scan_md_files_excludes_small_binary_file() {
+        let dir = TempDir::new().unwrap();
+        let mut bytes = vec![b'a'; 100];
+        bytes[50] = 0;
+        make_file_with_bytes(dir.path(), "tiny-bin.md", &bytes);
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "100-byte file with NUL byte should be excluded, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn scan_md_files_includes_empty_file() {
+        let dir = TempDir::new().unwrap();
+        make_file_with_bytes(dir.path(), "empty.md", b"");
+
+        let result = scan_md_files(dir.path()).unwrap();
+        assert_eq!(collect_sorted_relative(&result), vec!["empty.md"]);
+    }
+
+    // ── per-entry I/O エラー skip（cfg(unix) 限定） ────────────────
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_md_files_skips_unreadable_file_silently() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        make_file_with_bytes(dir.path(), "readable.md", b"hello");
+        make_file_with_bytes(dir.path(), "locked.md", b"secret");
+
+        let locked = dir.path().join("locked.md");
+        let mut perms = std::fs::metadata(&locked).unwrap().permissions();
+        perms.set_mode(0o000);
+        std::fs::set_permissions(&locked, perms).unwrap();
+
+        // uid 0 環境では `chmod 000` でも読めてしまうため、実測してから挙動を分岐させる。
+        let locked_is_actually_unreadable = std::fs::File::open(&locked).is_err();
+        let result = scan_md_files(dir.path());
+
+        // TempDir クリーンアップ失敗を避けるため必ず権限を復元。
+        let mut restore = std::fs::metadata(&locked).unwrap().permissions();
+        restore.set_mode(0o644);
+        std::fs::set_permissions(&locked, restore).unwrap();
+
+        let result = result.expect("scan should succeed even when one entry is unreadable");
+        let collected = collect_sorted_relative(&result);
+        if locked_is_actually_unreadable {
+            assert_eq!(collected, vec!["readable.md"]);
+        } else {
+            assert_eq!(collected, vec!["locked.md", "readable.md"]);
+        }
     }
 }

--- a/src-tauri/crates/fs/src/file_scanner.rs
+++ b/src-tauri/crates/fs/src/file_scanner.rs
@@ -66,7 +66,10 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
             Ok(e) => e,
             Err(_) => continue,
         };
-        if let Some(rel) = accept_entry(&entry, root) {
+        if !should_include(&entry) {
+            continue;
+        }
+        if let Some(rel) = relative_path(entry.path(), root) {
             results.push(rel);
         }
     }
@@ -74,28 +77,27 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
     Ok(results)
 }
 
-/// 単一の `WalkDir` エントリを採用するかを判定し、採用するなら root からの相対パスを返す。
+/// `WalkDir` のエントリをスキャン結果に含めるべきかを判定する。
 ///
-/// 採用条件は早期 return で並べ、軽い判定を先に行う:
+/// 採用条件（早期 return 順、軽い判定 → 重い判定）:
 /// 1. root 自身ではない（`depth() > 0`）
 /// 2. 通常ファイル
 /// 3. 拡張子 `.md`（大文字小文字非区別）
 /// 4. ファイル名がドットで始まらない
-/// 5. root からの相対パスが算出でき、UTF-8 として表現可能
-/// 6. サイズが [`MAX_FILE_SIZE`] byte 以下
-/// 7. 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
+/// 5. サイズが [`MAX_FILE_SIZE`] byte 以下
+/// 6. 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
 ///
-/// I/O 失敗（metadata 取得失敗 / open 失敗 / read 失敗）は `None` を返し、呼び出し側で skip される。
-fn accept_entry(entry: &walkdir::DirEntry, root: &Path) -> Option<PathBuf> {
+/// I/O 失敗（metadata 取得失敗 / open 失敗 / read 失敗）は `false`（除外側）として扱う。
+fn should_include(entry: &walkdir::DirEntry) -> bool {
     if entry.depth() == 0 {
-        return None;
+        return false;
     }
     if !entry.file_type().is_file() {
-        return None;
+        return false;
     }
     let path = entry.path();
     if !is_md_extension(path) {
-        return None;
+        return false;
     }
     let starts_with_dot = path
         .file_name()
@@ -103,16 +105,23 @@ fn accept_entry(entry: &walkdir::DirEntry, root: &Path) -> Option<PathBuf> {
         .map(|name| name.starts_with('.'))
         .unwrap_or(true);
     if starts_with_dot {
-        return None;
+        return false;
     }
-    let rel = path.strip_prefix(root).ok()?;
-    rel.to_str()?;
     if !is_size_within_limit(entry) {
-        return None;
+        return false;
     }
     if !is_text_by_probe(path) {
-        return None;
+        return false;
     }
+    true
+}
+
+/// `path` を `root` からの相対パスに変換し、UTF-8 として表現可能な場合のみ返す。
+///
+/// `path` が `root` 配下でない場合、または相対パスが UTF-8 として表現できない場合は `None`。
+fn relative_path(path: &Path, root: &Path) -> Option<PathBuf> {
+    let rel = path.strip_prefix(root).ok()?;
+    rel.to_str()?;
     Some(rel.to_path_buf())
 }
 

--- a/src-tauri/crates/fs/src/file_scanner.rs
+++ b/src-tauri/crates/fs/src/file_scanner.rs
@@ -77,9 +77,9 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
     Ok(results)
 }
 
-/// `WalkDir` のエントリをスキャン結果に含めるべきかを判定する。
+/// `WalkDir` のエントリ属性 / ファイル内容ベースのフィルタを満たすかを判定する。
 ///
-/// 採用条件（早期 return 順、軽い判定 → 重い判定）:
+/// 判定条件（早期 return 順、軽い判定 → 重い判定）:
 /// 1. root 自身ではない（`depth() > 0`）
 /// 2. 通常ファイル
 /// 3. 拡張子 `.md`（大文字小文字非区別）
@@ -88,6 +88,10 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
 /// 6. 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
 ///
 /// I/O 失敗（metadata 取得失敗 / open 失敗 / read 失敗）は `false`（除外側）として扱う。
+///
+/// **責務の境界**: 本関数はエントリ単体のフィルタのみを担当する。
+/// root 相対パスへの変換と UTF-8 表現可能性の確認は [`relative_path`] が担当し、
+/// 最終的にスキャン結果に含めるかは「`should_include` が `true` かつ `relative_path` が `Some`」の AND 条件で決まる。
 fn should_include(entry: &walkdir::DirEntry) -> bool {
     if entry.depth() == 0 {
         return false;


### PR DESCRIPTION
## 概要

`spec-board-fs::file_scanner::scan_md_files` が返す `.md` ファイル一覧に **per-entry の一次フィルタ** を 2 種類追加し、後段（frontmatter parse / Tauri command 層）に「タスクとして読み込む価値のあるテキスト .md」のみを渡すようにする。

- サイズが **1MB（1,048,576 byte）を超える** ファイルを除外（1MB ちょうどは含める）
- 先頭 **8KB（8,192 byte）に NUL byte (`0x00`) を含む** バイナリ判定ファイルを除外（プローブ範囲外の NUL byte は判定しない）

## 変更の種類

- ✨ 新機能（per-entry フィルタ追加）
- ♻️ リファクタリング（per-entry 判定を `accept_entry` に切り出し、挙動非変更）
- 🧪 テスト（境界値 5 件 + バイナリ 4 件 + per-entry skip + 正常系 2 件 = 11 件追加）
- 📝 ドキュメント（`docs/spec-board/file-system-spec.md` に BL-002d / BL-002e 追加）

## 追加した内容

- モジュールスコープ const
  - `MAX_FILE_SIZE: u64 = 1024 * 1024`
  - `BINARY_PROBE_LEN: usize = 8 * 1024`
- private ヘルパー
  - `accept_entry(entry: &walkdir::DirEntry, root: &Path) -> Option<PathBuf>` — per-entry 採用判定 + 相対パス算出を集約
  - `is_size_within_limit(entry: &walkdir::DirEntry) -> bool`
  - `is_text_by_probe(path: &Path) -> bool`（固定長 stack buffer + `read` ループ）
- テストヘルパー
  - `make_file_with_bytes` — NUL byte の有無を制御したテスト用
  - `make_file_with_size` — sparse file（サイズチェックで先に弾かれるケース専用）
- 新規テスト 11 件
  - 境界値: 1MB ちょうど含める / 1MB+1 byte 除外 / 8KB 内 NUL 除外 / 8KB 超 NUL 含める / 0 byte 含める
  - バイナリ判定: 8KB 内 NUL 除外 / 8KB 境界 NUL 除外 / 100 byte 中央 NUL 除外
  - 正常系: 1KB テキスト / NUL byte なしテキスト
  - per-entry I/O skip: `chmod 000` の `.md` を読めるファイルと同居（`#[cfg(unix)]`、uid 0 緩和分岐込み）

## 変更した内容

- `scan_md_files` 本体ループの per-entry 判定列を `accept_entry` 呼び出しに簡略化（挙動非変更）
- `scan_md_files` の rustdoc に「1MB 超 / バイナリ skip」「per-entry I/O エラーは skip（metadata / open / read）」を追記
- `docs/spec-board/file-system-spec.md`
  - BL-002d（巨大ファイル除外、1MB ちょうどは含める）追加
  - BL-002e（先頭 8KB の NUL byte によるバイナリ判定除外）追加
  - `scan_md_files` 仕様表の「除外パターン」参照を `BL-002 / BL-002a / BL-002b / BL-002c / BL-002d / BL-002e` に更新

## 削除した内容

なし（公開 API・`ScanError` バリアント不変、新規外部 crate なし）。

## 仕様ドキュメント更新

- ✅ `docs/spec-board/file-system-spec.md` に BL-002d / BL-002e を追加
- `docs/spec-board/task-format-spec.md` 行 238「バイナリファイルや極端に大きいファイル（1MB超）はスキップ」は既存記述のまま維持（言及済みのため変更不要）

## システム図

```mermaid
flowchart TD
    walker[WalkDir entry] --> r{entry_result Ok?}
    r -- No --> skip1[continue]
    r -- Yes --> ae["accept_entry(entry, root)"]

    subgraph accept_entry["accept_entry (private)"]
        d{depth > 0?}
        d -- No --> none1[None]
        d -- Yes --> ft{is_file?}
        ft -- No --> none2[None]
        ft -- Yes --> ext{.md?}
        ext -- No --> none3[None]
        ext -- Yes --> dot{not dot-prefixed?}
        dot -- No --> none4[None]
        dot -- Yes --> sp{strip_prefix + UTF-8?}
        sp -- No --> none5[None]
        sp -- Yes --> sz{"size ≤ 1MB? [NEW]"}
        sz -- No --> none6[None]
        sz -- Yes --> bin{"first 8KB has no NUL? [NEW]"}
        bin -- No --> none7[None]
        bin -- Yes --> ok[Some&#40;rel&#41;]
    end

    ae --> push{Some?}
    push -- Yes --> results[results.push&#40;rel&#41;]
    push -- No --> skip2[skip]

    style sz fill:#fff4cc,stroke:#d4a017
    style bin fill:#fff4cc,stroke:#d4a017
```

## 関連Issue

Refs #45

## テスト

- ✅ `cargo test -p spec-board-fs` — 22 / 22 pass（既存 11 + 新規 11）
- ✅ `cargo test --workspace` — 全件 pass
- ✅ `cargo fmt --all -- --check` — clean
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` — 警告ゼロ
- フロントエンド変更なし（`pnpm test:run` / `pnpm build` 該当なし）
- UI 変更なし（Tauri 実機確認該当なし）
- Codex CLI による全変更レビュー 2 ラウンド実施 → 「問題なし」

## レビューポイント

- **境界規約遵守**: `accept_entry` / `is_size_within_limit` は `walkdir::DirEntry` を受けるが `pub` にせず private 維持。サブクレート公開 API 境界に外部 crate 型を漏らさない原則を守っているか
- **per-entry I/O skip ポリシー**: `metadata()` / `File::open` / `read()` の Err はすべて `None` を返して skip し、`ScanError` は変化なし。既存の per-entry skip ポリシーと一貫しているか
- **バイナリ判定の固定**: 「先頭 8KB を超えた位置の NUL byte は判定しない」を仕様として固定。テスト `scan_md_files_includes_file_with_nul_after_probe_range` で明示
- **テストヘルパーの使い分け**: `make_file_with_size`（sparse、内容 NUL 埋め）はサイズチェックで先に弾かれるケース専用。「1MB ちょうど含める」のようにサイズ通過 + バイナリ通過を期待するケースは `make_file_with_bytes` で `b'a'` 埋めにしている点
- **`accept_entry` 抽出リファクタ**: 挙動非変更を担保するため、新フィルタ追加前のコミットで本体ループ簡略化のみを行った（diff の Hunk）

## チェックリスト

- [x] セルフレビューを実施した
- [x] cargo test / cargo clippy / cargo fmt --check が通る（src-tauri 変更時）
- [x] 仕様変更があるため `docs/spec-board/file-system-spec.md` を更新した
- [x] 関連 Issue を本文に記載（Refs #45）
- [x] 公開 API（`scan_md_files` シグネチャ・`ScanError`）は不変、破壊的変更なし