### PR TITLE
✨ [New Feature]: #78 [BE] get_tasks Tauri command を実装

### DIFF
--- a/src-tauri/src/get_tasks.rs
+++ b/src-tauri/src/get_tasks.rs
@@ -1,0 +1,193 @@
+//! `get_tasks` Tauri command 本体。
+//!
+//! `AppState.tasks_cache` に格納済みの `Task` 一覧を `id` 昇順でクローンして返す
+//! 純粋な読み取り専用 command。`open_project` で commit された state を消費する
+//! 後続 API としての位置付け。
+//!
+//! # 構成
+//!
+//! - `GetTasksError`: FE へ返すエラー（`StateLockPoisoned` のみ）
+//! - `get_tasks`: `#[tauri::command]` シン
+//! - `get_tasks_impl`: 単体テストの境界となる本体関数
+//!
+//! # エラー文字列の契約
+//!
+//! `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"` で、
+//! `OpenProjectError::StateLockPoisoned` と完全一致させる。FE 側
+//! `TauriError.PATTERNS` 未対応のため `UNKNOWN` 分類になる。
+
+use tauri::State;
+use thiserror::Error;
+
+use crate::state::{AppState, AppStateError};
+use crate::task_index::Task;
+
+/// `get_tasks` コマンドのエラー。
+///
+/// `tasks_cache` の lock 取得時に poison が確定している場合のみ返る。
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GetTasksError {
+    /// `AppState` 内部 mutex (`tasks_cache`) が poison 状態。
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+}
+
+impl From<AppStateError> for GetTasksError {
+    fn from(_: AppStateError) -> Self {
+        GetTasksError::StateLockPoisoned
+    }
+}
+
+/// Tauri command 薄層。`get_tasks_impl` を呼び、エラーを文字列化して返す。
+///
+/// 戻り値の `Result<_, String>` の Err 文字列は `GetTasksError` の Display 文字列。
+///
+/// # Errors
+///
+/// `tasks_cache` の `Mutex` が poison している場合に
+/// `"内部状態のロックが破損しました"` を返す。
+#[tauri::command]
+pub fn get_tasks(state: State<'_, AppState>) -> Result<Vec<Task>, String> {
+    get_tasks_impl(state.inner()).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の本体関数。
+///
+/// `AppState::tasks_snapshot` で `Vec<Task>` を取得し、`id` 昇順 sort して返す。
+/// `tasks_cache` が空の場合は空 Vec をそのまま返す（未 open ケースを成功扱い）。
+///
+/// # Errors
+///
+/// `tasks_cache` の `Mutex` が poison している場合に
+/// `GetTasksError::StateLockPoisoned` を返す。
+pub(crate) fn get_tasks_impl(state: &AppState) -> Result<Vec<Task>, GetTasksError> {
+    let mut tasks = state.tasks_snapshot()?;
+    tasks.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(tasks)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::open_project::open_project_impl;
+
+    fn tempdir() -> TempDir {
+        tempfile::tempdir().expect("create temp dir")
+    }
+
+    fn write_md(root: &Path, rel: &str, body: &str) {
+        let absolute = root.join(rel);
+        if let Some(parent) = absolute.parent() {
+            fs::create_dir_all(parent).expect("create parent dir");
+        }
+        fs::write(&absolute, body).expect("write md");
+    }
+
+    fn task_md(title: &str, status: &str, parent: Option<&str>) -> String {
+        task_md_with_links(title, status, parent, &[])
+    }
+
+    fn task_md_with_links(
+        title: &str,
+        status: &str,
+        parent: Option<&str>,
+        links: &[&str],
+    ) -> String {
+        let mut s = String::from("---\n");
+        s.push_str(&format!("title: {title}\n"));
+        s.push_str(&format!("status: {status}\n"));
+        if let Some(p) = parent {
+            s.push_str(&format!("parent: {p}\n"));
+        }
+        if !links.is_empty() {
+            let joined = links
+                .iter()
+                .map(|l| format!("\"{l}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            s.push_str(&format!("links: [{joined}]\n"));
+        }
+        s.push_str("---\n\nbody\n");
+        s
+    }
+
+    #[test]
+    fn from_app_state_error_maps_to_state_lock_poisoned() {
+        let converted: GetTasksError = AppStateError::LockPoisoned.into();
+        assert_eq!(GetTasksError::StateLockPoisoned, converted);
+    }
+
+    #[test]
+    fn state_lock_poisoned_display_matches_open_project_contract() {
+        assert_eq!(
+            "内部状態のロックが破損しました",
+            GetTasksError::StateLockPoisoned.to_string()
+        );
+    }
+
+    #[test]
+    fn returns_empty_vec_when_app_state_is_uninitialized() {
+        let state = AppState::new();
+
+        let tasks = get_tasks_impl(&state).expect("should succeed even before open_project");
+
+        assert!(tasks.is_empty());
+    }
+
+    #[test]
+    fn returns_tasks_sorted_by_id_after_open_project() {
+        let state = AppState::new();
+        let dir = tempdir();
+        write_md(dir.path(), "tasks/b.md", &task_md("B", "Todo", None));
+        write_md(
+            dir.path(),
+            "tasks/a.md",
+            &task_md("A", "Todo", Some("tasks/b.md")),
+        );
+        let raw = dir.path().to_str().expect("utf-8").to_string();
+        open_project_impl(&state, &raw).expect("open should succeed");
+
+        let tasks = get_tasks_impl(&state).expect("get_tasks should succeed");
+
+        let ids: Vec<&str> = tasks.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(vec!["tasks/a.md", "tasks/b.md"], ids);
+    }
+
+    #[test]
+    fn preserves_children_and_reverse_links_built_by_open_project() {
+        let state = AppState::new();
+        let dir = tempdir();
+        write_md(dir.path(), "tasks/b.md", &task_md("B", "Todo", None));
+        write_md(
+            dir.path(),
+            "tasks/a.md",
+            &task_md_with_links("A", "Todo", Some("tasks/b.md"), &["tasks/b.md"]),
+        );
+        let raw = dir.path().to_str().expect("utf-8").to_string();
+        open_project_impl(&state, &raw).expect("open should succeed");
+
+        let tasks = get_tasks_impl(&state).expect("get_tasks should succeed");
+
+        let task_a = tasks
+            .iter()
+            .find(|t| t.id == "tasks/a.md")
+            .expect("task a exists");
+        let task_b = tasks
+            .iter()
+            .find(|t| t.id == "tasks/b.md")
+            .expect("task b exists");
+
+        assert_eq!(vec!["tasks/a.md".to_string()], task_b.children);
+        assert!(task_a.children.is_empty());
+
+        assert_eq!(vec!["tasks/a.md".to_string()], task_b.reverse_links);
+        assert!(task_a.reverse_links.is_empty());
+
+        assert_eq!(vec!["tasks/b.md".to_string()], task_a.links);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod frontmatter;
+pub mod get_tasks;
 pub mod open_project;
 pub mod state;
 pub mod task_index;
@@ -27,7 +28,11 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState::new())
-        .invoke_handler(tauri::generate_handler![greet, open_project::open_project])
+        .invoke_handler(tauri::generate_handler![
+            greet,
+            open_project::open_project,
+            get_tasks::get_tasks
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
## 概要

`open_project` で構築済みの `AppState.tasks_cache` を読み取り専用で返す `get_tasks` Tauri command を新規追加。FE 側 `invokeWrapped<TaskPayload[]>(\"get_tasks\")` は既に存在するため、BE 側 command 登録のみで疎通成立。

## 変更の種類

- ✨ 新機能（読み取り専用 Tauri command）

## 追加した内容

- `src-tauri/src/get_tasks.rs`（新規）
  - `GetTasksError::StateLockPoisoned` enum + `From<AppStateError>` 変換
  - `get_tasks_impl(&AppState) -> Result<Vec<Task>, GetTasksError>`: `tasks_snapshot()` を取得し `id` 昇順で sort
  - `#[tauri::command] get_tasks(state: State<AppState>) -> Result<Vec<Task>, String>`: 薄層で Display 文字列化
  - 単体テスト 5 本（`From` 変換 / Display 文字列 / 未 open 空 / id 昇順 / `children` + `reverse_links` 構造保持）

## 変更した内容

- `src-tauri/src/lib.rs`
  - `pub mod get_tasks;` を追加
  - `tauri::generate_handler!` に `get_tasks::get_tasks` を登録（`[greet, open_project::open_project, get_tasks::get_tasks]`）

## 削除した内容

なし。

## 仕様ドキュメント更新

不要（純粋に Tauri command 1 本の追加。既存の公開 API・データ形式・画面挙動・設定項目に変更なし）。

## システム図

```mermaid
flowchart TD
    FE["FE: invoke('get_tasks')"]
    CMD["#[tauri::command]<br/>get_tasks(state)"]
    IMPL["get_tasks_impl(&amp;AppState)"]
    SNAP["AppState::tasks_snapshot()"]
    SORT["sort_by(id ASC)"]
    OK["Ok(Vec&lt;Task&gt;)"]
    ERR["Err(GetTasksError::StateLockPoisoned)<br/>→ '内部状態のロックが破損しました'"]

    FE -->|IPC| CMD
    CMD --> IMPL
    IMPL --> SNAP
    SNAP -->|Ok| SORT
    SORT --> OK
    SNAP -->|Err AppStateError::LockPoisoned<br/>From 変換| ERR
    OK -->|TaskPayload[]| FE
    ERR -->|String| FE

    style CMD fill:#e6ffe6,stroke:#3a3
    style IMPL fill:#e6ffe6,stroke:#3a3
    style ERR fill:#ffe6e6,stroke:#a33
```

- 緑: 本 PR で新規追加
- 赤: poison 経路（FE では `TauriError(UNKNOWN)` 分類）

## 関連Issue

Closes #78

## テスト

- `cargo fmt --all -- --check`: 通過
- `cargo clippy --workspace --all-targets -- -D warnings`: 通過
- `cargo test --workspace`: 245 (`spec_board`) + 92 (`spec_board_fs`) + Doc-tests 全通過。新規 5 テスト含む
  - `from_app_state_error_maps_to_state_lock_poisoned`
  - `state_lock_poisoned_display_matches_open_project_contract`
  - `returns_empty_vec_when_app_state_is_uninitialized`
  - `returns_tasks_sorted_by_id_after_open_project`
  - `preserves_children_and_reverse_links_built_by_open_project`
- `pnpm test:run -- src/lib/tauri/taskCommands/getTasks`: 78 ファイル / 626 テスト通過（FE 側既存テストへのリグレッション無し）
- 手動検証（Tauri 実機）: 未実施。PR 取り込み前に DevTools から `await window.__TAURI__.core.invoke('get_tasks')` を実行し、未 open で `[]` / open 後に Task 配列（camelCase）が返ることを確認推奨。

## レビューポイント

- **エラー文字列契約**: `GetTasksError::StateLockPoisoned` の Display を `OpenProjectError::StateLockPoisoned` と完全一致 (`"内部状態のロックが破損しました"`) させている。FE 側 `TauriError.PATTERNS` 未対応のため `UNKNOWN` 分類になる前提（Issue 範囲外）。
- **未 open 時の挙動**: `tasks_cache` が空 HashMap の場合は `Ok(vec![])` を返してエラーにしない（hearing-notes 確定事項）。
- **lock pre-flight しない設計**: `get_tasks_impl` は read-only accessor のため `tasks_snapshot()` のみを呼ぶ。`watcher_handle` / `project_path` / `config` などの他 mutex の poison は `get_tasks` の結果に影響しない（`open_project::check_all_locks()` の方針とは意図的に異なる）。
- **lock poison の実発火テスト省略**: `tasks_cache` が `state.rs` 内 private のため `get_tasks.rs` から発火不可。`From` 変換 + Display 文字列の単体テストで代替（実 poison 検証は `state.rs` 既存テストで網羅済み）。
- **戻り値**: `Vec<Task>` 直返し（payload wrapper 作らず）。`Task` 自体が `#[serde(rename_all = "camelCase")]` を持つため IPC 上は `TaskPayload[]` として正しく到達。

## チェックリスト

- [x] セルフレビューを実施した
- [x] cargo test / cargo clippy / cargo fmt --check が通る（src-tauri 変更時）
- [x] pnpm test:run が通る（FE 既存テストへのリグレッション確認）
- [x] feature 間の依存は index.ts の公開 API 経由になっている（BE 変更のため対象外）
- [x] 関連 Issue を PR にリンクした
- [x] 破壊的変更なし