### PR TITLE
♻️ project domain logic placementを整理

### DIFF
--- a/src/domains/project-columns/__tests__/index.test.ts
+++ b/src/domains/project-columns/__tests__/index.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "vitest";
+import type { Column } from "@/types/column";
+import { ProjectColumns, type ProjectColumnsChange } from "..";
+
+const columns = (...names: string[]): Column[] =>
+  names.map((name, order) => ({ name, order }));
+
+test("isDoneColumnSensitive は rename があれば true を返す", () => {
+  const change: ProjectColumnsChange = {
+    columns: columns("Todo", "完了"),
+    renames: [{ from: "Done", to: "完了" }],
+  };
+
+  const result = ProjectColumns.isDoneColumnSensitive(
+    columns("Todo", "Done"),
+    change,
+  );
+
+  expect(result).toBe(true);
+});
+
+test("isDoneColumnSensitive は既存 column が削除されるなら true を返す", () => {
+  const change: ProjectColumnsChange = {
+    columns: columns("Todo"),
+  };
+
+  const result = ProjectColumns.isDoneColumnSensitive(
+    columns("Todo", "Done"),
+    change,
+  );
+
+  expect(result).toBe(true);
+});
+
+test("isDoneColumnSensitive は rename も削除もなければ false を返す", () => {
+  const change: ProjectColumnsChange = {
+    columns: columns("Todo", "Done", "Backlog"),
+  };
+
+  const result = ProjectColumns.isDoneColumnSensitive(
+    columns("Todo", "Done"),
+    change,
+  );
+
+  expect(result).toBe(false);
+});
+
+test("validateDoneColumn は doneColumn 削除時に domain error を返す", () => {
+  const result = ProjectColumns.validateDoneColumn("Done", {
+    columns: columns("Todo"),
+  });
+
+  expect(result).toEqual({
+    ok: false,
+    error: {
+      code: "doneColumnRemoved",
+      message: "doneColumn を削除する操作は新しい doneColumn の指定が必要です",
+    },
+  });
+});
+
+test("validateDoneColumn は指定 doneColumn が columns に存在しなければ domain error を返す", () => {
+  const result = ProjectColumns.validateDoneColumn("Done", {
+    columns: columns("Todo"),
+    doneColumn: "Done",
+  });
+
+  expect(result).toEqual({
+    ok: false,
+    error: {
+      code: "doneColumnNotInColumns",
+      message: 'doneColumn "Done" は columns に存在しません',
+    },
+  });
+});
+
+test("validateDoneColumn は doneColumn が columns に存在すれば ok を返す", () => {
+  const result = ProjectColumns.validateDoneColumn("Done", {
+    columns: columns("Todo", "Done"),
+  });
+
+  expect(result.ok).toBe(true);
+});

--- a/src/domains/project-columns/index.ts
+++ b/src/domains/project-columns/index.ts
@@ -1,12 +1,20 @@
-import type { ColumnRename } from "@/lib/tauri";
 import type { Column } from "@/types/column";
 import { Result, type Result as ResultT } from "@/utils/result";
-import { ProjectError } from "../errors";
+
+export type ProjectColumnRename = {
+  from: string;
+  to: string;
+};
 
 export type ProjectColumnsChange = {
   columns: Column[];
-  renames?: ColumnRename[];
+  renames?: ProjectColumnRename[];
   doneColumn?: string;
+};
+
+export type ProjectColumnsValidationError = {
+  code: "doneColumnRemoved" | "doneColumnNotInColumns";
+  message: string;
 };
 
 /**
@@ -44,33 +52,32 @@ export const ProjectColumns = {
    *
    * @param knownDoneColumn 現在判明している doneColumn
    * @param change 適用予定の column 変更
-   * @returns 不変条件を満たすなら ok、壊す可能性があれば invalid-state
+   * @returns 不変条件を満たすなら ok、壊す可能性があれば domain error
    */
   validateDoneColumn: (
     knownDoneColumn: string | undefined,
     change: ProjectColumnsChange,
-  ): ResultT<void, ProjectError> => {
+  ): ResultT<void, ProjectColumnsValidationError> => {
     if (
       knownDoneColumn !== undefined &&
       !change.columns.some((column) => column.name === knownDoneColumn) &&
       change.doneColumn === undefined
     ) {
-      return Result.err(
-        ProjectError.invalidState(
+      return Result.err({
+        code: "doneColumnRemoved",
+        message:
           "doneColumn を削除する操作は新しい doneColumn の指定が必要です",
-        ),
-      );
+      });
     }
 
     if (
       change.doneColumn !== undefined &&
       !change.columns.some((column) => column.name === change.doneColumn)
     ) {
-      return Result.err(
-        ProjectError.invalidState(
-          `doneColumn "${change.doneColumn}" は columns に存在しません`,
-        ),
-      );
+      return Result.err({
+        code: "doneColumnNotInColumns",
+        message: `doneColumn "${change.doneColumn}" は columns に存在しません`,
+      });
     }
 
     return Result.ok(undefined);

--- a/src/domains/project-data/__tests__/index.test.ts
+++ b/src/domains/project-data/__tests__/index.test.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "vitest";
+import { makeTask } from "@/domains/__tests__/taskFixtures";
+import type { Column } from "@/types/column";
+import { ProjectData, type ProjectData as ProjectDataT } from "..";
+
+const columns = (...names: string[]): Column[] =>
+  names.map((name, order) => ({ name, order }));
+
+test("applyTaskCreated は task を追加し parent task の children を同期する", () => {
+  const parent = makeTask({
+    id: "p",
+    filePath: "tasks/p.md",
+    children: [],
+  });
+  const child = makeTask({
+    id: "c",
+    filePath: "tasks/c.md",
+    parent: ".\\tasks\\p.md",
+  });
+  const data: ProjectDataT = {
+    tasks: [parent],
+    columns: columns("Todo"),
+  };
+
+  const next = ProjectData.applyTaskCreated(data, child);
+
+  expect(next.tasks).toHaveLength(2);
+  expect(
+    next.tasks.find((task) => task.filePath === "tasks/p.md")?.hierarchy
+      .childFilePaths,
+  ).toEqual(["tasks/c.md"]);
+});
+
+test("applyTaskCreated は parent children を二重追加しない", () => {
+  const parent = makeTask({
+    id: "p",
+    filePath: "tasks/p.md",
+    children: ["tasks/c.md"],
+  });
+  const child = makeTask({
+    id: "c",
+    filePath: "tasks/c.md",
+    parent: "tasks/p.md",
+  });
+  const data: ProjectDataT = {
+    tasks: [parent],
+    columns: columns("Todo"),
+  };
+
+  const next = ProjectData.applyTaskCreated(data, child);
+
+  expect(
+    next.tasks.find((task) => task.filePath === "tasks/p.md")?.hierarchy
+      .childFilePaths,
+  ).toEqual(["tasks/c.md"]);
+});
+
+test("applyTaskUpdated は originalFilePath に一致する task を差し替える", () => {
+  const current = makeTask({ id: "a", filePath: "tasks/a.md" });
+  const updated = makeTask({
+    id: "a",
+    filePath: "tasks/a-renamed.md",
+    title: "renamed",
+  });
+  const data: ProjectDataT = {
+    tasks: [current],
+    columns: columns("Todo"),
+  };
+
+  const next = ProjectData.applyTaskUpdated(data, "tasks/a.md", updated);
+
+  expect(next.tasks).toEqual([updated]);
+});
+
+test("applyTaskDeleted は task を削除し hierarchy と links から参照を掃除する", () => {
+  const parent = makeTask({
+    id: "p",
+    filePath: "tasks/p.md",
+    children: ["tasks/c.md"],
+    links: ["tasks/c.md"],
+  });
+  const child = makeTask({
+    id: "c",
+    filePath: "tasks/c.md",
+    parent: "tasks/p.md",
+    reverseLinks: ["tasks/p.md"],
+  });
+  const data: ProjectDataT = {
+    tasks: [parent, child],
+    columns: columns("Todo"),
+  };
+
+  const next = ProjectData.applyTaskDeleted(data, "tasks/c.md");
+
+  expect(next.tasks).toHaveLength(1);
+  expect(next.tasks[0].filePath).toBe("tasks/p.md");
+  expect(next.tasks[0].hierarchy.childFilePaths).toEqual([]);
+  expect(next.tasks[0].links.linkedFilePaths).toEqual([]);
+});
+
+test("replaceColumns は status と doneColumn を rename に追従させる", () => {
+  const task = makeTask({
+    id: "a",
+    filePath: "tasks/a.md",
+    status: "Done",
+  });
+  const data: ProjectDataT = {
+    tasks: [task],
+    columns: columns("Todo", "Done"),
+    doneColumn: "Done",
+  };
+
+  const next = ProjectData.replaceColumns(data, {
+    columns: columns("Todo", "完了"),
+    renames: [{ from: "Done", to: "完了" }],
+  });
+
+  expect(next.tasks[0].status).toBe("完了");
+  expect(next.doneColumn).toBe("完了");
+});
+
+test("replaceColumns は指定された doneColumn を rename 追従より優先する", () => {
+  const data: ProjectDataT = {
+    tasks: [],
+    columns: columns("Todo", "Done"),
+    doneColumn: "Done",
+  };
+
+  const next = ProjectData.replaceColumns(data, {
+    columns: columns("Todo"),
+    doneColumn: "Todo",
+  });
+
+  expect(next.doneColumn).toBe("Todo");
+});

--- a/src/domains/project-data/index.ts
+++ b/src/domains/project-data/index.ts
@@ -1,9 +1,9 @@
+import type { ProjectColumnsChange } from "@/domains/project-columns";
 import { TaskHierarchy } from "@/domains/task-hierarchy";
 import { TaskLinks } from "@/domains/task-links";
 import { parentReferencesTaskPath } from "@/domains/task-path";
 import type { Column } from "@/types/column";
 import type { Task } from "@/types/task";
-import type { ProjectColumnsChange } from "./projectColumns";
 
 export type ProjectData = {
   tasks: Task[];

--- a/src/features/board/hooks/useProject/actions/columnsCommand.ts
+++ b/src/features/board/hooks/useProject/actions/columnsCommand.ts
@@ -1,12 +1,13 @@
-import { type ColumnRename, TauriError } from "@/lib/tauri";
+import type { ProjectColumnRename } from "@/domains/project-columns";
+import type { ProjectData } from "@/domains/project-data";
+import { TauriError } from "@/lib/tauri";
 import type { Column } from "@/types/column";
 import { Result, type Result as ResultT } from "@/utils/result";
-import type { ProjectData } from "../domain/projectData";
 import { ProjectError } from "../errors";
 
 export type ColumnsCommand = {
   columns: Column[];
-  renames?: ColumnRename[];
+  renames?: ProjectColumnRename[];
   doneColumn?: string;
 };
 

--- a/src/features/board/hooks/useProject/actions/tasks.ts
+++ b/src/features/board/hooks/useProject/actions/tasks.ts
@@ -15,8 +15,8 @@ import {
   type ProjectVersion,
 } from "../concurrency";
 import { ProjectError } from "../errors";
-import { ProjectState } from "../domain/projectState";
 import type { ProjectAction, ProjectState as ProjectStateT } from "../reducer";
+import { ProjectSessionState } from "../state/projectSessionState";
 
 export type TaskActionDeps = {
   projectVersion: ProjectVersion;
@@ -39,7 +39,7 @@ export type TaskActionDeps = {
 const ensureLoaded = <T>({
   getState,
 }: Pick<TaskActionDeps, "getState">): ResultT<T, ProjectError> => {
-  if (!ProjectState.canAcceptDataCommand(getState())) {
+  if (!ProjectSessionState.canAcceptDataCommand(getState())) {
     return Result.err(ProjectError.invalidState());
   }
   return Result.ok(undefined as T);
@@ -64,7 +64,7 @@ export const createTaskAction = (
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {
     if (
-      !ProjectState.canAcceptDataCommand(deps.getState()) ||
+      !ProjectSessionState.canAcceptDataCommand(deps.getState()) ||
       !isProjectCurrent(deps.projectVersion, version)
     ) {
       return Result.err(ProjectError.invalidState("プロジェクトが切り替わりました"));
@@ -101,7 +101,7 @@ export const updateTaskAction = (
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {
     if (
-      !ProjectState.canAcceptDataCommand(deps.getState()) ||
+      !ProjectSessionState.canAcceptDataCommand(deps.getState()) ||
       !isProjectCurrent(deps.projectVersion, version)
     ) {
       return Result.err(ProjectError.invalidState("プロジェクトが切り替わりました"));
@@ -142,7 +142,7 @@ export const deleteTaskAction = (
   const version = deps.projectVersion.current;
   return enqueueProjectCommand(deps.projectCommandQueue, async () => {
     if (
-      !ProjectState.canAcceptDataCommand(deps.getState()) ||
+      !ProjectSessionState.canAcceptDataCommand(deps.getState()) ||
       !isProjectCurrent(deps.projectVersion, version)
     ) {
       return Result.err(ProjectError.invalidState("プロジェクトが切り替わりました"));

--- a/src/features/board/hooks/useProject/actions/updateColumns.ts
+++ b/src/features/board/hooks/useProject/actions/updateColumns.ts
@@ -1,4 +1,9 @@
 import {
+  ProjectColumns,
+  type ProjectColumnsValidationError,
+} from "@/domains/project-columns";
+import type { ProjectData } from "@/domains/project-data";
+import {
   getColumns as getColumnsInvoke,
   updateColumns as updateColumnsInvoke,
 } from "@/lib/tauri";
@@ -9,11 +14,9 @@ import {
   type ProjectCommandQueue,
   type ProjectVersion,
 } from "../concurrency";
-import { ProjectColumns } from "../domain/projectColumns";
-import type { ProjectData } from "../domain/projectData";
-import { ProjectState } from "../domain/projectState";
 import { ProjectError } from "../errors";
 import type { ProjectAction, ProjectState as ProjectStateT } from "../reducer";
+import { ProjectSessionState } from "../state/projectSessionState";
 import { ColumnsCommand, type ColumnsCommandBuilder } from "./columnsCommand";
 
 export type UpdateColumnsActionDeps = {
@@ -37,6 +40,15 @@ const switchedProject = (): ResultT<{ applied: boolean }, ProjectError> =>
   Result.err(ProjectError.invalidState("プロジェクトが切り替わりました"));
 
 /**
+ * ProjectColumns の domain validation error を useProject の error 型に変換する。
+ *
+ * @param error column domain validation error
+ * @returns useProject が呼び出し側に返す invalid-state error
+ */
+const toProjectError = (error: ProjectColumnsValidationError): ProjectError =>
+  ProjectError.invalidState(error.message);
+
+/**
  * column 更新 command を解決・検証し、Tauri update_columns と state 反映を直列実行する。
  *
  * @param deps column 更新に必要な queue / version / state / dispatch 依存
@@ -47,7 +59,7 @@ export const updateColumnsAction = (
   deps: UpdateColumnsActionDeps,
   command: ColumnsCommand | ColumnsCommandBuilder,
 ): Promise<ResultT<{ applied: boolean }, ProjectError>> => {
-  if (!ProjectState.canAcceptDataCommand(deps.getState())) {
+  if (!ProjectSessionState.canAcceptDataCommand(deps.getState())) {
     return Promise.resolve(Result.err(ProjectError.invalidState()));
   }
 
@@ -57,7 +69,7 @@ export const updateColumnsAction = (
       return switchedProject();
     }
 
-    const visibleData = ProjectState.visibleData(deps.getState());
+    const visibleData = ProjectSessionState.visibleData(deps.getState());
     if (visibleData === null) {
       return Result.err(ProjectError.invalidState());
     }
@@ -106,7 +118,7 @@ export const updateColumnsAction = (
       commandToApply = resolved.value;
     }
 
-    const knownDoneColumn = ProjectState.visibleData(
+    const knownDoneColumn = ProjectSessionState.visibleData(
       deps.getState(),
     )?.doneColumn;
     const validation = ProjectColumns.validateDoneColumn(
@@ -114,7 +126,7 @@ export const updateColumnsAction = (
       commandToApply,
     );
     if (!validation.ok) {
-      return Result.err(validation.error);
+      return Result.err(toProjectError(validation.error));
     }
 
     if (!isProjectCurrent(deps.projectVersion, version)) {

--- a/src/features/board/hooks/useProject/reducer.ts
+++ b/src/features/board/hooks/useProject/reducer.ts
@@ -1,17 +1,18 @@
-import type { ColumnRename, TauriError } from "@/lib/tauri";
-import type { Column } from "@/types/column";
-import type { Task } from "@/types/task";
+import type { ProjectColumnRename } from "@/domains/project-columns";
 import {
   ProjectData as ProjectDataDomain,
   type ProjectData as ProjectDataT,
-} from "./domain/projectData";
+} from "@/domains/project-data";
+import type { TauriError } from "@/lib/tauri";
+import type { Column } from "@/types/column";
+import type { Task } from "@/types/task";
 import {
-  ProjectState as ProjectStateDomain,
-  type ProjectState as ProjectStateT,
-} from "./domain/projectState";
+  ProjectSessionState,
+  type ProjectSessionState as ProjectSessionStateT,
+} from "./state/projectSessionState";
 
 export type ProjectData = ProjectDataT;
-export type ProjectState = ProjectStateT;
+export type ProjectState = ProjectSessionStateT;
 
 export type ProjectAction =
   | { type: "open-start"; path: string }
@@ -23,16 +24,16 @@ export type ProjectAction =
   | {
       type: "columns-replaced";
       columns: Column[];
-      renames?: ColumnRename[];
+      renames?: ProjectColumnRename[];
       doneColumn?: string;
     }
   | { type: "done-column-refreshed"; doneColumn: string }
   | { type: "reset" };
 
-export const initialState: ProjectState = ProjectStateDomain.initial;
+export const initialState: ProjectState = ProjectSessionState.initial;
 
 /**
- * useProject の state transition を domain companion object に委譲して適用する。
+ * useProject の state transition を session state と domain API に委譲して適用する。
  *
  * @param state 現在の ProjectState
  * @param action 適用する ProjectAction
@@ -44,17 +45,17 @@ export const reducer = (
 ): ProjectState => {
   switch (action.type) {
     case "open-start":
-      return ProjectStateDomain.openStart(state, action.path);
+      return ProjectSessionState.openStart(state, action.path);
     case "open-succeed":
-      return ProjectStateDomain.openSucceed(action.path, action.data);
+      return ProjectSessionState.openSucceed(action.path, action.data);
     case "open-fail":
-      return ProjectStateDomain.openFail(state, action.path, action.error);
+      return ProjectSessionState.openFail(state, action.path, action.error);
     case "task-created":
-      return ProjectStateDomain.updateData(state, (data) =>
+      return ProjectSessionState.updateData(state, (data) =>
         ProjectDataDomain.applyTaskCreated(data, action.task),
       );
     case "task-updated":
-      return ProjectStateDomain.updateData(state, (data) =>
+      return ProjectSessionState.updateData(state, (data) =>
         ProjectDataDomain.applyTaskUpdated(
           data,
           action.originalFilePath,
@@ -62,11 +63,11 @@ export const reducer = (
         ),
       );
     case "task-deleted":
-      return ProjectStateDomain.updateData(state, (data) =>
+      return ProjectSessionState.updateData(state, (data) =>
         ProjectDataDomain.applyTaskDeleted(data, action.filePath),
       );
     case "columns-replaced":
-      return ProjectStateDomain.updateData(state, (data) =>
+      return ProjectSessionState.updateData(state, (data) =>
         ProjectDataDomain.replaceColumns(data, {
           columns: action.columns,
           renames: action.renames,
@@ -74,11 +75,11 @@ export const reducer = (
         }),
       );
     case "done-column-refreshed":
-      return ProjectStateDomain.updateData(state, (data) =>
+      return ProjectSessionState.updateData(state, (data) =>
         ProjectDataDomain.refreshDoneColumn(data, action.doneColumn),
       );
     case "reset":
-      return ProjectStateDomain.reset();
+      return ProjectSessionState.reset();
     default: {
       action satisfies never;
       return state;

--- a/src/features/board/hooks/useProject/state/projectSessionState.ts
+++ b/src/features/board/hooks/useProject/state/projectSessionState.ts
@@ -1,7 +1,7 @@
+import type { ProjectData } from "@/domains/project-data";
 import type { TauriError } from "@/lib/tauri";
-import type { ProjectData } from "./projectData";
 
-export type ProjectState =
+export type ProjectSessionState =
   | { kind: "idle" }
   | {
       kind: "loading";
@@ -13,26 +13,26 @@ export type ProjectState =
 
 type ProjectDataMapper = (data: ProjectData) => ProjectData;
 
-export const ProjectState = {
-  initial: { kind: "idle" } satisfies ProjectState,
+export const ProjectSessionState = {
+  initial: { kind: "idle" } satisfies ProjectSessionState,
 
   /**
    * task / column command を受け付けられる state か判定する。
    *
-   * @param state 現在の ProjectState
+   * @param state 現在の ProjectSessionState
    * @returns loaded または loading.previousLoaded なら true
    */
-  canAcceptDataCommand: (state: ProjectState): boolean =>
+  canAcceptDataCommand: (state: ProjectSessionState): boolean =>
     state.kind === "loaded" ||
     (state.kind === "loading" && state.previousLoaded !== undefined),
 
   /**
    * UI と command builder が参照できる ProjectData を取り出す。
    *
-   * @param state 現在の ProjectState
+   * @param state 現在の ProjectSessionState
    * @returns loaded の data、loading.previousLoaded の data、それ以外なら null
    */
-  visibleData: (state: ProjectState): ProjectData | null => {
+  visibleData: (state: ProjectSessionState): ProjectData | null => {
     if (state.kind === "loaded") {
       return state.data;
     }
@@ -45,11 +45,14 @@ export const ProjectState = {
   /**
    * project open 開始時の loading state を作る。
    *
-   * @param _state 現在の ProjectState
+   * @param state 現在の ProjectSessionState
    * @param path open 対象 path
    * @returns previousLoaded を退避した loading state
    */
-  openStart: (state: ProjectState, path: string): ProjectState => {
+  openStart: (
+    state: ProjectSessionState,
+    path: string,
+  ): ProjectSessionState => {
     const previousLoaded =
       state.kind === "loaded"
         ? { path: state.path, data: state.data }
@@ -66,7 +69,7 @@ export const ProjectState = {
    * @param data 読み込んだ ProjectData
    * @returns loaded state
    */
-  openSucceed: (path: string, data: ProjectData): ProjectState => ({
+  openSucceed: (path: string, data: ProjectData): ProjectSessionState => ({
     kind: "loaded",
     path,
     data,
@@ -75,16 +78,16 @@ export const ProjectState = {
   /**
    * project open 失敗時の state を作る。
    *
-   * @param state 現在の ProjectState
+   * @param state 現在の ProjectSessionState
    * @param path open に失敗した project path
    * @param error Tauri command 由来の error
    * @returns previousLoaded があれば loaded に復元し、なければ error state
    */
   openFail: (
-    state: ProjectState,
+    state: ProjectSessionState,
     path: string,
     error: TauriError,
-  ): ProjectState => {
+  ): ProjectSessionState => {
     if (state.kind === "loading" && state.previousLoaded !== undefined) {
       return {
         kind: "loaded",
@@ -98,14 +101,14 @@ export const ProjectState = {
   /**
    * loaded state の ProjectData だけを更新する。
    *
-   * @param state 現在の ProjectState
+   * @param state 現在の ProjectSessionState
    * @param update ProjectData の変換関数
    * @returns loaded / loading.previousLoaded なら data 更新後 state、それ以外は元 state
    */
   updateData: (
-    state: ProjectState,
+    state: ProjectSessionState,
     update: ProjectDataMapper,
-  ): ProjectState => {
+  ): ProjectSessionState => {
     if (state.kind === "loaded") {
       return { ...state, data: update(state.data) };
     }
@@ -126,5 +129,5 @@ export const ProjectState = {
    *
    * @returns idle state
    */
-  reset: (): ProjectState => ProjectState.initial,
+  reset: (): ProjectSessionState => ProjectSessionState.initial,
 } as const;

--- a/src/features/board/hooks/useProject/types.ts
+++ b/src/features/board/hooks/useProject/types.ts
@@ -9,8 +9,8 @@ import type {
   ColumnsCommand,
   ColumnsCommandBuilder,
 } from "./actions/columnsCommand";
-import type { ProjectState } from "./domain/projectState";
 import type { ProjectError } from "./errors";
+import type { ProjectSessionState } from "./state/projectSessionState";
 
 export type {
   ColumnsCommand,
@@ -24,7 +24,7 @@ export type UseProjectOptions = {
 };
 
 export type UseProjectResult = {
-  state: ProjectState;
+  state: ProjectSessionState;
   /** ディレクトリダイアログを開いて project を読み込む。 */
   openProject: () => Promise<void>;
   /**


### PR DESCRIPTION
## 概要

`useProject/domain` に混在していた domain logic と project session state を責務別に再配置しました。`ProjectData` / `ProjectColumns` は `src/domains` 配下へ移し、`ProjectState` は `ProjectSessionState` として `useProject/state` 配下へ分離しています。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [x] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [ ] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `src/domains/project-data/` に `ProjectData` の集約データ変換を移動
- `src/domains/project-columns/` に `ProjectColumns` の column / doneColumn domain rule を移動
- `ProjectColumns.validateDoneColumn` が `ProjectError` へ直接依存しないよう domain error を返す形に変更
- `src/features/board/hooks/useProject/state/projectSessionState.ts` に project session state machine を分離
- `ProjectData` / `ProjectColumns` の移動先に単体テストを追加

#### 変更されたファイル

- `src/features/board/hooks/useProject/reducer.ts`
- `src/features/board/hooks/useProject/actions/updateColumns.ts`
- `src/features/board/hooks/useProject/actions/tasks.ts`
- `src/features/board/hooks/useProject/actions/columnsCommand.ts`
- `src/features/board/hooks/useProject/types.ts`

#### 削除されたファイル・機能

- `src/features/board/hooks/useProject/domain/` 配下の旧配置を削除

## 📊 システム図

### データフロー

```mermaid
flowchart TD
    Action[useProject actions] --> Session[ProjectSessionState<br/>useProject/state]
    Action --> Columns[ProjectColumns<br/>src/domains/project-columns]
    Action --> Reducer[reducer]
    Reducer --> Data[ProjectData<br/>src/domains/project-data]
    Data --> TaskDomains[TaskHierarchy / TaskLinks / TaskPath]
    Session --> UI[React UI state]
    Data --> UI

    classDef moved fill:#e0f2fe,stroke:#0284c7,stroke-width:2px
    class Data,Columns,Session moved
```

## 📋 関連 Issue

- なし

## 🧪 テスト

### テスト実行方法

```bash
./node_modules/.bin/tsc -b
./node_modules/.bin/biome check src
./node_modules/.bin/vitest run src/domains/project-columns/__tests__/index.test.ts src/domains/project-data/__tests__/index.test.ts src/features/board/hooks/useProject/__tests__/useProject.behavior.test.ts
./node_modules/.bin/oxlint
git diff --check
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `./node_modules/.bin/tsc -b`: PASS
- `./node_modules/.bin/biome check src`: PASS
- `./node_modules/.bin/vitest run src/domains/project-columns/__tests__/index.test.ts src/domains/project-data/__tests__/index.test.ts src/features/board/hooks/useProject/__tests__/useProject.behavior.test.ts`: PASS（3 files / 40 tests）
- `./node_modules/.bin/oxlint`: PASS
- `git diff --check`: PASS

## 📸 スクリーンショット/動画

UI変更なし。

## 🔍 レビューポイント

- `ProjectData` / `ProjectColumns` を domain として扱う境界が自然か
- `ProjectSessionState` の命名と `useProject/state` 配置が読みやすいか
- `ProjectColumnsValidationError` から `ProjectError.invalidState` への変換位置が action 層として妥当か

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## 📚 追加情報

### 注意事項

- 公開型 `ProjectState` は互換のため `reducer.ts` から維持しています。
- docs/spec-board の公開仕様は変更していないため、仕様ドキュメント更新は不要です。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [ ] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている