### PR TITLE
✨ [New Feature]: #103 useOpenProject フック (状態マシン + 後勝ち + アンマウント safeguard)

### DIFF
--- a/src/features/board/hooks/useOpenProject/__tests__/useOpenProject.behavior.test.ts
+++ b/src/features/board/hooks/useOpenProject/__tests__/useOpenProject.behavior.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+import { type OpenProjectPayload, TauriError } from "@/lib/tauri";
+import { type OpenProjectState, reducer } from "..";
+
+const samplePayload: OpenProjectPayload = { tasks: [], columns: [] };
+
+test("reducer: start で loading{path} に遷移する", () => {
+  const next = reducer({ kind: "idle" }, { type: "start", path: "/a" });
+  expect(next).toEqual({ kind: "loading", path: "/a" });
+});
+
+test("reducer: succeed で loaded{path,data} に遷移する", () => {
+  const next = reducer(
+    { kind: "loading", path: "/a" },
+    { type: "succeed", path: "/a", data: samplePayload },
+  );
+  expect(next).toEqual({ kind: "loaded", path: "/a", data: samplePayload });
+});
+
+test("reducer: fail で error{path,error} に遷移する", () => {
+  const error = new TauriError("UNKNOWN", "boom");
+  const next = reducer(
+    { kind: "loading", path: "/a" },
+    { type: "fail", path: "/a", error },
+  );
+  expect(next).toEqual({ kind: "error", path: "/a", error });
+});
+
+test("reducer: reset で任意状態から idle に戻る", () => {
+  const states: OpenProjectState[] = [
+    { kind: "idle" },
+    { kind: "loading", path: "/a" },
+    { kind: "loaded", path: "/a", data: samplePayload },
+    { kind: "error", path: "/a", error: new TauriError("UNKNOWN", "x") },
+  ];
+  for (const s of states) {
+    expect(reducer(s, { type: "reset" })).toEqual({ kind: "idle" });
+  }
+});

--- a/src/features/board/hooks/useOpenProject/__tests__/useOpenProject.interaction.test.tsx
+++ b/src/features/board/hooks/useOpenProject/__tests__/useOpenProject.interaction.test.tsx
@@ -1,0 +1,366 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { type OpenProjectPayload, openProject, TauriError } from "@/lib/tauri";
+import { Result } from "@/utils/result";
+import {
+  type UseOpenProjectOptions,
+  type UseOpenProjectResult,
+  useOpenProject,
+} from "..";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    openProject: vi.fn(),
+  };
+});
+
+const openProjectMock = vi.mocked(openProject);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+let hadIsReactActEnvironment = false;
+
+beforeAll(() => {
+  hadIsReactActEnvironment =
+    "IS_REACT_ACT_ENVIRONMENT" in reactActEnvironmentGlobal;
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+  const keysToDelete = hadIsReactActEnvironment
+    ? []
+    : (["IS_REACT_ACT_ENVIRONMENT"] as const);
+  for (const key of keysToDelete) {
+    Reflect.deleteProperty(reactActEnvironmentGlobal, key);
+  }
+});
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeEach(() => {
+  openProjectMock.mockReset();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+/**
+ * useOpenProject の戻り値を観測する Probe コンポーネント。
+ * @param props hook 引数 + 観測コールバック
+ * @returns null
+ */
+const Probe = (
+  props: UseOpenProjectOptions & {
+    onResult: (r: UseOpenProjectResult) => void;
+  },
+) => {
+  const { onResult, ...args } = props;
+  const result = useOpenProject(args);
+  useEffect(() => {
+    onResult(result);
+  });
+  return null;
+};
+
+/**
+ * Probe をマウントして latest accessor を返すヘルパ。
+ * @param args useOpenProject の引数
+ * @returns latest accessor
+ */
+const renderHook = (args: UseOpenProjectOptions) => {
+  let latest: UseOpenProjectResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      createElement(Probe, {
+        ...args,
+        onResult: (r) => {
+          latest = r;
+        },
+      }),
+    );
+  });
+  return {
+    get latest(): UseOpenProjectResult {
+      return latest as UseOpenProjectResult;
+    },
+  };
+};
+
+const payloadA: OpenProjectPayload = {
+  tasks: [],
+  columns: ["TODO"],
+};
+const payloadB: OpenProjectPayload = {
+  tasks: [],
+  columns: ["DONE"],
+};
+
+test("初期 state は { kind: 'idle' }", () => {
+  openProjectMock.mockResolvedValue(Result.ok(payloadA));
+  const probe = renderHook({ onError: vi.fn() });
+  expect(probe.latest.state).toEqual({ kind: "idle" });
+});
+
+test("open(path) を呼ぶと state は { kind: 'loading', path }", async () => {
+  let resolve!: (r: Result<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockReturnValue(
+    new Promise<Result<OpenProjectPayload, TauriError>>((r) => {
+      resolve = r;
+    }),
+  );
+  const probe = renderHook({ onError: vi.fn() });
+
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.open("/a");
+  });
+  expect(probe.latest.state).toEqual({ kind: "loading", path: "/a" });
+
+  await act(async () => {
+    resolve(Result.ok(payloadA));
+    await pending;
+  });
+});
+
+test("成功時 { kind: 'loaded', path, data } / onError 未呼び出し", async () => {
+  openProjectMock.mockResolvedValue(Result.ok(payloadA));
+  const onError = vi.fn();
+  const probe = renderHook({ onError });
+
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.open("/a");
+  });
+  await act(async () => {
+    await pending;
+  });
+
+  expect(probe.latest.state).toEqual({
+    kind: "loaded",
+    path: "/a",
+    data: payloadA,
+  });
+  expect(onError).toHaveBeenCalledTimes(0);
+});
+
+test("失敗時 { kind: 'error', path, error } / onError(error) で 1 回", async () => {
+  const error = new TauriError("NOT_FOUND", "nope");
+  openProjectMock.mockResolvedValue(Result.err(error));
+  const onError = vi.fn();
+  const probe = renderHook({ onError });
+
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.open("/a");
+  });
+  await act(async () => {
+    await pending;
+  });
+
+  expect(probe.latest.state).toEqual({ kind: "error", path: "/a", error });
+  expect(onError).toHaveBeenCalledTimes(1);
+  expect(onError).toHaveBeenCalledWith(error);
+});
+
+test("error 状態から open(other) で loading{other}", async () => {
+  const firstError = new TauriError("UNKNOWN", "boom");
+  openProjectMock.mockResolvedValueOnce(Result.err(firstError));
+
+  let resolveB!: (r: Result<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockImplementationOnce(
+    () =>
+      new Promise<Result<OpenProjectPayload, TauriError>>((r) => {
+        resolveB = r;
+      }),
+  );
+
+  const onError = vi.fn();
+  const probe = renderHook({ onError });
+
+  let pendingA!: Promise<void>;
+  act(() => {
+    pendingA = probe.latest.open("/a");
+  });
+  await act(async () => {
+    await pendingA;
+  });
+  expect(probe.latest.state.kind).toBe("error");
+
+  let pendingB!: Promise<void>;
+  act(() => {
+    pendingB = probe.latest.open("/b");
+  });
+  expect(probe.latest.state).toEqual({ kind: "loading", path: "/b" });
+
+  await act(async () => {
+    resolveB(Result.ok(payloadB));
+    await pendingB;
+  });
+});
+
+test("loaded 状態から open(other) で loading{other}", async () => {
+  openProjectMock.mockResolvedValueOnce(Result.ok(payloadA));
+
+  let resolveB!: (r: Result<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockImplementationOnce(
+    () =>
+      new Promise<Result<OpenProjectPayload, TauriError>>((r) => {
+        resolveB = r;
+      }),
+  );
+
+  const probe = renderHook({ onError: vi.fn() });
+
+  let pendingA!: Promise<void>;
+  act(() => {
+    pendingA = probe.latest.open("/a");
+  });
+  await act(async () => {
+    await pendingA;
+  });
+  expect(probe.latest.state.kind).toBe("loaded");
+
+  let pendingB!: Promise<void>;
+  act(() => {
+    pendingB = probe.latest.open("/b");
+  });
+  expect(probe.latest.state).toEqual({ kind: "loading", path: "/b" });
+
+  await act(async () => {
+    resolveB(Result.ok(payloadB));
+    await pendingB;
+  });
+});
+
+test("reset() で idle に戻る（loading 中の reset でも in-flight resolve が idle を上書きしない）", async () => {
+  let resolve!: (r: Result<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockReturnValue(
+    new Promise<Result<OpenProjectPayload, TauriError>>((r) => {
+      resolve = r;
+    }),
+  );
+
+  const onError = vi.fn();
+  const probe = renderHook({ onError });
+
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.open("/a");
+  });
+  expect(probe.latest.state.kind).toBe("loading");
+
+  act(() => {
+    probe.latest.reset();
+  });
+  expect(probe.latest.state).toEqual({ kind: "idle" });
+
+  await act(async () => {
+    resolve(Result.ok(payloadA));
+    await pending;
+  });
+
+  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(onError).toHaveBeenCalledTimes(0);
+});
+
+test("連続 open(a) → open(b) で a の resolve は state に反映されない（後勝ち）", async () => {
+  let resolveA!: (r: Result<OpenProjectPayload, TauriError>) => void;
+  let resolveB!: (r: Result<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockImplementationOnce(
+    () =>
+      new Promise<Result<OpenProjectPayload, TauriError>>((r) => {
+        resolveA = r;
+      }),
+  );
+  openProjectMock.mockImplementationOnce(
+    () =>
+      new Promise<Result<OpenProjectPayload, TauriError>>((r) => {
+        resolveB = r;
+      }),
+  );
+
+  const onError = vi.fn();
+  const probe = renderHook({ onError });
+
+  let pendingA!: Promise<void>;
+  act(() => {
+    pendingA = probe.latest.open("/a");
+  });
+  let pendingB!: Promise<void>;
+  act(() => {
+    pendingB = probe.latest.open("/b");
+  });
+
+  await act(async () => {
+    resolveB(Result.ok(payloadB));
+    await pendingB;
+  });
+  await act(async () => {
+    resolveA(Result.ok(payloadA));
+    await pendingA;
+  });
+
+  expect(probe.latest.state).toEqual({
+    kind: "loaded",
+    path: "/b",
+    data: payloadB,
+  });
+  expect(onError).toHaveBeenCalledTimes(0);
+});
+
+test("アンマウント後の resolve で dispatch / onError が発火しない", async () => {
+  let resolve!: (r: Result<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockReturnValue(
+    new Promise<Result<OpenProjectPayload, TauriError>>((r) => {
+      resolve = r;
+    }),
+  );
+
+  const onError = vi.fn();
+  const probe = renderHook({ onError });
+
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.open("/a");
+  });
+
+  act(() => {
+    root?.unmount();
+    root = null;
+  });
+
+  await act(async () => {
+    resolve(Result.err(new TauriError("UNKNOWN", "after-unmount")));
+    await pending;
+  });
+
+  expect(onError).toHaveBeenCalledTimes(0);
+});

--- a/src/features/board/hooks/useOpenProject/index.ts
+++ b/src/features/board/hooks/useOpenProject/index.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import {
+  type OpenProjectPayload,
+  openProject,
+  type TauriError,
+} from "@/lib/tauri";
+
+/**
+ * useOpenProject hook の状態（discriminated union）。
+ * - idle: 未選択
+ * - loading: invoke 実行中（path 保持）
+ * - loaded: 成功（path / data 保持）
+ * - error: 失敗（path / error 保持）
+ */
+export type OpenProjectState =
+  | { kind: "idle" }
+  | { kind: "loading"; path: string }
+  | { kind: "loaded"; path: string; data: OpenProjectPayload }
+  | { kind: "error"; path: string; error: TauriError };
+
+/**
+ * reducer 内部で扱う action（hook の内部実装詳細のため export しない）。
+ */
+type OpenProjectAction =
+  | { type: "start"; path: string }
+  | { type: "succeed"; path: string; data: OpenProjectPayload }
+  | { type: "fail"; path: string; error: TauriError }
+  | { type: "reset" };
+
+const initialState: OpenProjectState = { kind: "idle" };
+
+/**
+ * useReducer 用の pure な遷移関数。React 非依存で単体テスト可能。
+ * `default` 句の `action satisfies never` で action 種別の網羅性を型レベルで保証する。
+ *
+ * @internal hook 内部実装だが behavior.test.ts から import するため module export する。
+ *           features barrel (src/features/board/index.ts) からは re-export しない。
+ *
+ * @param state 現在の状態
+ * @param action 適用する action
+ * @returns 次の状態
+ */
+export const reducer = (
+  state: OpenProjectState,
+  action: OpenProjectAction,
+): OpenProjectState => {
+  switch (action.type) {
+    case "start":
+      return { kind: "loading", path: action.path };
+    case "succeed":
+      return { kind: "loaded", path: action.path, data: action.data };
+    case "fail":
+      return { kind: "error", path: action.path, error: action.error };
+    case "reset":
+      return { kind: "idle" };
+    default: {
+      action satisfies never;
+      return state;
+    }
+  }
+};
+
+/**
+ * useOpenProject hook のオプション引数。
+ */
+export type UseOpenProjectOptions = {
+  /**
+   * 失敗時に 1 度だけ呼ばれる汎用エラーコールバック（optional）。
+   * Toast 表示やログなど通知方法は呼び出し側に委ねる。
+   * 後勝ちキャンセル / アンマウント時には呼ばれない。
+   */
+  onError?: (error: TauriError) => void;
+};
+
+/**
+ * useOpenProject hook の戻り値。
+ */
+export type UseOpenProjectResult = {
+  /** 現在の状態 */
+  state: OpenProjectState;
+  /**
+   * プロジェクトディレクトリを開く。後勝ちキャンセル / アンマウント safeguard 付き。
+   * @param path プロジェクトディレクトリの絶対パス
+   * @returns invoke の解決を待つ Promise（state 反映は requestId 一致時のみ）
+   */
+  open: (path: string) => Promise<void>;
+  /** 任意状態から idle に戻す（in-flight resolve は requestId を進めて破棄） */
+  reset: () => void;
+};
+
+/**
+ * useOpenProject — プロジェクトディレクトリを開く状態マシン hook。
+ *
+ * idle / loading / loaded / error の 4 状態を管理し、`open(path)` / `reset()` で遷移する。
+ * 失敗時は optional な `onError(error)` コールバックを 1 度だけ呼ぶ。
+ * 後勝ちキャンセル（`useRef<number>` リクエスト ID 方式）とアンマウント safeguard
+ * （useEffect cleanup で ID を進める）を 1 つの ID 機構で兼ねる。
+ *
+ * @param options hook オプション（onError は optional）
+ * @returns state / open / reset を持つ result
+ */
+export const useOpenProject = (
+  options: UseOpenProjectOptions = {},
+): UseOpenProjectResult => {
+  const { onError } = options;
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const requestIdRef = useRef<number>(0);
+
+  useEffect(() => {
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, []);
+
+  const open = useCallback(
+    async (path: string): Promise<void> => {
+      requestIdRef.current += 1;
+      const myId = requestIdRef.current;
+      dispatch({ type: "start", path });
+
+      const result = await openProject({ path });
+
+      if (myId !== requestIdRef.current) {
+        return;
+      }
+
+      if (!result.ok) {
+        dispatch({ type: "fail", path, error: result.error });
+        onError?.(result.error);
+        return;
+      }
+
+      dispatch({ type: "succeed", path, data: result.value });
+    },
+    [onError],
+  );
+
+  const reset = useCallback((): void => {
+    requestIdRef.current += 1;
+    dispatch({ type: "reset" });
+  }, []);
+
+  return { state, open, reset };
+};

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -1,3 +1,9 @@
 export { Board } from "./components/Board";
 export { EmptyState } from "./components/EmptyState";
 export { HeaderBar } from "./components/HeaderBar";
+export {
+  type OpenProjectState,
+  type UseOpenProjectOptions,
+  type UseOpenProjectResult,
+  useOpenProject,
+} from "./hooks/useOpenProject";


### PR DESCRIPTION
## 概要

ユーザーが選択したプロジェクトディレクトリを Tauri バックエンドの `open_project` invoke で読み込み、その状態（idle / loading / loaded / error）を React コンポーネントに公開するカスタムフック `useOpenProject` を新規実装。

## 変更の種類

- ✨ [New Feature]: 新機能（`useOpenProject` カスタムフック）

## 追加した内容

- `src/features/board/hooks/useOpenProject/index.ts` — hook 本体
  - `OpenProjectState` discriminated union（`kind: idle/loading/loaded/error`）
  - `useReducer` ベースの状態管理（reducer は pure 関数として module export）
  - `useRef<number>` の requestId による **後勝ちキャンセル** + `useEffect` cleanup での **アンマウント safeguard**（同一 ID 機構で兼用）
  - `onError?: (error: TauriError) => void` の optional コールバック（Toast / 文言生成は呼び出し側責務）
- reducer 単体 4 件 + interaction 9 件 = 計 **13 件**のテスト
- `src/features/board/index.ts` への re-export 追加（`useOpenProject` / `OpenProjectState` / `UseOpenProjectOptions` / `UseOpenProjectResult`）

## 変更した内容

- `src/features/board/index.ts` に hook の公開 API を追加（既存 export 行は変更なし）
- `App.tsx` の配線置き換えは **本 PR の範囲外**（別 Issue で実施予定）

## 仕様ドキュメント更新

不要（純粋な hook 追加 / 公開 API 既存仕様には変更なし。Toast 文言は呼び出し側責務に design pivot 済で `docs/spec-board/` に該当記述なし）。

## システム図

### 状態遷移（flowchart）

\`\`\`mermaid
flowchart LR
    idle((idle)) -- "open(path)" --> loading
    loading -- "result.ok" --> loaded
    loading -- "!result.ok / onError(error)" --> error
    loaded -- "open(other)" --> loading
    error -- "open(other)" --> loading
    idle -- "reset()" --> idle
    loading -- "reset()" --> idle
    loaded -- "reset()" --> idle
    error -- "reset()" --> idle

    style idle stroke:#888
    style loading stroke:#1976d2
    style loaded stroke:#2e7d32
    style error stroke:#c62828
\`\`\`

### データフロー（後勝ち + アンマウント safeguard）

\`\`\`mermaid
flowchart TD
    A[UI: open path] --> B["requestIdRef++ / myId capture"]
    B --> C["dispatch start"]
    C --> D["await openProject params"]
    D --> E{"myId === requestIdRef ?"}
    E -- no --> X[no-op: 後勝ち / unmount]
    E -- yes --> F{result.ok ?}
    F -- ok --> G[dispatch succeed]
    F -- err --> H["dispatch fail / onError? error"]

    R[reset] --> R1["requestIdRef++ / dispatch reset"]
    U[unmount] --> U1["useEffect cleanup: requestIdRef++"]
\`\`\`

## 関連Issue

Refs #103

## テスト

- \`pnpm exec vitest run src/features/board/hooks/useOpenProject\` — **13 / 13 passed**（reducer 4 / interaction 9）
- \`pnpm test:run\` — 534 件全 green（既存テストへの影響なし）
- \`pnpm build\` — 型エラー 0 / Vite ビルド成功
- \`pnpm exec biome check .\` — 0 errors
- \`pnpm exec oxlint\` — 0 warnings / 0 errors
- Codex CLI による全変更レビュー実施（review-001.md: **問題なし** / 1 ループで完了）
- UI 動作確認: 本 PR は hook 追加のみで UI 配線は範囲外のため未実施（次 Issue で `App.tsx` 配線時に実施予定）

## レビューポイント

- **後勝ちキャンセル + アンマウント safeguard を 1 つの `requestIdRef` 機構で兼ねる設計**: `mountedRef` を別途持たず、`useEffect` cleanup で `requestIdRef.current += 1` を行うことで in-flight resolve の `myId` と現在 ID を不一致にし、dispatch / `onError` を no-op 化する
- **`reset()` でも ID を進める**: loading 中の `reset()` で in-flight resolve が idle 状態を上書きしない不変条件を担保（テスト「reset() で idle に戻る」で検証）
- **reducer の export スコープ**: hook ファイルからは `export const reducer` するが features barrel からは re-export しない（"module-exported for behavior test, not barrel-exported"）。これにより behavior テストから直接 import 可能でありつつ利用者から見た公開 API には現れない
- **`onError` の責務分離**: hook は Toast / `useToasts` / `@/types/toast` を一切 import せず、`TauriError` をそのまま optional コールバックに渡す。文言 fallback / Toast 表示は呼び出し側 UI レイヤーの責務
- **`OpenProjectAction` 網羅性**: `default: { action satisfies never; return state; }` で action 種別の網羅を型レベルで保証

## チェックリスト

- [x] セルフレビューを実施した
- [x] pnpm test:run が通る
- [x] pnpm build が通る
- [x] Biome / oxlint の警告を解消した
- [x] UI 変更なし（hook 追加のみ / `App.tsx` 配線は別 Issue）
- [x] 仕様ドキュメント更新は不要（理由: 純粋な hook 追加 / 公開仕様変更なし）
- [x] feature 間の依存は index.ts の公開 API 経由（`@/lib/tauri` / `@/utils/result` のみ参照）
- [x] 関連 Issue (#103) を本文に記載
- [x] 破壊的変更なし