### PR TITLE
✨ [New Feature]: #73 [BE] watcher Create/Modify/Rename を IPC イベントとして配信

### DIFF
--- a/docs/impl/watcher.md
+++ b/docs/impl/watcher.md
@@ -697,7 +697,78 @@ Err(RecvTimeoutError::Disconnected) => {
 
 ---
 
-## 14. 関連リンク
+## 14. `watcher_event` adapter（IPC 配信層）
+
+`spec-board-fs::watcher` から流れる `FsEvent` をフロントエンドの `task-created` /
+`task-updated` / `task-deleted` IPC イベントに変換する役割は、本体クレート
+`spec-board` 側の `src/watcher_event/` モジュールが担う。`spec-board-fs` を tauri
+非依存に保つため、`AppHandle::emit` を呼ぶ層は本体クレート側に置いている。
+
+### 14.1 モジュール構成
+
+| ファイル | 役割 |
+|:--------|:----|
+| `src/watcher_event/mod.rs` | `prepare_watcher` / `spawn_adapter` / `EmittingWatcherHandle` |
+| `src/watcher_event/handler.rs` | `handle_event`（純粋関数）と `run_event_loop`（adapter 本体） |
+| `src/watcher_event/tests.rs` | `handle_event` への単体テスト + smoke テスト |
+
+### 14.2 起動の 4 段階
+
+`open_project_impl` では以下の 4 段階で watcher を起動する。step 1 が失敗した
+ときは `AppState` を一切変更せずに `OpenProjectError::WatcherInitFailed` を返す
+契約（旧プロジェクトを表示したまま動作を継続できる）。
+
+1. **prepare**: `prepare_watcher(root)` で `Watcher::start` を呼び `(Watcher, Receiver<FsEvent>)` を確保する。**失敗時はこの段階で復帰**し、AppState のどのフィールドも書き換わらない
+2. **stop_old**: `state.take_watcher_handle()` で旧 handle を取り出し `stop()` する。lock 解放後に `stop()` を呼ぶため、panic しても `watcher_handle` mutex は poison しない
+3. **commit**: project_path / config / tasks_cache / write_ignore.clear を順に書き込む
+4. **spawn**: `spawn_adapter(...)` で adapter スレッドを起動し、`EmittingWatcherHandle` を `install_watcher_handle` で AppState に格納する
+
+### 14.3 `EmittingWatcherHandle::stop()` の同期停止
+
+`stop()` は (a) `Watcher` を drop して notify バックエンドの送信側を切断 → (b)
+adapter スレッドを `JoinHandle::join()` する 2 段で同期停止する。Rust の
+`Receiver::recv()` は対応するすべての `Sender` が drop されると `Err(RecvError)`
+を返すため、Watcher を先に drop すれば adapter ループが自動的に抜ける。
+
+`stop()` は冪等で、AppState の lock を一切取らない（取ると `watcher_handle` 保持
+中の deadlock になり得る）。
+
+### 14.4 `handle_event` 純粋関数
+
+adapter スレッドのループ本体（`run_event_loop`）は `Receiver::recv()` で blocking
+し、`Disconnected` を受けたら return するだけ。`FsEvent` 1 件あたりの差分更新と
+emit は `handle_event(event, &ctx)` に集約する。emit は `EmitFn` closure で抽象化し、
+本番では `AppHandle::emit`、テストでは `Vec<(String, Value)>` の push に差し替え
+られる。
+
+| 入力 | 出力 |
+|:----|:----|
+| `Created(p)` / `Modified(p)` | tasks_cache に key 不在なら `task-created`、存在すれば `task-updated`（atomic save の Created でも判定が変わらない） |
+| `Renamed { from, to }` | from で `task-deleted`（cache に存在した場合のみ）、to で `task-created` を順に emit |
+| `Removed(_)` | 本 PR では何もしない（log::trace のみ）。`task-deleted` は別 Issue で対応 |
+| `Other(_)` / `Rescan` / `Error(_)` | log::trace / warn のみ。FE への通知はしない |
+
+副作用は `tasks_cache` の差分書き込み + emit のみ。**emit より先に cache を更新**
+することで、FE が emit を受けた時点で `get_tasks` の cache が一貫しているこ
+とを保証する。
+
+### 14.5 panic 隔離
+
+adapter スレッド本体は `std::panic::catch_unwind(AssertUnwindSafe(...))` で包む。
+emit closure や handler 内部で panic が起きても adapter スレッドだけが終了し、
+プロセス全体やテスト本体は巻き込まれない。panic payload は `log::error!` で記録
+する。`AssertUnwindSafe` を被せているのは、`Receiver` や `AdapterContext` 内の
+`Arc<AppState>` が `UnwindSafe` を自動実装しないため。catch_unwind 後に AppState
+を再利用しないので、安全性は手動で担保している。
+
+### 14.6 関連リンク
+
+- 実装: [`src-tauri/src/watcher_event/`](../../src-tauri/src/watcher_event/)
+- 関連 Issue: #73（adapter 本体）/ #70（親 Issue）/ #74（`Removed` 対応）
+
+---
+
+## 15. 関連リンク
 
 - 仕様: [`docs/spec-board/file-system-spec.md`](../spec-board/file-system-spec.md) の「`spec-board-fs::watcher` 公開 API」節
 - 実装: [`src-tauri/crates/fs/src/watcher.rs`](../../src-tauri/crates/fs/src/watcher.rs)

--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -11,7 +11,7 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 
 | コマンド | 説明 |
 |:---------|:-----|
-| `open_project` | プロジェクトディレクトリを開き、mdファイルを一括読み込みして watcher ハンドルを初期化（現時点では Noop） |
+| `open_project` | プロジェクトディレクトリを開き、mdファイルを一括読み込みし、`notify` ベースの実 watcher を起動して FE への `task-created` / `task-updated` / `task-deleted` 配信を開始する |
 | `get_tasks` | 現在のプロジェクト内の全タスクを取得 |
 | `create_task` | 新規タスクのmdファイルを作成 |
 | `update_task` | 既存タスクのmdファイルを更新 |
@@ -26,9 +26,9 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 
 ### `open_project`
 
-**説明**: 指定ディレクトリをプロジェクトとして開き、配下のmdファイルをスキャンしてタスク一覧を返す。同時に watcher ハンドルを `AppState` に設置する。
+**説明**: 指定ディレクトリをプロジェクトとして開き、配下のmdファイルをスキャンしてタスク一覧を返す。同時に `notify` ベースの実 watcher を起動し、`task-created` / `task-updated` / `task-deleted` を `tauri::AppHandle::emit` でフロントエンドに配信する adapter を `AppState` に設置する。
 
-> 現時点では watcher 具象は `NoopWatcherHandle`（no-op）であり、実ファイル変更検知は別 Issue で `notify` crate 導入時に追加する。本コマンド呼び出しでは GUIDE.md の best-effort 書き出し（`<project_root>/.spec-board/GUIDE.md`）と `AppState` の 5 フィールド（`project_path` / `config` / `tasks_cache` / `watcher_handle` / `write_ignore`）の一括更新を行う。
+> 本コマンド呼び出しでは GUIDE.md の best-effort 書き出し（`<project_root>/.spec-board/GUIDE.md`）と `AppState` の 5 フィールド（`project_path` / `config` / `tasks_cache` / `watcher_handle` / `write_ignore`）の更新を、(1) watcher 起動準備 → (2) 旧 watcher 停止 → (3) state commit → (4) adapter spawn の 4 段階で行う。watcher 起動が失敗した場合は AppState を一切変更せず `WatcherInitFailed` を返す（旧プロジェクトを表示したまま動作継続）。
 
 **引数**:
 
@@ -85,8 +85,11 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | 内部状態の lock 破損 | `AppState` の Mutex / `WriteIgnoreRegistry` が poison 状態 | `内部状態のロックが破損しました` |
 | スキャン致命エラー | parent 循環 / scan I/O など | `io scan failed: {message}` |
 | config 読み込み失敗 | `config.json` が壊れている等 | `config load failed (io|parse): {message}` |
+| ファイル監視の初期化失敗 | inotify 上限超過 / poll fallback 失敗 / path 消失等で `Watcher::start` が `Err` を返した場合 | `ファイル監視の初期化に失敗しました: {source}` |
 
 > 個別 md ファイルの `fs::read` 失敗、および `task_from_markdown` のパース失敗は致命扱いせず、`log::warn!` で記録して該当ファイルだけ skip する（コマンド全体は成功する）。warning を payload へ同梱する仕様は別 Issue 扱い。
+>
+> ファイル監視の初期化失敗時は AppState の全フィールド（`project_path` / `config` / `tasks_cache` / `watcher_handle` / `write_ignore`）が **一切変更されず**、フロントエンドは旧プロジェクトを表示したまま動作を継続する。FE 側 `TauriError.PATTERNS` には未対応のため `UNKNOWN` 分類になる（必要なら FE 側で「ファイル監視の初期化」パターンを個別追加する）。
 
 ---
 
@@ -243,7 +246,7 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | 監視ライブラリ | `notify` crate（Rust） |
 | モジュール配置 | サブクレート `spec-board-fs`（`src-tauri/crates/fs/`）配下に置く（重い外部 crate を集約する規約。CLAUDE.md「Rust バックエンド構成ルール」参照）。公開 API には `notify::*` の型を漏らさず、`std` の型と独自エラー型のみで構成する |
 | 監視対象 | プロジェクトディレクトリ以下の `.md` ファイル |
-| 監視イベント | Create / Modify / Remove / Rename |
+| 監視イベント | Create / Modify / Remove / Rename。**現時点で FE に配信されるのは Create / Modify / Rename のみ**で、`Remove` は本体クレート側 adapter で `log::trace!` のみとする。Remove → `task-deleted` 配線は別 Issue で対応する |
 | デバウンス | 後述の「デバウンス（スライディングウィンドウ集約）」セクション参照 |
 | 自己書き込み抑制 | 後述の「自己書き込み抑制」セクション参照 |
 | フロントエンドへの通知 | Tauri のイベントシステム（`emit`）を使用 |
@@ -268,7 +271,7 @@ flowchart TD
     B --> C{イベント種別}
     C -->|Create| D[ファイルを読み込み・パース]
     C -->|Modify| D
-    C -->|Remove| E[task-deleted イベントを発火]
+    C -->|Remove| E[本体 adapter で log::trace のみ。FE への通知は別 Issue]
     C -->|Rename| R[旧パスで task-deleted + 新パスで読み込み・パース]
     D --> F{パース成功?}
     R --> F
@@ -314,6 +317,8 @@ spec-board 自身がmdファイルを書き込んだ直後に、ファイル監�
 
 - 書き込みパスセットは `HashSet<PathBuf>` で管理し、`Mutex` で排他制御
 - セット登録後に対応するイベントが来なかった場合の解除は呼び出し側が明示的に行う
+- **パス表現は絶対パス**で揃える。`FsEvent` から渡される `PathBuf` をそのまま key として比較するため、書き込み側も `register` 時に絶対パスを使うこと。相対表記や区切り違い（`./tasks/x.md` と `tasks/x.md` 等）は別キーとして扱われ、`consume` がヒットせずに自己書き込みが二重通知される
+- **stale entry の TTL cleanup は行わない**。書き込み後に対応するイベントが届かなかった場合の登録は、`open_project` で別プロジェクトを開いたタイミングの `WriteIgnoreRegistry::clear()` でのみ解消される。プロジェクトを開き直さずに長時間動作させても自己書き込み判定が壊れない仕様にしたい場合は、呼び出し側で `unregister` または `consume` を明示する
 
 ## エラーハンドリング
 
@@ -324,7 +329,7 @@ spec-board 自身がmdファイルを書き込んだ直後に、ファイル監�
 | ファイル読み込み失敗 | 権限不足、ファイルロック中 | `log::warn!` で記録し該当ファイルだけ skip。`open_project` 全体は成功する。フロントエンドへの個別通知 / payload 同梱は別 Issue | WARN |
 | フロントマターパース失敗 | YAML構文エラー、必須フィールド欠損 | `log::warn!` で記録し該当ファイルだけ skip。`open_project` 全体は成功する。フロントエンドへの個別通知 / payload 同梱は別 Issue | WARN |
 | ファイル書き込み失敗 | ディスク容量不足、権限不足 | エラーをフロントエンドに返却 | ERROR |
-| 監視の初期化失敗 | OS制限（inotify上限等） | エラーをフロントエンドに通知、ポーリングにフォールバック | ERROR |
+| 監視の初期化失敗 | OS制限（inotify上限等） | `Watcher::start` 内部で recommended → poll の自動フォールバックを試み、両方失敗した場合のみ `open_project` から `ファイル監視の初期化に失敗しました: ...` を返す。AppState は **一切変更せず**、フロントエンドは旧プロジェクトを表示したまま動作を継続する | ERROR |
 
 ## バックエンド API（内部）
 
@@ -468,13 +473,19 @@ pub enum WatcherError {
 | `Init(String)` | recommended と poll の両方が初期化または再帰 `watch()` に失敗。両者の原因メッセージを結合した文字列を保持する |
 | `Io(std::io::Error)` | `metadata()` 取得時の I/O 失敗（`NotFound` 以外。例: 権限不足） |
 
-#### スコープ外（後続 Issue で扱う）
+#### `spec-board-fs::watcher` のスコープ外
 
-- 拡張子フィルタ（`.md` 等）— 呼び出し側責務
+`spec-board-fs::watcher` は OS の watcher backend を抽象化し `FsEvent` までを返す層であり、本体クレート `spec-board` 側の `watcher_event` adapter で以下を担当する:
+
+- 拡張子フィルタ（`.md` 等）— `watcher_event::handler::rel_md_path` で root 配下の `.md` のみを処理
+- Tauri IPC 経由のフロントエンド emit（`task-created` / `task-updated` / `task-deleted` への変換）— `watcher_event::handler::handle_event` + `EmittingWatcherHandle`
+- `WriteIgnoreRegistry` との統合（自己書き込み抑制）— `watcher_event::handler` 内で `consume(abs_path)` を呼ぶ
+
+引き続き後続 Issue で扱うもの:
+
 - 監視対象パスの動的追加・削除
-- Tauri IPC 経由のフロントエンド emit（`task-created` / `task-updated` / `task-deleted` への変換）
-- `WriteIgnoreRegistry` との統合（自己書き込み抑制）
 - root が symlink ディレクトリの場合の追加検査（現状は notify に委ねる）
+- `FsEvent::Removed` を受けた `task-deleted` 配信（Issue #74）
 
 ## カラム設定・カード並び順の永続化
 

--- a/src-tauri/crates/fs/src/file_scanner.rs
+++ b/src-tauri/crates/fs/src/file_scanner.rs
@@ -203,6 +203,53 @@ fn is_md_extension(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// 単一の絶対パスがタスク `.md` ファイルとして取り込み対象になるかを判定し、
+/// 対象であれば `root` 相対の `PathBuf` を返す。
+///
+/// `scan_md_files` の判定ロジックと同じ条件を **1 件**の絶対パスに対して
+/// 適用する。watcher 経由のイベントなど、`scan_md_files` を経ずに任意の
+/// 絶対パスを判定したい場面で使う。
+///
+/// 対象条件（すべて満たした場合のみ `Some`）:
+/// - `abs_path` が `root` の配下である
+/// - 通常ファイルである（dir / symlink などは除外）。判定は
+///   `symlink_metadata` で行い、symlink を辿らない（`scan_md_files` の
+///   `WalkDir::follow_links(false)` と挙動を揃える）
+/// - 拡張子が `.md`（大文字小文字非区別）
+/// - root 配下の各 path component が `.` で始まらず `node_modules` でもない
+/// - サイズが [`MAX_FILE_SIZE`] byte 以下
+/// - 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
+/// - root 相対パスが UTF-8 として表現可能
+///
+/// I/O 失敗（metadata 取得失敗 / open 失敗 / read 失敗）は `None`（除外側）として扱う。
+pub fn task_md_relative_path(abs_path: &Path, root: &Path) -> Option<PathBuf> {
+    let rel = abs_path.strip_prefix(root).ok()?;
+    if rel.as_os_str().is_empty() {
+        return None;
+    }
+    if !is_md_extension(abs_path) {
+        return None;
+    }
+    for component in rel.iter() {
+        let name = component.to_str()?;
+        if is_excluded_entry_name(name) {
+            return None;
+        }
+    }
+    let metadata = std::fs::symlink_metadata(abs_path).ok()?;
+    if !metadata.file_type().is_file() {
+        return None;
+    }
+    if metadata.len() > MAX_FILE_SIZE {
+        return None;
+    }
+    if !is_text(abs_path) {
+        return None;
+    }
+    rel.to_str()?;
+    Some(rel.to_path_buf())
+}
+
 /// `WalkDir` のエントリが pruning 対象（除外ディレクトリ自身、または除外ディレクトリ配下）かを判定する。
 ///
 /// `entry.depth() == 0` の場合は root 自身であり、除外パターンは適用しない

--- a/src-tauri/src/get_tasks.rs
+++ b/src-tauri/src/get_tasks.rs
@@ -16,6 +16,8 @@
 //! `OpenProjectError::StateLockPoisoned` と完全一致させる。FE 側
 //! `TauriError.PATTERNS` 未対応のため `UNKNOWN` 分類になる。
 
+use std::sync::Arc;
+
 use tauri::State;
 use thiserror::Error;
 
@@ -47,7 +49,7 @@ impl From<AppStateError> for GetTasksError {
 /// `tasks_cache` の `Mutex` が poison している場合に
 /// `"内部状態のロックが破損しました"` を返す。
 #[tauri::command]
-pub fn get_tasks(state: State<'_, AppState>) -> Result<Vec<Task>, String> {
+pub fn get_tasks(state: State<'_, Arc<AppState>>) -> Result<Vec<Task>, String> {
     get_tasks_impl(state.inner()).map_err(|e| e.to_string())
 }
 
@@ -70,11 +72,24 @@ pub(crate) fn get_tasks_impl(state: &AppState) -> Result<Vec<Task>, GetTasksErro
 mod tests {
     use std::fs;
     use std::path::Path;
+    use std::sync::Arc;
 
     use tempfile::TempDir;
 
     use super::*;
-    use crate::open_project::open_project_impl;
+    use crate::open_project::open_project_with_factories;
+    use crate::state::BoxedWatcherHandle;
+    use spec_board_fs::watcher_handle::NoopWatcherHandle;
+
+    fn open_with_noop(state: Arc<AppState>, path: &str) {
+        open_project_with_factories(
+            state,
+            path,
+            |_root| Ok::<(), super::super::open_project::OpenProjectError>(()),
+            |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
+        )
+        .expect("open should succeed");
+    }
 
     fn tempdir() -> TempDir {
         tempfile::tempdir().expect("create temp dir")
@@ -141,7 +156,7 @@ mod tests {
 
     #[test]
     fn returns_tasks_sorted_by_id_after_open_project() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         write_md(dir.path(), "tasks/b.md", &task_md("B", "Todo", None));
         write_md(
@@ -150,7 +165,7 @@ mod tests {
             &task_md("A", "Todo", Some("tasks/b.md")),
         );
         let raw = dir.path().to_str().expect("utf-8").to_string();
-        open_project_impl(&state, &raw).expect("open should succeed");
+        open_with_noop(Arc::clone(&state), &raw);
 
         let tasks = get_tasks_impl(&state).expect("get_tasks should succeed");
 
@@ -160,7 +175,7 @@ mod tests {
 
     #[test]
     fn preserves_children_and_reverse_links_built_by_open_project() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         write_md(dir.path(), "tasks/b.md", &task_md("B", "Todo", None));
         write_md(
@@ -169,7 +184,7 @@ mod tests {
             &task_md_with_links("A", "Todo", Some("tasks/b.md"), &["tasks/b.md"]),
         );
         let raw = dir.path().to_str().expect("utf-8").to_string();
-        open_project_impl(&state, &raw).expect("open should succeed");
+        open_with_noop(Arc::clone(&state), &raw);
 
         let tasks = get_tasks_impl(&state).expect("get_tasks should succeed");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,9 @@ pub mod get_tasks;
 pub mod open_project;
 pub mod state;
 pub mod task_index;
+pub mod watcher_event;
+
+use std::sync::Arc;
 
 use crate::state::AppState;
 
@@ -27,7 +30,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
-        .manage(AppState::new())
+        .manage(Arc::new(AppState::new()))
         .invoke_handler(tauri::generate_handler![
             greet,
             open_project::open_project,

--- a/src-tauri/src/open_project.rs
+++ b/src-tauri/src/open_project.rs
@@ -228,9 +228,14 @@ where
     let tasks = build_children(tasks).map_err(map_hierarchy_error)?;
     let tasks = build_reverse_links(tasks);
 
+    // GUIDE.md 書き込みより **前に** prepare を実行する。watcher 初期化失敗で
+    // 復帰する場合に新 dir 配下の `.spec-board/GUIDE.md` が副作用として残らない
+    // ようにするため。prepare 自体は AppState を一切更新しない。
+    let prepared = prepare(root)?;
+
     write_guide_markdown_best_effort(root, &config);
 
-    commit_app_state_with_factories(&state, root, &config, &tasks, prepare, spawn)?;
+    commit_app_state_with_prepared(&state, root, &config, &tasks, prepared, spawn)?;
 
     Ok(build_payload(tasks, &config))
 }
@@ -436,38 +441,33 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 /// 既に root 相対の正規化済み文字列）。
 /// `open_project` の commit 段階の一般化版。
 ///
-/// `prepare` / `spawn` を closure で注入することで、`AppHandle` や
-/// `Watcher::start` 実体を持たないテストでも 4 段階の手順を保ったまま動作を
-/// 検証できる。本番コードでは `commit_app_state` 経由で呼ばれる。
+/// `prepare` の実行と GUIDE.md 書き込みは呼び出し側
+/// （`open_project_with_factories`）で順序を制御するため、本関数には
+/// **既に確保済みの `prepared`** を直接渡す。これにより watcher 起動失敗時に
+/// `.spec-board/GUIDE.md` を新 dir に書き込んでしまう副作用を避けられる。
 ///
-/// 4 段階手順:
+/// 残りの手順は仕様どおり:
 ///
-/// 1. `prepare(root)` で watcher 起動準備（実体: `Watcher::start`）。失敗時は
-///    `AppState` を一切更新せずに `Err` を返す。
-/// 2. 旧 watcher を `take_watcher_handle` で取り出して `stop()` する。新 cache
-///    が書き込まれる前に旧 watcher を必ず停止することで、旧 adapter が新値で
-///    キャッシュを破壊する race を防ぐ。
-/// 3. project_path / config / tasks_cache / write_ignore.clear の commit を
-///    1 ステップずつ実行する。
-/// 4. `spawn(prepared, state, root, config)` で adapter スレッドを起動し、
-///    返り値を `install_watcher_handle` で AppState に格納する。spawn は
-///    panic 以外で失敗しない契約。
-pub(crate) fn commit_app_state_with_factories<P, S, T>(
+/// 1. 旧 watcher を `take_watcher_handle` で取り出して `stop()`（新 cache が
+///    書かれる前に旧 watcher を必ず停止して race を防ぐ）
+/// 2. project_path / config / tasks_cache / write_ignore.clear の commit を
+///    1 ステップずつ実行
+/// 3. `spawn(prepared, state, root, config)` で adapter スレッドを起動し、
+///    返り値を `install_watcher_handle` で AppState に格納する。spawn は panic
+///    以外で失敗しない契約。
+pub(crate) fn commit_app_state_with_prepared<S, T>(
     state: &Arc<AppState>,
     root: &Path,
     config: &Config,
     tasks: &[Task],
-    prepare: P,
+    prepared: T,
     spawn: S,
 ) -> Result<(), OpenProjectError>
 where
-    P: FnOnce(&Path) -> Result<T, OpenProjectError>,
     S: FnOnce(T, &Arc<AppState>, &Path, &Config) -> BoxedWatcherHandle,
 {
     state.check_all_locks()?;
     state.write_ignore().is_empty()?;
-
-    let prepared = prepare(root)?;
 
     if let Some(mut prev) = state.take_watcher_handle()? {
         prev.stop();
@@ -1031,6 +1031,37 @@ mod tests {
             .expect("readable")
             .expect("watcher should still be present");
         drop(still_installed);
+    }
+
+    #[test]
+    fn watcher_init_failure_does_not_write_guide_md_in_new_dir() {
+        // prepare が GUIDE.md 書き込みより前に呼ばれる契約を担保する。
+        // watcher 初期化失敗時に新 dir 配下の `.spec-board/GUIDE.md` が副作用
+        // として残らないことを確認する。
+        let state = Arc::new(AppState::new());
+        let dir = tempdir();
+        let raw = dir.path().to_str().expect("utf-8").to_string();
+
+        let err = open_project_with_factories(
+            Arc::clone(&state),
+            &raw,
+            |_root| -> Result<(), OpenProjectError> {
+                Err(OpenProjectError::WatcherInitFailed {
+                    source: spec_board_fs::watcher::WatcherError::Init(
+                        "synthetic init failure".to_string(),
+                    ),
+                })
+            },
+            |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
+        )
+        .expect_err("watcher init failure");
+        assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
+
+        let guide = dir.path().join(".spec-board").join("GUIDE.md");
+        assert!(
+            !guide.exists(),
+            "GUIDE.md should not be written when watcher init fails"
+        );
     }
 
     #[test]

--- a/src-tauri/src/open_project.rs
+++ b/src-tauri/src/open_project.rs
@@ -62,15 +62,18 @@ use serde::Serialize;
 use tauri::State;
 use thiserror::Error;
 
+use std::sync::Arc;
+
 use crate::config::{
     load_or_default, write_guide_markdown_best_effort, Column, Config, LoadConfigError,
 };
-use crate::state::{AppState, AppStateError};
+use crate::state::{AppState, AppStateError, BoxedWatcherHandle};
 use crate::task_index::{
-    build_children, build_reverse_links, task_from_markdown, Task, TaskParseContext, TaskParseError,
+    build_children, build_reverse_links, default_status_for, task_from_markdown, Task,
+    TaskParseContext, TaskParseError,
 };
 use spec_board_fs::file_scanner::{scan_md_files, ScanError};
-use spec_board_fs::watcher_handle::NoopWatcherHandle;
+use spec_board_fs::watcher::WatcherError;
 use spec_board_fs::write_ignore::WriteIgnoreError;
 
 /// `open_project` コマンドのペイロード。
@@ -112,6 +115,16 @@ pub enum OpenProjectError {
         category: &'static str,
         message: String,
     },
+    /// Watcher 初期化失敗（inotify 上限 / poll fallback 失敗 / path missing 等）。
+    ///
+    /// FE 側 `PATTERNS` には未対応のため `UNKNOWN` 分類になる。失敗時は
+    /// `commit_app_state` の (1) 段階で復帰し、`AppState` の全フィールドが
+    /// 一切変更されない契約。
+    #[error("ファイル監視の初期化に失敗しました: {source}")]
+    WatcherInitFailed {
+        #[from]
+        source: WatcherError,
+    },
 }
 
 impl From<AppStateError> for OpenProjectError {
@@ -144,10 +157,11 @@ impl From<WriteIgnoreError> for OpenProjectError {
 /// FE 側でパターンマッチして `TauriError` に変換される。
 #[tauri::command]
 pub fn open_project(
-    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    state: State<'_, Arc<AppState>>,
     path: String,
 ) -> Result<OpenProjectPayload, String> {
-    open_project_impl(state.inner(), &path).map_err(|e| e.to_string())
+    open_project_impl(&app, state.inner().clone(), &path).map_err(|e| e.to_string())
 }
 
 /// 単体テスト境界の本体関数。
@@ -161,12 +175,48 @@ pub fn open_project(
 /// `check_app_state_locks` で一括 probe する。lock poison が確定している場合は
 /// `.spec-board/GUIDE.md` の不要な書き出しや scan / parse の無駄を最初から避ける。
 pub(crate) fn open_project_impl(
-    state: &AppState,
+    app: &tauri::AppHandle,
+    state: Arc<AppState>,
     path: &str,
 ) -> Result<OpenProjectPayload, OpenProjectError> {
+    open_project_with_factories(
+        state,
+        path,
+        |root| {
+            crate::watcher_event::prepare_watcher(root)
+                .map_err(|source| OpenProjectError::WatcherInitFailed { source })
+        },
+        |(watcher, rx), state, root, config| {
+            let handle = crate::watcher_event::spawn_adapter(
+                app,
+                root,
+                config,
+                Arc::clone(state),
+                watcher,
+                rx,
+            );
+            Box::new(handle) as BoxedWatcherHandle
+        },
+    )
+}
+
+/// `open_project_impl` のテスト容易性のための一般化版。
+///
+/// `prepare` / `spawn` を closure で注入することで、`AppHandle` を持たない
+/// テストでも実装本体を直接駆動できる。
+pub(crate) fn open_project_with_factories<P, S, T>(
+    state: Arc<AppState>,
+    path: &str,
+    prepare: P,
+    spawn: S,
+) -> Result<OpenProjectPayload, OpenProjectError>
+where
+    P: FnOnce(&Path) -> Result<T, OpenProjectError>,
+    S: FnOnce(T, &Arc<AppState>, &Path, &Config) -> BoxedWatcherHandle,
+{
     let root = Path::new(path);
     validate_directory(root, path)?;
-    check_app_state_locks(state)?;
+    check_app_state_locks(&state)?;
 
     let config = load_or_default(root).map_err(map_load_config_error)?;
 
@@ -175,15 +225,12 @@ pub(crate) fn open_project_impl(
     let default_status = default_status_for(&config);
     let tasks = collect_tasks(root, &md_paths, &default_status);
 
-    // build_children は内部で validate_parent_existence + validate_parent_hierarchy を
-    // 順に呼ぶ。本層では明示呼び出しを行わず、致命的エラー (CycleOrTooDeep) のみを
-    // ScanFailed に詰め直す。
     let tasks = build_children(tasks).map_err(map_hierarchy_error)?;
     let tasks = build_reverse_links(tasks);
 
     write_guide_markdown_best_effort(root, &config);
 
-    commit_app_state(state, root, &config, &tasks)?;
+    commit_app_state_with_factories(&state, root, &config, &tasks, prepare, spawn)?;
 
     Ok(build_payload(tasks, &config))
 }
@@ -284,17 +331,6 @@ fn collect_tasks(root: &Path, md_paths: &[PathBuf], default_status: &str) -> Vec
         }
     }
     tasks
-}
-
-/// `default_status` を `config.columns` の `order` 昇順先頭の `name` から決定する。
-/// `columns` が空の場合は空文字列を返す（`task_from_markdown` 側でも空文字 fallback を許容）。
-fn default_status_for(config: &Config) -> String {
-    config
-        .columns
-        .iter()
-        .min_by_key(|column| column.order)
-        .map(|column| column.name.clone())
-        .unwrap_or_default()
 }
 
 /// `ScanError` を `OpenProjectError` に詰め直す。
@@ -398,18 +434,44 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 ///
 /// `tasks_cache` の key は `PathBuf::from(task.file_path)`（`task.file_path` は
 /// 既に root 相対の正規化済み文字列）。
-fn commit_app_state(
-    state: &AppState,
+/// `open_project` の commit 段階の一般化版。
+///
+/// `prepare` / `spawn` を closure で注入することで、`AppHandle` や
+/// `Watcher::start` 実体を持たないテストでも 4 段階の手順を保ったまま動作を
+/// 検証できる。本番コードでは `commit_app_state` 経由で呼ばれる。
+///
+/// 4 段階手順:
+///
+/// 1. `prepare(root)` で watcher 起動準備（実体: `Watcher::start`）。失敗時は
+///    `AppState` を一切更新せずに `Err` を返す。
+/// 2. 旧 watcher を `take_watcher_handle` で取り出して `stop()` する。新 cache
+///    が書き込まれる前に旧 watcher を必ず停止することで、旧 adapter が新値で
+///    キャッシュを破壊する race を防ぐ。
+/// 3. project_path / config / tasks_cache / write_ignore.clear の commit を
+///    1 ステップずつ実行する。
+/// 4. `spawn(prepared, state, root, config)` で adapter スレッドを起動し、
+///    返り値を `install_watcher_handle` で AppState に格納する。spawn は
+///    panic 以外で失敗しない契約。
+pub(crate) fn commit_app_state_with_factories<P, S, T>(
+    state: &Arc<AppState>,
     root: &Path,
     config: &Config,
     tasks: &[Task],
-) -> Result<(), OpenProjectError> {
-    // Pre-flight: AppState 4 mutex + WriteIgnoreRegistry の健全性を副作用なしで
-    // 確認し、poison していれば副作用前に Err 復帰する。`tasks_snapshot()` などの
-    // クローン系を probe に使うと既存タスク数に比例した clone が走ってしまうため、
-    // no-op probe (`check_*_lock` / `is_empty`) を用いる。
+    prepare: P,
+    spawn: S,
+) -> Result<(), OpenProjectError>
+where
+    P: FnOnce(&Path) -> Result<T, OpenProjectError>,
+    S: FnOnce(T, &Arc<AppState>, &Path, &Config) -> BoxedWatcherHandle,
+{
     state.check_all_locks()?;
     state.write_ignore().is_empty()?;
+
+    let prepared = prepare(root)?;
+
+    if let Some(mut prev) = state.take_watcher_handle()? {
+        prev.stop();
+    }
 
     let mut cache = HashMap::with_capacity(tasks.len());
     for task in tasks {
@@ -420,7 +482,9 @@ fn commit_app_state(
     state.replace_config(Some(config.clone()))?;
     state.replace_tasks_cache(cache)?;
     state.write_ignore().clear()?;
-    state.install_watcher_handle(Box::new(NoopWatcherHandle::new()))?;
+
+    let handle = spawn(prepared, state, root, config);
+    state.install_watcher_handle(handle)?;
     Ok(())
 }
 
@@ -441,12 +505,12 @@ fn build_payload(mut tasks: Vec<Task>, config: &Config) -> OpenProjectPayload {
 
 #[cfg(test)]
 mod tests {
-    use super::{open_project_impl, OpenProjectError, OpenProjectPayload};
+    use super::{open_project_with_factories, OpenProjectError, OpenProjectPayload};
 
     use crate::config::{CardOrder, Column, Config};
-    use crate::state::AppState;
+    use crate::state::{AppState, BoxedWatcherHandle};
     use crate::task_index::Task;
-    use spec_board_fs::watcher_handle::WatcherHandle;
+    use spec_board_fs::watcher_handle::{NoopWatcherHandle, WatcherHandle};
 
     use std::fs;
     use std::path::Path;
@@ -457,6 +521,20 @@ mod tests {
 
     fn tempdir() -> TempDir {
         tempfile::tempdir().expect("create temp dir")
+    }
+
+    /// 4 段階手順を保ったまま、`AppHandle` / `Watcher::start` を使わずに
+    /// `open_project_with_factories` を駆動するための shorthand。
+    fn open_with_noop(
+        state: Arc<AppState>,
+        path: &str,
+    ) -> Result<OpenProjectPayload, OpenProjectError> {
+        open_project_with_factories(
+            state,
+            path,
+            |_root| Ok::<(), OpenProjectError>(()),
+            |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
+        )
     }
 
     fn write_md(root: &Path, rel: &str, body: &str) {
@@ -504,13 +582,14 @@ mod tests {
 
     #[test]
     fn returns_directory_not_found_for_missing_path() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         // TempDir 配下に未作成のサブディレクトリを作って、確実に NotFound 入力を生成する。
         let dir = tempdir();
         let missing_path = dir.path().join("does-not-exist").join("project");
         let missing = missing_path.to_str().expect("utf-8 path");
 
-        let err = open_project_impl(&state, missing).expect_err("missing path should fail");
+        let err =
+            open_with_noop(Arc::clone(&state), missing).expect_err("missing path should fail");
 
         match err {
             OpenProjectError::DirectoryNotFound { ref path } => {
@@ -525,13 +604,13 @@ mod tests {
 
     #[test]
     fn returns_not_a_directory_for_file_path() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         let file_path = dir.path().join("regular.txt");
         fs::write(&file_path, "hello").expect("write file");
         let raw = file_path.to_str().expect("utf-8 path");
 
-        let err = open_project_impl(&state, raw).expect_err("file path should fail");
+        let err = open_with_noop(Arc::clone(&state), raw).expect_err("file path should fail");
 
         match err {
             OpenProjectError::NotADirectory { ref path } => assert_eq!(raw, path),
@@ -550,7 +629,7 @@ mod tests {
             return;
         }
 
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         let target = dir.path().join("locked");
         fs::create_dir(&target).expect("create dir");
@@ -559,7 +638,8 @@ mod tests {
         fs::set_permissions(&target, perms).expect("chmod");
 
         let raw = target.to_str().expect("utf-8 path").to_string();
-        let err = open_project_impl(&state, &raw).expect_err("inaccessible dir should fail");
+        let err =
+            open_with_noop(Arc::clone(&state), &raw).expect_err("inaccessible dir should fail");
 
         // 権限を戻して TempDir のドロップを成功させる。
         let mut restore = fs::metadata(&target).expect("metadata").permissions();
@@ -587,11 +667,11 @@ mod tests {
 
     #[test]
     fn empty_directory_returns_default_columns_and_no_tasks() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         let raw = dir.path().to_str().expect("utf-8 path").to_string();
 
-        let payload = open_project_impl(&state, &raw).expect("empty dir should succeed");
+        let payload = open_with_noop(Arc::clone(&state), &raw).expect("empty dir should succeed");
 
         assert!(payload.tasks.is_empty());
         let default_columns: Vec<String> = Config::default()
@@ -604,7 +684,7 @@ mod tests {
 
     #[test]
     fn tasks_are_sorted_by_id_and_children_are_built() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         write_md(dir.path(), "tasks/b.md", &task_md("B", "Todo", None));
         write_md(
@@ -614,7 +694,7 @@ mod tests {
         );
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let payload = open_project_impl(&state, &raw).expect("should succeed");
+        let payload = open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         let ids: Vec<&str> = payload.tasks.iter().map(|t| t.id.as_str()).collect();
         assert_eq!(vec!["tasks/a.md", "tasks/b.md"], ids);
@@ -629,7 +709,7 @@ mod tests {
 
     #[test]
     fn loads_user_config_when_available() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         let config_json = r#"{
             "version": 1,
@@ -643,7 +723,7 @@ mod tests {
         write_config_json(dir.path(), config_json);
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let payload = open_project_impl(&state, &raw).expect("should succeed");
+        let payload = open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         assert_eq!(
             vec![
@@ -657,7 +737,7 @@ mod tests {
 
     #[test]
     fn columns_sorted_by_order_irrespective_of_input_array_order() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         let config_json = r#"{
             "version": 1,
@@ -671,7 +751,7 @@ mod tests {
         write_config_json(dir.path(), config_json);
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let payload = open_project_impl(&state, &raw).expect("should succeed");
+        let payload = open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         assert_eq!(
             vec!["A".to_string(), "B".to_string(), "C".to_string()],
@@ -681,11 +761,11 @@ mod tests {
 
     #[test]
     fn writes_guide_markdown_to_disk() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        open_project_impl(&state, &raw).expect("should succeed");
+        open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         let guide = dir.path().join(".spec-board").join("GUIDE.md");
         assert!(guide.exists(), "GUIDE.md should be created");
@@ -695,12 +775,12 @@ mod tests {
 
     #[test]
     fn updates_app_state_fields_on_success() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         write_md(dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        open_project_impl(&state, &raw).expect("should succeed");
+        open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         assert_eq!(
             Some(dir.path().to_path_buf()),
@@ -720,13 +800,13 @@ mod tests {
 
     #[test]
     fn config_load_failure_for_invalid_json_returns_parse_category() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         // 壊れた JSON
         write_config_json(dir.path(), "{ this is not json");
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let err = open_project_impl(&state, &raw).expect_err("invalid config should fail");
+        let err = open_with_noop(Arc::clone(&state), &raw).expect_err("invalid config should fail");
 
         match err {
             OpenProjectError::ConfigLoadFailed {
@@ -744,13 +824,13 @@ mod tests {
 
     #[test]
     fn config_load_failure_for_empty_columns_returns_parse_category() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         let config_json = r#"{ "version": 1, "columns": [], "cardOrder": {} }"#;
         write_config_json(dir.path(), config_json);
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let err = open_project_impl(&state, &raw).expect_err("empty columns should fail");
+        let err = open_with_noop(Arc::clone(&state), &raw).expect_err("empty columns should fail");
 
         match err {
             OpenProjectError::ConfigLoadFailed { category, .. } => {
@@ -763,14 +843,15 @@ mod tests {
 
     #[test]
     fn config_load_failure_when_spec_board_path_is_a_file_returns_io_category() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         // .spec-board をファイルにしておく → config.json への読み込みが Io エラーになる。
         let spec_path = dir.path().join(".spec-board");
         fs::write(&spec_path, "not a directory").expect("write file at .spec-board");
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let err = open_project_impl(&state, &raw).expect_err(".spec-board as file should fail");
+        let err =
+            open_with_noop(Arc::clone(&state), &raw).expect_err(".spec-board as file should fail");
 
         match err {
             OpenProjectError::ConfigLoadFailed { category, .. } => {
@@ -783,7 +864,7 @@ mod tests {
 
     #[test]
     fn parent_cycle_returns_scan_failed_with_io_marker() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         // a -> b -> a の循環
         write_md(
@@ -798,7 +879,7 @@ mod tests {
         );
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let err = open_project_impl(&state, &raw).expect_err("cycle should fail");
+        let err = open_with_noop(Arc::clone(&state), &raw).expect_err("cycle should fail");
 
         match err {
             OpenProjectError::ScanFailed { ref message } => {
@@ -816,7 +897,7 @@ mod tests {
 
     #[test]
     fn corrupted_md_files_are_skipped_and_command_succeeds() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         // 通常の md
         write_md(dir.path(), "tasks/ok.md", &task_md("OK", "Todo", None));
@@ -824,7 +905,7 @@ mod tests {
         write_md(dir.path(), "tasks/nofm.md", "no frontmatter here\n");
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        let payload = open_project_impl(&state, &raw).expect("should succeed");
+        let payload = open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         let ids: Vec<&str> = payload.tasks.iter().map(|t| t.id.as_str()).collect();
         assert_eq!(vec!["tasks/ok.md"], ids);
@@ -832,7 +913,7 @@ mod tests {
 
     #[test]
     fn reopen_stops_previous_watcher_exactly_once() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let counter = Arc::new(AtomicUsize::new(0));
         state
             .install_watcher_handle(Box::new(CountingHandle {
@@ -843,14 +924,14 @@ mod tests {
         let dir = tempdir();
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        open_project_impl(&state, &raw).expect("should succeed");
+        open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         assert_eq!(1, counter.load(Ordering::SeqCst));
     }
 
     #[test]
     fn reopen_clears_previous_write_ignore_paths() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         state
             .write_ignore()
             .register("tasks/dirty.md")
@@ -860,13 +941,17 @@ mod tests {
         let dir = tempdir();
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        open_project_impl(&state, &raw).expect("should succeed");
+        open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         assert!(state.write_ignore().is_empty().expect("readable"));
     }
 
     #[test]
-    fn watcher_panic_propagates_and_subsequent_call_returns_state_lock_poisoned() {
+    fn watcher_stop_panic_propagates_without_poisoning_watcher_handle_mutex() {
+        // 新しい 4 段階フローでは旧 watcher の `stop()` は
+        // `take_watcher_handle()` で取り出した後（lock 解放後）に呼ばれる。
+        // panic は伝播するが watcher_handle mutex は poison しないため、
+        // 後続 open は成功する。
         let state = Arc::new(AppState::new());
         state
             .install_watcher_handle(Box::new(PanickingHandle))
@@ -875,34 +960,25 @@ mod tests {
         let dir = tempdir();
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        // 1 回目: 旧 watcher.stop() が panic するため open_project_impl 自体が panic を伝播。
         let panic_state = Arc::clone(&state);
         let panic_path = raw.clone();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            let _ = open_project_impl(panic_state.as_ref(), &panic_path);
+            let _ = open_with_noop(Arc::clone(&panic_state), &panic_path);
         }));
         assert!(result.is_err(), "stop panic should propagate");
 
-        // 2 回目以降: watcher_handle mutex が poison しているため StateLockPoisoned。
-        let err = open_project_impl(state.as_ref(), &raw)
-            .expect_err("subsequent call should report lock poisoned");
-
-        match err {
-            OpenProjectError::StateLockPoisoned => {}
-            other => panic!("expected StateLockPoisoned, got {other:?}"),
-        }
-        assert_eq!("内部状態のロックが破損しました", err.to_string());
+        open_with_noop(Arc::clone(&state), &raw).expect("subsequent open should succeed");
     }
 
     #[test]
     fn tasks_cache_uses_path_buf_keys_from_file_path() {
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let dir = tempdir();
         write_md(dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
         write_md(dir.path(), "tasks/b.md", &task_md("B", "Todo", None));
         let raw = dir.path().to_str().expect("utf-8").to_string();
 
-        open_project_impl(&state, &raw).expect("should succeed");
+        open_with_noop(Arc::clone(&state), &raw).expect("should succeed");
 
         let snapshot = state.tasks_snapshot().expect("readable");
         let mut paths: Vec<String> = snapshot.iter().map(|t| t.file_path.clone()).collect();
@@ -914,83 +990,121 @@ mod tests {
     }
 
     #[test]
-    fn early_pre_flight_skips_guide_md_write_when_watcher_lock_is_poisoned() {
-        // 1 回目の open でプロジェクトを確定させる。
+    fn watcher_init_failure_keeps_app_state_completely_unchanged() {
+        // 1 回目の open で AppState を確定させる。
         let state = Arc::new(AppState::new());
         let first_dir = tempdir();
+        write_md(first_dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
         let first_raw = first_dir.path().to_str().expect("utf-8").to_string();
-        open_project_impl(state.as_ref(), &first_raw).expect("first open");
+        open_with_noop(Arc::clone(&state), &first_raw).expect("first open");
 
-        // 旧 watcher を panic 経由で poison させる。
-        state
-            .install_watcher_handle(Box::new(PanickingHandle))
-            .expect("install panicking watcher");
-        let panic_state = Arc::clone(&state);
-        let panic_dir = tempdir();
-        let panic_raw = panic_dir.path().to_str().expect("utf-8").to_string();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            let _ = open_project_impl(panic_state.as_ref(), &panic_raw);
-        }));
-        assert!(result.is_err(), "stop panic should propagate");
+        let project_before = state.project_path().expect("readable");
+        let config_before = state.config().expect("readable");
+        let snapshot_before = state.tasks_snapshot().expect("readable");
 
-        // 2 回目: poison 状態の AppState で別 dir を open する。GUIDE.md が
-        // 新 dir に書かれてはならない（早期 pre-flight が副作用前に Err 復帰させる）。
+        // 2 回目: prepare で WatcherInitFailed を返すスタブを使う。
         let other_dir = tempdir();
         let other_raw = other_dir.path().to_str().expect("utf-8").to_string();
-        let err = open_project_impl(state.as_ref(), &other_raw)
-            .expect_err("subsequent call should report lock poisoned");
-        assert!(matches!(err, OpenProjectError::StateLockPoisoned));
+        let err = open_project_with_factories(
+            Arc::clone(&state),
+            &other_raw,
+            |_root| -> Result<(), OpenProjectError> {
+                Err(OpenProjectError::WatcherInitFailed {
+                    source: spec_board_fs::watcher::WatcherError::Init(
+                        "synthetic init failure".to_string(),
+                    ),
+                })
+            },
+            |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
+        )
+        .expect_err("watcher init failure should be returned");
+        assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
 
-        let guide = other_dir.path().join(".spec-board").join("GUIDE.md");
-        assert!(
-            !guide.exists(),
-            "GUIDE.md should not be written when AppState lock is poisoned"
-        );
+        // AppState の全フィールドが 1 回目の状態のまま残ることを確認する。
+        assert_eq!(project_before, state.project_path().expect("readable"));
+        assert_eq!(config_before, state.config().expect("readable"));
+        let snapshot_after = state.tasks_snapshot().expect("readable");
+        assert_eq!(snapshot_before.len(), snapshot_after.len());
+        // watcher_handle はまだ前回の NoopWatcherHandle が install されたまま。
+        let still_installed = state
+            .take_watcher_handle()
+            .expect("readable")
+            .expect("watcher should still be present");
+        drop(still_installed);
     }
 
     #[test]
-    fn commit_app_state_pre_flight_blocks_partial_updates_when_watcher_lock_poisoned() {
-        // 旧 watcher を panic 経由で poison させる。
+    fn watcher_init_failure_does_not_invoke_old_watcher_stop() {
+        // 失敗 prepare のあとに `take_watcher_handle()` が呼ばれないことを担保する
+        // ための回帰テスト。PanickingHandle が install されていても panic しない。
         let state = Arc::new(AppState::new());
         state
             .install_watcher_handle(Box::new(PanickingHandle))
             .expect("install panicking watcher");
 
-        // 1 回目: watcher.stop() panic を伝播させて watcher_handle mutex を poison させる。
         let dir = tempdir();
         let raw = dir.path().to_str().expect("utf-8").to_string();
-        let panic_state = Arc::clone(&state);
-        let panic_path = raw.clone();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            let _ = open_project_impl(panic_state.as_ref(), &panic_path);
-        }));
-        assert!(result.is_err(), "stop panic should propagate");
 
-        // 1 回目で書き込まれたフィールドのスナップショットを取る。
-        let project_after_panic = state.project_path().expect("readable");
-        let config_after_panic = state.config().expect("readable");
+        let err = open_project_with_factories(
+            Arc::clone(&state),
+            &raw,
+            |_root| -> Result<(), OpenProjectError> {
+                Err(OpenProjectError::WatcherInitFailed {
+                    source: spec_board_fs::watcher::WatcherError::Init("synth".to_string()),
+                })
+            },
+            |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
+        )
+        .expect_err("watcher init failure");
+        assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
+    }
 
-        // 2 回目: watcher_handle が poison しているので pre-flight が早期 Err を返し、
-        // project_path / config / tasks_cache / write_ignore は一切書き換わらない。
-        let other_dir = tempdir();
-        let other_raw = other_dir.path().to_str().expect("utf-8").to_string();
-        let err = open_project_impl(state.as_ref(), &other_raw)
-            .expect_err("subsequent call should report lock poisoned");
-        assert!(matches!(err, OpenProjectError::StateLockPoisoned));
+    #[test]
+    fn old_watcher_is_stopped_before_state_commit() {
+        // CountingHandle を pre-install し、spawn factory 内で `tasks_snapshot`
+        // が新値を返すこと、stop call カウンタが spawn 前に 1 になっていることを
+        // 観察し、(1) prepare → (2) stop_old → (3) commit → (4) spawn の順序を
+        // 検証する。
+        let state = Arc::new(AppState::new());
+        let stop_counter = Arc::new(AtomicUsize::new(0));
+        state
+            .install_watcher_handle(Box::new(CountingHandle {
+                stop_calls: Arc::clone(&stop_counter),
+            }))
+            .expect("install old watcher");
 
-        // pre-flight 失敗で副作用が走っていないことを確認する。
-        assert_eq!(project_after_panic, state.project_path().expect("readable"));
-        assert_eq!(config_after_panic, state.config().expect("readable"));
+        let dir = tempdir();
+        write_md(dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
+        let raw = dir.path().to_str().expect("utf-8").to_string();
+
+        let observed_counter = Arc::clone(&stop_counter);
+        let observed_state = Arc::clone(&state);
+        open_project_with_factories(
+            Arc::clone(&state),
+            &raw,
+            |_root| Ok::<(), OpenProjectError>(()),
+            move |(), _state, _root, _config| {
+                // spawn 段階では旧 stop が既に呼ばれており、cache も新値で commit 済み。
+                assert_eq!(1, observed_counter.load(Ordering::SeqCst));
+                let snapshot = observed_state.tasks_snapshot().expect("readable");
+                assert_eq!(1, snapshot.len());
+                assert_eq!("tasks/a.md", snapshot[0].file_path);
+                Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle
+            },
+        )
+        .expect("open should succeed");
+
+        assert_eq!(1, stop_counter.load(Ordering::SeqCst));
     }
 
     #[test]
     fn previous_app_state_is_preserved_when_load_fails() {
         // 1 回目の open で AppState を確定させる。
-        let state = AppState::new();
+        let state = Arc::new(AppState::new());
         let first_dir = tempdir();
         write_md(first_dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
         let first_raw = first_dir.path().to_str().expect("utf-8").to_string();
-        open_project_impl(&state, &first_raw).expect("first open should succeed");
+        open_with_noop(Arc::clone(&state), &first_raw).expect("first open should succeed");
 
         let snapshot_before = state.tasks_snapshot().expect("readable");
         let project_before = state.project_path().expect("readable");
@@ -999,7 +1113,7 @@ mod tests {
         let bad_dir = tempdir();
         write_config_json(bad_dir.path(), "{ this is not json");
         let bad_raw = bad_dir.path().to_str().expect("utf-8").to_string();
-        let err = open_project_impl(&state, &bad_raw)
+        let err = open_with_noop(Arc::clone(&state), &bad_raw)
             .expect_err("second open with broken config should fail");
         assert!(matches!(err, OpenProjectError::ConfigLoadFailed { .. }));
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -133,6 +133,23 @@ impl AppState {
         Ok(guard.values().cloned().collect())
     }
 
+    /// `tasks_cache` を可変で借りて closure 内で in-place 操作する。
+    ///
+    /// `tasks_snapshot` → 編集 → `replace_tasks_cache` のフローでは全 task を
+    /// clone してから新 HashMap で書き戻すため O(n) のコピーが発生する。
+    /// 1 path 単位の差分更新（watcher 由来の created / updated / deleted など）
+    /// では本 API を使うことで O(1) のロック内 in-place 更新ができる。
+    ///
+    /// closure は guard を保持したまま呼ばれるため、内部で AppState の他
+    /// アクセサを呼んではならない（自己 deadlock の原因）。
+    pub fn with_tasks_cache_mut<F, R>(&self, f: F) -> Result<R, AppStateError>
+    where
+        F: FnOnce(&mut HashMap<PathBuf, Task>) -> R,
+    {
+        let mut guard = lock(&self.tasks_cache)?;
+        Ok(f(&mut guard))
+    }
+
     /// watcher ハンドルを差し替える。
     ///
     /// 旧ハンドルが存在する場合は、新ハンドルを置く前に `stop()` を呼び出す。

--- a/src-tauri/src/task_index.rs
+++ b/src-tauri/src/task_index.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::frontmatter::{parse_bytes, FrontmatterError, Parsed, Priority};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -590,9 +591,22 @@ fn title_fallback_from_file_path(path: &Path) -> String {
 ///
 /// @param path 正規化する Task file path。
 /// @returns payload に格納する forward slash 区切りの正規化済み path。
-fn normalized_task_file_path(path: &Path) -> String {
+pub(crate) fn normalized_task_file_path(path: &Path) -> String {
     let path_text = path.to_string_lossy().replace('\\', "/");
     normalize_path_parts(&path_text, true)
+}
+
+/// `Config::columns` の `order` 昇順先頭の `name` を default status として返す。
+///
+/// `columns` が空の場合は空文字列を返す。`task_from_markdown` 側でも空文字
+/// fallback を許容するため、空 columns でも parse は成立する。
+pub(crate) fn default_status_for(config: &Config) -> String {
+    config
+        .columns
+        .iter()
+        .min_by_key(|column| column.order)
+        .map(|column| column.name.clone())
+        .unwrap_or_default()
 }
 
 /// Task の file path を lookup 用に正規化する。

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -1,0 +1,239 @@
+//! 1 件の `FsEvent` をパース・分類して `tasks_cache` の差分更新と emit を行う
+//! 純粋ハンドラ。adapter スレッド本体（`run_event_loop`）はこれを recv ループ
+//! で呼ぶだけの薄いシェル。
+//!
+//! emit は closure (`EmitFn`) として外から差し込むため、tauri 実装に依存せず
+//! テストで Vec push スタブに置き換えられる。
+//!
+//! 本モジュールが触る AppState フィールドは `tasks_cache` と
+//! `write_ignore` のみ。`watcher_handle` は触らない（`stop()` 中の deadlock
+//! を防ぐ）。
+//!
+//! 拡張子フィルタ: `rel_md_path` で root 配下の `.md` ファイルだけを処理対象
+//! とする。`.spec-board/config.json` や一時ファイル等は早期 return。
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, RecvError};
+
+use serde_json::json;
+
+use crate::state::AppState;
+use crate::task_index::{normalized_task_file_path, task_from_markdown, Task, TaskParseContext};
+use spec_board_fs::file_scanner::task_md_relative_path;
+use spec_board_fs::watcher::FsEvent;
+
+use super::AdapterContext;
+
+/// adapter スレッド本体。`Receiver<FsEvent>` を blocking で消費し、
+/// Disconnected で抜ける。
+pub(crate) fn run_event_loop(rx: Receiver<FsEvent>, ctx: AdapterContext) {
+    loop {
+        match rx.recv() {
+            Ok(event) => {
+                if let Err(err) = handle_event(&event, &ctx) {
+                    log::warn!("watcher_event handler error: {err}");
+                }
+            }
+            Err(RecvError) => {
+                log::trace!("watcher_event channel disconnected; adapter stopping");
+                return;
+            }
+        }
+    }
+}
+
+/// `handle_upsert` が emit する event 名の決定方法。
+#[derive(Debug, Clone, Copy)]
+enum UpsertMode {
+    /// cache 存在で `task-updated` / `task-created` を自動切替する通常モード。
+    /// `Created` / `Modified` 単独イベントで使う（atomic save 互換）。
+    Auto,
+    /// 常に `task-created` を emit する。`Renamed { from, to }` の `to` 側で使う。
+    /// rename を「旧 path delete + 新 path create」として仕様化しているため、
+    /// `to` が既に cache にあっても `task-updated` ではなく `task-created` を出す。
+    ForceCreated,
+}
+
+/// 1 件の FsEvent を処理する純粋ハンドラ。
+///
+/// emit / state は ctx 経由で受け取り、本関数は副作用と
+/// `AppState::tasks_cache` の差分更新だけを行う。
+pub(crate) fn handle_event(event: &FsEvent, ctx: &AdapterContext) -> Result<(), HandleError> {
+    match event {
+        FsEvent::Created(p) | FsEvent::Modified(p) => handle_upsert(p, ctx, UpsertMode::Auto),
+        FsEvent::Renamed { from, to } => {
+            handle_delete(from, ctx)?;
+            handle_upsert(to, ctx, UpsertMode::ForceCreated)
+        }
+        FsEvent::Removed(_) => {
+            // 別 Issue で対応する。本ハンドラでは何もしない。
+            log::trace!("watcher_event: ignoring Removed event");
+            Ok(())
+        }
+        FsEvent::Other(p) => {
+            log::trace!("watcher_event: ignoring Other event for {}", p.display());
+            Ok(())
+        }
+        FsEvent::Rescan => {
+            log::warn!("watcher_event: Rescan received; FE notification not yet wired");
+            Ok(())
+        }
+        FsEvent::Error(msg) => {
+            log::warn!("watcher_event: backend error: {msg}");
+            Ok(())
+        }
+    }
+}
+
+/// 与えられた絶対パスが `open_project` のスキャン仕様に合う **タスク `.md`**
+/// であれば、Task payload 用の正規化済み相対パスを返す。それ以外（root 外 /
+/// `.md` 以外 / ドット始まり / `node_modules` 配下 / サイズ超過 / バイナリ等）
+/// は `None` を返す。
+///
+/// 判定ロジックは `spec_board_fs::file_scanner::task_md_relative_path` を経由
+/// することで `scan_md_files` と完全に揃える。これにより初回 scan で読まれない
+/// ファイルが watcher 経由で `task-created` されたり、初回 scan で読まれた
+/// `.MD` の変更が watcher で無視されたりすることを防ぐ。
+///
+/// `Removed` 系のイベントなど **既に削除された path** に対しては metadata
+/// 取得が失敗するため `None` が返る。`handle_delete` は cache に存在するか
+/// だけで動作するため、本関数の戻り値が `None` でも cache 上の rename / delete
+/// 処理を阻害しないよう、呼び出し側は **rel_md_path_lenient** を併用する。
+fn rel_md_path(abs_path: &Path, root: &Path) -> Option<String> {
+    task_md_relative_path(abs_path, root).map(|rel| normalized_task_file_path(&rel))
+}
+
+/// `rel_md_path` と異なり **ファイル内容や metadata に依存しない** 軽量チェック。
+/// `Renamed` の `from` 側のように既にファイルが存在しない（または別ファイルに
+/// 置き換わっている）場合でも、cache 上の delete 判定だけは行えるようにする。
+///
+/// チェック対象: root 相対であること / `.md`（大小文字非区別）/ root 配下の
+/// path component に `.` 始まり / `node_modules` を含まないこと / UTF-8 表現可能。
+fn rel_md_path_lenient(abs_path: &Path, root: &Path) -> Option<String> {
+    let rel = abs_path.strip_prefix(root).ok()?;
+    if rel.as_os_str().is_empty() {
+        return None;
+    }
+    if abs_path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| !s.eq_ignore_ascii_case("md"))
+        .unwrap_or(true)
+    {
+        return None;
+    }
+    for component in rel.iter() {
+        let name = component.to_str()?;
+        if name.starts_with('.') || name == "node_modules" {
+            return None;
+        }
+    }
+    rel.to_str()?;
+    Some(normalized_task_file_path(rel))
+}
+
+/// AppState から HashMap<PathBuf, Task> 形式の cache スナップショットを取得する。
+fn load_cache_map(state: &AppState) -> Result<HashMap<PathBuf, Task>, HandleError> {
+    Ok(state
+        .tasks_snapshot()?
+        .into_iter()
+        .map(|t| (PathBuf::from(t.file_path.as_str()), t))
+        .collect())
+}
+
+/// write_ignore registry を consume し、自己書き込みなら `true` を返して
+/// 呼び出し側に skip させる。
+fn try_consume_write_ignore(ctx: &AdapterContext, abs_path: &Path) -> Result<bool, HandleError> {
+    Ok(ctx.state.write_ignore().consume(abs_path)?)
+}
+
+fn handle_upsert(
+    abs_path: &Path,
+    ctx: &AdapterContext,
+    mode: UpsertMode,
+) -> Result<(), HandleError> {
+    let Some(rel_str) = rel_md_path(abs_path, &ctx.root) else {
+        log::trace!(
+            "watcher_event: skipping non-md or out-of-root path: {}",
+            abs_path.display()
+        );
+        return Ok(());
+    };
+    if try_consume_write_ignore(ctx, abs_path)? {
+        return Ok(());
+    }
+    let bytes = match fs::read(abs_path) {
+        Ok(b) => b,
+        Err(err) => {
+            log::warn!(
+                "watcher_event: failed to read `{}`: {err}",
+                abs_path.display()
+            );
+            return Ok(());
+        }
+    };
+    let context = TaskParseContext {
+        file_path: PathBuf::from(rel_str.as_str()),
+        default_status: ctx.default_status.clone(),
+    };
+    let task = match task_from_markdown(&bytes, &context) {
+        Ok(t) => t,
+        Err(err) => {
+            log::warn!(
+                "watcher_event: failed to parse `{}`: {err}",
+                abs_path.display()
+            );
+            return Ok(());
+        }
+    };
+    let cache_key = PathBuf::from(task.file_path.as_str());
+    let mut cache = load_cache_map(&ctx.state)?;
+    let event_name = match mode {
+        UpsertMode::Auto if cache.contains_key(&cache_key) => "task-updated",
+        UpsertMode::Auto => "task-created",
+        UpsertMode::ForceCreated => "task-created",
+    };
+    cache.insert(cache_key, task.clone());
+    ctx.state.replace_tasks_cache(cache)?;
+    (ctx.emit)(event_name, json!({ "task": task }));
+    Ok(())
+}
+
+/// 削除系（Rename の `from` 側）。`tasks_cache` から実際に entry を remove
+/// できた場合のみ `task-deleted` を emit する。エディタの atomic save 時に
+/// 出る一時ファイル rename で偽 delete が飛ばないようにするための運用。
+///
+/// from 側のファイルは既に削除済み（metadata 取得不可）なケースが多いため、
+/// metadata に依存しない `rel_md_path_lenient` を使う。
+fn handle_delete(abs_path: &Path, ctx: &AdapterContext) -> Result<(), HandleError> {
+    let Some(rel_str) = rel_md_path_lenient(abs_path, &ctx.root) else {
+        return Ok(());
+    };
+    if try_consume_write_ignore(ctx, abs_path)? {
+        return Ok(());
+    }
+    let mut cache = load_cache_map(&ctx.state)?;
+    let cache_key = PathBuf::from(rel_str.as_str());
+    if cache.remove(&cache_key).is_some() {
+        ctx.state.replace_tasks_cache(cache)?;
+        (ctx.emit)("task-deleted", json!({ "filePath": rel_str }));
+    } else {
+        log::trace!(
+            "watcher_event: ignoring delete for path not in cache: {}",
+            abs_path.display()
+        );
+    }
+    Ok(())
+}
+
+/// `handle_event` 内で発生し得るエラー。adapter ループ側では `log::warn!` で
+/// 記録するだけで loop を継続する。
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum HandleError {
+    #[error("AppState lock poisoned: {0}")]
+    StateLock(#[from] crate::state::AppStateError),
+    #[error("WriteIgnore lock poisoned: {0}")]
+    WriteIgnore(#[from] spec_board_fs::write_ignore::WriteIgnoreError),
+}

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -144,8 +144,13 @@ fn handle_upsert(
     mode: UpsertMode,
 ) -> Result<(), HandleError> {
     let Some(rel_str) = rel_md_path(abs_path, &ctx.root) else {
+        // task_md_relative_path はプロジェクト規約に合わない path を一括で
+        // フィルタする。具体的なフィルタ条件は file_scanner 側のドキュメント
+        // を参照（root 外 / 非 .md / dotfile / node_modules / size 超 / バイナリ
+        // / symlink / 非 UTF-8 のいずれか）。本層では理由の内訳を分離せず
+        // 「scanner と同じ条件で除外した」とまとめて記録する。
         log::trace!(
-            "watcher_event: skipping non-md or out-of-root path: {}",
+            "watcher_event: skipping path not eligible as task .md (scanner filter excluded): {}",
             abs_path.display()
         );
         return Ok(());

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -12,15 +12,13 @@
 //! 拡張子フィルタ: `rel_md_path` で root 配下の `.md` ファイルだけを処理対象
 //! とする。`.spec-board/config.json` や一時ファイル等は早期 return。
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, RecvError};
 
 use serde_json::json;
 
-use crate::state::AppState;
-use crate::task_index::{normalized_task_file_path, task_from_markdown, Task, TaskParseContext};
+use crate::task_index::{normalized_task_file_path, task_from_markdown, TaskParseContext};
 use spec_board_fs::file_scanner::task_md_relative_path;
 use spec_board_fs::watcher::FsEvent;
 
@@ -134,15 +132,6 @@ fn rel_md_path_lenient(abs_path: &Path, root: &Path) -> Option<String> {
     Some(normalized_task_file_path(rel))
 }
 
-/// AppState から HashMap<PathBuf, Task> 形式の cache スナップショットを取得する。
-fn load_cache_map(state: &AppState) -> Result<HashMap<PathBuf, Task>, HandleError> {
-    Ok(state
-        .tasks_snapshot()?
-        .into_iter()
-        .map(|t| (PathBuf::from(t.file_path.as_str()), t))
-        .collect())
-}
-
 /// write_ignore registry を consume し、自己書き込みなら `true` を返して
 /// 呼び出し側に skip させる。
 fn try_consume_write_ignore(ctx: &AdapterContext, abs_path: &Path) -> Result<bool, HandleError> {
@@ -189,14 +178,15 @@ fn handle_upsert(
         }
     };
     let cache_key = PathBuf::from(task.file_path.as_str());
-    let mut cache = load_cache_map(&ctx.state)?;
-    let event_name = match mode {
-        UpsertMode::Auto if cache.contains_key(&cache_key) => "task-updated",
-        UpsertMode::Auto => "task-created",
-        UpsertMode::ForceCreated => "task-created",
-    };
-    cache.insert(cache_key, task.clone());
-    ctx.state.replace_tasks_cache(cache)?;
+    let event_name = ctx.state.with_tasks_cache_mut(|cache| {
+        let event = match mode {
+            UpsertMode::Auto if cache.contains_key(&cache_key) => "task-updated",
+            UpsertMode::Auto => "task-created",
+            UpsertMode::ForceCreated => "task-created",
+        };
+        cache.insert(cache_key, task.clone());
+        event
+    })?;
     (ctx.emit)(event_name, json!({ "task": task }));
     Ok(())
 }
@@ -214,10 +204,11 @@ fn handle_delete(abs_path: &Path, ctx: &AdapterContext) -> Result<(), HandleErro
     if try_consume_write_ignore(ctx, abs_path)? {
         return Ok(());
     }
-    let mut cache = load_cache_map(&ctx.state)?;
     let cache_key = PathBuf::from(rel_str.as_str());
-    if cache.remove(&cache_key).is_some() {
-        ctx.state.replace_tasks_cache(cache)?;
+    let removed = ctx
+        .state
+        .with_tasks_cache_mut(|cache| cache.remove(&cache_key).is_some())?;
+    if removed {
         (ctx.emit)("task-deleted", json!({ "filePath": rel_str }));
     } else {
         log::trace!(

--- a/src-tauri/src/watcher_event/mod.rs
+++ b/src-tauri/src/watcher_event/mod.rs
@@ -1,0 +1,149 @@
+//! `spec_board_fs::watcher::Watcher` の `FsEvent` を読み込み、`AppState`
+//! の `tasks_cache` を差分更新したうえで `task-created` / `task-updated`
+//! / `task-deleted` を `tauri::AppHandle::emit` で配信する adapter 層。
+//!
+//! # モジュール構成
+//!
+//! - `prepare_watcher(root)`: `Watcher::start` を呼んで `(Watcher, Receiver)`
+//!   を確保するだけ。`open_project_impl` の commit より前に実行される 1 段目。
+//! - `spawn_adapter(app, root, config, state, watcher, rx)`: 既に確保済みの
+//!   watcher / rx から adapter スレッドを spawn し、`EmittingWatcherHandle` を
+//!   返す 2 段目。spawn は panic 以外で失敗しない。
+//! - `handler::handle_event`: 1 件の `FsEvent` を処理する純粋関数。テストは
+//!   ここに対して書く。
+//! - `handler::run_event_loop`: adapter スレッド本体。`Receiver::recv` を
+//!   blocking で消費し、`Disconnected` で抜ける。
+//!
+//! # スレッド寿命
+//!
+//! `EmittingWatcherHandle::stop()` は内部で
+//! 1. `Watcher` を `drop` して `notify` バックエンドの送信側を切断する
+//! 2. adapter スレッドを `join` する
+//!
+//! の 2 段で同期的に停止する。`stop()` は冪等で `AppState` の lock を
+//! 一切取得しない（`watcher_handle` 取得中の deadlock を防ぐ）。
+
+pub(crate) mod handler;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::Receiver;
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+use tauri::{AppHandle, Emitter};
+
+use crate::config::Config;
+use crate::state::AppState;
+use crate::task_index::default_status_for;
+use spec_board_fs::watcher::{FsEvent, Watcher, WatcherError};
+use spec_board_fs::watcher_handle::WatcherHandle;
+
+/// emit の抽象化（本番 = `AppHandle::emit`、テスト = Vec push）。
+pub(crate) type EmitFn = Box<dyn Fn(&str, serde_json::Value) + Send + Sync + 'static>;
+
+/// adapter スレッドが共有する不変コンテキスト。
+pub(crate) struct AdapterContext {
+    pub(crate) root: PathBuf,
+    pub(crate) default_status: String,
+    pub(crate) state: Arc<AppState>,
+    pub(crate) emit: EmitFn,
+}
+
+/// 実 `WatcherHandle` 実装。Watcher Drop + adapter join を内包する。
+///
+/// `watcher` が `Some` のうちは notify バックエンドの送信側が生きている。
+/// `stop()` で `watcher` を drop して送信側を切断したのち adapter スレッドを
+/// join することで、同期的に停止が完了する。
+pub struct EmittingWatcherHandle {
+    watcher: Option<Watcher>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl WatcherHandle for EmittingWatcherHandle {
+    fn stop(&mut self) {
+        // (1) Watcher を drop → Receiver<FsEvent> Disconnected
+        // (2) adapter スレッド join（recv() ループが Err で抜ける）
+        // 注: stop() は冪等。AppState lock を一切取らない（deadlock 回避）。
+        if let Some(w) = self.watcher.take() {
+            drop(w);
+        }
+        if let Some(handle) = self.join.take() {
+            // panic は握り潰す（mutex poison を起こさない）。adapter 本体は
+            // 既に catch_unwind で包んでいるので通常は panic で抜けない。
+            let _ = handle.join();
+        }
+    }
+}
+
+/// `open_project_impl` の **state commit より前に**呼び出される 1 段目。
+///
+/// `Watcher::start` を試みて Watcher と Receiver を確保するだけで、adapter は
+/// まだ spawn しない。失敗時はこの段階で `WatcherError` を返し、呼び出し側は
+/// AppState を一切変更せずに `WatcherInitFailed` として伝播できる。
+pub(crate) fn prepare_watcher(root: &Path) -> Result<(Watcher, Receiver<FsEvent>), WatcherError> {
+    Watcher::start(root)
+}
+
+/// `open_project_impl` の **state commit 完了後**に呼び出される 2 段目。
+///
+/// 確保済みの `(watcher, rx)` から adapter スレッドを spawn し、実
+/// `EmittingWatcherHandle` を組み立てる。spawn は panic 以外で失敗しないため
+/// 戻り値は `EmittingWatcherHandle` 直接。
+pub(crate) fn spawn_adapter(
+    app: &AppHandle,
+    root: &Path,
+    config: &Config,
+    state: Arc<AppState>,
+    watcher: Watcher,
+    rx: Receiver<FsEvent>,
+) -> EmittingWatcherHandle {
+    let app_for_emit = app.clone();
+    let emit: EmitFn = Box::new(move |event, payload| {
+        if let Err(err) = app_for_emit.emit(event, payload) {
+            log::warn!("failed to emit `{event}`: {err}");
+        }
+    });
+    let ctx = AdapterContext {
+        root: root.to_path_buf(),
+        default_status: default_status_for(config),
+        state,
+        emit,
+    };
+    spawn_adapter_with_ctx(watcher, rx, ctx)
+}
+
+/// 既に組み立て済みの `AdapterContext` から adapter スレッドを spawn する。
+/// テストでは emit を Vec push スタブにした context を渡すために直接呼ぶ。
+pub(crate) fn spawn_adapter_with_ctx(
+    watcher: Watcher,
+    rx: Receiver<FsEvent>,
+    ctx: AdapterContext,
+) -> EmittingWatcherHandle {
+    let join = thread::spawn(move || {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            handler::run_event_loop(rx, ctx);
+        }));
+        if let Err(payload) = result {
+            let msg = panic_payload_string(&payload);
+            log::error!("watcher_event adapter thread panicked: {msg}");
+        }
+    });
+    EmittingWatcherHandle {
+        watcher: Some(watcher),
+        join: Some(join),
+    }
+}
+
+/// `catch_unwind` payload を可能な範囲で文字列化する。
+fn panic_payload_string(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}

--- a/src-tauri/src/watcher_event/tests.rs
+++ b/src-tauri/src/watcher_event/tests.rs
@@ -1,0 +1,547 @@
+//! `watcher_event::handler` の純粋ハンドラに対する単体テスト。
+//!
+//! emit を `Vec<(String, serde_json::Value)>` push スタブに差し替え、
+//! `Watcher` を起動せずに `handle_event` を直接駆動する。
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+use super::handler::{handle_event, run_event_loop};
+use super::{AdapterContext, EmitFn};
+use crate::state::AppState;
+use spec_board_fs::watcher::FsEvent;
+
+type EmitLog = Arc<Mutex<Vec<(String, Value)>>>;
+
+fn build_ctx(root: PathBuf, state: Arc<AppState>) -> (AdapterContext, EmitLog) {
+    let log: EmitLog = Arc::new(Mutex::new(Vec::new()));
+    let log_clone = Arc::clone(&log);
+    let emit: EmitFn = Box::new(move |ev, payload| {
+        log_clone.lock().unwrap().push((ev.to_string(), payload));
+    });
+    let ctx = AdapterContext {
+        root,
+        default_status: "Todo".to_string(),
+        state,
+        emit,
+    };
+    (ctx, log)
+}
+
+fn task_md(title: &str) -> String {
+    format!("---\ntitle: {title}\nstatus: Todo\n---\n\nbody\n")
+}
+
+fn write_md(root: &Path, rel: &str, body: &str) -> PathBuf {
+    let absolute = root.join(rel);
+    if let Some(parent) = absolute.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(&absolute, body).expect("write md");
+    absolute
+}
+
+fn snapshot_paths(state: &AppState) -> Vec<String> {
+    let mut paths: Vec<String> = state
+        .tasks_snapshot()
+        .expect("readable")
+        .into_iter()
+        .map(|t| t.file_path)
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn drain_log(log: &EmitLog) -> Vec<(String, Value)> {
+    log.lock().unwrap().drain(..).collect()
+}
+
+#[test]
+fn create_event_for_new_path_emits_task_created_and_caches_task() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("handler should succeed");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len(), "one emit expected");
+    assert_eq!("task-created", entries[0].0);
+    assert_eq!("tasks/a.md", entries[0].1["task"]["filePath"]);
+
+    assert_eq!(vec!["tasks/a.md".to_string()], snapshot_paths(&state));
+}
+
+#[test]
+fn modify_event_for_existing_path_emits_task_updated_and_replaces_cache_entry() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    // 事前に Created で投入する。
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("seed create");
+    drain_log(&log);
+
+    // 内容を更新して Modified を投入。
+    write_md(dir.path(), "tasks/a.md", &task_md("A2"));
+    handle_event(&FsEvent::Modified(abs), &ctx).expect("modify ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len());
+    assert_eq!("task-updated", entries[0].0);
+    assert_eq!("A2", entries[0].1["task"]["title"]);
+
+    let tasks = state.tasks_snapshot().expect("readable");
+    assert_eq!(1, tasks.len());
+    assert_eq!("A2", tasks[0].title);
+}
+
+#[test]
+fn create_event_for_already_cached_path_emits_task_updated_for_atomic_save() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("seed create");
+    drain_log(&log);
+
+    write_md(dir.path(), "tasks/a.md", &task_md("A2"));
+    // atomic save では rename 後の to-side が Created で再通知されることがある。
+    handle_event(&FsEvent::Created(abs), &ctx).expect("create-on-existing");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len());
+    assert_eq!("task-updated", entries[0].0);
+}
+
+#[test]
+fn rename_event_emits_deleted_for_from_and_created_for_to() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let from_abs = write_md(dir.path(), "tasks/from.md", &task_md("F"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(from_abs.clone()), &ctx).expect("seed");
+    drain_log(&log);
+
+    // ファイルを物理的に rename してから FsEvent::Renamed を投入する。
+    let to_abs = dir.path().join("tasks/to.md");
+    std::fs::rename(&from_abs, &to_abs).expect("rename");
+
+    handle_event(
+        &FsEvent::Renamed {
+            from: from_abs,
+            to: to_abs,
+        },
+        &ctx,
+    )
+    .expect("rename ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(2, entries.len());
+    assert_eq!("task-deleted", entries[0].0);
+    assert_eq!("tasks/from.md", entries[0].1["filePath"]);
+    assert_eq!("task-created", entries[1].0);
+    assert_eq!("tasks/to.md", entries[1].1["task"]["filePath"]);
+
+    assert_eq!(vec!["tasks/to.md".to_string()], snapshot_paths(&state));
+}
+
+#[test]
+fn rename_with_to_already_in_cache_emits_created_not_updated() {
+    // 仕様上 Rename は「from で task-deleted、to で task-created」と定義されている。
+    // to が既存 cache にある場合でも task-updated にならず task-created が emit される
+    // ことを担保する。
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let from_abs = write_md(dir.path(), "tasks/from.md", &task_md("F"));
+    let to_abs = write_md(dir.path(), "tasks/to.md", &task_md("T"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(from_abs.clone()), &ctx).expect("seed from");
+    handle_event(&FsEvent::Created(to_abs.clone()), &ctx).expect("seed to");
+    drain_log(&log);
+
+    // ファイルシステム上は from を消して to を上書きで置き換える想定。
+    std::fs::remove_file(&to_abs).ok();
+    std::fs::rename(&from_abs, &to_abs).expect("rename");
+
+    handle_event(
+        &FsEvent::Renamed {
+            from: from_abs,
+            to: to_abs,
+        },
+        &ctx,
+    )
+    .expect("rename ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(2, entries.len(), "deleted + created expected");
+    assert_eq!("task-deleted", entries[0].0);
+    assert_eq!("tasks/from.md", entries[0].1["filePath"]);
+    assert_eq!(
+        "task-created", entries[1].0,
+        "to-side should always be task-created in rename"
+    );
+    assert_eq!("tasks/to.md", entries[1].1["task"]["filePath"]);
+}
+
+#[test]
+fn rename_with_unparseable_to_emits_only_deleted_and_removes_from_cache() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let from_abs = write_md(dir.path(), "tasks/from.md", &task_md("F"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(from_abs.clone()), &ctx).expect("seed");
+    drain_log(&log);
+
+    // to-side の md は frontmatter なし → parse 失敗
+    let to_abs = write_md(dir.path(), "tasks/to.md", "no frontmatter\n");
+    std::fs::remove_file(&from_abs).ok();
+
+    handle_event(
+        &FsEvent::Renamed {
+            from: from_abs,
+            to: to_abs,
+        },
+        &ctx,
+    )
+    .expect("rename ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len());
+    assert_eq!("task-deleted", entries[0].0);
+    assert_eq!("tasks/from.md", entries[0].1["filePath"]);
+
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn rename_with_from_not_in_cache_does_not_emit_deleted_for_atomic_save() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    // from は cache に未登録（atomic save の swap 元のような扱い）。
+    let from_abs = dir.path().join("tasks/from.md.tmp");
+    let to_abs = write_md(dir.path(), "tasks/to.md", &task_md("T"));
+
+    handle_event(
+        &FsEvent::Renamed {
+            from: from_abs,
+            to: to_abs,
+        },
+        &ctx,
+    )
+    .expect("rename ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len(), "only created should fire");
+    assert_eq!("task-created", entries[0].0);
+    assert_eq!(vec!["tasks/to.md".to_string()], snapshot_paths(&state));
+}
+
+#[test]
+fn write_ignore_consume_skips_emit_for_self_originated_create() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    state
+        .write_ignore()
+        .register(&abs)
+        .expect("register write_ignore");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty(), "self write should not emit");
+    assert!(snapshot_paths(&state).is_empty());
+    assert!(state.write_ignore().is_empty().expect("readable"));
+}
+
+#[test]
+fn parse_failure_does_not_emit_or_mutate_cache() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", "---\n: invalid\n---\n");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn read_failure_does_not_emit_or_mutate_cache() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = dir.path().join("tasks/missing.md");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Modified(abs), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn path_outside_root_is_ignored() {
+    let root = TempDir::new().expect("root tempdir");
+    let other = TempDir::new().expect("other tempdir");
+    let state = Arc::new(AppState::new());
+    let outside = write_md(other.path(), "tasks/x.md", &task_md("X"));
+    let (ctx, log) = build_ctx(root.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(outside), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn uppercase_md_extension_is_accepted() {
+    // scanner は `.MD` / `.Md` も対象。watcher 側でも揃える必要がある（初回 scan
+    // で読まれた `A.MD` の変更を watcher で取りこぼさないため）。
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/A.MD", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len());
+    assert_eq!("task-created", entries[0].0);
+    assert_eq!("tasks/A.MD", entries[0].1["task"]["filePath"]);
+}
+
+#[test]
+fn dotfile_md_is_ignored() {
+    // scanner はドット始まりのファイル名を除外する（`.hidden.md` 等）。
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/.hidden.md", &task_md("H"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn dot_directory_descendant_md_is_ignored() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), ".git/notes.md", &task_md("Hidden"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn node_modules_descendant_md_is_ignored() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "node_modules/x/readme.md", &task_md("X"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn oversized_md_is_ignored() {
+    // scanner は 1MB 超を除外する。watcher 側でも揃える（巨大ファイルを read で
+    // 丸読みして OOM / レスポンス劣化を起こさない）。
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let header = "---\ntitle: Big\nstatus: Todo\n---\n";
+    let mut body = String::with_capacity(1024 * 1024 + header.len() + 64);
+    body.push_str(header);
+    body.push_str(&"x".repeat(1024 * 1024 + 32));
+    let abs = write_md(dir.path(), "tasks/big.md", &body);
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_md_to_outside_root_is_ignored() {
+    // scanner は WalkDir::follow_links(false) で symlink を辿らない。watcher 側でも
+    // 揃えることで、root 外の任意ファイルを watcher 経由で読み取られないようにする。
+    let dir = TempDir::new().expect("tempdir");
+    let other = TempDir::new().expect("other tempdir");
+    let state = Arc::new(AppState::new());
+
+    let outside = write_md(other.path(), "tasks/outside.md", &task_md("Outside"));
+    let link = dir.path().join("tasks/link.md");
+    std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&outside, &link).expect("create symlink");
+
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(link), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn binary_md_with_nul_byte_is_ignored() {
+    // scanner は先頭 8KB に NUL を含むファイルを除外する。
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = dir.path().join("tasks/bin.md");
+    std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+    let mut bytes = b"---\ntitle: Bin\nstatus: Todo\n---\n".to_vec();
+    bytes.push(0u8);
+    bytes.extend_from_slice(b"binary tail");
+    std::fs::write(&abs, bytes).expect("write");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn non_markdown_extension_is_ignored() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let txt = write_md(dir.path(), "tasks/a.txt", "plain text");
+    let cfg = write_md(dir.path(), ".spec-board/config.json", "{}");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(txt), &ctx).expect("ok");
+    handle_event(&FsEvent::Modified(cfg), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn removed_other_rescan_error_variants_are_no_op() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Removed(abs.clone()), &ctx).expect("ok");
+    handle_event(&FsEvent::Other(abs), &ctx).expect("ok");
+    handle_event(&FsEvent::Rescan, &ctx).expect("ok");
+    handle_event(&FsEvent::Error("backend boom".to_string()), &ctx).expect("ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn task_created_payload_uses_camel_case_with_full_task() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Created(abs), &ctx).expect("ok");
+
+    let entries = drain_log(&log);
+    let payload = &entries[0].1;
+    let task = &payload["task"];
+    assert_eq!("tasks/a.md", task["filePath"]);
+    assert_eq!("tasks/a.md", task["id"]);
+    assert!(task.get("reverseLinks").is_some(), "camelCase reverseLinks");
+}
+
+#[test]
+fn task_deleted_payload_contains_forward_slash_relative_path() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/sub/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("seed");
+    drain_log(&log);
+
+    let from_abs = abs;
+    let to_abs = dir.path().join("tasks/sub/b.md");
+    std::fs::rename(&from_abs, &to_abs).expect("rename");
+
+    handle_event(
+        &FsEvent::Renamed {
+            from: from_abs,
+            to: to_abs,
+        },
+        &ctx,
+    )
+    .expect("rename ok");
+
+    let entries = drain_log(&log);
+    let deleted = entries
+        .iter()
+        .find(|(name, _)| name == "task-deleted")
+        .expect("deleted emitted");
+    assert_eq!(json!("tasks/sub/a.md"), deleted.1["filePath"]);
+}
+
+#[test]
+fn run_event_loop_processes_multiple_events_then_exits_on_disconnect() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs_a = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let abs_b = write_md(dir.path(), "tasks/b.md", &task_md("B"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    let (tx, rx) = std::sync::mpsc::channel::<FsEvent>();
+
+    let join = std::thread::spawn(move || run_event_loop(rx, ctx));
+    tx.send(FsEvent::Created(abs_a)).expect("send a");
+    tx.send(FsEvent::Created(abs_b)).expect("send b");
+    drop(tx);
+    join.join().expect("loop should exit cleanly");
+
+    let entries = drain_log(&log);
+    assert_eq!(2, entries.len());
+}
+
+#[test]
+fn adapter_thread_with_panicking_emit_does_not_crash_test_thread() {
+    // emit closure が panic しても、`spawn_adapter_with_ctx` の catch_unwind が
+    // adapter スレッド内で握り潰し、テスト本体プロセスは生存することを確認する。
+    // `Watcher` の所有を扱う煩雑さを避けるため、`spawn_adapter_with_ctx` 自体は
+    // 使わず、同じ catch_unwind 構造を持つ thread::spawn を直接立てる。
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let panicking_emit: EmitFn = Box::new(|_event, _payload| {
+        panic!("emit panic in test");
+    });
+    let ctx = AdapterContext {
+        root: dir.path().to_path_buf(),
+        default_status: "Todo".to_string(),
+        state,
+        emit: panicking_emit,
+    };
+    let (tx, rx) = std::sync::mpsc::channel::<FsEvent>();
+
+    let join = std::thread::spawn(move || {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            run_event_loop(rx, ctx);
+        }));
+        result.is_err()
+    });
+    tx.send(FsEvent::Created(abs)).expect("send create");
+    drop(tx);
+    let panicked = join.join().expect("thread should not abort the process");
+    assert!(panicked, "emit panic should be caught by catch_unwind");
+}


### PR DESCRIPTION
## 概要

`spec_board_fs::watcher::Watcher` のデバウンス済み `FsEvent` を本体クレートで読込・パースし、`AppState.tasks_cache` を 1 path 単位で差分更新したうえで `tauri::AppHandle::emit` でフロントエンドへ `task-created` / `task-updated` / `task-deleted` を配信する adapter 層を追加した。`open_project_impl` で実 watcher を起動するよう、`NoopWatcherHandle` を実 `EmittingWatcherHandle` に置き換える。

## 変更の種類

- ✨ 新機能
- ♻️ リファクタリング（`task_index` / `file_scanner` の helper 公開）
- 📝 ドキュメント（`docs/spec-board/file-system-spec.md` / `docs/impl/watcher.md`）
- 💥 破壊的変更（`tauri::Builder::manage(AppState::new())` → `Arc::new(AppState::new())`）

## 追加した内容

- `src-tauri/src/watcher_event/` モジュール（`mod.rs` / `handler.rs` / `tests.rs`）
  - `prepare_watcher(root) -> Result<(Watcher, Receiver<FsEvent>), WatcherError>`
  - `spawn_adapter(app, root, config, state, watcher, rx) -> EmittingWatcherHandle`
  - `EmittingWatcherHandle::stop()` で Watcher drop + JoinHandle::join の同期停止
  - `handle_event` 純粋ハンドラ + `run_event_loop` adapter 本体
  - 17 件の単体テスト（Create/Modified/Rename/atomic save/write_ignore/parse fail/read fail/outside root/dotfile/node_modules/oversize/binary/symlink/payload 形式 など）
- `OpenProjectError::WatcherInitFailed { source: WatcherError }` variant
- `spec_board_fs::file_scanner::task_md_relative_path(abs_path, root) -> Option<PathBuf>` 公開 API
- `commit_app_state_with_factories<P, S, T>` テスト容易性のための一般化版
- `open_project_with_factories<P, S, T>` 同様にテスト境界を提供

## 変更した内容

- `tauri::Builder::manage(AppState::new())` を `Arc::new(AppState::new())` に変更し、`#[tauri::command] open_project` / `get_tasks` を `state: State<'_, Arc<AppState>>` で受けるよう修正
- `open_project_impl` の commit を **4 段階手順**に再構成:
  1. `prepare_watcher` で `(Watcher, Receiver)` を確保（失敗時は AppState を一切変更せず復帰）
  2. 旧 watcher を `take_watcher_handle()` で取り出し `stop()`（lock 解放後に呼ぶため panic で mutex が poison しない）
  3. `project_path` / `config` / `tasks_cache` / `write_ignore.clear` を順に commit
  4. `spawn_adapter` で adapter スレッド起動 → `install_watcher_handle`
- adapter スレッドは `std::panic::catch_unwind(AssertUnwindSafe(...))` で包み、emit closure 等が panic してもプロセスを巻き込まない
- Renamed の `to`-side は `UpsertMode::ForceCreated` で常に `task-created` を emit（仕様: 「rename = 旧 path delete + 新 path create」）
- watcher 経由の `.md` 判定を `task_md_relative_path` に集約し、`scan_md_files` と同じフィルタ（拡張子大小 / dotfile / `node_modules` / 1MB 超 / バイナリ / symlink 不追従）を適用
- `crate::task_index::normalized_task_file_path` / `default_status_for` を `pub(crate)` 化（adapter から再利用）

## 削除した内容

- `open_project.rs` 内の `default_status_for` private 関数（`task_index` 側に移動）
- `commit_app_state` 内の `NoopWatcherHandle` install 配線（実 watcher 起動に置き換え）

## 仕様ドキュメント更新

- `docs/spec-board/file-system-spec.md`
  - `open_project` の説明を「実 watcher 起動 + IPC 配信」に更新（`NoopWatcherHandle` 前提の旧記述を差し替え）
  - `WatcherInitFailed` エラー（\`ファイル監視の初期化に失敗しました: ...\`）を追加し、AppState を一切変更しない契約を明記
  - 自己書き込み抑制セクションに「**絶対パスで register / consume する規約**」と「**stale entry の TTL cleanup は行わず project reopen 時の `clear()` でのみ解消**」を追記
  - 監視イベントの FE 配信が現時点で Create/Modify/Rename のみで、`Removed` は本体 adapter で `log::trace` のみ（FE 通知は別 Issue #74）であることを処理フローに明記
  - `spec-board-fs::watcher` のスコープ外を整理し、IPC emit / WriteIgnore 統合 / 拡張子フィルタは `watcher_event` adapter 側で実装済みであることを明記
- `docs/impl/watcher.md`
  - `watcher_event` adapter のモジュール構成 / 4 段階起動手順 / `EmittingWatcherHandle::stop` の同期停止 / `catch_unwind` による panic 隔離を追記

## システム図

```mermaid
flowchart TD
    OS[OS FS イベント] --> Backend[notify backend]
    Backend -->|100ms debounce| Rx[Receiver FsEvent]
    Rx --> Loop[run_event_loop]
    Loop --> Classify{event 分類}
    Classify -->|Created/Modified| Up[handle_upsert]
    Classify -->|Renamed from,to| Del[handle_delete from]
    Del --> Up2[handle_upsert to ForceCreated]
    Classify -->|Removed/Other/Rescan/Error| Trace[log のみ]

    Up --> Filt{root 配下の .md?<br/>scanner と同条件}
    Up2 --> Filt
    Filt -->|No| Skip[skip]
    Filt -->|Yes| Wi{write_ignore<br/>consume?}
    Wi -->|true| Skip
    Wi -->|false| Read[fs::read + parse]
    Read --> Cache[tasks_cache 差分更新]
    Cache --> Emit[AppHandle::emit]
    Emit --> FE[task-created/updated/deleted]

    style Loop fill:#e0f2fe,stroke:#0284c7
    style Cache fill:#fef3c7,stroke:#d97706
    style Emit fill:#dcfce7,stroke:#16a34a
```

```mermaid
flowchart LR
    Start[open_project_impl] --> Validate[validate_directory<br/>check_locks<br/>load+scan+parse<br/>build_children/reverse_links<br/>write GUIDE.md]
    Validate --> S1[1 prepare_watcher]
    S1 -->|Err| Fail[WatcherInitFailed<br/>AppState 完全無変更]
    S1 -->|Ok| S2[2 take_watcher_handle<br/>+ prev.stop]
    S2 --> S3[3 state commit<br/>project_path/config/tasks_cache<br/>write_ignore.clear]
    S3 --> S4[4 spawn_adapter<br/>+ install_watcher_handle]
    S4 --> Done[OpenProjectPayload]

    style S1 fill:#dbeafe,stroke:#2563eb
    style S2 fill:#dbeafe,stroke:#2563eb
    style S3 fill:#dbeafe,stroke:#2563eb
    style S4 fill:#dbeafe,stroke:#2563eb
    style Fail fill:#fee2e2,stroke:#dc2626
```

## 関連Issue

Closes #73
Refs #70 (親 Issue) / #74 (Removed 対応の後続) / #105 (FE 配線の後続)

## テスト

- `cargo test --workspace --all-targets`: **386 tests passed**（spec_board_lib 270 + spec_board_fs 116）
- `cargo clippy --workspace --all-targets -- -D warnings`: 通過
- `cargo fmt --all -- --check`: 通過
- 手動検証 1〜7（`pnpm tauri dev` でアプリ起動 → md 作成/編集/リネーム）は **未実施**。FE 配線（Issue #105）と組み合わせる段階で別途確認する想定

主な追加テストケース:

- `handle_event` 単体テスト（17 件）: Created 新規、Modified 既存更新、atomic save、Rename（正常系 / to-parse 失敗 / from cache 不在 / to 既存 cache→ForceCreated）、write_ignore consume skip、parse failure、read failure、outside root、`.MD` 大文字、dotfile、`node_modules`、1MB 超、バイナリ、symlink、Removed/Other/Rescan/Error no-op、payload camelCase、payload filePath
- `run_event_loop` smoke（2 件）: 複数 event 順次処理、emit panic を catch_unwind で隔離
- `open_project` 新規（2 件）: WatcherInitFailed 時に AppState が完全無変更、起動順序検証（prepare → stop_old → commit → spawn）

## レビューポイント

1. **API 破壊的変更**: `tauri::Builder::manage(Arc::new(AppState::new()))` 化に伴い、すべての `#[tauri::command]` で `state: State<'_, Arc<AppState>>` に変更。`State::inner()` の戻り型が `&Arc<AppState>` になるため、`.clone()` で `Arc<AppState>` を取り出して adapter スレッドへ move する形に統一
2. **`watcher_stop_panic_propagates_without_poisoning_watcher_handle_mutex` テストの仕様変更**: 旧フローでは `install_watcher_handle` が lock 保持中に `stop()` を呼んでいたため panic で mutex が poison していたが、新フローは `take_watcher_handle()` で取り出した後 lock 解放下で `stop()` を呼ぶため、panic は伝播しても mutex は健全のまま。後続 open は成功する仕様に変更
3. **scanner-watcher フィルタの統一**: `task_md_relative_path` を共有 API として切り出すことで、初回 scan と watcher の判定を 1 箇所に集約。symlink を辿らない挙動を含めて完全に一致させた
4. **`UpsertMode` enum**: Renamed の `to`-side が cache 既存の場合でも `task-created` を emit する仕様（rename = delete+create）を `ForceCreated` バリアントで明示
5. **Codex CLI による 5 ラウンドの自己レビュー**: `.plugin-workspace/.specs/008-watcher-task-events/code-review/` に履歴を残し、指摘された (1) Rename to-side bug, (2) 仕様書記述矛盾, (3) scanner-watcher 不一致, (4) symlink 取り込み の 4 件をすべて修正済み

## チェックリスト

- [x] セルフレビューを実施した
- [x] `cargo test` / `cargo clippy` / `cargo fmt --check` が通る
- [x] 仕様変更があるため `docs/spec-board/file-system-spec.md` を更新した
- [x] 関連 Issue #73 を PR にリンクした
- [x] 破壊的変更（`Arc<AppState>` 化）を本文に明記した
- [ ] UI 変更がある場合は Tauri アプリで動作確認した（FE 未配線のため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)