### PR TITLE
✨ #50 [BE] config 読み込み + デフォルト初期化 (load_or_default + resolved_done_column)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3454,6 +3454,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,3 +30,6 @@ serde_yaml_ng = "0.10"
 thiserror = "2"
 spec-board-fs = { path = "crates/fs" }
 
+[dev-dependencies]
+tempfile = "3"
+

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -234,7 +234,11 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().join("locked");
         std::fs::create_dir(&root).unwrap();
-        let mut perms = std::fs::metadata(&root).unwrap().permissions();
+        // umask / TempDir 実装差を吸収するため、復元用に元の Permissions を捕捉してから
+        // chmod 000 する（hardcoded 0o755 だと TempDir が作成した 0o700 等とずれて
+        // クリーンアップが flaky になる）。
+        let original = std::fs::metadata(&root).unwrap().permissions();
+        let mut perms = original.clone();
         perms.set_mode(0o000);
         std::fs::set_permissions(&root, perms).unwrap();
 
@@ -242,9 +246,7 @@ mod tests {
         // probe のクリーンアップは最後にまとめる
         let result = ensure_spec_board_dir(&root);
 
-        let mut restore = std::fs::metadata(&root).unwrap().permissions();
-        restore.set_mode(0o755);
-        std::fs::set_permissions(&root, restore).unwrap();
+        std::fs::set_permissions(&root, original).unwrap();
         let _ = std::fs::remove_dir_all(root.join("__probe"));
 
         match (actually_writable, result) {

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -49,6 +49,15 @@ fn io_err(path: &Path, source: std::io::Error) -> ConfigIoError {
     }
 }
 
+/// `<project_root>/.spec-board/config.json` の絶対パス相当を返す（純粋計算、I/O なし）。
+///
+/// 呼び出し側がエラー文脈用にパス文字列を再構築する際の「真の正典」として使うことで、
+/// `.spec-board` / `config.json` の名前定数を本モジュールに一本化する。
+/// `project_root` が相対パスなら戻り値も相対パスになる（`canonicalize` は行わない）。
+pub fn config_path(project_root: &Path) -> PathBuf {
+    project_root.join(SPEC_BOARD_DIR).join(CONFIG_FILE_NAME)
+}
+
 /// `<project_root>/.spec-board/` を冪等に作成し、その `PathBuf` を返す。
 ///
 /// 既に存在する場合は何もせず成功扱い（`std::fs::create_dir_all` のセマンティクス）。
@@ -127,7 +136,7 @@ pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoE
     let spec_board_dir = project_root.join(SPEC_BOARD_DIR);
     validate_dir(&spec_board_dir)?;
 
-    let config_path = spec_board_dir.join(CONFIG_FILE_NAME);
+    let config_path = config_path(project_root);
     // dir entry の存在は `symlink_metadata` で先に確認する。`metadata` は
     // symlink を辿るため、dangling symlink (リンク先が消えた状態) を
     // `NotFound` として `Ok(None)` 扱いしてしまうが、これは「設定ファイル

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -1,0 +1,362 @@
+//! `.spec-board/` ディレクトリと `config.json` のファイル I/O を担うモジュール。
+//!
+//! 本モジュールはサブクレート `spec-board-fs` の境界規約に従い、
+//! 公開 API のシグネチャに外部 crate の型（`serde_json::Error` 等）を出さない。
+//! JSON のパースは本体クレート `spec-board` 側の責務とし、本モジュールは
+//! 「ディレクトリ作成」「ファイル存在チェック + 文字列読み込み」までを担当する。
+//!
+//! # スコープ
+//!
+//! - [`ensure_spec_board_dir`]: `<project_root>/.spec-board/` を冪等に作成
+//! - [`read_config_json`]: `<project_root>/.spec-board/config.json` の中身を文字列で返す
+//!   （ファイル不在は `Ok(None)`）
+//!
+//! # スコープ外
+//!
+//! - `config.json` の書き出し（atomic write / `.bak` 退避）は別モジュール / 別 Issue
+//! - JSON のパース / シリアライズは本体クレート側
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+const SPEC_BOARD_DIR: &str = ".spec-board";
+const CONFIG_FILE_NAME: &str = "config.json";
+
+/// `config_io` モジュールのファイル I/O で発生し得るエラー。
+///
+/// `path` には失敗時の対象パスのコピーを保持し、エラー文脈を残す
+/// （OS のエラーメッセージだけではどのパスで失敗したか不明になるため）。
+/// `.spec-board/` ディレクトリへのアクセス / 作成と `config.json` の読み込みの
+/// 両方で同じバリアントを使うため、メッセージは特定操作に偏らない汎用文言とする。
+#[derive(Debug, Error)]
+pub enum ConfigIoError {
+    /// 致命的 I/O エラー（ディレクトリ作成 / `is_dir` チェック / ファイル読み込みなど）。
+    /// `path` は失敗対象のパス（`.spec-board/` ディレクトリ自身 / `config.json` ファイル
+    /// のいずれか）。詳細は `source` の `std::io::ErrorKind` を参照。
+    #[error("config_io: I/O error at `{path}`: {source}", path = path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+fn io_err(path: &Path, source: std::io::Error) -> ConfigIoError {
+    ConfigIoError::Io {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+/// `<project_root>/.spec-board/` を冪等に作成し、その `PathBuf` を返す。
+///
+/// 既に存在する場合は何もせず成功扱い（`std::fs::create_dir_all` のセマンティクス）。
+///
+/// 戻り値は `project_root.join(".spec-board")` の素朴な join 結果であり、
+/// `project_root` が相対パスなら戻り値も相対パスになる（`canonicalize` は行わない）。
+/// 絶対パスが必要な場合は呼び出し側が `project_root` を絶対パスで渡すこと。
+///
+/// # Errors
+///
+/// - `project_root` が存在しない / アクセスできない
+/// - `<project_root>/.spec-board` が **ファイル**として存在する（`is_dir() == false`）
+/// - 権限不足等で `create_dir_all` が失敗する
+pub fn ensure_spec_board_dir(project_root: &Path) -> Result<PathBuf, ConfigIoError> {
+    let root_meta = std::fs::metadata(project_root).map_err(|e| io_err(project_root, e))?;
+    if !root_meta.is_dir() {
+        return Err(io_err(
+            project_root,
+            std::io::Error::from(std::io::ErrorKind::NotADirectory),
+        ));
+    }
+
+    let spec_board_dir = project_root.join(SPEC_BOARD_DIR);
+
+    match std::fs::metadata(&spec_board_dir) {
+        Ok(meta) => {
+            if !meta.is_dir() {
+                return Err(io_err(
+                    &spec_board_dir,
+                    std::io::Error::from(std::io::ErrorKind::NotADirectory),
+                ));
+            }
+            Ok(spec_board_dir)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(&spec_board_dir).map_err(|e| io_err(&spec_board_dir, e))?;
+            Ok(spec_board_dir)
+        }
+        Err(e) => Err(io_err(&spec_board_dir, e)),
+    }
+}
+
+/// `<project_root>/.spec-board/config.json` の中身を `String` で読み込む。
+///
+/// - `config.json` が存在しない場合のみ `Ok(None)` を返す（呼び出し側で
+///   Default 初期化に分岐するため）。
+/// - 読み取りに成功した場合は `Ok(Some(content))` を返す。中身が不正 JSON でも
+///   本モジュールでは検査せず、生の文字列として返す（パースは本体クレートの責務）。
+///
+/// # 前提条件
+///
+/// `project_root` および `<project_root>/.spec-board/` は呼び出し側で
+/// 事前に存在を保証してから渡すこと（通常は [`ensure_spec_board_dir`] を
+/// 直前に呼ぶ）。
+///
+/// 実装は防御的に内部で `<project_root>/.spec-board/` の存在 + ディレクトリ性も
+/// 検査する：
+///
+/// - `project_root` 不在 / `<project_root>/.spec-board/` 不在 / どちらかが
+///   ディレクトリでない場合は `Err(ConfigIoError::Io)` を返す（`Ok(None)` には
+///   しない。「設定ファイル不在」と「環境異常」を呼び出し側で区別可能にするため）
+/// - `Ok(None)` を返すのは「`.spec-board/` は存在 + `config.json` のみ不在」
+///   の正常系のみ
+///
+/// # Errors
+///
+/// - `project_root` 不在 / アクセス不可 / ディレクトリでない
+/// - `<project_root>/.spec-board/` 不在 / アクセス不可 / ディレクトリでない
+/// - 権限不足等で `read_to_string` が失敗する場合
+/// - `<project_root>/.spec-board/config.json` がディレクトリとして存在する等の異常ケース
+pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoError> {
+    validate_dir(project_root)?;
+    let spec_board_dir = project_root.join(SPEC_BOARD_DIR);
+    validate_dir(&spec_board_dir)?;
+
+    let config_path = spec_board_dir.join(CONFIG_FILE_NAME);
+    match std::fs::metadata(&config_path) {
+        Ok(meta) => {
+            if !meta.is_file() {
+                return Err(io_err(
+                    &config_path,
+                    std::io::Error::from(std::io::ErrorKind::InvalidInput),
+                ));
+            }
+            let content =
+                std::fs::read_to_string(&config_path).map_err(|e| io_err(&config_path, e))?;
+            Ok(Some(content))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(io_err(&config_path, e)),
+    }
+}
+
+fn validate_dir(path: &Path) -> Result<(), ConfigIoError> {
+    let meta = std::fs::metadata(path).map_err(|e| io_err(path, e))?;
+    if !meta.is_dir() {
+        return Err(io_err(
+            path,
+            std::io::Error::from(std::io::ErrorKind::NotADirectory),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // ───────── ensure_spec_board_dir ─────────
+
+    #[test]
+    fn ensure_spec_board_dir_creates_dir_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        let result = ensure_spec_board_dir(tmp.path()).unwrap();
+        assert_eq!(result, tmp.path().join(".spec-board"));
+        assert!(result.is_dir());
+    }
+
+    #[test]
+    fn ensure_spec_board_dir_is_idempotent_when_dir_exists() {
+        let tmp = TempDir::new().unwrap();
+        let existing = tmp.path().join(".spec-board");
+        std::fs::create_dir(&existing).unwrap();
+        // マーカーファイルを置き、no-op であることを確認する
+        std::fs::write(existing.join("marker.txt"), b"keep me").unwrap();
+
+        let result = ensure_spec_board_dir(tmp.path()).unwrap();
+        assert_eq!(result, existing);
+        assert!(
+            existing.join("marker.txt").exists(),
+            "既存ディレクトリの中身が消えてはならない"
+        );
+    }
+
+    #[test]
+    fn ensure_spec_board_dir_returns_err_when_path_is_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".spec-board");
+        std::fs::write(&path, b"not a directory").unwrap();
+
+        let err = ensure_spec_board_dir(tmp.path()).unwrap_err();
+        let ConfigIoError::Io { path: err_path, .. } = err;
+        assert_eq!(err_path, path);
+    }
+
+    #[test]
+    fn ensure_spec_board_dir_returns_err_when_project_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+
+        let err = ensure_spec_board_dir(&missing).unwrap_err();
+        let ConfigIoError::Io { path, source } = err;
+        assert_eq!(path, missing);
+        assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_spec_board_dir_returns_err_when_project_root_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("locked");
+        std::fs::create_dir(&root).unwrap();
+        let mut perms = std::fs::metadata(&root).unwrap().permissions();
+        perms.set_mode(0o000);
+        std::fs::set_permissions(&root, perms).unwrap();
+
+        let actually_writable = std::fs::create_dir(root.join("__probe")).is_ok();
+        // probe のクリーンアップは最後にまとめる
+        let result = ensure_spec_board_dir(&root);
+
+        let mut restore = std::fs::metadata(&root).unwrap().permissions();
+        restore.set_mode(0o755);
+        std::fs::set_permissions(&root, restore).unwrap();
+        let _ = std::fs::remove_dir_all(root.join("__probe"));
+
+        match (actually_writable, result) {
+            (false, Err(ConfigIoError::Io { path, source })) => {
+                // 実装は project_root の metadata は通る (chmod 000 でも親が読めれば metadata 自体は OK)
+                // → create_dir_all で PermissionDenied になる想定
+                assert!(
+                    path == root || path == root.join(".spec-board"),
+                    "想定パス以外: {path:?}"
+                );
+                assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+            }
+            (false, Ok(unexpected)) => {
+                panic!("PermissionDenied 期待だが Ok({unexpected:?})")
+            }
+            (true, _) => {
+                // uid 0 等で実際に書き込めてしまう環境では何もチェックしない
+            }
+        }
+    }
+
+    // ───────── read_config_json ─────────
+
+    #[test]
+    fn read_config_json_returns_none_when_config_absent() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".spec-board")).unwrap();
+
+        let result = read_config_json(tmp.path()).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn read_config_json_returns_content_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let content = r#"{"version":1,"columns":[],"cardOrder":{}}"#;
+        std::fs::write(dir.join("config.json"), content).unwrap();
+
+        let result = read_config_json(tmp.path()).unwrap();
+        assert_eq!(result.as_deref(), Some(content));
+    }
+
+    #[test]
+    fn read_config_json_returns_invalid_json_as_raw_string() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let raw = "{not valid json";
+        std::fs::write(dir.join("config.json"), raw).unwrap();
+
+        let result = read_config_json(tmp.path()).unwrap();
+        assert_eq!(result.as_deref(), Some(raw));
+    }
+
+    #[test]
+    fn read_config_json_returns_err_when_project_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+
+        let err = read_config_json(&missing).unwrap_err();
+        let ConfigIoError::Io { path, .. } = err;
+        assert_eq!(path, missing);
+    }
+
+    #[test]
+    fn read_config_json_returns_err_when_spec_board_dir_missing() {
+        let tmp = TempDir::new().unwrap();
+        let err = read_config_json(tmp.path()).unwrap_err();
+        let ConfigIoError::Io { path, source } = err;
+        assert_eq!(path, tmp.path().join(".spec-board"));
+        assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn read_config_json_returns_err_when_spec_board_dir_is_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".spec-board");
+        std::fs::write(&path, b"not a directory").unwrap();
+
+        let err = read_config_json(tmp.path()).unwrap_err();
+        let ConfigIoError::Io { path: err_path, .. } = err;
+        assert_eq!(err_path, path);
+    }
+
+    #[test]
+    fn read_config_json_returns_err_when_config_is_directory() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let config_as_dir = dir.join("config.json");
+        std::fs::create_dir(&config_as_dir).unwrap();
+
+        let err = read_config_json(tmp.path()).unwrap_err();
+        let ConfigIoError::Io { path, .. } = err;
+        assert_eq!(path, config_as_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_config_json_returns_err_when_config_is_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let config_path = dir.join("config.json");
+        std::fs::write(&config_path, b"{}").unwrap();
+
+        let mut perms = std::fs::metadata(&config_path).unwrap().permissions();
+        perms.set_mode(0o000);
+        std::fs::set_permissions(&config_path, perms).unwrap();
+
+        let actually_readable = std::fs::read_to_string(&config_path).is_ok();
+        let result = read_config_json(tmp.path());
+
+        let mut restore = std::fs::metadata(&config_path).unwrap().permissions();
+        restore.set_mode(0o644);
+        std::fs::set_permissions(&config_path, restore).unwrap();
+
+        match (actually_readable, result) {
+            (false, Err(ConfigIoError::Io { path, source })) => {
+                assert_eq!(path, config_path);
+                assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+            }
+            (false, Ok(unexpected)) => {
+                panic!("PermissionDenied 期待だが Ok({unexpected:?})")
+            }
+            (true, _) => {
+                // uid 0 環境では権限を無視できるためチェックしない
+            }
+        }
+    }
+}

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -119,12 +119,25 @@ pub fn ensure_spec_board_dir(project_root: &Path) -> Result<PathBuf, ConfigIoErr
 /// - `<project_root>/.spec-board/` 不在 / アクセス不可 / ディレクトリでない
 /// - 権限不足等で `read_to_string` が失敗する場合
 /// - `<project_root>/.spec-board/config.json` がディレクトリとして存在する等の異常ケース
+/// - `<project_root>/.spec-board/config.json` が壊れた symlink（dangling symlink）として
+///   存在する場合（`Ok(None)` には**しない**。dir entry は存在するため「設定ファイル
+///   不在」ではなく環境異常として扱う）
 pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoError> {
     validate_dir(project_root)?;
     let spec_board_dir = project_root.join(SPEC_BOARD_DIR);
     validate_dir(&spec_board_dir)?;
 
     let config_path = spec_board_dir.join(CONFIG_FILE_NAME);
+    // dir entry の存在は `symlink_metadata` で先に確認する。`metadata` は
+    // symlink を辿るため、dangling symlink (リンク先が消えた状態) を
+    // `NotFound` として `Ok(None)` 扱いしてしまうが、これは「設定ファイル
+    // 不在」ではなく環境異常（壊れた symlink）として `Err(Io)` を返したい。
+    match std::fs::symlink_metadata(&config_path) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(io_err(&config_path, e)),
+    }
+
     match std::fs::metadata(&config_path) {
         Ok(meta) => {
             if !meta.is_file() {
@@ -142,7 +155,9 @@ pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoE
                 std::fs::read_to_string(&config_path).map_err(|e| io_err(&config_path, e))?;
             Ok(Some(content))
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        // symlink_metadata が成功した時点で dir entry は存在するため、
+        // ここで `NotFound` が返るのは dangling symlink のときのみ。
+        // 「壊れた symlink」を `Ok(None)` にしないため、`Err` として伝播する。
         Err(e) => Err(io_err(&config_path, e)),
     }
 }
@@ -328,6 +343,25 @@ mod tests {
         let ConfigIoError::Io { path, source } = err;
         assert_eq!(path, config_as_dir);
         assert_eq!(source.kind(), std::io::ErrorKind::IsADirectory);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_config_json_returns_err_when_config_is_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let config_path = dir.join("config.json");
+        // 存在しないターゲットへの symlink（= dangling symlink）
+        symlink(tmp.path().join("does-not-exist.json"), &config_path).unwrap();
+
+        let err = read_config_json(tmp.path()).unwrap_err();
+        let ConfigIoError::Io { path, source } = err;
+        assert_eq!(path, config_path);
+        // dangling symlink を Ok(None) と誤認しないこと（NotFound は来るが Err として伝播）
+        assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[cfg(unix)]

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -137,38 +137,36 @@ pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoE
     validate_dir(&spec_board_dir)?;
 
     let config_path = config_path(project_root);
+
     // dir entry の存在は `symlink_metadata` で先に確認する。`metadata` は
     // symlink を辿るため、dangling symlink (リンク先が消えた状態) を
     // `NotFound` として `Ok(None)` 扱いしてしまうが、これは「設定ファイル
     // 不在」ではなく環境異常（壊れた symlink）として `Err(Io)` を返したい。
-    match std::fs::symlink_metadata(&config_path) {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(io_err(&config_path, e)),
+    if let Err(e) = std::fs::symlink_metadata(&config_path) {
+        return if e.kind() == std::io::ErrorKind::NotFound {
+            Ok(None)
+        } else {
+            Err(io_err(&config_path, e))
+        };
     }
 
-    match std::fs::metadata(&config_path) {
-        Ok(meta) => {
-            if !meta.is_file() {
-                // ディレクトリの場合は `IsADirectory` を、それ以外の非ファイル
-                // （特殊ファイル等）は `InvalidInput` を返す。呼び出し側が
-                // `ErrorKind` で分岐できるよう、ディレクトリを明示する。
-                let kind = if meta.is_dir() {
-                    std::io::ErrorKind::IsADirectory
-                } else {
-                    std::io::ErrorKind::InvalidInput
-                };
-                return Err(io_err(&config_path, std::io::Error::from(kind)));
-            }
-            let content =
-                std::fs::read_to_string(&config_path).map_err(|e| io_err(&config_path, e))?;
-            Ok(Some(content))
-        }
-        // symlink_metadata が成功した時点で dir entry は存在するため、
-        // ここで `NotFound` が返るのは dangling symlink のときのみ。
-        // 「壊れた symlink」を `Ok(None)` にしないため、`Err` として伝播する。
-        Err(e) => Err(io_err(&config_path, e)),
+    // symlink_metadata が成功 = dir entry は存在する。ここで `metadata` が
+    // `NotFound` を返すのは dangling symlink のときのみ。
+    // 「壊れた symlink」を `Ok(None)` にしないため、`Err` として伝播する。
+    let meta = std::fs::metadata(&config_path).map_err(|e| io_err(&config_path, e))?;
+    if !meta.is_file() {
+        // ディレクトリの場合は `IsADirectory`、それ以外の非ファイル（特殊ファイル等）は
+        // `InvalidInput` を返す。呼び出し側が `ErrorKind` で分岐できるよう明示する。
+        let kind = if meta.is_dir() {
+            std::io::ErrorKind::IsADirectory
+        } else {
+            std::io::ErrorKind::InvalidInput
+        };
+        return Err(io_err(&config_path, std::io::Error::from(kind)));
     }
+
+    let content = std::fs::read_to_string(&config_path).map_err(|e| io_err(&config_path, e))?;
+    Ok(Some(content))
 }
 
 fn validate_dir(path: &Path) -> Result<(), ConfigIoError> {

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -377,16 +377,17 @@ mod tests {
         let config_path = dir.join("config.json");
         std::fs::write(&config_path, b"{}").unwrap();
 
-        let mut perms = std::fs::metadata(&config_path).unwrap().permissions();
+        // umask / OS 差を吸収するため、復元用に元の Permissions を捕捉してから
+        // chmod 000 する（hardcoded 0o644 だと環境によって設定モードと不一致）。
+        let original = std::fs::metadata(&config_path).unwrap().permissions();
+        let mut perms = original.clone();
         perms.set_mode(0o000);
         std::fs::set_permissions(&config_path, perms).unwrap();
 
         let actually_readable = std::fs::read_to_string(&config_path).is_ok();
         let result = read_config_json(tmp.path());
 
-        let mut restore = std::fs::metadata(&config_path).unwrap().permissions();
-        restore.set_mode(0o644);
-        std::fs::set_permissions(&config_path, restore).unwrap();
+        std::fs::set_permissions(&config_path, original).unwrap();
 
         match (actually_readable, result) {
             (false, Err(ConfigIoError::Io { path, source })) => {

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -128,10 +128,15 @@ pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoE
     match std::fs::metadata(&config_path) {
         Ok(meta) => {
             if !meta.is_file() {
-                return Err(io_err(
-                    &config_path,
-                    std::io::Error::from(std::io::ErrorKind::InvalidInput),
-                ));
+                // ディレクトリの場合は `IsADirectory` を、それ以外の非ファイル
+                // （特殊ファイル等）は `InvalidInput` を返す。呼び出し側が
+                // `ErrorKind` で分岐できるよう、ディレクトリを明示する。
+                let kind = if meta.is_dir() {
+                    std::io::ErrorKind::IsADirectory
+                } else {
+                    std::io::ErrorKind::InvalidInput
+                };
+                return Err(io_err(&config_path, std::io::Error::from(kind)));
             }
             let content =
                 std::fs::read_to_string(&config_path).map_err(|e| io_err(&config_path, e))?;
@@ -320,8 +325,9 @@ mod tests {
         std::fs::create_dir(&config_as_dir).unwrap();
 
         let err = read_config_json(tmp.path()).unwrap_err();
-        let ConfigIoError::Io { path, .. } = err;
+        let ConfigIoError::Io { path, source } = err;
         assert_eq!(path, config_as_dir);
+        assert_eq!(source.kind(), std::io::ErrorKind::IsADirectory);
     }
 
     #[cfg(unix)]

--- a/src-tauri/crates/fs/src/lib.rs
+++ b/src-tauri/crates/fs/src/lib.rs
@@ -23,6 +23,7 @@
 //! - パッケージ名: `spec-board-fs`（ハイフン）
 //! - Rust 識別子: `spec_board_fs`（アンダースコア）
 
+pub mod config_io;
 pub mod file_scanner;
 pub mod kebab_case;
 pub mod unique_filename;

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -171,9 +171,8 @@ pub fn load_or_default(project_root: &Path) -> Result<Config, LoadConfigError> {
     match raw {
         None => Ok(Config::default()),
         Some(content) => {
-            let config_path = project_root.join(".spec-board").join("config.json");
             serde_json::from_str::<Config>(&content).map_err(|source| LoadConfigError::Parse {
-                path: config_path,
+                path: config_io::config_path(project_root),
                 source,
             })
         }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -8,17 +8,33 @@
 //! - `done_column` ↔ `doneColumn`
 //!
 //! # Default
-//! [`Config::default`] は `version = 1`、空コレクション、`done_column = None` を返す。
-//! 「完了」カラム名のフォールバック解決（最後のカラムを使う等）は呼び出し層の責務。
+//! [`Config::default`] は `version = 1`、`columns = [Todo, In Progress, Done]`
+//! （`order` は 0/1/2）、`card_order = {}`、`done_column = Some("Done")` を返す。
+//! 設定仕様書の「設定の初期化」「エラーハンドリング」節のベースラインとして使用される。
+//! `done_column` 未設定の既存 config を読み込んだ場合の「最後のカラム採用」フォールバックは、
+//! 本モジュールが提供する [`Config::resolved_done_column`] を呼び出し層が利用する設計
+//! （保存値には書き戻さない）。
+//!
+//! # ファイル I/O の境界
+//! 低レベル I/O（`.spec-board/` の作成、`config.json` の raw 読み込み）は
+//! サブクレート `spec-board-fs::config_io` に集約する。本モジュールは
+//! その raw 文字列を `serde_json::from_str::<Config>` でパースし、不在時の
+//! `Default` フォールバックと `done_column` の解決ヘルパを提供する薄い層に留める。
 //!
 //! # スコープ外（別 Issue で実装）
-//! - ファイル I/O（読み書き）
-//! - バリデーション（columns 重複・doneColumn 整合性）
-//! - 初期化フロー / マイグレーション
+//! - `config.json` の書き出し（atomic write / `.bak` 退避 / 並行書き込み制御）
+//! - バリデーション（columns 重複・doneColumn 整合性 / 名前空間整合）
+//! - version マイグレーション
+//! - md スキャン結果からのカラム自動生成
+//! - GUIDE.md 自動生成
 //! - Tauri コマンド層
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use spec_board_fs::config_io::{self, ConfigIoError};
+use thiserror::Error;
 
 /// `cardOrder` の型エイリアス。キー = カラム名、値 = タスクファイルパスの並び順配列。
 ///
@@ -83,6 +99,83 @@ impl Default for Config {
             columns,
             card_order: BTreeMap::new(),
             done_column,
+        }
+    }
+}
+
+impl Config {
+    /// `done_column` の解決結果を返す。
+    ///
+    /// - `done_column` が `Some(_)` ならその参照をそのまま返す
+    ///   （`columns` に存在しない値であっても解決層では検証しない）
+    /// - `done_column` が `None` の場合は `columns` のうち `order` 最大の
+    ///   カラム名を返す（= 表示上の末尾）
+    /// - `done_column` が `None` かつ `columns` が空なら `None` を返す
+    ///
+    /// 設定仕様書の「`doneColumn` 未設定時は末尾カラムを採用」ルールに対応する純粋関数。
+    /// `columns[].order` が表示順の真値であり、JSON 配列順とは独立しているため、
+    /// `Vec::last()` ではなく `Iterator::max_by_key(|c| c.order)` で
+    /// 「表示上の末尾」を計算する。同一 `order` の場合は `Iterator::max_by_key`
+    /// の安定性により最後に現れた要素が選ばれる（同一 `order` は仕様非推奨）。
+    pub fn resolved_done_column(&self) -> Option<&str> {
+        if let Some(name) = self.done_column.as_deref() {
+            return Some(name);
+        }
+        self.columns
+            .iter()
+            .max_by_key(|c| c.order)
+            .map(|c| c.name.as_str())
+    }
+}
+
+/// [`load_or_default`] で発生し得るエラー。
+///
+/// [`ConfigIoError`] は `#[from]` で透過的に伝播し、JSON パース失敗は
+/// 本層で [`LoadConfigError::Parse`] に包んで返す
+/// （境界規約: パースは本体クレートの責務）。
+#[derive(Debug, Error)]
+pub enum LoadConfigError {
+    #[error(transparent)]
+    Io(#[from] ConfigIoError),
+
+    #[error("failed to parse config.json at `{path}`: {source}", path = path.display())]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// `<project_root>/.spec-board/config.json` を読み込み、[`Config`] を返す。
+///
+/// 1. `.spec-board/` ディレクトリを冪等に作成する
+/// 2. `config.json` の存在を確認し、不在なら [`Config::default`] を返す
+/// 3. 存在する場合は `serde_json::from_str::<Config>` でパースする
+///
+/// # Default を返す条件
+///
+/// 関数名の `_or_default` は **「`config.json` が存在しないとき」のみ** Default を
+/// 返すことを意味する。読み込み I/O の失敗 / JSON パースの失敗は `Err` として
+/// 返却され、呼び出し層（Tauri コマンド層など）が必要に応じて
+/// [`Config::default`] へのフォールバック判断 + 通知を行う想定
+/// （仕様書「読み込み失敗 → デフォルト + トースト」は呼び出し層の責務として切り出す）。
+///
+/// # Errors
+///
+/// - `.spec-board/` の作成 / アクセスに失敗 → [`LoadConfigError::Io`]
+/// - `config.json` の読み取りに失敗 → [`LoadConfigError::Io`]
+/// - `config.json` のパースに失敗 → [`LoadConfigError::Parse`]
+pub fn load_or_default(project_root: &Path) -> Result<Config, LoadConfigError> {
+    config_io::ensure_spec_board_dir(project_root)?;
+    let raw = config_io::read_config_json(project_root)?;
+    match raw {
+        None => Ok(Config::default()),
+        Some(content) => {
+            let config_path = project_root.join(".spec-board").join("config.json");
+            serde_json::from_str::<Config>(&content).map_err(|source| LoadConfigError::Parse {
+                path: config_path,
+                source,
+            })
         }
     }
 }
@@ -320,5 +413,160 @@ mod tests {
             err.to_string().contains("cardOrder"),
             "expected error to mention `cardOrder`: {err}"
         );
+    }
+
+    // ───────── Config::resolved_done_column ─────────
+
+    #[test]
+    fn resolved_done_column_parametrized() {
+        fn col(name: &str, order: u32) -> Column {
+            Column {
+                name: name.into(),
+                order,
+            }
+        }
+
+        struct Case {
+            label: &'static str,
+            done_column: Option<&'static str>,
+            columns: Vec<Column>,
+            expected: Option<&'static str>,
+        }
+
+        let cases: Vec<Case> = vec![
+            Case {
+                label: "Some(Done) returns Some(Done)",
+                done_column: Some("Done"),
+                columns: vec![col("Todo", 0), col("In Progress", 1), col("Done", 2)],
+                expected: Some("Done"),
+            },
+            Case {
+                label: "None + 空 columns → None",
+                done_column: None,
+                columns: vec![],
+                expected: None,
+            },
+            Case {
+                label: "None + 単一 columns → そのカラム名",
+                done_column: None,
+                columns: vec![col("Todo", 0)],
+                expected: Some("Todo"),
+            },
+            Case {
+                label: "None + 3 カラム → order 最大の Done",
+                done_column: None,
+                columns: vec![col("Todo", 0), col("In Progress", 1), col("Done", 2)],
+                expected: Some("Done"),
+            },
+            Case {
+                label: "Some(Custom) は columns に無くても素通し",
+                done_column: Some("Custom"),
+                columns: vec![col("Todo", 0), col("Done", 1)],
+                expected: Some("Custom"),
+            },
+            Case {
+                label: "配列順が order 昇順でなくても order 最大が返る",
+                done_column: None,
+                columns: vec![col("Done", 2), col("Todo", 0), col("In Progress", 1)],
+                expected: Some("Done"),
+            },
+            Case {
+                label: "同一 order の場合は最後に現れた要素",
+                done_column: None,
+                columns: vec![col("A", 1), col("B", 1)],
+                expected: Some("B"),
+            },
+        ];
+
+        for case in cases {
+            let cfg = Config {
+                version: 1,
+                columns: case.columns,
+                card_order: BTreeMap::new(),
+                done_column: case.done_column.map(|s| s.to_string()),
+            };
+            assert_eq!(
+                cfg.resolved_done_column(),
+                case.expected,
+                "case: {}",
+                case.label
+            );
+        }
+    }
+
+    // ───────── load_or_default ─────────
+
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_or_default_creates_dir_and_returns_default_when_nothing_exists() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = load_or_default(tmp.path()).unwrap();
+        assert_eq!(cfg, Config::default());
+        assert!(tmp.path().join(".spec-board").is_dir());
+    }
+
+    #[test]
+    fn load_or_default_returns_default_when_only_dir_exists() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".spec-board")).unwrap();
+
+        let cfg = load_or_default(tmp.path()).unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn load_or_default_parses_existing_config_json() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let content = r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {
+                "Todo": ["tasks/a.md"],
+                "Done": []
+            },
+            "doneColumn": null
+        }"#;
+        std::fs::write(dir.join("config.json"), content).unwrap();
+
+        let cfg = load_or_default(tmp.path()).unwrap();
+        assert_eq!(cfg.version, 1);
+        assert_eq!(cfg.columns.len(), 2);
+        assert_eq!(cfg.done_column, None);
+        // done_column が無くても resolved_done_column は末尾カラムを返す
+        assert_eq!(cfg.resolved_done_column(), Some("Done"));
+    }
+
+    #[test]
+    fn load_or_default_returns_parse_err_for_invalid_json() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("config.json"), "{not valid json").unwrap();
+
+        let err = load_or_default(tmp.path()).unwrap_err();
+        match err {
+            LoadConfigError::Parse { path, .. } => {
+                assert_eq!(path, dir.join("config.json"));
+            }
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_or_default_returns_io_err_when_project_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+
+        let err = load_or_default(&missing).unwrap_err();
+        match err {
+            LoadConfigError::Io(_) => {}
+            other => panic!("expected Io error, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## 概要

Issue #50「[BE] config - 読み込み + デフォルト初期化」の Rust バックエンド実装。`<project_root>/.spec-board/config.json` を読み込み、不在時は `Config::default()` を返すフローを追加した。`done_column` 未設定時に末尾カラムを返す純粋ヘルパも併せて提供する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `spec-board-fs::config_io` モジュール新設
  - `ensure_spec_board_dir(&Path) -> Result<PathBuf, ConfigIoError>` — `.spec-board/` を冪等に作成
  - `read_config_json(&Path) -> Result<Option<String>, ConfigIoError>` — `config.json` の中身を文字列で返す（不在時のみ `Ok(None)`、環境異常は `Err(Io)`）
  - `ConfigIoError::Io { path, source }` — エラー文脈にパスを保持
- `spec-board::config` に薄い層を追加
  - `Config::resolved_done_column(&self) -> Option<&str>` — `done_column` 未設定時に `columns` の `order` 最大カラムを返す純粋関数
  - `LoadConfigError::Io / Parse` — I/O 透過 + JSON パース失敗（パス文脈付き）
  - `load_or_default(&Path) -> Result<Config, LoadConfigError>` — `.spec-board/` 作成 → `config.json` 読み込み → 不在なら `Config::default()`、存在すれば `serde_json::from_str` でパース

#### 変更されたファイル

- `src-tauri/crates/fs/src/config_io.rs` (新規)
- `src-tauri/crates/fs/src/lib.rs` — `pub mod config_io;` 追加
- `src-tauri/src/config.rs` — モジュール doc 更新 + `resolved_done_column` / `load_or_default` / `LoadConfigError` 追加 + テスト追加
- `src-tauri/Cargo.toml` — `[dev-dependencies] tempfile = "3"` 追加（`load_or_default` の統合テスト用）
- `src-tauri/Cargo.lock` — tempfile 依存解決

## 📊 システム図

### `load_or_default` の状態遷移

```mermaid
flowchart TD
    Start([load_or_default project_root]) --> S1[ensure_spec_board_dir<br/>.spec-board/ 冪等作成]
    S1 -->|root 不在 / .spec-board がファイル| EIo[Err LoadConfigError::Io]
    S1 -->|OK| S2[read_config_json]
    S2 -->|Ok None: config.json 不在| Def[Config::default を返す]
    S2 -->|I/O エラー| EIo
    S2 -->|Ok Some content| Parse[serde_json::from_str::Config]
    Parse -->|Ok cfg| OkCfg[Ok cfg]
    Parse -->|Err| EParse[Err LoadConfigError::Parse path source]
    Def --> End([Result Config LoadConfigError])
    OkCfg --> End
    EIo --> End
    EParse --> End

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class S1,S2,Def,Parse,OkCfg,EIo,EParse new
```

### `resolved_done_column` の決定木

```mermaid
flowchart TD
    In([Config columns done_column]) --> Q1{done_column.as_deref}
    Q1 -->|Some s| RetSome[Some s]
    Q1 -->|None| Q2{columns.iter.max_by_key order}
    Q2 -->|Some col| RetCol[Some col.name]
    Q2 -->|None columns 空| RetNone[None]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Q1,Q2,RetSome,RetCol,RetNone new
```

### モジュール境界

```
spec-board (本体 crate)
  src/config.rs
    Config / Column / CardOrder         (Issue #49 で追加済み)
    resolved_done_column                [NEW] 純粋ヘルパ
    load_or_default + LoadConfigError   [NEW] パース + Default フォールバック
        │
        │  &Path
        ▼
spec-board-fs (サブクレート / path 依存)
  crates/fs/src/config_io.rs            [NEW]
    ensure_spec_board_dir               [NEW] std::fs::create_dir_all
    read_config_json                    [NEW] std::fs::read_to_string
    ConfigIoError                       [NEW] path 文脈付き I/O エラー
```

## 📋 関連 Issue

- Closes #50
- Refs #49（型定義の上に乗る形）

## 🧪 テスト

### テスト実行方法

```bash
cd src-tauri && cargo test --workspace
cd src-tauri && cargo clippy --workspace --all-targets -- -D warnings
cd src-tauri && cargo fmt --all -- --check
```

### テスト項目

- [x] 単体テスト (Unit tests) — `Config::resolved_done_column` パラメータ化 7 ケース
- [x] 統合テスト (Integration tests) — `tempfile::TempDir` 配下の実 I/O
  - `ensure_spec_board_dir`: 5 ケース（不在 / 既存 / ファイル衝突 / root 不在 / `#[cfg(unix)]` 権限なし）
  - `read_config_json`: 8 ケース（不在 → `Ok(None)` / 正常 / 不正 JSON も raw / root 不在 / `.spec-board/` 不在 / `.spec-board/` がファイル / `config.json` がディレクトリ / `#[cfg(unix)]` 権限なし）
  - `load_or_default`: 5 ケース（フル不在 / dir のみ / 正常 JSON / 不正 JSON / root 不在）

### テスト結果

- `cargo test --workspace`: 全 144 件パス（spec-board 81 + spec-board-fs 45 + 既存 + 新規）
- `cargo clippy --workspace --all-targets -- -D warnings`: warnings ゼロ
- `cargo fmt --all -- --check`: 差分なし
- `cargo doc --workspace --no-deps`: 警告なくビルド成功

## 🔍 レビューポイント

- **境界規約遵守**: `spec-board-fs/Cargo.toml` に `serde` / `serde_json` を追加していない。`config_io.rs` の公開 API シグネチャに `serde_json::Error` 等の型を露出していない（パースは本体クレート側の責務）。
- **`Ok(None)` の意味**: `read_config_json` が `Ok(None)` を返すのは「`.spec-board/` 存在 + `config.json` のみ不在」の正常系のみ。環境異常（`.spec-board/` が無い等）は `Err(Io)` で返し、呼び出し側で区別可能にしている。
- **`resolved_done_column` の表示順**: `Vec::last()` ではなく `Iterator::max_by_key(|c| c.order)` を採用。JSON 配列順とは独立した `order` フィールドが表示順の真値であるため。
- **`_or_default` のセマンティクス**: I/O 失敗 / パース失敗は `Err` として返却し、Default フォールバック（仕様書 L223 の「読み込み失敗 → デフォルト + トースト」）は呼び出し層（Tauri コマンド層、別 Issue）の責務として切り出している。

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

なし（追加のみ）。

## 📚 追加情報

### スコープ外（別 Issue で実装予定）

- `config.json` の書き出し（atomic write / `.bak` 退避 / 並行書き込み制御）
- バリデーション（columns 重複・doneColumn 整合性）
- version マイグレーション
- md スキャン結果からのカラム自動生成
- GUIDE.md 自動生成
- Tauri コマンド層

### 仕様ドキュメント更新の要否

仕様変更ではなく既存仕様の一部実装のため、`docs/spec-board/config-spec.md` / `docs/spec-board/file-system-spec.md` の更新は不要。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（不要、上記参照）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #50` で Issue が記載されている
- [x] セルフレビューを実施した（Codex CLI で「問題なし」確認済み）
- [x] 破壊的変更なし