### PR TITLE
✨ [New Feature]: #69 GUIDE.md書き込みをbest-effortで実装

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3472,6 +3472,7 @@ dependencies = [
 name = "spec-board"
 version = "0.1.0"
 dependencies = [
+ "log",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
@@ -33,4 +34,3 @@ spec-board-fs = { path = "crates/fs" }
 
 [dev-dependencies]
 tempfile = "3"
-

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -1,15 +1,19 @@
-//! `.spec-board/` ディレクトリと `config.json` のファイル I/O を担うモジュール。
+//! `.spec-board/` ディレクトリ、`config.json`、補助ファイル `GUIDE.md` の
+//! ファイル I/O を担うモジュール。
 //!
 //! 本モジュールはサブクレート `spec-board-fs` の境界規約に従い、
 //! 公開 API のシグネチャに外部 crate の型（`serde_json::Error` 等）を出さない。
 //! JSON のパースは本体クレート `spec-board` 側の責務とし、本モジュールは
-//! 「ディレクトリ作成」「ファイル存在チェック + 文字列読み込み」までを担当する。
+//! 「ディレクトリ作成」「ファイル存在チェック + 文字列読み込み」
+//! 「補助ファイル書き込み」までを担当する。
 //!
 //! # スコープ
 //!
 //! - [`ensure_spec_board_dir`]: `<project_root>/.spec-board/` を冪等に作成
 //! - [`read_config_json`]: `<project_root>/.spec-board/config.json` の中身を文字列で返す
 //!   （ファイル不在は `Ok(None)`）
+//! - [`guide_markdown_path`]: `<project_root>/.spec-board/GUIDE.md` のパスを返す
+//! - [`write_guide_markdown`]: `<project_root>/.spec-board/GUIDE.md` へ文字列を書き込む
 //!
 //! # スコープ外
 //!
@@ -22,6 +26,7 @@ use thiserror::Error;
 
 const SPEC_BOARD_DIR: &str = ".spec-board";
 const CONFIG_FILE_NAME: &str = "config.json";
+const GUIDE_MARKDOWN_FILE_NAME: &str = "GUIDE.md";
 
 /// `config_io` モジュールのファイル I/O で発生し得るエラー。
 ///
@@ -63,6 +68,19 @@ fn io_err(path: &Path, source: std::io::Error) -> ConfigIoError {
 /// `project_root` が相対パスなら戻り値も相対パスになる（`canonicalize` は行わない）。
 pub fn config_path(project_root: &Path) -> PathBuf {
     project_root.join(SPEC_BOARD_DIR).join(CONFIG_FILE_NAME)
+}
+
+/// `<project_root>/.spec-board/GUIDE.md` の絶対パス相当を返す（純粋計算、I/O なし）。
+///
+/// `project_root` が相対パスなら戻り値も相対パスになる（`canonicalize` は行わない）。
+///
+/// # Returns
+///
+/// GUIDE.md の配置先パス。
+pub fn guide_markdown_path(project_root: &Path) -> PathBuf {
+    project_root
+        .join(SPEC_BOARD_DIR)
+        .join(GUIDE_MARKDOWN_FILE_NAME)
 }
 
 /// `<project_root>/.spec-board/` を冪等に作成し、その `PathBuf` を返す。
@@ -174,6 +192,23 @@ pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoE
 
     let content = std::fs::read_to_string(&config_path).map_err(|e| io_err(&config_path, e))?;
     Ok(Some(content))
+}
+
+/// `<project_root>/.spec-board/GUIDE.md` へ Markdown 文字列を書き込む。
+///
+/// 書き込み前に [`ensure_spec_board_dir`] を呼び、`.spec-board/` が無い場合は作成する。
+/// 既存 `GUIDE.md` は `std::fs::write` の通常セマンティクスで上書きする。
+///
+/// # Errors
+///
+/// - `project_root` が存在しない / ディレクトリでない / アクセスできない
+/// - `<project_root>/.spec-board` がファイルとして存在する
+/// - 権限不足等で `.spec-board/` 作成または `GUIDE.md` 書き込みが失敗する
+pub fn write_guide_markdown(project_root: &Path, content: &str) -> Result<PathBuf, ConfigIoError> {
+    ensure_spec_board_dir(project_root)?;
+    let guide_path = guide_markdown_path(project_root);
+    std::fs::write(&guide_path, content).map_err(|e| io_err(&guide_path, e))?;
+    Ok(guide_path)
 }
 
 /// 指定パスが存在するディレクトリであることを検証する。
@@ -307,6 +342,43 @@ mod tests {
 
         let result = read_config_json(tmp.path()).unwrap();
         assert_eq!(result.as_deref(), Some(content));
+    }
+
+    #[test]
+    fn write_guide_markdown_creates_spec_board_dir_and_file_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        let content = "# Guide\n";
+
+        let path = write_guide_markdown(tmp.path(), content).unwrap();
+
+        assert_eq!(path, tmp.path().join(".spec-board").join("GUIDE.md"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), content);
+    }
+
+    #[test]
+    fn write_guide_markdown_overwrites_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("GUIDE.md");
+        std::fs::write(&path, "old").unwrap();
+
+        let written_path = write_guide_markdown(tmp.path(), "new").unwrap();
+
+        assert_eq!(written_path, path);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "new");
+    }
+
+    #[test]
+    fn guide_markdown_path_returns_spec_board_guide_path() {
+        let root = Path::new("/project");
+
+        let path = guide_markdown_path(root);
+
+        assert_eq!(
+            path,
+            Path::new("/project").join(".spec-board").join("GUIDE.md")
+        );
     }
 
     #[test]

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -227,7 +227,10 @@ fn reject_existing_symlink(path: &Path) -> Result<(), ConfigIoError> {
     match std::fs::symlink_metadata(path) {
         Ok(meta) if meta.file_type().is_symlink() => Err(io_err(
             path,
-            std::io::Error::from(std::io::ErrorKind::InvalidInput),
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("{} is a symlink", path.display()),
+            ),
         )),
         Ok(_) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -452,6 +455,7 @@ mod tests {
         let ConfigIoError::Io { path, source } = err;
         assert_eq!(path, tmp.path().join(".spec-board"));
         assert_eq!(source.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(source.to_string().contains("is a symlink"));
         assert!(!outside_guide.exists());
     }
 
@@ -474,6 +478,7 @@ mod tests {
         let ConfigIoError::Io { path, source } = err;
         assert_eq!(path, guide_path);
         assert_eq!(source.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(source.to_string().contains("is a symlink"));
         assert_eq!(std::fs::read_to_string(target).unwrap(), "keep");
     }
 

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -276,10 +276,27 @@ fn write_file_via_tmp(dst: &Path, content: &str, tmp: &Path) -> Result<(), Confi
 
     drop(tmp_file);
 
-    std::fs::rename(tmp, dst).map_err(|e| {
+    replace_file_with_tmp(tmp, dst).map_err(|e| {
         let _ = std::fs::remove_file(tmp);
         io_err(dst, e)
     })
+}
+
+#[cfg(not(windows))]
+fn replace_file_with_tmp(tmp: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::rename(tmp, dst)
+}
+
+#[cfg(windows)]
+fn replace_file_with_tmp(tmp: &Path, dst: &Path) -> std::io::Result<()> {
+    match std::fs::rename(tmp, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(dst)?;
+            std::fs::rename(tmp, dst)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// 指定パスが存在するディレクトリであることを検証する。

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -20,13 +20,17 @@
 //! - `config.json` の書き出し（atomic write / `.bak` 退避）は別モジュール / 別 Issue
 //! - JSON のパース / シリアライズは本体クレート側
 
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use thiserror::Error;
 
 const SPEC_BOARD_DIR: &str = ".spec-board";
 const CONFIG_FILE_NAME: &str = "config.json";
 const GUIDE_MARKDOWN_FILE_NAME: &str = "GUIDE.md";
+static GUIDE_MARKDOWN_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// `config_io` モジュールのファイル I/O で発生し得るエラー。
 ///
@@ -197,18 +201,82 @@ pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoE
 /// `<project_root>/.spec-board/GUIDE.md` へ Markdown 文字列を書き込む。
 ///
 /// 書き込み前に [`ensure_spec_board_dir`] を呼び、`.spec-board/` が無い場合は作成する。
-/// 既存 `GUIDE.md` は `std::fs::write` の通常セマンティクスで上書きする。
+/// 既存 `GUIDE.md` は fresh tmp file へ書いてから `rename` で置き換える。
+/// `.spec-board/` または `GUIDE.md` が symlink の場合は、project root 外のファイルを
+/// 上書きしないよう拒否する。
 ///
 /// # Errors
 ///
 /// - `project_root` が存在しない / ディレクトリでない / アクセスできない
-/// - `<project_root>/.spec-board` がファイルとして存在する
+/// - `<project_root>/.spec-board` がファイルまたは symlink として存在する
+/// - `<project_root>/.spec-board/GUIDE.md` が symlink として存在する
 /// - 権限不足等で `.spec-board/` 作成または `GUIDE.md` 書き込みが失敗する
 pub fn write_guide_markdown(project_root: &Path, content: &str) -> Result<PathBuf, ConfigIoError> {
-    ensure_spec_board_dir(project_root)?;
+    let spec_board_dir = ensure_spec_board_dir(project_root)?;
+    reject_existing_symlink(&spec_board_dir)?;
     let guide_path = guide_markdown_path(project_root);
-    std::fs::write(&guide_path, content).map_err(|e| io_err(&guide_path, e))?;
+    reject_existing_symlink(&guide_path)?;
+
+    let tmp_path = unique_guide_markdown_tmp_path(&spec_board_dir);
+    write_file_via_tmp(&guide_path, content, &tmp_path)?;
+
     Ok(guide_path)
+}
+
+fn reject_existing_symlink(path: &Path) -> Result<(), ConfigIoError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => Err(io_err(
+            path,
+            std::io::Error::from(std::io::ErrorKind::InvalidInput),
+        )),
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(io_err(path, e)),
+    }
+}
+
+fn unique_guide_markdown_tmp_path(spec_board_dir: &Path) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let counter = GUIDE_MARKDOWN_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    spec_board_dir.join(format!(
+        "{GUIDE_MARKDOWN_FILE_NAME}.tmp.{pid}.{nanos}.{counter}"
+    ))
+}
+
+fn write_file_via_tmp(dst: &Path, content: &str, tmp: &Path) -> Result<(), ConfigIoError> {
+    match std::fs::remove_file(tmp) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(io_err(tmp, e)),
+    }
+
+    let mut tmp_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(tmp)
+        .map_err(|e| io_err(tmp, e))?;
+
+    if let Err(e) = tmp_file.write_all(content.as_bytes()) {
+        drop(tmp_file);
+        let _ = std::fs::remove_file(tmp);
+        return Err(io_err(tmp, e));
+    }
+
+    if let Err(e) = tmp_file.sync_all() {
+        drop(tmp_file);
+        let _ = std::fs::remove_file(tmp);
+        return Err(io_err(tmp, e));
+    }
+
+    drop(tmp_file);
+
+    std::fs::rename(tmp, dst).map_err(|e| {
+        let _ = std::fs::remove_file(tmp);
+        io_err(dst, e)
+    })
 }
 
 /// 指定パスが存在するディレクトリであることを検証する。
@@ -367,6 +435,65 @@ mod tests {
 
         assert_eq!(written_path, path);
         assert_eq!(std::fs::read_to_string(path).unwrap(), "new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_guide_markdown_rejects_spec_board_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_guide = outside.path().join("GUIDE.md");
+        symlink(outside.path(), tmp.path().join(".spec-board")).unwrap();
+
+        let err = write_guide_markdown(tmp.path(), "new").unwrap_err();
+
+        let ConfigIoError::Io { path, source } = err;
+        assert_eq!(path, tmp.path().join(".spec-board"));
+        assert_eq!(source.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(!outside_guide.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_guide_markdown_rejects_guide_symlink_without_overwriting_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let target = outside.path().join("target.txt");
+        std::fs::write(&target, "keep").unwrap();
+        let guide_path = dir.join("GUIDE.md");
+        symlink(&target, &guide_path).unwrap();
+
+        let err = write_guide_markdown(tmp.path(), "new").unwrap_err();
+
+        let ConfigIoError::Io { path, source } = err;
+        assert_eq!(path, guide_path);
+        assert_eq!(source.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "keep");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_guide_markdown_replaces_hard_link_without_overwriting_target_inode() {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let target = outside.path().join("target.txt");
+        std::fs::write(&target, "keep").unwrap();
+        let guide_path = dir.join("GUIDE.md");
+        std::fs::hard_link(&target, &guide_path).unwrap();
+
+        let written_path = write_guide_markdown(tmp.path(), "new").unwrap();
+
+        assert_eq!(written_path, guide_path);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "keep");
+        assert_eq!(std::fs::read_to_string(guide_path).unwrap(), "new");
     }
 
     #[test]

--- a/src-tauri/crates/fs/src/config_io.rs
+++ b/src-tauri/crates/fs/src/config_io.rs
@@ -292,11 +292,52 @@ fn replace_file_with_tmp(tmp: &Path, dst: &Path) -> std::io::Result<()> {
     match std::fs::rename(tmp, dst) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            std::fs::remove_file(dst)?;
-            std::fs::rename(tmp, dst)
+            replace_existing_file_with_tmp_via_backup(tmp, dst)
         }
         Err(e) => Err(e),
     }
+}
+
+#[cfg(windows)]
+fn replace_existing_file_with_tmp_via_backup(tmp: &Path, dst: &Path) -> std::io::Result<()> {
+    let backup = unique_sibling_path(dst, "bak");
+    std::fs::rename(dst, &backup)?;
+    match std::fs::rename(tmp, dst) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&backup);
+            Ok(())
+        }
+        Err(rename_err) => {
+            if let Err(restore_err) = std::fs::rename(&backup, dst) {
+                return Err(std::io::Error::new(
+                    rename_err.kind(),
+                    format!(
+                        "failed to replace `{dst}` with `{tmp}` ({rename_err}); \
+                         restoring backup `{backup}` also failed: {restore_err}",
+                        dst = dst.display(),
+                        tmp = tmp.display(),
+                        backup = backup.display(),
+                    ),
+                ));
+            }
+            Err(rename_err)
+        }
+    }
+}
+
+#[cfg(windows)]
+fn unique_sibling_path(base: &Path, suffix: &str) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let counter = GUIDE_MARKDOWN_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let file_name = base
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let parent = base.parent().unwrap_or_else(|| Path::new(""));
+    parent.join(format!("{file_name}.{suffix}.{pid}.{nanos}.{counter}"))
 }
 
 /// 指定パスが存在するディレクトリであることを検証する。

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -35,27 +35,27 @@
 //! 古い `version` のマイグレーション結果はメモリ上の [`Config`] として返り、
 //! `config.json` への書き戻しは行わない（書き出し経路は別 Issue の責務）。
 //!
-//! # GUIDE.md 生成境界
-//! 本モジュールは [`Config::columns`] から GUIDE.md の Markdown 本文を組み立てる
-//! 純粋関数のみを提供する。`.spec-board/GUIDE.md` への書き込み、更新タイミング制御、
-//! Tauri コマンド公開は別 Issue の責務。
+//! # GUIDE.md 生成 / 書き込み境界
+//! 本モジュールは [`Config::columns`] から GUIDE.md の Markdown 本文を組み立て、
+//! `.spec-board/GUIDE.md` への best-effort 書き込み helper を提供する。
+//! 更新タイミング制御と Tauri コマンド公開は command 層の責務。
 //!
 //! # スコープ外（別 Issue で実装）
 //! - `config.json` の書き出し（atomic write / `.bak` 退避の永続化 / 並行書き込み制御）
 //! - `doneColumn` の整合性検証 / カラム名空間の正規化
 //! - 実フィールド変換を伴う実マイグレーション（本モジュールはフックのみ提供）
-//! - GUIDE.md ファイルの自動生成 / 書き込み
 //! - Tauri コマンド層
 //!
 //! 既存タスクの `(path, status)` 列から `Config` を組み立てる純粋関数
 //! [`build_config_from_statuses`] は本モジュールに同居する。
 //! md ファイルの走査・フロントマター抽出・`config.json` への書き出しは別レイヤの責務。
 
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use spec_board_fs::config_io::{self, ConfigIoError};
+use spec_board_fs::config_io::{self, write_guide_markdown, ConfigIoError};
 use thiserror::Error;
 
 /// `cardOrder` の型エイリアス。キー = カラム名、値 = タスクファイルパスの並び順配列。
@@ -188,6 +188,34 @@ pub fn generate_guide_markdown(config: &Config) -> String {
 pub fn generate_guide_markdown_for_columns(columns: &[Column]) -> String {
     let parts = build_guide_markdown_parts(columns);
     render_guide_markdown(&parts)
+}
+
+/// [`Config::guide_markdown`] の戻り値を `.spec-board/GUIDE.md` へ best-effort で書き込む。
+///
+/// GUIDE.md は補助ファイルのため、I/O 失敗を呼び出し元へ返さず WARN ログのみを残す。
+/// logger 未初期化環境でも観測できるよう stderr fallback も併用する。
+///
+/// @param project_root `.spec-board/GUIDE.md` を配置するプロジェクトルート。
+/// @param config GUIDE.md 本文生成に使う設定。
+pub fn write_guide_markdown_best_effort(project_root: &Path, config: &Config) {
+    let content = config.guide_markdown();
+
+    if let Err(error) = write_guide_markdown(project_root, &content) {
+        warn_guide_write_failure(project_root, &error);
+    }
+}
+
+fn warn_guide_write_failure(project_root: &Path, error: &impl std::fmt::Display) {
+    let message = format_guide_write_warning(project_root, error);
+    warn!("{message}");
+    eprintln!("WARN {message}");
+}
+
+fn format_guide_write_warning(project_root: &Path, error: &impl std::fmt::Display) -> String {
+    format!(
+        "failed to write .spec-board/GUIDE.md for project '{}': {error}",
+        project_root.display()
+    )
 }
 
 fn build_guide_markdown_parts(columns: &[Column]) -> GuideMarkdownParts<'_> {
@@ -1311,6 +1339,107 @@ mod tests {
         assert!(
             guide.ends_with("- `parent` に指定するパスはプロジェクトルートからの相対パスです\n")
         );
+    }
+
+    // ───────── write_guide_markdown_best_effort ─────────
+
+    #[test]
+    fn write_guide_markdown_best_effort_writes_config_guide_markdown() {
+        let tmp = TempDir::new().unwrap();
+        let config = Config {
+            version: 1,
+            columns: vec![col("Review", 1), col("Backlog", 0)],
+            card_order: BTreeMap::new(),
+            done_column: Some("Review".into()),
+        };
+
+        write_guide_markdown_best_effort(tmp.path(), &config);
+
+        let guide_path = tmp.path().join(".spec-board").join("GUIDE.md");
+        let written = std::fs::read_to_string(guide_path).unwrap();
+        assert_eq!(written, config.guide_markdown());
+        assert!(written.contains("status: Backlog（推奨・省略時は既定カラムにフォールバック。指定する場合は下記の有効な値から選択）"));
+    }
+
+    #[test]
+    fn write_guide_markdown_best_effort_overwrites_existing_guide() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let guide_path = dir.join("GUIDE.md");
+        std::fs::write(&guide_path, "old").unwrap();
+        let config = Config {
+            version: 1,
+            columns: vec![],
+            card_order: BTreeMap::new(),
+            done_column: None,
+        };
+
+        write_guide_markdown_best_effort(tmp.path(), &config);
+
+        assert_eq!(
+            std::fs::read_to_string(guide_path).unwrap(),
+            config.guide_markdown()
+        );
+    }
+
+    #[test]
+    fn write_guide_markdown_best_effort_does_not_panic_when_project_root_missing() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+
+        write_guide_markdown_best_effort(&missing, &Config::default());
+    }
+
+    #[test]
+    fn write_guide_markdown_best_effort_does_not_panic_when_project_root_is_file() {
+        let tmp = TempDir::new().unwrap();
+        let file_root = tmp.path().join("project.md");
+        std::fs::write(&file_root, "not a directory").unwrap();
+
+        write_guide_markdown_best_effort(&file_root, &Config::default());
+    }
+
+    #[test]
+    fn write_guide_markdown_best_effort_does_not_panic_when_spec_board_is_file() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".spec-board"), "not a directory").unwrap();
+
+        write_guide_markdown_best_effort(tmp.path(), &Config::default());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_guide_markdown_best_effort_does_not_panic_when_guide_is_unwritable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".spec-board");
+        std::fs::create_dir(&dir).unwrap();
+        let guide_path = dir.join("GUIDE.md");
+        std::fs::write(&guide_path, "old").unwrap();
+        let original = std::fs::metadata(&guide_path).unwrap().permissions();
+        let mut perms = original.clone();
+        perms.set_mode(0o000);
+        std::fs::set_permissions(&guide_path, perms).unwrap();
+
+        write_guide_markdown_best_effort(tmp.path(), &Config::default());
+
+        std::fs::set_permissions(&guide_path, original).unwrap();
+    }
+
+    #[test]
+    fn format_guide_write_warning_includes_project_root_and_error_context() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let error =
+            spec_board_fs::config_io::write_guide_markdown(&missing, "content").unwrap_err();
+
+        let message = format_guide_write_warning(&missing, &error);
+
+        assert!(message.contains("failed to write .spec-board/GUIDE.md"));
+        assert!(message.contains(&missing.display().to_string()));
+        assert!(message.contains("config_io: I/O error"));
     }
 
     // ───────── load_or_default ─────────

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -208,7 +208,9 @@ pub fn write_guide_markdown_best_effort(project_root: &Path, config: &Config) {
 fn warn_guide_write_failure(project_root: &Path, error: &impl std::fmt::Display) {
     let message = format_guide_write_warning(project_root, error);
     warn!("{message}");
-    eprintln!("WARN {message}");
+    if !log::log_enabled!(log::Level::Warn) {
+        eprintln!("WARN {message}");
+    }
 }
 
 fn format_guide_write_warning(project_root: &Path, error: &impl std::fmt::Display) -> String {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -193,7 +193,8 @@ pub fn generate_guide_markdown_for_columns(columns: &[Column]) -> String {
 /// [`Config::guide_markdown`] の戻り値を `.spec-board/GUIDE.md` へ best-effort で書き込む。
 ///
 /// GUIDE.md は補助ファイルのため、I/O 失敗を呼び出し元へ返さず WARN ログのみを残す。
-/// logger 未初期化環境でも観測できるよう stderr fallback も併用する。
+/// WARN が有効でない環境（logger 未初期化、または WARN レベルが無効）でも
+/// 観測できるよう stderr fallback も併用する。
 ///
 /// @param project_root `.spec-board/GUIDE.md` を配置するプロジェクトルート。
 /// @param config GUIDE.md 本文生成に使う設定。

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1428,12 +1428,20 @@ mod tests {
         perms.set_mode(0o500);
         std::fs::set_permissions(&dir, perms).unwrap();
 
+        // root / 権限昇格環境では chmod を無視して書き込めてしまうため、
+        // 実際に書き込めない環境かを probe で判定し、その場合のみ内容変化を検証する。
+        let probe = dir.join("__probe");
+        let actually_unwritable = std::fs::write(&probe, b"x").is_err();
+        let _ = std::fs::remove_file(&probe);
+
         write_guide_markdown_best_effort(tmp.path(), &Config::default());
 
         std::fs::set_permissions(&dir, original_dir_perms).unwrap();
 
-        let after = std::fs::read_to_string(&guide_path).unwrap();
-        assert_eq!(after, "old");
+        if actually_unwritable {
+            let after = std::fs::read_to_string(&guide_path).unwrap();
+            assert_eq!(after, "old");
+        }
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1420,14 +1420,19 @@ mod tests {
         std::fs::create_dir(&dir).unwrap();
         let guide_path = dir.join("GUIDE.md");
         std::fs::write(&guide_path, "old").unwrap();
-        let original = std::fs::metadata(&guide_path).unwrap().permissions();
-        let mut perms = original.clone();
-        perms.set_mode(0o000);
-        std::fs::set_permissions(&guide_path, perms).unwrap();
+        // tmp ファイル + rename で置き換える実装のため、書き込み失敗を再現するには
+        // GUIDE.md ではなく親ディレクトリ .spec-board/ の書き込み権限を落とす必要がある。
+        let original_dir_perms = std::fs::metadata(&dir).unwrap().permissions();
+        let mut perms = original_dir_perms.clone();
+        perms.set_mode(0o500);
+        std::fs::set_permissions(&dir, perms).unwrap();
 
         write_guide_markdown_best_effort(tmp.path(), &Config::default());
 
-        std::fs::set_permissions(&guide_path, original).unwrap();
+        std::fs::set_permissions(&dir, original_dir_perms).unwrap();
+
+        let after = std::fs::read_to_string(&guide_path).unwrap();
+        assert_eq!(after, "old");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

バックエンドで `.spec-board/GUIDE.md` を生成・書き込みできるようにし、書き込み失敗時は WARN ログのみを残して通常処理を継続する best-effort 境界を追加しました。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [ ] 📖 ドキュメント更新 (Documentation)
- [x] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `spec-board-fs::config_io` に `guide_markdown_path` と `write_guide_markdown` を追加
- `Config::guide_markdown()` の戻り値を `.spec-board/GUIDE.md` に書き込む `write_guide_markdown_best_effort` を追加
- 書き込み失敗時に `log::warn!` と stderr fallback で `WARN failed to write .spec-board/GUIDE.md ...` を出力
- project root 不正、`.spec-board` がファイル、権限不足などで panic しないテストを追加
- WARN ログ用に軽量な `log` crate を追加

#### 変更されたファイル

- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock`
- `src-tauri/crates/fs/src/config_io.rs`
- `src-tauri/src/config.rs`

#### 削除されたファイル・機能

- なし

## 📊 システム図

### 状態マシン / フロー図

```mermaid
flowchart TD
    Start([呼び出し元処理]) --> Render[Config::guide_markdown]
    Render --> Write[write_guide_markdown_best_effort]
    Write --> Ensure[ensure_spec_board_dir]
    Ensure -->|OK| FsWrite[write_guide_markdown]
    Ensure -->|Err| Warn[WARNログ + stderr fallback]
    FsWrite -->|OK| Continue[通常処理継続]
    FsWrite -->|Err| Warn
    Warn --> Continue

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    class Write,FsWrite,Warn new
```

### データフロー

```mermaid
flowchart LR
    Config[Config] --> Markdown[Config::guide_markdown]
    Markdown --> BestEffort[write_guide_markdown_best_effort]
    ProjectRoot[project_root] --> BestEffort
    BestEffort --> FsCrate[spec_board_fs::config_io::write_guide_markdown]
    FsCrate --> GuideFile[.spec-board/GUIDE.md]
    FsCrate -->|Err| Warn[log::warn! + eprintln WARN]
```

## 📋 関連 Issue

- Closes #69

## 🧪 テスト

### テスト実行方法

```bash
cd src-tauri
cargo test --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- `cargo test --workspace` 通過
- `cargo fmt --all -- --check` 通過
- `cargo clippy --workspace --all-targets -- -D warnings` 通過
- `cargo test --workspace write_guide_markdown_best_effort_does_not_panic_when_project_root_missing -- --nocapture` で stderr の WARN 出力を確認

## 📸 スクリーンショット/動画

UI変更なし

## 🔍 レビューポイント

- `spec-board-fs` の public API に外部 crate 型を漏らしていないこと
- `write_guide_markdown_best_effort` が I/O エラーを呼び出し元へ返さず WARN のみに閉じていること
- `log` 依存が本体 crate に限定され、`spec-board-fs` に logging 依存を追加していないこと

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## 📚 追加情報

### 注意事項

- 現ブランチでは backend の `open_project` / `update_columns` command が未実装のため、command 成功フローへの統合は未実施です。該当 command 実装時に `write_guide_markdown_best_effort` を呼び出す想定です。
- `docs/spec-board/config-spec.md` の GUIDE.md 仕様と今回の実装挙動に差分はないため、仕様ドキュメント更新は不要と判断しました。
- Codex CLI レビューは承認システムにより外部送信リスクとしてブロックされたため未実施です。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている

## 🤝 レビュアーへのお願い

- WARN/no-panic の責務境界が `config.rs` に閉じているか確認してください。