### PR TITLE
✨ #63 parent存在検証warningを追加

### DIFF
--- a/docs/spec-board/task-format-spec.md
+++ b/docs/spec-board/task-format-spec.md
@@ -121,7 +121,7 @@ flowchart TD
 | PL-004 | status フォールバック | `status` フィールドが未定義の場合、最初のカラムのステータスをデフォルトとして設定 |
 | PL-005 | priority 正規化 | `high` → `High`、`MEDIUM` → `Medium` のように先頭大文字に正規化 |
 | PL-006 | labels 正規化 | 文字列が渡された場合は単一要素の配列に変換。重複を除去 |
-| PL-007 | parent 解決 | `parent` フィールドのパスを解決し、親タスクの存在を検証。存在しない場合は警告 |
+| PL-007 | parent 解決 | `parent` フィールドのパスを解決し、親タスクの存在を検証。存在しない場合は `parentNotFound` warning を記録し、Task 自体は読み込み成功として扱う |
 | PL-008 | parent 循環参照検出 | 親子関係のツリーを辿り、循環参照がないか検証。検出時はパースエラー。探索深さ上限は20階層 |
 | PL-009 | links 正規化 | 文字列が渡された場合は単一要素の配列に変換。重複を除去。存在しないパスは警告付きで保持 |
 | PL-010 | links 逆引きインデックス | 全タスク読み込み後、links の逆引きインデックスを構築。双方向リンクの表示に使用 |
@@ -136,8 +136,17 @@ flowchart TD
 - `status` が未定義の場合は既定ステータスを fallback とし、`missingStatusUsedDefault` warning を付与する
 - `status` が文字列以外の場合は既定ステータスを fallback とし、`invalidStatusUsedDefault` warning を付与する
 - `parent` が文字列以外の場合は値を無視し、`invalidParentIgnored` warning を付与する
+- `parent` が文字列だが読み込み済み Task の `file_path` に存在しない場合は、値を保持したまま `parentNotFound` warning を付与する
+- `parent` の存在検証では比較時のみ `\` と `./` を軽量正規化する。先頭 `/` または Windows drive prefix 付きの値は相対パス仕様外として `parentNotFound` warning を付与する
+- 自己参照 `parent` は存在する Task として扱い、循環検出は PL-008 で扱う
 - `extras` の非文字列 key は除外し、`nonStringExtraKeyIgnored` warning を付与する
 - `extras` の JSON 非互換 value は除外し、`extraValueNotJsonCompatible` warning を付与する
+
+### Task 変換時 warning code
+
+| code | field | 条件 | 挙動 |
+|:--|:--|:--|:--|
+| `parentNotFound` | `parent` | `parent` が文字列だが、読み込み済み Task の `file_path` に存在しない | `parent` 値は保持し、Task の `warnings` に追加する |
 
 ## シリアライズ仕様
 

--- a/src-tauri/src/task_index.rs
+++ b/src-tauri/src/task_index.rs
@@ -133,7 +133,7 @@ fn append_parent_not_found_warning(task: &mut Task, task_paths: &HashSet<String>
     };
 
     let Some(parent_lookup_path) = normalize_parent_path_for_lookup(parent) else {
-        append_parent_not_found_once(task);
+        push_parent_not_found(task);
         return;
     };
 
@@ -141,10 +141,10 @@ fn append_parent_not_found_warning(task: &mut Task, task_paths: &HashSet<String>
         return;
     }
 
-    append_parent_not_found_once(task);
+    push_parent_not_found(task);
 }
 
-fn append_parent_not_found_once(task: &mut Task) {
+fn push_parent_not_found(task: &mut Task) {
     let already_exists = task.warnings.iter().any(|warning| {
         warning.code == TaskWarningCode::ParentNotFound
             && warning.field.as_deref() == Some("parent")

--- a/src-tauri/src/task_index.rs
+++ b/src-tauri/src/task_index.rs
@@ -1,6 +1,6 @@
 use crate::frontmatter::{parse_bytes, FrontmatterError, Parsed, Priority};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -14,6 +14,7 @@ pub enum TaskWarningCode {
     MissingStatusUsedDefault,
     InvalidStatusUsedDefault,
     InvalidParentIgnored,
+    ParentNotFound,
     NonStringExtraKeyIgnored,
     ExtraValueNotJsonCompatible,
 }
@@ -103,6 +104,60 @@ pub fn task_from_parsed(parsed: Parsed, context: &TaskParseContext) -> Task {
         extras,
         warnings,
     }
+}
+
+/// 全 Task の file_path に対して parent 参照の存在を検証する。
+///
+/// @param tasks 検証対象の Task 一覧。
+/// @returns 存在しない parent を warning として追加した Task 一覧。
+pub fn validate_parent_existence(mut tasks: Vec<Task>) -> Vec<Task> {
+    let task_paths = task_path_index(&tasks);
+
+    for task in &mut tasks {
+        append_parent_not_found_warning(task, &task_paths);
+    }
+
+    tasks
+}
+
+fn task_path_index(tasks: &[Task]) -> HashSet<String> {
+    tasks
+        .iter()
+        .map(|task| normalize_task_path_for_lookup(&task.file_path))
+        .collect()
+}
+
+fn append_parent_not_found_warning(task: &mut Task, task_paths: &HashSet<String>) {
+    let Some(parent) = &task.parent else {
+        return;
+    };
+
+    let Some(parent_lookup_path) = normalize_parent_path_for_lookup(parent) else {
+        append_parent_not_found_once(task);
+        return;
+    };
+
+    if task_paths.contains(&parent_lookup_path) {
+        return;
+    }
+
+    append_parent_not_found_once(task);
+}
+
+fn append_parent_not_found_once(task: &mut Task) {
+    let already_exists = task.warnings.iter().any(|warning| {
+        warning.code == TaskWarningCode::ParentNotFound
+            && warning.field.as_deref() == Some("parent")
+    });
+    if already_exists {
+        return;
+    }
+
+    task.warnings.push(warning(
+        TaskWarningCode::ParentNotFound,
+        Some("parent"),
+        "parent task was not found",
+    ));
 }
 
 fn extract_title(
@@ -235,17 +290,52 @@ fn title_fallback_from_file_path(path: &Path) -> String {
 
 fn normalized_task_file_path(path: &Path) -> String {
     let path_text = path.to_string_lossy().replace('\\', "/");
+    normalize_path_parts(&path_text, true)
+}
+
+fn normalize_task_path_for_lookup(path: &str) -> String {
+    let path_text = path.replace('\\', "/");
+    normalize_path_parts(&path_text, true)
+}
+
+fn normalize_parent_path_for_lookup(parent: &str) -> Option<String> {
+    if parent.is_empty() || parent.starts_with('/') || parent.starts_with('\\') {
+        return None;
+    }
+    if has_windows_drive_prefix(parent) {
+        return None;
+    }
+
+    let path_text = parent.replace('\\', "/");
+    let normalized = normalize_path_parts(&path_text, false);
+    if normalized.is_empty() {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+fn normalize_path_parts(path_text: &str, remove_drive_prefix: bool) -> String {
     let mut parts = Vec::new();
     for part in path_text.split('/') {
         if part.is_empty() || part == "." {
             continue;
         }
-        if part.ends_with(':') {
+        if remove_drive_prefix && part.ends_with(':') {
             continue;
         }
         parts.push(part);
     }
     parts.join("/")
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    if bytes.len() < 2 {
+        return false;
+    }
+
+    bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 fn yaml_value_to_json(value: &serde_yaml_ng::Value) -> Option<serde_json::Value> {
@@ -415,6 +505,163 @@ mod tests {
     }
 
     #[test]
+    fn parent_existence_validation_does_not_warn_when_parent_is_missing_or_existing() {
+        let tasks = validate_parent_existence(vec![
+            task_from("---\ntitle: Root\nstatus: Todo\n---\n", "tasks/root.md"),
+            task_from("---\ntitle: Parent\nstatus: Todo\n---\n", "tasks/parent.md"),
+            task_from(
+                "---\ntitle: Child\nstatus: Todo\nparent: tasks/parent.md\n---\n",
+                "tasks/child.md",
+            ),
+        ]);
+
+        assert!(tasks[0].warnings.is_empty());
+        assert!(tasks[2]
+            .warnings
+            .iter()
+            .all(|warning| warning.code != TaskWarningCode::ParentNotFound));
+    }
+
+    #[test]
+    fn missing_parent_adds_warning_without_dropping_task_or_parent_value() {
+        let tasks = validate_parent_existence(vec![task_from(
+            "---\ntitle: Child\nstatus: Todo\nparent: tasks/missing.md\n---\n",
+            "tasks/child.md",
+        )]);
+
+        assert_eq!(tasks[0].parent, Some("tasks/missing.md".to_string()));
+        assert!(tasks[0].warnings.iter().any(|warning| {
+            warning.code == TaskWarningCode::ParentNotFound
+                && warning.field.as_deref() == Some("parent")
+        }));
+    }
+
+    #[test]
+    fn empty_parent_adds_warning_without_normalizing_parent_value() {
+        let tasks = validate_parent_existence(vec![task_from(
+            "---\ntitle: Child\nstatus: Todo\nparent: ''\n---\n",
+            "tasks/child.md",
+        )]);
+
+        assert_eq!(tasks[0].parent, Some(String::new()));
+        assert!(tasks[0].warnings.iter().any(|warning| {
+            warning.code == TaskWarningCode::ParentNotFound
+                && warning.field.as_deref() == Some("parent")
+        }));
+    }
+
+    #[test]
+    fn parent_existence_validation_warns_each_task_and_keeps_existing_warnings() {
+        let tasks = validate_parent_existence(vec![
+            task_from(
+                "---\ntitle: Child\nstatus: Todo\nparent: tasks/missing-a.md\n---\n",
+                "tasks/child-a.md",
+            ),
+            task_from(
+                "---\ntitle: 123\nstatus: Todo\nparent: tasks/missing-b.md\n---\n",
+                "tasks/child-b.md",
+            ),
+        ]);
+
+        assert!(tasks[0].warnings.iter().any(|warning| {
+            warning.code == TaskWarningCode::ParentNotFound
+                && warning.field.as_deref() == Some("parent")
+        }));
+        assert!(tasks[1]
+            .warnings
+            .iter()
+            .any(|warning| warning.code == TaskWarningCode::InvalidTitleUsedFileName));
+        assert!(tasks[1].warnings.iter().any(|warning| {
+            warning.code == TaskWarningCode::ParentNotFound
+                && warning.field.as_deref() == Some("parent")
+        }));
+    }
+
+    #[test]
+    fn parent_existence_validation_does_not_duplicate_parent_not_found_warning() {
+        let mut task = task_from(
+            "---\ntitle: Child\nstatus: Todo\nparent: tasks/missing.md\n---\n",
+            "tasks/child.md",
+        );
+        task.warnings.push(TaskWarning {
+            code: TaskWarningCode::ParentNotFound,
+            field: Some("parent".to_string()),
+            message: "parent task was not found".to_string(),
+        });
+
+        let tasks = validate_parent_existence(vec![task]);
+        let warning_count = tasks[0]
+            .warnings
+            .iter()
+            .filter(|warning| {
+                warning.code == TaskWarningCode::ParentNotFound
+                    && warning.field.as_deref() == Some("parent")
+            })
+            .count();
+
+        assert_eq!(warning_count, 1);
+    }
+
+    #[test]
+    fn self_parent_is_treated_as_existing_parent() {
+        let tasks = validate_parent_existence(vec![task_from(
+            "---\ntitle: Child\nstatus: Todo\nparent: tasks/child.md\n---\n",
+            "tasks/child.md",
+        )]);
+
+        assert!(tasks[0]
+            .warnings
+            .iter()
+            .all(|warning| warning.code != TaskWarningCode::ParentNotFound));
+    }
+
+    #[test]
+    fn parent_lookup_accepts_separator_and_current_directory_variations() {
+        let cases = ["tasks\\parent.md", "./tasks/parent.md"];
+
+        for parent in cases {
+            let tasks = validate_parent_existence(vec![
+                task_from("---\ntitle: Parent\nstatus: Todo\n---\n", "tasks/parent.md"),
+                task_from(
+                    &format!("---\ntitle: Child\nstatus: Todo\nparent: {parent}\n---\n"),
+                    "tasks/child.md",
+                ),
+            ]);
+
+            assert!(
+                tasks[1]
+                    .warnings
+                    .iter()
+                    .all(|warning| warning.code != TaskWarningCode::ParentNotFound),
+                "{parent}"
+            );
+        }
+    }
+
+    #[test]
+    fn parent_lookup_rejects_absolute_or_drive_prefixed_parent_paths() {
+        let cases = ["/tasks/parent.md", "C:\\tasks\\parent.md"];
+
+        for parent in cases {
+            let tasks = validate_parent_existence(vec![
+                task_from("---\ntitle: Parent\nstatus: Todo\n---\n", "tasks/parent.md"),
+                task_from(
+                    &format!("---\ntitle: Child\nstatus: Todo\nparent: {parent}\n---\n"),
+                    "tasks/child.md",
+                ),
+            ]);
+
+            assert!(
+                tasks[1].warnings.iter().any(|warning| {
+                    warning.code == TaskWarningCode::ParentNotFound
+                        && warning.field.as_deref() == Some("parent")
+                }),
+                "{parent}"
+            );
+        }
+    }
+
+    #[test]
     fn unknown_fields_are_kept_in_extras_as_json_values() {
         let task = task_from(
             "---\ntitle: Fix bug\nstatus: Todo\nestimate: 3\nmeta:\n  owner: alice\n---\n",
@@ -513,6 +760,19 @@ mod tests {
             json_value["warnings"][0]["code"],
             json!("missingTitleUsedFileName")
         );
+    }
+
+    #[test]
+    fn parent_not_found_warning_code_serializes_as_camel_case() {
+        let warning = TaskWarning {
+            code: TaskWarningCode::ParentNotFound,
+            field: Some("parent".to_string()),
+            message: "parent task was not found".to_string(),
+        };
+
+        let json_value = serde_json::to_value(warning).unwrap();
+
+        assert_eq!(json_value["code"], json!("parentNotFound"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`task_index` に全 Task 収集後の parent 存在検証 helper を追加し、存在しない parent を fatal error ではなく `parentNotFound` warning として記録できるようにしました。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `validate_parent_existence` を追加し、全 Task の `file_path` index から parent の存在を検証
- 不在 parent に `ParentNotFound` / JSON `parentNotFound` warning を追加
- `parentNotFound` warning の重複追加を防止
- `\\` / `./` の path 揺れを比較時のみ軽量正規化
- 先頭 `/` や Windows drive prefix 付き parent は相対パス仕様外として warning 化
- parent 未指定、既存 parent、不在 parent、空文字 parent、複数不在 parent、既存 warning 併存、重複防止、自己参照、serde camelCase の unit test を追加

#### 変更されたファイル

- `src-tauri/src/task_index.rs`
- `docs/spec-board/task-format-spec.md`

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Parsed[Task parsed] --> Index[Build HashSet of task file_path]
    Index --> Check{Task has parent?}
    Check -->|No| Keep[Keep task without new warning]
    Check -->|Yes| Normalize[Normalize parent for lookup]
    Normalize --> Lookup{Parent path exists?}
    Lookup -->|Yes| Keep
    Lookup -->|No| Warn[Add parentNotFound warning]:::new
    Warn --> Done[Return Vec<Task>]
    Keep --> Done

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

### データフロー

```mermaid
flowchart TD
    ParsedTasks[Vec<Task>] --> Validator[validate_parent_existence]:::new
    Validator --> PathIndex[HashSet normalized file_path]:::new
    Validator --> ParentCheck[Compare Task.parent to path index]:::new
    ParentCheck --> Existing[Existing parent: no warning]
    ParentCheck --> Missing[Missing parent: append parentNotFound warning]:::new
    Existing --> Result[Vec<Task>]
    Missing --> Result

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #63

## 🧪 テスト

### テスト実行方法

```bash
cd src-tauri
cargo test task_index
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- `cargo test task_index`: 成功
- `cargo fmt --all -- --check`: 成功
- `cargo clippy --workspace --all-targets -- -D warnings`: 成功
- Codex レビュー: 問題なし

## 📸 スクリーンショット/動画

UI変更なし

## 🔍 レビューポイント

- `validate_parent_existence` が単一 Task parse API に混ざらず、全 Task 後処理 helper として分離されていること
- `Task.parent` の保持値を変更せず、比較時のみ軽量正規化していること
- `open_project` / frontend 型 / children 収集 / 循環検出 / reverse links が今回の差分に混入していないこと

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

### 破壊的変更の詳細

なし

## 📚 追加情報

### 参考資料

- `.plugin-workspace/.specs/012-issue-63/implementation-plan.md`

### 注意事項

- この Issue 完了時点では実アプリ経由の `open_project` payload には `parentNotFound` はまだ返りません。接続は後続 Issue で扱います。
- `docs/spec-board/file-system-spec.md` は warning 構造の例示のみで code 一覧ではないため、`parentNotFound` の公開仕様は `task-format-spec.md` に集約しています。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている

## 🤝 レビュアーへのお願い

- parent path の正規化方針が Issue #63 の範囲に収まっているか確認してください。