### PR TITLE
✨ #62 Task変換モデルを追加

### DIFF
--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -49,7 +49,15 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
       "children": ["tasks/child-1.md", "tasks/child-2.md"],
       "reverseLinks": ["tasks/other-task.md"],
       "body": "Markdown本文",
-      "filePath": "tasks/fix-bug.md"
+      "filePath": "tasks/fix-bug.md",
+      "extras": { "estimate": 3 },
+      "warnings": [
+        {
+          "code": "missingStatusUsedDefault",
+          "field": "status",
+          "message": "status is missing; default status was used"
+        }
+      ]
     }
   ],
   "columns": ["Todo", "In Progress", "Done"]
@@ -58,8 +66,10 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 
 - `parent`: フロントマターの `parent` フィールドの値
 - `links`: フロントマターの `links` フィールドの値
-- `children`: このタスクを `parent` に指定している子タスクのパス一覧（逆引き算出）
-- `reverseLinks`: このタスクを `links` に含んでいる他タスクのパス一覧（逆引き算出）
+- `children`: このタスクを `parent` に指定している子タスクのパス一覧（全タスク index 構築後の派生値）
+- `reverseLinks`: このタスクを `links` に含んでいる他タスクのパス一覧（全タスク index 構築後の派生値）
+- `extras`: 定義外フロントマターを JSON 互換値として保持したオブジェクト
+- `warnings`: `title` / `status` の fallback や `parent` / `extras` の型不一致など、Task 生成を継続できる非致命警告の一覧
 
 **エラー**:
 

--- a/docs/spec-board/task-format-spec.md
+++ b/docs/spec-board/task-format-spec.md
@@ -126,7 +126,18 @@ flowchart TD
 | PL-009 | links 正規化 | 文字列が渡された場合は単一要素の配列に変換。重複を除去。存在しないパスは警告付きで保持 |
 | PL-010 | links 逆引きインデックス | 全タスク読み込み後、links の逆引きインデックスを構築。双方向リンクの表示に使用 |
 | PL-011 | 子タスク収集 | 全タスク読み込み後、各タスクの `parent` を元に子タスク一覧を構築 |
-| PL-012 | 未知フィールド | フロントマターに定義外のフィールドが存在する場合、そのまま保持（削除しない） |
+| PL-012 | 未知フィールド | フロントマターに定義外のフィールドが存在する場合、`Task.extras` に JSON 互換値として保持する |
+| PL-013 | 非致命警告 | `title` / `status` の fallback や `parent` / `extras` の型不一致は `Task.warnings` に保持し、Task 生成自体は継続する |
+
+### Task 変換時の補足
+
+- `title` が未定義の場合はファイル名（拡張子除去、ハイフンをスペースに変換）を fallback とし、`missingTitleUsedFileName` warning を付与する
+- `title` が空文字または文字列以外の場合はファイル名 fallback とし、`invalidTitleUsedFileName` warning を付与する
+- `status` が未定義の場合は既定ステータスを fallback とし、`missingStatusUsedDefault` warning を付与する
+- `status` が文字列以外の場合は既定ステータスを fallback とし、`invalidStatusUsedDefault` warning を付与する
+- `parent` が文字列以外の場合は値を無視し、`invalidParentIgnored` warning を付与する
+- `extras` の非文字列 key は除外し、`nonStringExtraKeyIgnored` warning を付与する
+- `extras` の JSON 非互換 value は除外し、`extraValueNotJsonCompatible` warning を付与する
 
 ## シリアライズ仕様
 

--- a/src-tauri/src/frontmatter.rs
+++ b/src-tauri/src/frontmatter.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Cow;
 use std::collections::HashSet;
 use thiserror::Error;
@@ -8,7 +8,7 @@ use thiserror::Error;
 ///
 /// 未定義文字列（例: `urgent`）や型不一致（数値・配列・mapping・null・bool）は
 /// `Frontmatter::priority` 上で `None` として表現される（バッジ非表示扱い）。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Priority {
     High,
     Medium,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod frontmatter;
+pub mod task_index;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]

--- a/src-tauri/src/task_index.rs
+++ b/src-tauri/src/task_index.rs
@@ -1,0 +1,521 @@
+use crate::frontmatter::{parse_bytes, FrontmatterError, Parsed, Priority};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+pub type TaskExtras = BTreeMap<String, serde_json::Value>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TaskWarningCode {
+    MissingTitleUsedFileName,
+    InvalidTitleUsedFileName,
+    MissingStatusUsedDefault,
+    InvalidStatusUsedDefault,
+    InvalidParentIgnored,
+    NonStringExtraKeyIgnored,
+    ExtraValueNotJsonCompatible,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskWarning {
+    pub code: TaskWarningCode,
+    pub field: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Task {
+    pub id: String,
+    pub file_path: String,
+    pub title: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<Priority>,
+    pub labels: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    pub links: Vec<String>,
+    pub children: Vec<String>,
+    pub reverse_links: Vec<String>,
+    pub body: String,
+    pub extras: TaskExtras,
+    pub warnings: Vec<TaskWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskParseContext {
+    pub file_path: PathBuf,
+    pub default_status: String,
+}
+
+#[derive(Debug, Error)]
+pub enum TaskParseError {
+    #[error("frontmatter was not found")]
+    NotTask,
+    #[error(transparent)]
+    Frontmatter(#[from] FrontmatterError),
+}
+
+/// Markdown bytes and parse contextから Task を生成する。
+///
+/// @param input UTF-8 Markdown bytes。
+/// @param context file path と status fallback を持つ変換 context。
+/// @returns 生成された Task。frontmatter が無い場合は `TaskParseError::NotTask`。
+pub fn task_from_markdown(
+    input: &[u8],
+    context: &TaskParseContext,
+) -> Result<Task, TaskParseError> {
+    let Some(parsed) = parse_bytes(input)? else {
+        return Err(TaskParseError::NotTask);
+    };
+    Ok(task_from_parsed(parsed, context))
+}
+
+/// Parsed frontmatter と parse context から Task を生成する。
+///
+/// @param parsed `frontmatter::parse_bytes` 由来の Parsed。
+/// @param context file path と status fallback を持つ変換 context。
+/// @returns fallback と warning を反映した Task。
+pub fn task_from_parsed(parsed: Parsed, context: &TaskParseContext) -> Task {
+    let mut warnings = Vec::new();
+    let title = extract_title(&parsed, context, &mut warnings);
+    let status = extract_status(&parsed, context, &mut warnings);
+    let parent = extract_parent(&parsed, &mut warnings);
+    let extras = convert_extras(&parsed, &mut warnings);
+    let file_path = context.file_path.to_string_lossy().to_string();
+
+    Task {
+        id: file_path.clone(),
+        file_path,
+        title,
+        status,
+        priority: parsed.frontmatter.priority,
+        labels: parsed.frontmatter.labels,
+        parent,
+        links: parsed.frontmatter.links,
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: parsed.body,
+        extras,
+        warnings,
+    }
+}
+
+fn extract_title(
+    parsed: &Parsed,
+    context: &TaskParseContext,
+    warnings: &mut Vec<TaskWarning>,
+) -> String {
+    match extract_string_extra(&parsed.frontmatter.extras, "title") {
+        Ok(Some(title)) if !title.is_empty() => title,
+        Ok(Some(_)) | Err(()) => {
+            warnings.push(warning(
+                TaskWarningCode::InvalidTitleUsedFileName,
+                Some("title"),
+                "title is invalid; file name was used",
+            ));
+            title_fallback_from_file_path(&context.file_path)
+        }
+        Ok(None) => {
+            warnings.push(warning(
+                TaskWarningCode::MissingTitleUsedFileName,
+                Some("title"),
+                "title is missing; file name was used",
+            ));
+            title_fallback_from_file_path(&context.file_path)
+        }
+    }
+}
+
+fn extract_status(
+    parsed: &Parsed,
+    context: &TaskParseContext,
+    warnings: &mut Vec<TaskWarning>,
+) -> String {
+    match extract_string_extra(&parsed.frontmatter.extras, "status") {
+        Ok(Some(status)) => status,
+        Err(()) => {
+            warnings.push(warning(
+                TaskWarningCode::InvalidStatusUsedDefault,
+                Some("status"),
+                "status is invalid; default status was used",
+            ));
+            context.default_status.clone()
+        }
+        Ok(None) => {
+            warnings.push(warning(
+                TaskWarningCode::MissingStatusUsedDefault,
+                Some("status"),
+                "status is missing; default status was used",
+            ));
+            context.default_status.clone()
+        }
+    }
+}
+
+fn extract_parent(parsed: &Parsed, warnings: &mut Vec<TaskWarning>) -> Option<String> {
+    match extract_string_extra(&parsed.frontmatter.extras, "parent") {
+        Ok(parent) => parent,
+        Err(()) => {
+            warnings.push(warning(
+                TaskWarningCode::InvalidParentIgnored,
+                Some("parent"),
+                "parent is invalid; value was ignored",
+            ));
+            None
+        }
+    }
+}
+
+fn convert_extras(parsed: &Parsed, warnings: &mut Vec<TaskWarning>) -> TaskExtras {
+    const TYPED_KEYS: [&str; 6] = ["title", "status", "priority", "labels", "parent", "links"];
+    let mut extras = BTreeMap::new();
+
+    for (key, value) in &parsed.frontmatter.extras {
+        let serde_yaml_ng::Value::String(key) = key else {
+            warnings.push(warning(
+                TaskWarningCode::NonStringExtraKeyIgnored,
+                None,
+                "non-string extra key was ignored",
+            ));
+            continue;
+        };
+
+        if TYPED_KEYS.contains(&key.as_str()) {
+            continue;
+        }
+
+        let Some(json_value) = yaml_value_to_json(value) else {
+            warnings.push(warning(
+                TaskWarningCode::ExtraValueNotJsonCompatible,
+                Some(key),
+                "extra value is not JSON compatible; value was ignored",
+            ));
+            continue;
+        };
+
+        extras.insert(key.clone(), json_value);
+    }
+
+    extras
+}
+
+fn warning(code: TaskWarningCode, field: Option<&str>, message: &str) -> TaskWarning {
+    TaskWarning {
+        code,
+        field: field.map(str::to_string),
+        message: message.to_string(),
+    }
+}
+
+fn extract_string_extra(extras: &serde_yaml_ng::Mapping, key: &str) -> Result<Option<String>, ()> {
+    let Some(value) = extras.get(key) else {
+        return Ok(None);
+    };
+    let serde_yaml_ng::Value::String(s) = value else {
+        return Err(());
+    };
+    Ok(Some(s.clone()))
+}
+
+fn title_fallback_from_file_path(path: &Path) -> String {
+    let Some(stem) = path.file_stem() else {
+        return "Untitled".to_string();
+    };
+    let title = stem.to_string_lossy().replace('-', " ");
+    if title.is_empty() {
+        return "Untitled".to_string();
+    }
+    title
+}
+
+fn yaml_value_to_json(value: &serde_yaml_ng::Value) -> Option<serde_json::Value> {
+    if matches!(value, serde_yaml_ng::Value::Tagged(_)) {
+        return None;
+    }
+    serde_json::to_value(value).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontmatter::{Frontmatter, Priority};
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn context(path: &str) -> TaskParseContext {
+        TaskParseContext {
+            file_path: PathBuf::from(path),
+            default_status: "Todo".to_string(),
+        }
+    }
+
+    fn task_from(input: &str, path: &str) -> Task {
+        task_from_markdown(input.as_bytes(), &context(path)).unwrap()
+    }
+
+    fn parsed_with_extras(extras: serde_yaml_ng::Mapping) -> Parsed {
+        Parsed {
+            frontmatter: Frontmatter {
+                extras,
+                ..Frontmatter::default()
+            },
+            body: String::new(),
+        }
+    }
+
+    #[test]
+    fn minimum_frontmatter_generates_task() {
+        let task = task_from(
+            "---\ntitle: Fix bug\nstatus: Doing\n---\n",
+            "tasks/fix-bug.md",
+        );
+
+        assert_eq!(task.id, "tasks/fix-bug.md");
+        assert_eq!(task.file_path, "tasks/fix-bug.md");
+        assert_eq!(task.title, "Fix bug");
+        assert_eq!(task.status, "Doing");
+        assert_eq!(task.priority, None);
+        assert_eq!(task.labels, Vec::<String>::new());
+        assert_eq!(task.parent, None);
+        assert_eq!(task.links, Vec::<String>::new());
+        assert_eq!(task.children, Vec::<String>::new());
+        assert_eq!(task.reverse_links, Vec::<String>::new());
+        assert_eq!(task.body, "");
+        assert_eq!(task.extras, BTreeMap::new());
+        assert_eq!(task.warnings, Vec::<TaskWarning>::new());
+    }
+
+    #[test]
+    fn typed_parser_fields_and_body_are_reflected() {
+        let task = task_from(
+            "---\ntitle: Feature\nstatus: Doing\npriority: high\nlabels: [bug, bug, api]\nlinks: related.md\n---\nBody\n",
+            "feature.md",
+        );
+
+        assert_eq!(task.priority, Some(Priority::High));
+        assert_eq!(task.labels, vec!["bug".to_string(), "api".to_string()]);
+        assert_eq!(task.links, vec!["related.md".to_string()]);
+        assert_eq!(task.body, "Body\n");
+    }
+
+    #[test]
+    fn missing_title_uses_file_name_fallback_with_warning() {
+        let task = task_from("---\nstatus: Todo\n---\n", "tasks/fix-login.md");
+
+        assert_eq!(task.title, "fix login");
+        assert_eq!(
+            task.warnings,
+            vec![TaskWarning {
+                code: TaskWarningCode::MissingTitleUsedFileName,
+                field: Some("title".to_string()),
+                message: "title is missing; file name was used".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn invalid_title_uses_file_name_fallback_with_warning() {
+        let cases = [
+            ("---\ntitle: ''\nstatus: Todo\n---\n", "空文字"),
+            ("---\ntitle: 123\nstatus: Todo\n---\n", "非文字列"),
+        ];
+
+        for (input, label) in cases {
+            let task = task_from(input, "tasks/fix-login.md");
+            assert_eq!(task.title, "fix login", "{label}");
+            assert_eq!(
+                task.warnings,
+                vec![TaskWarning {
+                    code: TaskWarningCode::InvalidTitleUsedFileName,
+                    field: Some("title".to_string()),
+                    message: "title is invalid; file name was used".to_string(),
+                }],
+                "{label}"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_status_uses_default_with_warning() {
+        let task = task_from("---\ntitle: Fix bug\n---\n", "tasks/fix-bug.md");
+
+        assert_eq!(task.status, "Todo");
+        assert_eq!(
+            task.warnings,
+            vec![TaskWarning {
+                code: TaskWarningCode::MissingStatusUsedDefault,
+                field: Some("status".to_string()),
+                message: "status is missing; default status was used".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn invalid_status_uses_default_with_warning() {
+        let task = task_from(
+            "---\ntitle: Fix bug\nstatus: [Doing]\n---\n",
+            "tasks/fix-bug.md",
+        );
+
+        assert_eq!(task.status, "Todo");
+        assert_eq!(
+            task.warnings,
+            vec![TaskWarning {
+                code: TaskWarningCode::InvalidStatusUsedDefault,
+                field: Some("status".to_string()),
+                message: "status is invalid; default status was used".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parent_is_reflected_when_string_and_ignored_when_missing_or_invalid() {
+        let parent_task = task_from(
+            "---\ntitle: Child\nstatus: Todo\nparent: tasks/parent.md\n---\n",
+            "tasks/child.md",
+        );
+        let missing_parent_task =
+            task_from("---\ntitle: Root\nstatus: Todo\n---\n", "tasks/root.md");
+        let invalid_parent_task = task_from(
+            "---\ntitle: Root\nstatus: Todo\nparent: 123\n---\n",
+            "tasks/root.md",
+        );
+
+        assert_eq!(parent_task.parent, Some("tasks/parent.md".to_string()));
+        assert_eq!(missing_parent_task.parent, None);
+        assert_eq!(invalid_parent_task.parent, None);
+        assert_eq!(
+            invalid_parent_task.warnings,
+            vec![TaskWarning {
+                code: TaskWarningCode::InvalidParentIgnored,
+                field: Some("parent".to_string()),
+                message: "parent is invalid; value was ignored".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn unknown_fields_are_kept_in_extras_as_json_values() {
+        let task = task_from(
+            "---\ntitle: Fix bug\nstatus: Todo\nestimate: 3\nmeta:\n  owner: alice\n---\n",
+            "tasks/fix-bug.md",
+        );
+
+        assert_eq!(task.extras.get("estimate"), Some(&json!(3)));
+        assert_eq!(task.extras.get("meta"), Some(&json!({ "owner": "alice" })));
+    }
+
+    #[test]
+    fn non_string_extra_key_is_excluded_with_warning() {
+        let mut extras = serde_yaml_ng::Mapping::new();
+        extras.insert(
+            serde_yaml_ng::Value::String("title".to_string()),
+            serde_yaml_ng::Value::String("Fix bug".to_string()),
+        );
+        extras.insert(
+            serde_yaml_ng::Value::String("status".to_string()),
+            serde_yaml_ng::Value::String("Todo".to_string()),
+        );
+        extras.insert(
+            serde_yaml_ng::Value::Sequence(vec![serde_yaml_ng::Value::String("a".to_string())]),
+            serde_yaml_ng::Value::String("value".to_string()),
+        );
+        let task = task_from_parsed(parsed_with_extras(extras), &context("tasks/fix-bug.md"));
+
+        assert_eq!(task.extras, BTreeMap::new());
+        assert_eq!(
+            task.warnings,
+            vec![TaskWarning {
+                code: TaskWarningCode::NonStringExtraKeyIgnored,
+                field: None,
+                message: "non-string extra key was ignored".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn json_incompatible_extra_value_is_excluded_with_warning() {
+        let mut extras = serde_yaml_ng::Mapping::new();
+        extras.insert(
+            serde_yaml_ng::Value::String("title".to_string()),
+            serde_yaml_ng::Value::String("Fix bug".to_string()),
+        );
+        extras.insert(
+            serde_yaml_ng::Value::String("status".to_string()),
+            serde_yaml_ng::Value::String("Todo".to_string()),
+        );
+        extras.insert(
+            serde_yaml_ng::Value::String("tagged".to_string()),
+            serde_yaml_ng::Value::Tagged(Box::new(serde_yaml_ng::value::TaggedValue {
+                tag: serde_yaml_ng::value::Tag::new("custom"),
+                value: serde_yaml_ng::Value::String("value".to_string()),
+            })),
+        );
+        let task = task_from_parsed(parsed_with_extras(extras), &context("tasks/fix-bug.md"));
+
+        assert_eq!(task.extras, BTreeMap::new());
+        assert_eq!(
+            task.warnings,
+            vec![TaskWarning {
+                code: TaskWarningCode::ExtraValueNotJsonCompatible,
+                field: Some("tagged".to_string()),
+                message: "extra value is not JSON compatible; value was ignored".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn typed_keys_are_excluded_from_extras() {
+        let task = task_from(
+            "---\ntitle: Fix bug\nstatus: Todo\npriority: High\nlabels: [bug]\nparent: parent.md\nlinks: [related.md]\nextra: kept\n---\n",
+            "tasks/fix-bug.md",
+        );
+
+        assert_eq!(
+            task.extras,
+            BTreeMap::from([("extra".to_string(), json!("kept"))])
+        );
+    }
+
+    #[test]
+    fn task_serializes_path_fields_and_warning_codes_as_camel_case() {
+        let task = task_from(
+            "---\nstatus: Todo\nestimate: 3\n---\nBody\n",
+            "tasks/fix-bug.md",
+        );
+
+        let json_value = serde_json::to_value(task).unwrap();
+
+        assert_eq!(json_value["filePath"], json!("tasks/fix-bug.md"));
+        assert_eq!(json_value["reverseLinks"], json!([]));
+        assert_eq!(json_value["extras"], json!({ "estimate": 3 }));
+        assert_eq!(
+            json_value["warnings"][0]["code"],
+            json!("missingTitleUsedFileName")
+        );
+    }
+
+    #[test]
+    fn frontmatter_absence_returns_not_task() {
+        let result = task_from_markdown(b"# Heading\nbody\n", &context("notes.md"));
+
+        assert!(matches!(result, Err(TaskParseError::NotTask)));
+    }
+
+    #[test]
+    fn invalid_yaml_or_encoding_returns_frontmatter_error() {
+        let invalid_yaml = task_from_markdown(b"---\n: bad\n---\n", &context("bad.md"));
+        let invalid_encoding = task_from_markdown(b"\xff\xfe---\n---\n", &context("bad.md"));
+
+        assert!(matches!(invalid_yaml, Err(TaskParseError::Frontmatter(_))));
+        assert!(matches!(
+            invalid_encoding,
+            Err(TaskParseError::Frontmatter(_))
+        ));
+    }
+}

--- a/src-tauri/src/task_index.rs
+++ b/src-tauri/src/task_index.rs
@@ -86,7 +86,7 @@ pub fn task_from_parsed(parsed: Parsed, context: &TaskParseContext) -> Task {
     let status = extract_status(&parsed, context, &mut warnings);
     let parent = extract_parent(&parsed, &mut warnings);
     let extras = convert_extras(&parsed, &mut warnings);
-    let file_path = context.file_path.to_string_lossy().to_string();
+    let file_path = normalized_task_file_path(&context.file_path);
 
     Task {
         id: file_path.clone(),
@@ -231,6 +231,21 @@ fn title_fallback_from_file_path(path: &Path) -> String {
         return "Untitled".to_string();
     }
     title
+}
+
+fn normalized_task_file_path(path: &Path) -> String {
+    let path_text = path.to_string_lossy().replace('\\', "/");
+    let mut parts = Vec::new();
+    for part in path_text.split('/') {
+        if part.is_empty() || part == "." {
+            continue;
+        }
+        if part.ends_with(':') {
+            continue;
+        }
+        parts.push(part);
+    }
+    parts.join("/")
 }
 
 fn yaml_value_to_json(value: &serde_yaml_ng::Value) -> Option<serde_json::Value> {
@@ -498,6 +513,21 @@ mod tests {
             json_value["warnings"][0]["code"],
             json!("missingTitleUsedFileName")
         );
+    }
+
+    #[test]
+    fn task_file_path_payload_is_relative_and_uses_forward_slashes() {
+        let cases = [
+            ("/project\\tasks\\fix-bug.md", "project/tasks/fix-bug.md"),
+            ("C:\\project\\tasks\\fix-bug.md", "project/tasks/fix-bug.md"),
+        ];
+
+        for (input_path, expected_path) in cases {
+            let task = task_from("---\ntitle: Fix bug\nstatus: Todo\n---\n", input_path);
+
+            assert_eq!(task.id, expected_path);
+            assert_eq!(task.file_path, expected_path);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 概要

Markdown/frontmatter から backend の `Task` ドメインモデルを生成する変換層を追加しました。`title` / `status` / `parent` / `extras` の fallback と warning を Rust 側で扱い、Tauri/frontend payload に載せるための JSON 互換構造を整えています。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `src-tauri/src/task_index.rs` を追加し、`Task` / `TaskWarning` / `TaskParseContext` / `TaskParseError` を定義
- `task_from_markdown` / `task_from_parsed` で frontmatter parse 結果から Task を生成
- `title` / `status` fallback、`parent` 型不一致、非文字列 extra key、JSON 非互換 extra value を `warnings` として観測可能に変更
- `children` / `reverseLinks` は全体 index 構築後の派生値として空配列で初期化
- `Priority` を Task JSON payload に載せられるよう serde derive を追加

#### 変更されたファイル

- `src-tauri/src/task_index.rs`
- `src-tauri/src/frontmatter.rs`
- `src-tauri/src/lib.rs`
- `docs/spec-board/file-system-spec.md`
- `docs/spec-board/task-format-spec.md`

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    Input[Markdown bytes + TaskParseContext] --> Parse[frontmatter::parse_bytes]
    Parse -->|None| NotTask[TaskParseError::NotTask]
    Parse -->|Err| ParseError[TaskParseError::Frontmatter]
    Parse -->|Some Parsed| Extract[title/status/parent/extras extraction]
    Extract --> Fallback[Apply fallback + warnings]
    Fallback --> Build[Build Task]
    Build --> Output[Task JSON payload]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    Extract:::new
    Fallback:::new
    Build:::new
```

## 📋 関連 Issue

- Closes #62

## 🧪 テスト

### テスト実行方法

```bash
cargo test task_index
cd src-tauri && cargo test
git diff --check
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `cargo test task_index`: 14 tests passed
- `cd src-tauri && cargo test`: 128 tests passed
- `git diff --check`: passed
- Codex CLI review: 問題なし

## 🔍 レビューポイント

- `Task` の serde camelCase payload と frontend/Tauri 境界の整合性
- `extras` を `BTreeMap<String, serde_json::Value>` に変換する方針
- fallback / warning code と spec doc の表現が一致しているか

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている