### PR TITLE
✨ #55 write-ignore registry APIを追加

### DIFF
--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -335,6 +335,7 @@ impl WriteIgnoreRegistry {
     pub fn new() -> Self;
     pub fn register(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
     pub fn should_ignore(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
+    pub fn consume(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
     pub fn unregister(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
     pub fn len(&self) -> Result<usize, WriteIgnoreError>;
     pub fn is_empty(&self) -> Result<bool, WriteIgnoreError>;
@@ -352,12 +353,13 @@ pub enum WriteIgnoreError {
 | 内部状態 | `Mutex<HashSet<PathBuf>>` で保護する |
 | `register` | パスを登録し、新規追加なら `Ok(true)`、重複なら `Ok(false)` を返す |
 | `should_ignore` | パスが登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す。状態は変更しない |
+| `consume` | 1回の lock 内でパスを確認して解除し、登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す。ファイル監視イベントの one-shot 消費に使う |
 | `unregister` | パスを解除し、登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す |
 | パス比較 | canonicalize / normalize は行わず、渡された `PathBuf` 表現の完全一致で扱う |
 | エラー | Mutex が poison された場合は `Err(WriteIgnoreError::LockPoisoned)` を返す |
 | Tauri 依存 | なし。Tauri state やファイル監視コンポーネントへの保持・統合は呼び出し側で行う |
 
-現在の `WriteIgnoreRegistry` は registry のみを提供し、タイムアウト解除やファイル監視イベントとの接続は担当しない。イベント無視後の `unregister` と、必要な場合のタイムアウト解除は、監視コンポーネント側で行う。
+現在の `WriteIgnoreRegistry` は registry のみを提供し、タイムアウト解除やファイル監視イベントとの接続は担当しない。ファイル監視イベントを無視する判定では race-free な `consume` を使い、必要な場合のタイムアウト解除は監視コンポーネント側で `unregister` を呼ぶ。
 
 ## カラム設定・カード並び順の永続化
 

--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -326,6 +326,39 @@ pub enum ScanError {
 
 `open_project` 等の Tauri command は本 API を呼び出し、`ScanError::Io` をフロントエンド表示用エラー（"ディレクトリが見つかりません" 等）に変換して返却する。
 
+### `WriteIgnoreRegistry`
+
+```rust
+pub struct WriteIgnoreRegistry;
+
+impl WriteIgnoreRegistry {
+    pub fn new() -> Self;
+    pub fn register(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
+    pub fn should_ignore(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
+    pub fn unregister(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
+    pub fn len(&self) -> Result<usize, WriteIgnoreError>;
+    pub fn is_empty(&self) -> Result<bool, WriteIgnoreError>;
+}
+
+pub enum WriteIgnoreError {
+    LockPoisoned,
+}
+```
+
+| 項目 | 仕様 |
+|:-----|:-----|
+| 機能 | spec-board 自身の書き込みで発生したファイル監視イベントを呼び出し側が識別するため、無視対象パスを登録・参照・解除する |
+| 配置 | `src-tauri/crates/fs/src/write_ignore.rs`（サブクレート `spec-board-fs`）。呼び出しは `spec_board_fs::write_ignore::WriteIgnoreRegistry` |
+| 内部状態 | `Mutex<HashSet<PathBuf>>` で保護する |
+| `register` | パスを登録し、新規追加なら `Ok(true)`、重複なら `Ok(false)` を返す |
+| `should_ignore` | パスが登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す。状態は変更しない |
+| `unregister` | パスを解除し、登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す |
+| パス比較 | canonicalize / normalize は行わず、渡された `PathBuf` 表現の完全一致で扱う |
+| エラー | Mutex が poison された場合は `Err(WriteIgnoreError::LockPoisoned)` を返す |
+| Tauri 依存 | なし。Tauri state やファイル監視コンポーネントへの保持・統合は呼び出し側で行う |
+
+現在の `WriteIgnoreRegistry` は registry のみを提供し、タイムアウト解除やファイル監視イベントとの接続は担当しない。イベント無視後の `unregister` と、必要な場合のタイムアウト解除は、監視コンポーネント側で行う。
+
 ## カラム設定・カード並び順の永続化
 
 カラム設定、カード並び順、AIエージェント向けガイドの仕様は [config-spec.md](./config-spec.md) を参照。

--- a/src-tauri/crates/fs/src/lib.rs
+++ b/src-tauri/crates/fs/src/lib.rs
@@ -27,3 +27,4 @@ pub mod config_io;
 pub mod file_scanner;
 pub mod kebab_case;
 pub mod unique_filename;
+pub mod write_ignore;

--- a/src-tauri/crates/fs/src/write_ignore.rs
+++ b/src-tauri/crates/fs/src/write_ignore.rs
@@ -1,0 +1,226 @@
+//! Registry for write-originated paths that a future file watcher can ignore.
+//!
+//! Paths are stored exactly as provided. The registry does not canonicalize,
+//! normalize, or otherwise resolve path representations.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WriteIgnoreError {
+    #[error("write_ignore registry lock poisoned")]
+    LockPoisoned,
+}
+
+#[derive(Debug, Default)]
+pub struct WriteIgnoreRegistry {
+    ignored_paths: Mutex<HashSet<PathBuf>>,
+}
+
+impl WriteIgnoreRegistry {
+    /// Creates an empty write-ignore registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a path and returns whether it was newly inserted.
+    pub fn register(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
+        let mut ignored_paths = self.lock()?;
+
+        Ok(ignored_paths.insert(path.as_ref().to_path_buf()))
+    }
+
+    /// Returns whether the path is currently registered.
+    pub fn should_ignore(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
+        let ignored_paths = self.lock()?;
+
+        Ok(ignored_paths.contains(path.as_ref()))
+    }
+
+    /// Removes a path and returns whether it was present.
+    pub fn unregister(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
+        let mut ignored_paths = self.lock()?;
+
+        Ok(ignored_paths.remove(path.as_ref()))
+    }
+
+    /// Returns the number of registered paths.
+    pub fn len(&self) -> Result<usize, WriteIgnoreError> {
+        Ok(self.lock()?.len())
+    }
+
+    /// Returns whether there are no registered paths.
+    pub fn is_empty(&self) -> Result<bool, WriteIgnoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    fn lock(&self) -> Result<MutexGuard<'_, HashSet<PathBuf>>, WriteIgnoreError> {
+        self.ignored_paths
+            .lock()
+            .map_err(|_| WriteIgnoreError::LockPoisoned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WriteIgnoreError, WriteIgnoreRegistry};
+
+    use std::path::PathBuf;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn new_registry_is_empty_and_unregistered_path_is_not_ignored() {
+        let registry = WriteIgnoreRegistry::new();
+
+        assert!(registry.is_empty().expect("registry should be readable"));
+        assert_eq!(0, registry.len().expect("registry should be readable"));
+        assert!(!registry
+            .should_ignore("tasks/example.md")
+            .expect("registry should be readable"));
+    }
+
+    #[test]
+    fn registered_path_is_ignored() {
+        let registry = WriteIgnoreRegistry::new();
+
+        assert!(registry
+            .register("tasks/example.md")
+            .expect("registry should be writable"));
+        assert!(registry
+            .should_ignore("tasks/example.md")
+            .expect("registry should be readable"));
+    }
+
+    #[test]
+    fn duplicate_register_returns_false_and_keeps_len() {
+        let registry = WriteIgnoreRegistry::new();
+
+        assert!(registry
+            .register("tasks/example.md")
+            .expect("registry should be writable"));
+        assert!(!registry
+            .register("tasks/example.md")
+            .expect("registry should be writable"));
+        assert_eq!(1, registry.len().expect("registry should be readable"));
+    }
+
+    #[test]
+    fn unregistered_path_is_not_ignored_after_unregister() {
+        let registry = WriteIgnoreRegistry::new();
+
+        registry
+            .register("tasks/example.md")
+            .expect("registry should be writable");
+
+        assert!(registry
+            .unregister("tasks/example.md")
+            .expect("registry should be writable"));
+        assert!(!registry
+            .should_ignore("tasks/example.md")
+            .expect("registry should be readable"));
+        assert!(registry.is_empty().expect("registry should be readable"));
+    }
+
+    #[test]
+    fn unregister_missing_path_returns_false() {
+        let registry = WriteIgnoreRegistry::new();
+
+        assert!(!registry
+            .unregister("tasks/missing.md")
+            .expect("registry should be writable"));
+    }
+
+    #[test]
+    fn different_path_representations_are_different_keys() {
+        let registry = WriteIgnoreRegistry::new();
+
+        registry
+            .register("tasks/example.md")
+            .expect("registry should be writable");
+
+        assert!(registry
+            .should_ignore("tasks/example.md")
+            .expect("registry should be readable"));
+        assert!(!registry
+            .should_ignore("./tasks/example.md")
+            .expect("registry should be readable"));
+        assert!(registry
+            .register("./tasks/example.md")
+            .expect("registry should be writable"));
+        assert_eq!(2, registry.len().expect("registry should be readable"));
+    }
+
+    #[test]
+    fn concurrent_access_is_synchronized() {
+        const THREAD_COUNT: usize = 8;
+
+        let registry = Arc::new(WriteIgnoreRegistry::new());
+        let barrier = Arc::new(Barrier::new(THREAD_COUNT));
+        let handles = (0..THREAD_COUNT)
+            .map(|index| {
+                let registry = Arc::clone(&registry);
+                let barrier = Arc::clone(&barrier);
+
+                thread::spawn(move || {
+                    let path = PathBuf::from(format!("tasks/{index}.md"));
+
+                    barrier.wait();
+
+                    assert!(registry.register(&path).expect("register should work"));
+                    assert!(registry
+                        .should_ignore(&path)
+                        .expect("should_ignore should work"));
+
+                    if index % 2 == 0 {
+                        assert!(registry.unregister(&path).expect("unregister should work"));
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().expect("thread should not panic");
+        }
+
+        assert_eq!(
+            THREAD_COUNT / 2,
+            registry.len().expect("registry should be readable")
+        );
+
+        for index in 0..THREAD_COUNT {
+            let path = PathBuf::from(format!("tasks/{index}.md"));
+            let should_ignore = registry
+                .should_ignore(path)
+                .expect("registry should be readable");
+
+            assert_eq!(index % 2 == 1, should_ignore);
+        }
+    }
+
+    #[test]
+    fn returns_error_when_lock_is_poisoned() {
+        let registry = Arc::new(WriteIgnoreRegistry::new());
+        let poisoned_registry = Arc::clone(&registry);
+
+        let handle = thread::spawn(move || {
+            let _guard = poisoned_registry
+                .ignored_paths
+                .lock()
+                .expect("registry should be lockable before poison");
+
+            panic!("poison write_ignore registry lock");
+        });
+
+        assert!(handle.join().is_err());
+        assert_eq!(
+            WriteIgnoreError::LockPoisoned,
+            registry
+                .should_ignore("tasks/example.md")
+                .expect_err("poisoned lock should be reported")
+        );
+    }
+}

--- a/src-tauri/crates/fs/src/write_ignore.rs
+++ b/src-tauri/crates/fs/src/write_ignore.rs
@@ -40,6 +40,13 @@ impl WriteIgnoreRegistry {
         Ok(ignored_paths.contains(path.as_ref()))
     }
 
+    /// Atomically removes a path and returns whether it was present.
+    pub fn consume(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
+        let mut ignored_paths = self.lock()?;
+
+        Ok(ignored_paths.remove(path.as_ref()))
+    }
+
     /// Removes a path and returns whether it was present.
     pub fn unregister(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
         let mut ignored_paths = self.lock()?;
@@ -135,6 +142,26 @@ mod tests {
     }
 
     #[test]
+    fn consume_returns_true_once_and_removes_path() {
+        let registry = WriteIgnoreRegistry::new();
+
+        registry
+            .register("tasks/example.md")
+            .expect("registry should be writable");
+
+        assert!(registry
+            .consume("tasks/example.md")
+            .expect("registry should be writable"));
+        assert!(!registry
+            .consume("tasks/example.md")
+            .expect("registry should be writable"));
+        assert!(!registry
+            .should_ignore("tasks/example.md")
+            .expect("registry should be readable"));
+        assert!(registry.is_empty().expect("registry should be readable"));
+    }
+
+    #[test]
     fn different_path_representations_are_different_keys() {
         let registry = WriteIgnoreRegistry::new();
 
@@ -199,6 +226,42 @@ mod tests {
 
             assert_eq!(index % 2 == 1, should_ignore);
         }
+    }
+
+    #[test]
+    fn concurrent_consume_allows_only_one_success() {
+        const THREAD_COUNT: usize = 8;
+
+        let registry = Arc::new(WriteIgnoreRegistry::new());
+        let barrier = Arc::new(Barrier::new(THREAD_COUNT));
+
+        registry
+            .register("tasks/example.md")
+            .expect("registry should be writable");
+
+        let handles = (0..THREAD_COUNT)
+            .map(|_| {
+                let registry = Arc::clone(&registry);
+                let barrier = Arc::clone(&barrier);
+
+                thread::spawn(move || {
+                    barrier.wait();
+
+                    registry
+                        .consume("tasks/example.md")
+                        .expect("consume should work")
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let success_count = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("thread should not panic"))
+            .filter(|consumed| *consumed)
+            .count();
+
+        assert_eq!(1, success_count);
+        assert!(registry.is_empty().expect("registry should be readable"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`spec-board-fs` に、自己書き込み由来のファイル監視イベントを呼び出し側で識別するための `WriteIgnoreRegistry` を追加します。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `WriteIgnoreRegistry` を追加し、`register` / `should_ignore` / `unregister` / `len` / `is_empty` を公開
- 内部状態を `Mutex<HashSet<PathBuf>>` で保護
- パス正規化を行わず、渡された `PathBuf` 表現の完全一致で管理
- lock poison 時に `WriteIgnoreError::LockPoisoned` を返却
- 重複登録、未登録解除、パス表現差分、並行アクセス、lock poison のユニットテストを追加
- `docs/spec-board/file-system-spec.md` に公開 API 仕様を追記

#### 変更されたファイル

- `src-tauri/crates/fs/src/write_ignore.rs`
- `src-tauri/crates/fs/src/lib.rs`
- `docs/spec-board/file-system-spec.md`

#### 削除されたファイル・機能

- なし

## 📋 関連 Issue

- Closes #55

## 🧪 テスト

### テスト実行方法

```bash
cd src-tauri
cargo test -p spec-board-fs write_ignore
cargo test -p spec-board-fs
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `cargo test -p spec-board-fs write_ignore`: 8 passed
- `cargo test -p spec-board-fs`: 54 passed
- `git diff --check`: passed

## 🔍 レビューポイント

- `WriteIgnoreRegistry` を global singleton ではなく所有可能な struct としている点
- `PathBuf` を canonicalize / normalize せず完全一致で扱う仕様
- 並行アクセステストが flaky にならないよう join 後の決定的な最終状態だけを検証している点

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている