### PR TITLE
[codex] Refactor task deletion domain cleanup

### DIFF
--- a/src/domains/__tests__/taskFixtures.ts
+++ b/src/domains/__tests__/taskFixtures.ts
@@ -1,0 +1,17 @@
+import type { Task } from "@/types/task";
+
+export const makeTask = (
+  overrides: Partial<Task> & Pick<Task, "id">,
+): Task => ({
+  id: overrides.id,
+  title: overrides.title ?? "t",
+  status: overrides.status ?? "Todo",
+  labels: overrides.labels ?? [],
+  parent: overrides.parent,
+  links: overrides.links ?? [],
+  children: overrides.children ?? [],
+  reverseLinks: overrides.reverseLinks ?? [],
+  body: overrides.body ?? "",
+  filePath: overrides.filePath ?? `tasks/${overrides.id}.md`,
+  priority: overrides.priority,
+});

--- a/src/domains/task-hierarchy/__tests__/taskHierarchy.behavior.test.ts
+++ b/src/domains/task-hierarchy/__tests__/taskHierarchy.behavior.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import { makeTask } from "@/domains/__tests__/taskFixtures";
+import { TaskHierarchy } from "@/domains/task-hierarchy";
+
+test("detachDeletedTask は削除済み task を指す parent を clear する", () => {
+  const task = makeTask({
+    id: "child",
+    parent: "tasks/deleted.md",
+  });
+
+  const next = TaskHierarchy.detachDeletedTask(task, "tasks/deleted.md");
+
+  expect(next.parent).toBeUndefined();
+  expect(next.children).toBe(task.children);
+});
+
+test("detachDeletedTask は parent path の表記ゆれを扱える", () => {
+  const task = makeTask({
+    id: "child",
+    parent: ".\\tasks\\deleted.md",
+  });
+
+  const next = TaskHierarchy.detachDeletedTask(task, "tasks/deleted.md");
+
+  expect(next.parent).toBeUndefined();
+});
+
+test("detachDeletedTask は children から削除済み filePath を取り除く", () => {
+  const task = makeTask({
+    id: "parent",
+    children: ["tasks/deleted.md", "tasks/kept.md"],
+  });
+
+  const next = TaskHierarchy.detachDeletedTask(task, "tasks/deleted.md");
+
+  expect(next.parent).toBe(task.parent);
+  expect(next.children).toEqual(["tasks/kept.md"]);
+});
+
+test("detachDeletedTask は hierarchy 関係が変わらなければ元 task object を返す", () => {
+  const task = makeTask({
+    id: "a",
+    parent: "tasks/parent.md",
+    children: ["tasks/child.md"],
+  });
+
+  const next = TaskHierarchy.detachDeletedTask(task, "tasks/deleted.md");
+
+  expect(next).toBe(task);
+});

--- a/src/domains/task-hierarchy/index.ts
+++ b/src/domains/task-hierarchy/index.ts
@@ -1,0 +1,62 @@
+import { parentReferencesTaskPath } from "@/domains/task-path";
+import type { Task } from "@/types/task";
+
+/** Task の親子階層情報 */
+export type TaskHierarchy = {
+  /** 親タスクのファイルパス（親がない場合は未設定） */
+  parent?: string;
+  /** 子タスクのファイルパスの配列（parent から逆引き） */
+  children: string[];
+};
+
+const removeChild = (children: string[], filePath: string): string[] => {
+  if (!children.includes(filePath)) {
+    return children;
+  }
+
+  return children.filter((child) => child !== filePath);
+};
+
+const detachParent = (
+  parent: string | undefined,
+  filePath: string,
+): string | undefined => {
+  if (!parentReferencesTaskPath(parent, filePath)) {
+    return parent;
+  }
+
+  return undefined;
+};
+
+const detachDeletedPath = (
+  hierarchy: TaskHierarchy,
+  deletedFilePath: string,
+): TaskHierarchy => ({
+  parent: detachParent(hierarchy.parent, deletedFilePath),
+  children: removeChild(hierarchy.children, deletedFilePath),
+});
+
+const hasHierarchyChanges = (
+  current: TaskHierarchy,
+  next: TaskHierarchy,
+): boolean =>
+  next.parent !== current.parent || next.children !== current.children;
+
+export const TaskHierarchy = {
+  /**
+   * Task の親子階層から削除済み task への参照を取り除く。
+   *
+   * @param task 階層関係を掃除する task
+   * @param deletedFilePath 削除済み task の filePath
+   * @returns 階層関係が変われば更新後 task、変わらなければ元 task
+   */
+  detachDeletedTask: (task: Task, deletedFilePath: string): Task => {
+    const hierarchy = detachDeletedPath(task, deletedFilePath);
+
+    if (!hasHierarchyChanges(task, hierarchy)) {
+      return task;
+    }
+
+    return { ...task, ...hierarchy };
+  },
+} as const;

--- a/src/domains/task-links/__tests__/taskLinks.behavior.test.ts
+++ b/src/domains/task-links/__tests__/taskLinks.behavior.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "vitest";
+import { makeTask } from "@/domains/__tests__/taskFixtures";
+import { TaskLinks } from "@/domains/task-links";
+
+test("removeLinkedTask は links から指定 filePath を取り除く", () => {
+  const task = makeTask({
+    id: "a",
+    links: ["tasks/deleted.md", "tasks/kept.md"],
+  });
+
+  const next = TaskLinks.removeLinkedTask(task, "tasks/deleted.md");
+
+  expect(next.links).toEqual(["tasks/kept.md"]);
+  expect(next.reverseLinks).toBe(task.reverseLinks);
+});
+
+test("removeLinkedTask は reverseLinks から指定 filePath を取り除く", () => {
+  const task = makeTask({
+    id: "a",
+    reverseLinks: ["tasks/deleted.md", "tasks/kept.md"],
+  });
+
+  const next = TaskLinks.removeLinkedTask(task, "tasks/deleted.md");
+
+  expect(next.links).toBe(task.links);
+  expect(next.reverseLinks).toEqual(["tasks/kept.md"]);
+});
+
+test("removeLinkedTask は links と reverseLinks の両方を一度に掃除する", () => {
+  const task = makeTask({
+    id: "a",
+    links: ["tasks/deleted.md"],
+    reverseLinks: ["tasks/deleted.md"],
+  });
+
+  const next = TaskLinks.removeLinkedTask(task, "tasks/deleted.md");
+
+  expect(next.links).toEqual([]);
+  expect(next.reverseLinks).toEqual([]);
+});
+
+test("removeLinkedTask は link 関係が変わらなければ元 task object を返す", () => {
+  const task = makeTask({
+    id: "a",
+    links: ["tasks/linked.md"],
+    reverseLinks: ["tasks/reverse.md"],
+  });
+
+  const next = TaskLinks.removeLinkedTask(task, "tasks/deleted.md");
+
+  expect(next).toBe(task);
+});

--- a/src/domains/task-links/index.ts
+++ b/src/domains/task-links/index.ts
@@ -1,0 +1,47 @@
+import type { Task } from "@/types/task";
+
+/** Task の関連リンク情報 */
+export type TaskLinks = {
+  /** 関連タスクのファイルパスの配列 */
+  links: string[];
+  /** 逆方向リンクのファイルパスの配列（links から逆引き） */
+  reverseLinks: string[];
+};
+
+const removePath = (paths: string[], filePath: string): string[] => {
+  if (!paths.includes(filePath)) {
+    return paths;
+  }
+
+  return paths.filter((path) => path !== filePath);
+};
+
+const removeLinkedPath = (
+  taskLinks: TaskLinks,
+  linkedFilePath: string,
+): TaskLinks => ({
+  links: removePath(taskLinks.links, linkedFilePath),
+  reverseLinks: removePath(taskLinks.reverseLinks, linkedFilePath),
+});
+
+const hasLinkChanges = (current: TaskLinks, next: TaskLinks): boolean =>
+  next.links !== current.links || next.reverseLinks !== current.reverseLinks;
+
+export const TaskLinks = {
+  /**
+   * Task の関連 link 関係から指定 task への参照を取り除く。
+   *
+   * @param task link 関係を掃除する task
+   * @param linkedFilePath 取り除く関連 task の filePath
+   * @returns link 関係が変われば更新後 task、変わらなければ元 task
+   */
+  removeLinkedTask: (task: Task, linkedFilePath: string): Task => {
+    const taskLinks = removeLinkedPath(task, linkedFilePath);
+
+    if (!hasLinkChanges(task, taskLinks)) {
+      return task;
+    }
+
+    return { ...task, ...taskLinks };
+  },
+} as const;

--- a/src/features/board/hooks/useProject/domain/projectData.ts
+++ b/src/features/board/hooks/useProject/domain/projectData.ts
@@ -1,3 +1,5 @@
+import { TaskHierarchy } from "@/domains/task-hierarchy";
+import { TaskLinks } from "@/domains/task-links";
 import { parentReferencesTaskPath } from "@/domains/task-path";
 import type { Column } from "@/types/column";
 import type { Task } from "@/types/task";
@@ -58,6 +60,12 @@ const syncParentChildren = (
   });
 };
 
+const applyTaskDeletedToTask = (task: Task, filePath: string): Task =>
+  TaskLinks.removeLinkedTask(
+    TaskHierarchy.detachDeletedTask(task, filePath),
+    filePath,
+  );
+
 export const ProjectData = {
   /**
    * 作成された task を追加し、親 task の children も同期する。
@@ -105,30 +113,7 @@ export const ProjectData = {
   applyTaskDeleted: (data: ProjectData, filePath: string): ProjectData => {
     const tasks = data.tasks
       .filter((task) => task.filePath !== filePath)
-      .map((task) => {
-        const parent = parentReferencesTaskPath(task.parent, filePath)
-          ? undefined
-          : task.parent;
-        const children = task.children.includes(filePath)
-          ? task.children.filter((child) => child !== filePath)
-          : task.children;
-        const links = task.links.includes(filePath)
-          ? task.links.filter((link) => link !== filePath)
-          : task.links;
-        const reverseLinks = task.reverseLinks.includes(filePath)
-          ? task.reverseLinks.filter((link) => link !== filePath)
-          : task.reverseLinks;
-
-        if (
-          parent === task.parent &&
-          children === task.children &&
-          links === task.links &&
-          reverseLinks === task.reverseLinks
-        ) {
-          return task;
-        }
-        return { ...task, parent, children, links, reverseLinks };
-      });
+      .map((task) => applyTaskDeletedToTask(task, filePath));
     return { ...data, tasks };
   },
 

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,27 +1,22 @@
 import type { Priority } from "@/domains/priority";
+import type { TaskHierarchy } from "@/domains/task-hierarchy";
+import type { TaskLinks } from "@/domains/task-links";
 
 /** タスク */
-export type Task = {
-  /** 一意な識別子 */
-  id: string;
-  /** タスクタイトル */
-  title: string;
-  /** ステータス（カラム名に対応） */
-  status: string;
-  /** 優先度（未設定可） */
-  priority?: Priority;
-  /** ラベルの配列 */
-  labels: string[];
-  /** 親タスクのファイルパス（親がない場合は未設定） */
-  parent?: string;
-  /** 関連タスクのファイルパスの配列 */
-  links: string[];
-  /** 子タスクのファイルパスの配列（parent から逆引き） */
-  children: string[];
-  /** 逆方向リンクのファイルパスの配列（links から逆引き） */
-  reverseLinks: string[];
-  /** Markdown 本文 */
-  body: string;
-  /** タスクファイルのパス */
-  filePath: string;
-};
+export type Task = TaskLinks &
+  TaskHierarchy & {
+    /** 一意な識別子 */
+    id: string;
+    /** タスクタイトル */
+    title: string;
+    /** ステータス（カラム名に対応） */
+    status: string;
+    /** 優先度（未設定可） */
+    priority?: Priority;
+    /** ラベルの配列 */
+    labels: string[];
+    /** Markdown 本文 */
+    body: string;
+    /** タスクファイルのパス */
+    filePath: string;
+  };


### PR DESCRIPTION
## Summary

- Added `TaskLinks` and `TaskHierarchy` domain modules under `src/domains/`, each using the type + companion object pattern.
- Simplified `ProjectData.applyTaskDeleted` so it filters the deleted task and delegates relationship cleanup to the new domains.
- Added focused behavior tests for both domains, with shared test helper setup under `src/domains/__tests__/`.

## Why

`applyTaskDeleted` had field-by-field cleanup logic with several ternaries, mixing collection-level deletion with task relationship maintenance. Separating links and hierarchy keeps the domain language clearer and makes the reducer path easier to read.

## Validation

- `pnpm test:run src/domains/task-links/__tests__/taskLinks.behavior.test.ts src/domains/task-hierarchy/__tests__/taskHierarchy.behavior.test.ts src/features/board/hooks/useProject/__tests__/useProject.behavior.test.ts`
- `pnpm exec biome check src/domains/__tests__/makeTask.ts src/domains/task-links/__tests__/taskLinks.behavior.test.ts src/domains/task-hierarchy/__tests__/taskHierarchy.behavior.test.ts src/domains/task-links/index.ts src/domains/task-hierarchy/index.ts src/types/task.ts src/features/board/hooks/useProject/domain/projectData.ts`
- `pnpm lint`
- `pnpm typecheck`

Docs were not updated because this is an internal refactor with no public behavior or data-format change.