### PR TITLE
➕ [Add Dep]: #102 tauri-plugin-dialog 導入（Builder 初期化 + dialog:default 付与）

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2
+        version: 2.7.0
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
@@ -921,6 +924,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
@@ -2388,6 +2394,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2264,6 +2264,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2996,6 +2997,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3453,6 +3478,7 @@ dependencies = [
  "spec-board-fs",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "thiserror 2.0.18",
 ]
@@ -3777,6 +3803,48 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "dialog:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ fn greet(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## 概要

OS ネイティブダイアログ（ディレクトリ選択 / メッセージ等）を呼び出すための基盤として、`@tauri-apps/plugin-dialog`（フロント SDK）と `tauri-plugin-dialog`（Rust crate）を導入し、`tauri::Builder` へのプラグイン登録と main window への `dialog:default` capability 付与までを行う。実際のダイアログ呼び出しコード（`useOpenProject` 等）は #101 / #103 に委譲する。

## 変更の種類

- ➕ [Add Dep] — 依存追加（pnpm: `@tauri-apps/plugin-dialog ^2`、Cargo: `tauri-plugin-dialog = "2"`）
- 🔧 [Config] — Tauri 設定変更（Builder にプラグイン登録、capability 付与）

## 追加した内容

- フロント依存: `@tauri-apps/plugin-dialog ^2`（実際の解決バージョン: `2.7.0`）
- Rust 依存: `tauri-plugin-dialog = "2"`（実際の解決バージョン: `2.7.0`、推移依存として `tauri-plugin-fs 2.5.0` / `rfd 0.16.0` 追加）

## 変更した内容

- `src-tauri/src/lib.rs`: `tauri::Builder::default()` チェーンに `.plugin(tauri_plugin_dialog::init())` を `tauri_plugin_opener::init()` の直後に追加
- `src-tauri/capabilities/default.json`: main window の `permissions` 配列末尾に `\"dialog:default\"` を追加（`allow-open` / `allow-save` / `allow-message` を粗く一括付与。`dialog:allow-ask` / `dialog:allow-confirm` は v2 で deprecated alias のため使用しない方針）
- `package.json` / `pnpm-lock.yaml` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock`: 依存追加に伴う更新

## 削除した内容

- なし

## 仕様ドキュメント更新

**不要**（純粋な基盤導入で、外部仕様の確定は #101 / #103 で行うため。CLAUDE.md「内部実装の最適化はドキュメント更新不要」に相当）。CSP / `docs/spec-board/` / CI ワークフローには変更なし。

## システム図

\`\`\`mermaid
flowchart TD
  subgraph BUILD[\"ビルド時 / インストール時\"]
    PKG[\"package.json<br/>(@tauri-apps/plugin-dialog ^2)\"]
    CARGO[\"src-tauri/Cargo.toml<br/>(tauri-plugin-dialog = 2)\"]
    LIB[\"src-tauri/src/lib.rs<br/>.plugin(tauri_plugin_dialog::init())\"]
    CAP[\"src-tauri/capabilities/default.json<br/>permissions: dialog:default\"]
  end

  PKG -->|pnpm install| NM[\"node_modules/<br/>@tauri-apps/plugin-dialog\"]
  CARGO -->|cargo build| TGT[\"target/<br/>libtauri_plugin_dialog\"]
  LIB --> BUILDER[\"tauri::Builder<br/>(plugin 登録)\"]
  CAP --> SCHEMA[\"src-tauri/gen/schemas/<br/>(権限スキーマ)\"]

  subgraph RUNTIME[\"ランタイム（#101 / #103 で実装予定）\"]
    REACT[\"React コンポーネント<br/>(将来)\"]
    SDK[\"@tauri-apps/plugin-dialog<br/>(JS SDK)\"]
    IPC[\"Tauri IPC<br/>capabilities 検証\"]
    PLUGIN[\"tauri-plugin-dialog<br/>(Rust)\"]
    OS[\"OS native ダイアログ\"]
  end

  REACT -->|open / save / message| SDK
  SDK -->|invoke plugin:dialog/...| IPC
  IPC -->|dialog:default 検証 OK| PLUGIN
  PLUGIN -->|rfd / GTK / WinAPI / Cocoa| OS

  NM -.-> SDK
  TGT -.-> PLUGIN
  BUILDER -.-> PLUGIN
  SCHEMA -.-> IPC

  classDef new fill:#e0ffe0,stroke:#22863a;
  class PKG,CARGO,LIB,CAP,NM,TGT,BUILDER,SCHEMA new;
\`\`\`

緑色のノード: 本 PR で追加・初期化される要素。点線（破線）は依存関係 / ランタイムでの参照経路。

## 関連Issue

Refs #102

## テスト

### 自動チェック（CI と同コマンド）

| チェック | コマンド | 結果 |
|---|---|---|
| TypeScript 型 | \`pnpm typecheck\` | ✅ pass |
| Vitest（CI 同等） | \`pnpm test:coverage\` | ✅ 68 files / 521 tests 全件 pass |
| Biome | \`pnpm exec biome check\` | ✅ 191 files, 違反なし |
| oxlint | \`pnpm exec oxlint\` | ✅ 189 files, 0 warnings / 0 errors |
| Rust fmt | \`cd src-tauri && cargo fmt --all -- --check\` | ✅ pass |
| Rust clippy | \`cd src-tauri && cargo clippy --workspace --all-targets -- -D warnings\` | ✅ pass |
| Rust check | \`cd src-tauri && cargo check\` | ✅ pass |

### SDK ロード確認

\`@tauri-apps/plugin-dialog\` の dynamic import で \`ask\` / \`confirm\` / \`message\` / \`open\` / \`save\` の export を確認済み。

### 手動動作確認（**マージ前にレビュアーで実施をお願いします**）

\`pnpm tauri dev\` 上で OS ネイティブダイアログが起動するかの目視確認は GUI 環境で人間が実施する必要があります（V3）。手順:

1. \`src/App.tsx\` などに一時的に以下を追加:
   \`\`\`ts
   import { open } from \"@tauri-apps/plugin-dialog\";
   void open({ directory: true });
   \`\`\`
2. \`pnpm tauri dev\` 起動 → OS ディレクトリ選択ダイアログが表示されることを確認
3. 一時コードを \`git restore\` で revert

### Codex レビュー

`.plugin-workspace/.specs/001-tauri-plugin-dialog-setup/code-review/` 配下に保存。最終結果: **問題なし**。

## レビューポイント

- **Capability の粒度**: 今回 `dialog:default`（粗い粒度: open / save / message を一括許可）で導入。MVP 期間中はこれで進め、必要が見えてから個別 `dialog:allow-open` 等に絞り込む方針。この粒度で問題ないか
- **配置先 crate**: `tauri-plugin-dialog` は本体 crate `spec-board` に追加（CLAUDE.md の集約規約: サブクレート `spec-board-fs` は重い外部 I/O crate 集約用で tauri 非依存）。dialog は IPC ブリッジに直接バインドする必要があるため本体側に置く判断
- **テスト戦略**: 本 PR は依存追加 + プラグイン初期化 + 権限付与のみで、実行時に呼び出されるアプリケーションコードを追加しないため Vitest / `cargo test` の新規追加なし。既存 CI チェックと手動動作確認のみで品質担保する方針で問題ないか

## チェックリスト

- [x] セルフレビューを実施した
- [x] pnpm test:run / test:coverage が通る
- [x] cargo test / cargo clippy / cargo fmt --check が通る
- [x] Biome / oxlint の警告を解消した
- [ ] UI 変更がある場合は Tauri アプリで動作確認した（**V3: レビュアーでの手動目視確認をお願いします**）
- [x] 仕様変更がある場合は docs/spec-board/ を更新した（仕様変更なしのため不要）
- [x] feature 間の依存は index.ts の公開 API 経由（本 PR では feature 間 import なし）
- [x] 関連 Issue を PR にリンクした
- [x] 破壊的変更なし