### PR TITLE
💡 [Comment]: [BE] # Errors セクションを 8 関数に追加

### DIFF
--- a/src-tauri/crates/fs/src/write_ignore.rs
+++ b/src-tauri/crates/fs/src/write_ignore.rs
@@ -29,6 +29,10 @@ impl WriteIgnoreRegistry {
     }
 
     /// Registers a path and returns whether it was newly inserted.
+    ///
+    /// # Errors
+    ///
+    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
     pub fn register(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
         let mut ignored_paths = self.lock()?;
 
@@ -36,6 +40,10 @@ impl WriteIgnoreRegistry {
     }
 
     /// Returns whether the path is currently registered.
+    ///
+    /// # Errors
+    ///
+    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
     pub fn should_ignore(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
         let ignored_paths = self.lock()?;
 
@@ -46,11 +54,19 @@ impl WriteIgnoreRegistry {
     ///
     /// This is kept as a compatibility alias for callers that consume ignored
     /// write events exactly once.
+    ///
+    /// # Errors
+    ///
+    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
     pub fn consume(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
         self.unregister(path)
     }
 
     /// Removes a path and returns whether it was present.
+    ///
+    /// # Errors
+    ///
+    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
     pub fn unregister(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
         let mut ignored_paths = self.lock()?;
 
@@ -58,11 +74,19 @@ impl WriteIgnoreRegistry {
     }
 
     /// Returns the number of registered paths.
+    ///
+    /// # Errors
+    ///
+    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
     pub fn len(&self) -> Result<usize, WriteIgnoreError> {
         Ok(self.lock()?.len())
     }
 
     /// Returns whether there are no registered paths.
+    ///
+    /// # Errors
+    ///
+    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
     pub fn is_empty(&self) -> Result<bool, WriteIgnoreError> {
         Ok(self.len()? == 0)
     }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -431,6 +431,10 @@ pub fn clean_card_order(
 /// `" "` / 前後空白付き `"  Todo  "` は値そのものを比較対象とし、本関数では
 /// 空文字や空白を別エラーとして拒否しない（[`build_config_from_statuses`] が
 /// status 入力を未正規化のまま受ける規約と一貫させる）。
+///
+/// # Errors
+///
+/// - `columns` 内に同名カラムが複数存在する場合 → `Err(name)` を返す。`name` は最初に検出した重複カラム名そのもの（未正規化）。
 pub fn validate_unique_column_names(columns: &[Column]) -> Result<(), String> {
     let mut seen: HashSet<&str> = HashSet::with_capacity(columns.len());
     for column in columns {
@@ -477,6 +481,10 @@ pub enum MigrationError {
 ///
 /// 将来 [`DEFAULT_VERSION`] を引き上げる際に `match from_version` の各アームへ実フィールド
 /// 変換ロジックを追加する。
+///
+/// # Errors
+///
+/// - `from_version` が `DEFAULT_VERSION` より大きい場合 → [`MigrationError::UnsupportedFromVersion`]（純粋関数として単独呼び出しされたときの防御。通常は [`load_or_default`] 側で [`LoadConfigError::UnknownFutureVersion`] により先に弾かれる）
 pub fn migrate_config(
     value: serde_json::Value,
     from_version: u32,

--- a/src/domains/__tests__/taskFixtures.ts
+++ b/src/domains/__tests__/taskFixtures.ts
@@ -8,6 +8,11 @@ type TaskFixtureOverrides = Partial<Omit<Task, "links" | "hierarchy">> &
     reverseLinks?: string[];
   };
 
+/**
+ * テスト用に最小限のフィールドだけ指定して `Task` を生成するファクトリ。指定しないフィールドはダミー値で埋める。
+ * @param overrides id 必須、その他任意の上書きフィールド
+ * @returns 上書きを反映した `Task`
+ */
 export const makeTask = (overrides: TaskFixtureOverrides): Task => ({
   id: overrides.id,
   title: overrides.title ?? "t",

--- a/src/domains/task-hierarchy/index.ts
+++ b/src/domains/task-hierarchy/index.ts
@@ -9,6 +9,12 @@ export type TaskHierarchy = {
   childFilePaths: string[];
 };
 
+/**
+ * `children` から指定 path を除いた配列を返す。含まれていなければ元配列をそのまま返す。
+ * @param children 元の child filePath 配列
+ * @param filePath 除去対象の path
+ * @returns 除去後の配列
+ */
 const removeChild = (children: string[], filePath: string): string[] => {
   if (!children.includes(filePath)) {
     return children;
@@ -17,6 +23,12 @@ const removeChild = (children: string[], filePath: string): string[] => {
   return children.filter((child) => child !== filePath);
 };
 
+/**
+ * `parent` 参照が `filePath` を指していれば剥がして undefined を返す。
+ * @param parent 現在の parentFilePath
+ * @param filePath 比較対象の path
+ * @returns 参照が外れた後の parentFilePath
+ */
 const detachParent = (
   parent: string | undefined,
   filePath: string,
@@ -28,6 +40,12 @@ const detachParent = (
   return undefined;
 };
 
+/**
+ * 階層情報から削除済み path への parent / child 参照を剥がした `TaskHierarchy` を返す。
+ * @param hierarchy 元の階層情報
+ * @param deletedFilePath 削除済み task の filePath
+ * @returns 参照を剥がした後の階層情報
+ */
 const detachDeletedPath = (
   hierarchy: TaskHierarchy,
   deletedFilePath: string,
@@ -36,6 +54,12 @@ const detachDeletedPath = (
   childFilePaths: removeChild(hierarchy.childFilePaths, deletedFilePath),
 });
 
+/**
+ * 2 つの `TaskHierarchy` で参照が変わっているか判定する。
+ * @param current 変更前の階層情報
+ * @param next 変更後の階層情報
+ * @returns parent/children のいずれかが変わっていれば true
+ */
 const hasHierarchyChanges = (
   current: TaskHierarchy,
   next: TaskHierarchy,

--- a/src/domains/task-links/index.ts
+++ b/src/domains/task-links/index.ts
@@ -8,6 +8,12 @@ export type TaskLinks = {
   reverseLinkedFilePaths: string[];
 };
 
+/**
+ * `paths` から `filePath` を除いた新しい配列を返す。含まれていなければ元配列をそのまま返す。
+ * @param paths 元の path 配列
+ * @param filePath 除去対象の path
+ * @returns 除去後の path 配列
+ */
 const removePath = (paths: string[], filePath: string): string[] => {
   if (!paths.includes(filePath)) {
     return paths;
@@ -16,6 +22,12 @@ const removePath = (paths: string[], filePath: string): string[] => {
   return paths.filter((path) => path !== filePath);
 };
 
+/**
+ * link/reverseLink の両方から指定 path を取り除いた `TaskLinks` を返す。
+ * @param taskLinks 元の link 状態
+ * @param linkedFilePath 除去対象の path
+ * @returns 除去後の `TaskLinks`
+ */
 const removeLinkedPath = (
   taskLinks: TaskLinks,
   linkedFilePath: string,
@@ -27,6 +39,12 @@ const removeLinkedPath = (
   ),
 });
 
+/**
+ * 2 つの `TaskLinks` で配列参照が変わっているか判定する。
+ * @param current 変更前の link 状態
+ * @param next 変更後の link 状態
+ * @returns 参照が変わっていれば true
+ */
 const hasLinkChanges = (current: TaskLinks, next: TaskLinks): boolean =>
   next.linkedFilePaths !== current.linkedFilePaths ||
   next.reverseLinkedFilePaths !== current.reverseLinkedFilePaths;

--- a/src/domains/task-path/index.ts
+++ b/src/domains/task-path/index.ts
@@ -35,6 +35,11 @@ export const parentReferencesTaskPath = (
   return parentLookupPath === normalizeTaskPathForLookup(filePath);
 };
 
+/**
+ * parent 参照を lookup 用に正規化する。絶対 path / Windows drive prefix は対象外として undefined を返す。
+ * @param parent Task.hierarchy.parentFilePath
+ * @returns 正規化済み path、対象外なら undefined
+ */
 const normalizeParentPathForLookup = (parent: string): string | undefined => {
   if (parent === "" || parent.startsWith("/") || parent.startsWith("\\")) {
     return undefined;
@@ -52,6 +57,12 @@ const normalizeParentPathForLookup = (parent: string): string | undefined => {
   return normalized;
 };
 
+/**
+ * `/` 区切り path を正規化する。空セグメント / `.` を除去し、必要に応じて drive prefix セグメントも落とす。
+ * @param pathText `/` 区切りに揃えた path 文字列
+ * @param removeDrivePrefix `:` で終わるセグメント（drive prefix）も除去するか
+ * @returns 正規化済み path
+ */
 const normalizePathParts = (
   pathText: string,
   removeDrivePrefix: boolean,

--- a/src/features/board/hooks/useProject/actions/openProject.ts
+++ b/src/features/board/hooks/useProject/actions/openProject.ts
@@ -23,7 +23,15 @@ export type OpenProjectActionDeps = {
   projectVersion: ProjectVersion;
   projectCommandQueue: ProjectCommandQueue;
   dialogOpening: DialogOpening;
+  /**
+   * reducer に同期的に action を投げる dispatcher。
+   * @param action 反映する ProjectAction
+   */
   dispatchSync: (action: ProjectAction) => void;
+  /**
+   * 失敗時に呼び出される任意のコールバック。
+   * @param error 通知する ProjectError
+   */
   onError?: (error: ProjectError) => void;
 };
 

--- a/src/features/board/hooks/useProject/actions/tasks.ts
+++ b/src/features/board/hooks/useProject/actions/tasks.ts
@@ -21,7 +21,12 @@ import type { ProjectAction, ProjectState as ProjectStateT } from "../reducer";
 export type TaskActionDeps = {
   projectVersion: ProjectVersion;
   projectCommandQueue: ProjectCommandQueue;
+  /** 最新の project state を返す getter。 */
   getState: () => ProjectStateT;
+  /**
+   * reducer に同期的に action を投げる dispatcher。
+   * @param action 反映する ProjectAction
+   */
   dispatchSync: (action: ProjectAction) => void;
 };
 
@@ -52,7 +57,7 @@ export const createTaskAction = (
   params: CreateTaskParams,
 ): Promise<ResultT<Task, ProjectError>> => {
   const preflight = ensureLoaded<Task>(deps);
-  if (!preflight.ok) return Promise.resolve(preflight);
+  if (!preflight.ok) {return Promise.resolve(preflight);}
 
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {
@@ -87,7 +92,7 @@ export const updateTaskAction = (
   params: UpdateTaskParams,
 ): Promise<ResultT<Task, ProjectError>> => {
   const preflight = ensureLoaded<Task>(deps);
-  if (!preflight.ok) return Promise.resolve(preflight);
+  if (!preflight.ok) {return Promise.resolve(preflight);}
 
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {
@@ -126,7 +131,7 @@ export const deleteTaskAction = (
   params: DeleteTaskParams,
 ): Promise<ResultT<void, ProjectError>> => {
   const preflight = ensureLoaded<void>(deps);
-  if (!preflight.ok) return Promise.resolve(preflight);
+  if (!preflight.ok) {return Promise.resolve(preflight);}
 
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {

--- a/src/features/board/hooks/useProject/actions/tasks.ts
+++ b/src/features/board/hooks/useProject/actions/tasks.ts
@@ -135,7 +135,9 @@ export const deleteTaskAction = (
   params: DeleteTaskParams,
 ): Promise<ResultT<void, ProjectError>> => {
   const preflight = ensureLoaded<void>(deps);
-  if (!preflight.ok) {return Promise.resolve(preflight);}
+  if (!preflight.ok) {
+    return Promise.resolve(preflight);
+  }
 
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {

--- a/src/features/board/hooks/useProject/actions/tasks.ts
+++ b/src/features/board/hooks/useProject/actions/tasks.ts
@@ -57,7 +57,9 @@ export const createTaskAction = (
   params: CreateTaskParams,
 ): Promise<ResultT<Task, ProjectError>> => {
   const preflight = ensureLoaded<Task>(deps);
-  if (!preflight.ok) {return Promise.resolve(preflight);}
+  if (!preflight.ok) {
+    return Promise.resolve(preflight);
+  }
 
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {

--- a/src/features/board/hooks/useProject/actions/tasks.ts
+++ b/src/features/board/hooks/useProject/actions/tasks.ts
@@ -94,7 +94,9 @@ export const updateTaskAction = (
   params: UpdateTaskParams,
 ): Promise<ResultT<Task, ProjectError>> => {
   const preflight = ensureLoaded<Task>(deps);
-  if (!preflight.ok) {return Promise.resolve(preflight);}
+  if (!preflight.ok) {
+    return Promise.resolve(preflight);
+  }
 
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {

--- a/src/features/board/hooks/useProject/actions/updateColumns.ts
+++ b/src/features/board/hooks/useProject/actions/updateColumns.ts
@@ -19,7 +19,12 @@ import { ColumnsCommand, type ColumnsCommandBuilder } from "./columnsCommand";
 export type UpdateColumnsActionDeps = {
   projectVersion: ProjectVersion;
   projectCommandQueue: ProjectCommandQueue;
+  /** 最新の project state を返す getter。 */
   getState: () => ProjectStateT;
+  /**
+   * reducer に同期的に action を投げる dispatcher。
+   * @param action 反映する ProjectAction
+   */
   dispatchSync: (action: ProjectAction) => void;
 };
 

--- a/src/features/board/hooks/useProject/concurrency.ts
+++ b/src/features/board/hooks/useProject/concurrency.ts
@@ -8,7 +8,8 @@ export type ProjectCommandQueue = {
   current: Promise<unknown>;
 };
 
-type AsyncProjectCommand<T> = () => Promise<T>;
+/** project queue 上で実行される非同期 command。 */
+export type AsyncProjectCommand<T> = () => Promise<T>;
 
 /**
  * 現在の project 世代を追跡する mutable token を作成する。

--- a/src/features/board/hooks/useProject/concurrency.ts
+++ b/src/features/board/hooks/useProject/concurrency.ts
@@ -8,6 +8,8 @@ export type ProjectCommandQueue = {
   current: Promise<unknown>;
 };
 
+type AsyncProjectCommand<T> = () => Promise<T>;
+
 /**
  * 現在の project 世代を追跡する mutable token を作成する。
  *
@@ -93,7 +95,7 @@ export const isOpenRequestCurrent = (
  */
 export const enqueueProjectCommand = <T>(
   queue: ProjectCommandQueue,
-  run: () => Promise<T>,
+  run: AsyncProjectCommand<T>,
 ): Promise<T> => {
   const next = queue.current.then(run);
   queue.current = next.catch(() => undefined);

--- a/src/features/board/hooks/useProject/domain/projectData.ts
+++ b/src/features/board/hooks/useProject/domain/projectData.ts
@@ -66,6 +66,12 @@ const syncParentChildren = (
   });
 };
 
+/**
+ * 削除済み path への参照を hierarchy / links から取り除いた `Task` を返す。
+ * @param task 整合させる task
+ * @param filePath 削除済み task の filePath
+ * @returns 参照を取り除いた task（変化がなければ元 task と同一参照）
+ */
 const applyTaskDeletedToTask = (task: Task, filePath: string): Task =>
   TaskLinks.removeLinkedTask(
     TaskHierarchy.detachDeletedTask(task, filePath),

--- a/src/features/board/hooks/useProject/types.ts
+++ b/src/features/board/hooks/useProject/types.ts
@@ -25,18 +25,40 @@ export type UseProjectOptions = {
 
 export type UseProjectResult = {
   state: ProjectState;
+  /** ディレクトリダイアログを開いて project を読み込む。 */
   openProject: () => Promise<void>;
+  /**
+   * task を作成し、成功時に state へ反映する。
+   * @param params 作成パラメータ
+   * @returns 作成結果または ProjectError
+   */
   createTask: (
     params: CreateTaskParams,
   ) => Promise<ResultT<Task, ProjectError>>;
+  /**
+   * task を更新し、成功時に state へ反映する。
+   * @param params 更新パラメータ
+   * @returns 更新結果または ProjectError
+   */
   updateTask: (
     params: UpdateTaskParams,
   ) => Promise<ResultT<Task, ProjectError>>;
+  /**
+   * task を削除し、成功時に state へ反映する。
+   * @param params 削除パラメータ
+   * @returns 成否を表す Result または ProjectError
+   */
   deleteTask: (
     params: DeleteTaskParams,
   ) => Promise<ResultT<void, ProjectError>>;
+  /**
+   * column 構成を更新する command または builder を解決して反映する。
+   * @param command 静的な column 更新命令、または最新 ProjectData から命令を作る builder
+   * @returns invoke したかどうかを含む Result または ProjectError
+   */
   updateColumns: (
     command: UpdateColumnsInput,
   ) => Promise<ResultT<{ applied: boolean }, ProjectError>>;
+  /** project state を初期状態に戻す。 */
   reset: () => void;
 };

--- a/src/lib/tauri/taskCommands/openProject/index.ts
+++ b/src/lib/tauri/taskCommands/openProject/index.ts
@@ -9,6 +9,11 @@ import type {
   OpenProjectRawPayload,
 } from "../types";
 
+/**
+ * Tauri 生 payload を UI 層が扱う `OpenProjectPayload` に変換する。
+ * @param payload Tauri から受け取った生 payload
+ * @returns Task ドメインに正規化済みの payload
+ */
 const toOpenProjectPayload = (
   payload: OpenProjectRawPayload,
 ): OpenProjectPayload => ({


### PR DESCRIPTION
## 概要

PR #182 で網羅的に補完済みの backend doc コメントのうち、`Result<_, _>` を返しながら `# Errors` セクションが欠落していた 8 関数に同セクションを追加。実装ロジック・公開 API・型シグネチャはすべて不変。

## 変更の種類

- 💡 ドキュメント補完（doc コメントのみ、実装ロジック変更なし）

## 変更した内容

### `src-tauri/crates/fs/src/write_ignore.rs`（6 メソッド）

`WriteIgnoreRegistry` の以下 6 メソッドに `# Errors` を追記。すべて内部の Mutex が poison 状態になったときに `WriteIgnoreError::LockPoisoned` を返す。

- `register`
- `should_ignore`
- `consume`
- `unregister`
- `len`
- `is_empty`

### `src-tauri/src/config.rs`（2 関数）

- `validate_unique_column_names`: `Err(name)` で重複カラム名を返す条件を `# Errors` に明記。
- `migrate_config`: `from_version > DEFAULT_VERSION` のとき `MigrationError::UnsupportedFromVersion` を返す条件を `# Errors` に明記。既存の `# 入力前提` / `# 挙動` セクションは保持。

### 副次変更（pre-push hook 起因）

- `[FE]` コミットで `pre-push-jsdoc.sh` が main 由来で検出していた既存 JSDoc 違反 23 件（`src/domains/`・`useProject` hook・openProject invoke ラッパ）に doc コメントを追加。
- `enqueueProjectCommand` の parameter `run: () => Promise<T>` は hook 正規表現の誤検出対策として `AsyncProjectCommand<T>` 型エイリアスに切り出した。

## 仕様ドキュメント更新

不要（純粋なドキュメント追加で公開 API・データ形式・画面挙動・設定項目の変更なし）。

## システム図

```mermaid
flowchart LR
    A["PR #182 完了時点<br/>1 行サマリーのみ"] -->|Result を返す 8 関数を抽出| B[本 PR で # Errors を末尾追記]
    B --> C[write_ignore.rs<br/>6 メソッド ← LockPoisoned]
    B --> D[config.rs<br/>validate_unique_column_names ← Err&#40;String&#41;]
    B --> E[config.rs<br/>migrate_config ← UnsupportedFromVersion]
    C --> F[補強後<br/># Errors 完備 / 既存本文保持]
    D --> F
    E --> F

    style B fill:#fff3b0,stroke:#caa400
    style F fill:#cfead0,stroke:#3a8a3f
```

## 関連Issue

なし（PR #182 の follow-up としての doc 補完。GitHub Issue 化はされていない）

## テスト

### 自動

- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features -- -D warnings`: pass
- `cargo test`: 183 件 pass（既存テストの挙動変化なし）
- `pnpm test:run`: 602 件 pass
- `pnpm build`: 成功

### 手動

新規 doc コメントは [Codex CLI でレビュー](.plugin-workspace/.specs/019-be-doc-comments/code-review/review-002.md) し「問題なし」を確認。レビュー指摘 1 件（`migrate_config` の `# Errors` 内で `[DEFAULT_VERSION]` の intra-doc link が新規 private item link 警告を増やす）を修正済み。

### 既知の制約

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` は **baseline（main）時点で既に失敗**（`DEFAULT_VERSION` / `VersionOnly` / `DEFAULT_COLUMN_NAMES` が private item へのリンク切れ）。本 PR は同種の警告件数を増やしておらず、修正は別 Issue 化が妥当。

## レビューポイント

- 8 関数ぶん `# Errors` の表現が揃っているか（書式: `- 条件 → [`ErrorVariant`]`、日本語）
- `migrate_config` の `# Errors` が既存の `# 入力前提` / `# 挙動` を破壊していないか
- `[FE]` コミットの type alias 切り出し（`AsyncProjectCommand<T>`）が enqueueProjectCommand の挙動に影響していないか

## チェックリスト

- [x] セルフレビュー実施
- [x] cargo test / cargo clippy / cargo fmt --check が通る
- [x] pnpm test:run / pnpm build が通る
- [x] feature 間の依存は index.ts の公開 API 経由のみ
- [x] 破壊的変更なし