### PR TITLE
✨ [New Feature]: #46 to_kebab_case 純粋関数を追加（タスクタイトル → ファイル名向け kebab-case 変換）

### DIFF
--- a/src-tauri/crates/fs/src/kebab_case.rs
+++ b/src-tauri/crates/fs/src/kebab_case.rs
@@ -1,0 +1,111 @@
+//! タスクタイトル文字列から、ファイル名として利用する kebab-case
+//! 文字列を生成する純粋関数を提供するモジュール。
+//!
+//! # 変換ルール
+//!
+//! - 入力が ASCII 文字を 1 つも含まない場合は、入力をそのまま返す
+//!   （日本語のみのタイトルは保持する）。
+//! - ASCII を 1 文字でも含む場合は以下を適用する。
+//!   - ASCII 英大文字は小文字化する。
+//!   - ASCII 英数字 `[a-z0-9]` 以外の ASCII 文字（スペース・記号・
+//!     アンダースコア・ドット等）はすべて区切りに置換する。
+//!   - 非 ASCII 文字（日本語など）はそのまま保持する。
+//!   - 区切りと既存ハイフンの連続は 1 個のハイフンに集約する。
+//!   - 先頭・末尾のハイフンは除去する。
+//! - 空入力、または変換後に空文字列となる入力では、空文字列を返す。
+//!   デフォルト名フォールバックは行わない。
+//!
+//! 拡張子 `.md` の付与や重複回避サフィックスは本関数の責務外であり、
+//! 呼び出し側で付与する。
+
+/// タスクタイトル文字列から kebab-case のファイル名文字列を生成する。
+///
+/// `title` が空 / 変換後に空となる場合は空文字列を返す。
+pub fn to_kebab_case(title: &str) -> String {
+    if !title.chars().any(|c| c.is_ascii()) {
+        return title.to_string();
+    }
+
+    let mut out = String::with_capacity(title.len());
+    let mut last_was_separator = true;
+    for ch in title.chars() {
+        if ch.is_ascii() {
+            if ch.is_ascii_alphanumeric() {
+                out.push(ch.to_ascii_lowercase());
+                last_was_separator = false;
+            } else if !last_was_separator {
+                out.push('-');
+                last_was_separator = true;
+            }
+        } else {
+            out.push(ch);
+            last_was_separator = false;
+        }
+    }
+
+    if out.ends_with('-') {
+        out.pop();
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ASCII のみ ────────────────────────────────────────────────
+
+    #[test]
+    fn to_kebab_case_basic_ascii_cases() {
+        let cases: Vec<(&str, &str, &str)> = vec![
+            ("Fix Login Bug", "fix-login-bug", "general ascii"),
+            ("FOO", "foo", "uppercase only"),
+            ("foo--bar", "foo-bar", "consecutive hyphens collapse"),
+            (
+                "  Fix login!! bug  ",
+                "fix-login-bug",
+                "trim and collapse symbols",
+            ),
+            (
+                "Hello_World.md",
+                "hello-world-md",
+                "underscore and dot are separators",
+            ),
+        ];
+
+        for (input, expected, label) in cases {
+            assert_eq!(to_kebab_case(input), expected, "{label}");
+        }
+    }
+
+    // ── mixed / 全非 ASCII ────────────────────────────────────────
+
+    #[test]
+    fn to_kebab_case_non_ascii_cases() {
+        let cases: Vec<(&str, &str, &str)> = vec![
+            ("タスク 1", "タスク-1", "mixed: cjk + ascii"),
+            ("Fix バグ", "fix-バグ", "mixed: ascii first + cjk"),
+            ("日本語 title", "日本語-title", "mixed: cjk + ascii word"),
+            ("バグ修正", "バグ修正", "all non-ascii passthrough"),
+        ];
+
+        for (input, expected, label) in cases {
+            assert_eq!(to_kebab_case(input), expected, "{label}");
+        }
+    }
+
+    // ── 空 / 記号のみ ─────────────────────────────────────────────
+
+    #[test]
+    fn to_kebab_case_empty_cases() {
+        let cases: Vec<(&str, &str, &str)> = vec![
+            ("", "", "empty input"),
+            ("!!!", "", "all symbols collapse to empty"),
+        ];
+
+        for (input, expected, label) in cases {
+            assert_eq!(to_kebab_case(input), expected, "{label}");
+        }
+    }
+}

--- a/src-tauri/crates/fs/src/kebab_case.rs
+++ b/src-tauri/crates/fs/src/kebab_case.rs
@@ -29,18 +29,21 @@ pub fn to_kebab_case(title: &str) -> String {
     let mut out = String::with_capacity(title.len());
     let mut last_was_separator = true;
     for ch in title.chars() {
-        if ch.is_ascii() {
-            if ch.is_ascii_alphanumeric() {
-                out.push(ch.to_ascii_lowercase());
-                last_was_separator = false;
-            } else if !last_was_separator {
-                out.push('-');
-                last_was_separator = true;
-            }
-        } else {
+        if !ch.is_ascii() {
             out.push(ch);
             last_was_separator = false;
+            continue;
         }
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_was_separator = false;
+            continue;
+        }
+        if last_was_separator {
+            continue;
+        }
+        out.push('-');
+        last_was_separator = true;
     }
 
     if out.ends_with('-') {

--- a/src-tauri/crates/fs/src/lib.rs
+++ b/src-tauri/crates/fs/src/lib.rs
@@ -24,3 +24,4 @@
 //! - Rust 識別子: `spec_board_fs`（アンダースコア）
 
 pub mod file_scanner;
+pub mod kebab_case;


### PR DESCRIPTION
## 概要

タスクタイトル文字列から、ファイル名として利用する kebab-case 文字列を生成する純粋関数 \`to_kebab_case\` を \`spec-board-fs\` サブクレートに追加する。後続の \`create_task\` IPC コマンド（別 Issue）から呼び出される基盤関数。外部 crate 不使用 / 標準ライブラリのみ。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- \`spec_board_fs::kebab_case::to_kebab_case(&str) -> String\` を新規追加
  - ASCII を 1 文字でも含む入力は kebab-case に変換（大文字 → 小文字 / \`[a-z0-9]\` 以外の ASCII → ハイフン区切り / 連続区切りは 1 個に集約 / 先頭末尾ハイフン除去）
  - 完全非 ASCII（例: \`バグ修正\`）は変換せずそのまま返す
  - 非 ASCII を含む mixed 入力は ASCII 部のみ変換し非 ASCII はそのまま保持
  - 空入力 / 変換後に空となる入力は \`""\` を返す（フォールバックなし）
- 拡張子 \`.md\` 付与・重複回避サフィックスは本関数の責務外（呼び出し側で付与）

#### 変更されたファイル

- \`src-tauri/crates/fs/src/kebab_case.rs\` (新規)
- \`src-tauri/crates/fs/src/lib.rs\` (\`pub mod kebab_case;\` 1 行追加)

## 📊 システム図

### 状態マシン / フロー図

\`\`\`mermaid
flowchart TD
    Start([&str title]) --> Empty{空文字列?}
    Empty -->|Yes| RetEmpty[\"\\\"\\\"\" を返す]
    Empty -->|No| AsciiCheck{ASCII を含む?}
    AsciiCheck -->|No 全て非 ASCII| Passthrough[title.to_string\\(\\) を返す]
    AsciiCheck -->|Yes| Scan[chars\\(\\) を 1 パス走査]
    Scan --> Classify[文字分類]
    Classify -->|ASCII 英数字| Lower[小文字化して push]
    Classify -->|その他 ASCII| Sep[区切りフラグ更新]
    Classify -->|非 ASCII| Keep[そのまま push]
    Lower --> Trim
    Sep --> Trim
    Keep --> Trim
    Trim[末尾 '-' を pop で除去] --> Done[String を返す]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Start,Empty,RetEmpty,AsciiCheck,Passthrough,Scan,Classify,Lower,Sep,Keep,Trim,Done new
\`\`\`

### データフロー

\`\`\`
呼び出し側 (将来 create_task IPC)
    │ &str (title)
    ▼
to_kebab_case(title) ── std のみ ─→ String
    │
    ▼
呼び出し側
  - 空なら独自フォールバック（責務外）
  - 非空なら ".md" を付与してファイル作成
\`\`\`

## 📋 関連 Issue

- Closes #46

## 🧪 テスト

### テスト実行方法

\`\`\`bash
cd src-tauri
cargo test -p spec-board-fs --lib kebab_case
cargo test --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests)

### テスト結果

- 11 ケースのテストを 3 つの \`#[test]\` 関数（ASCII / mixed / 空）に分けてインライン配置
  - \`Fix Login Bug\` → \`fix-login-bug\`
  - \`FOO\` → \`foo\`
  - \`foo--bar\` → \`foo-bar\`（連続ハイフン集約）
  - \`  Fix login!! bug  \` → \`fix-login-bug\`（trim + 記号集約）
  - \`Hello_World.md\` → \`hello-world-md\`（_ / . 置換）
  - \`タスク 1\` → \`タスク-1\`（mixed: 非 ASCII 先頭）
  - \`Fix バグ\` → \`fix-バグ\`（mixed: ASCII 先頭）
  - \`日本語 title\` → \`日本語-title\`
  - \`バグ修正\` → \`バグ修正\`（全非 ASCII passthrough）
  - \`\"\"\` → \`\"\"\`（空入力）
  - \`!!!\` → \`\"\"\`（変換後空）
- \`cargo test --workspace\`: 14 tests passed（既存 file_scanner 等にリグレッションなし）
- \`cargo fmt --all -- --check\`: pass
- \`cargo clippy --workspace --all-targets -- -D warnings\`: warning 0 で pass

## 🔍 レビューポイント

- 配置先を \`spec-board\` 本体ではなく \`spec-board-fs\` サブクレート配下とした判断（CLAUDE.md「重い外部 crate を集約」例外。理由: ファイル名生成は file_scanner と同じ fs 領域で整合性が高いため）
- 完全非 ASCII 入力 (\`バグ修正\`) は変換ルール非適用 / mixed (\`タスク 1\`) は変換適用＋非 ASCII 保持 という分岐挙動
- 変換後に空となる入力（\`!!!\` 等）でフォールバック名を付けず \`\"\"\` を返す方針（呼び出し側責務）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に \`Closes #\` で Issue が記載されている
- [x] セルフレビューを実施した

🤖 Generated with [Claude Code](https://claude.com/claude-code)