### PR TITLE
✨ [New Feature]: #81 [BE] create_task の parent 検証純粋関数を追加

### DIFF
--- a/src-tauri/src/create_task.rs
+++ b/src-tauri/src/create_task.rs
@@ -1,13 +1,15 @@
-//! `create_task` Tauri command の引数受け取り型とファイル名生成純粋関数。
+//! `create_task` Tauri command の引数受け取り型・入力検証純粋関数群。
 //!
-//! 本モジュールは現時点では以下のみを提供する:
+//! 本モジュールは現時点では以下を提供する:
 //! - [`CreateTaskArgs`][] : FE から受け取る引数 DTO
 //! - [`CreateTaskError`][]: 入力検証エラー
 //! - [`build_new_filename`][]: title と既存ファイル名集合からユニークな
 //!   md ファイル名を生成する純粋関数
+//! - [`validate_parent_for_new_task`][]: 新規タスクの parent 引数を既存タスク
+//!   スナップショットに対して検証する純粋関数（存在 + 循環/深さ）
 //!
-//! `#[tauri::command]` シン本体・AppState 反映・FS 書込み・parent 検証は
-//! 本モジュールには含まれず、後続 Issue で追加される。
+//! `#[tauri::command]` シン本体・AppState 反映・FS 書込みは本モジュールには含まれず、
+//! 後続 Issue で追加される（本モジュールの純粋関数を組み合わせて使う想定）。
 
 use std::collections::HashSet;
 
@@ -15,6 +17,10 @@ use serde::Deserialize;
 use spec_board_fs::kebab_case::to_kebab_case;
 use spec_board_fs::unique_filename::build_unique_filename;
 use thiserror::Error;
+
+use crate::task_index::{
+    resolve_parent_for_new_task, validate_chain_from_parent, ParentHierarchyErrorReason, Task,
+};
 
 /// `create_task` Tauri command の引数 DTO。
 ///
@@ -36,7 +42,7 @@ pub struct CreateTaskArgs {
     /// 親タスクへのプロジェクトルート相対パス（例: `tasks/parent-task.md`）。
     /// `.md` 拡張子込みのパス文字列で受け取る前提
     /// （task-format-spec.md の `parent` フィールド仕様に準拠）。
-    /// 存在検証・循環検証は後続Issue で実装。
+    /// 存在 + 循環/深さの検証は [`validate_parent_for_new_task`] で行う。
     pub parent: Option<String>,
     /// 本文（Markdown）。未指定時は空文字列扱い。
     pub body: Option<String>,
@@ -51,6 +57,18 @@ pub enum CreateTaskError {
     /// `title` が空、または `to_kebab_case(title)` の結果が空文字列となるケース。
     #[error("タイトルからファイル名を生成できません")]
     InvalidTitle,
+    /// `parent` で指定されたパスが既存タスクと一致しない。
+    /// 空文字 / 絶対パス / Windows drive prefix / 自己参照（新規タスクは未登録のため
+    /// 自然にここに該当） / 単純な不一致 をすべて含む。
+    #[error("親タスクが見つかりません: {parent}")]
+    ParentNotFound { parent: String },
+    /// `parent` 起点 chain に循環があるか、新規タスク 1 edge を加えた合計が
+    /// 最大深さ（20）を超える。
+    #[error("親タスクのチェーン検証に失敗しました ({parent}): {reason}")]
+    ParentCycleOrTooDeep {
+        parent: String,
+        reason: ParentHierarchyErrorReason,
+    },
 }
 
 /// title と既存ファイル名集合から、衝突しない md ファイル名を生成する。
@@ -90,12 +108,93 @@ pub fn build_new_filename(
     Ok(build_unique_filename(&base, "md", existing_filenames))
 }
 
+/// 新規タスクの `parent` 引数を検証する純粋関数。
+///
+/// 検証内容:
+/// 1. `parent = None` の場合は親なしとして `Ok(())`。
+/// 2. `parent = Some(path)` の場合、`existing_tasks` の `file_path` と一致するか
+///    （`./` 接頭辞や `\\` セパレータの正規化込み）。一致しなければ
+///    [`CreateTaskError::ParentNotFound`] を返す（空文字 / 絶対パス / Windows drive prefix /
+///    自己参照もここに含まれる）。
+/// 3. parent 起点 chain に新規タスク 1 edge を追加した合計深さが
+///    最大深さ（20）を超えないか・循環していないかを検証する。違反した場合は
+///    [`CreateTaskError::ParentCycleOrTooDeep`] を返す。
+///
+/// @param parent FE から受け取った parent 文字列（`None` または `tasks/foo.md` 形式）。
+/// @param existing_tasks `AppState.tasks_cache` のスナップショット。
+/// @returns Ok(()) / `ParentNotFound` / `ParentCycleOrTooDeep`。
+pub fn validate_parent_for_new_task(
+    parent: Option<&str>,
+    existing_tasks: &[Task],
+) -> Result<(), CreateTaskError> {
+    let Some(parent_str) = parent else {
+        return Ok(());
+    };
+
+    let parent_index =
+        resolve_parent_for_new_task(parent_str, existing_tasks).ok_or_else(|| {
+            CreateTaskError::ParentNotFound {
+                parent: parent_str.to_string(),
+            }
+        })?;
+
+    validate_chain_from_parent(parent_index, existing_tasks).map_err(|reason| {
+        CreateTaskError::ParentCycleOrTooDeep {
+            parent: parent_str.to_string(),
+            reason,
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::frontmatter::Priority;
+    use crate::task_index::{TaskExtras, TaskWarning};
 
     fn set_of(items: &[&str]) -> HashSet<String> {
         items.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn make_task(file_path: &str, parent: Option<&str>) -> Task {
+        Task {
+            id: file_path.to_string(),
+            file_path: file_path.to_string(),
+            title: "Task".to_string(),
+            status: "Todo".to_string(),
+            priority: None::<Priority>,
+            labels: Vec::new(),
+            parent: parent.map(str::to_string),
+            links: Vec::new(),
+            children: Vec::new(),
+            reverse_links: Vec::new(),
+            body: String::new(),
+            extras: TaskExtras::new(),
+            warnings: Vec::<TaskWarning>::new(),
+        }
+    }
+
+    fn task_with_parent(file_path: &str, parent: &str) -> Task {
+        make_task(file_path, Some(parent))
+    }
+
+    fn task_without_parent(file_path: &str) -> Task {
+        make_task(file_path, None)
+    }
+
+    /// 新規タスク → 起点 parent (`tasks/0.md`) → ... → root (`tasks/{edge_count}.md`) の
+    /// chain を表す Task 一覧を作る。`tasks[0]` が新規タスクの parent 候補。
+    /// 戻り値の長さは `edge_count + 1`、parent 側 edge 数は `edge_count`。
+    fn parent_chain_with_edge_count(edge_count: usize) -> Vec<Task> {
+        let mut tasks = Vec::with_capacity(edge_count + 1);
+        for index in 0..edge_count {
+            tasks.push(task_with_parent(
+                &format!("tasks/{index}.md"),
+                &format!("tasks/{}.md", index + 1),
+            ));
+        }
+        tasks.push(task_without_parent(&format!("tasks/{edge_count}.md")));
+        tasks
     }
 
     #[test]
@@ -185,6 +284,105 @@ mod tests {
             let existing: HashSet<String> = HashSet::new();
             let actual = build_new_filename(title, &existing);
             assert_eq!(actual, Err(CreateTaskError::InvalidTitle), "{label}");
+        }
+    }
+
+    #[test]
+    fn validate_parent_for_new_task_ok_cases() {
+        let single = vec![task_without_parent("tasks/a.md")];
+        let chain_19 = parent_chain_with_edge_count(19);
+
+        let cases: Vec<(Option<&str>, &[Task], &str)> = vec![
+            (None, &[], "parent=None / empty existing"),
+            (None, single.as_slice(), "parent=None / non-empty existing"),
+            (
+                Some("tasks/a.md"),
+                single.as_slice(),
+                "existing root parent",
+            ),
+            (
+                Some("./tasks/a.md"),
+                single.as_slice(),
+                "leading ./ normalized",
+            ),
+            (
+                Some("tasks\\a.md"),
+                single.as_slice(),
+                "backslash separator",
+            ),
+            (
+                Some("tasks/0.md"),
+                chain_19.as_slice(),
+                "edge 19 chain (total 20 = MAX)",
+            ),
+        ];
+        for (parent, tasks, label) in cases {
+            assert_eq!(
+                validate_parent_for_new_task(parent, tasks),
+                Ok(()),
+                "{label}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_parent_for_new_task_not_found_cases() {
+        let single = vec![task_without_parent("tasks/a.md")];
+
+        let cases: Vec<(&str, &[Task], &str)> = vec![
+            ("tasks/missing.md", single.as_slice(), "no matching path"),
+            ("", single.as_slice(), "empty parent string"),
+            ("/abs/path.md", single.as_slice(), "absolute path"),
+            ("C:\\foo.md", single.as_slice(), "windows drive prefix"),
+            (
+                "tasks/self.md",
+                single.as_slice(),
+                "self reference (new task not yet registered)",
+            ),
+            ("tasks/a.md", &[] as &[Task], "empty existing tasks"),
+        ];
+        for (parent, tasks, label) in cases {
+            assert_eq!(
+                validate_parent_for_new_task(Some(parent), tasks),
+                Err(CreateTaskError::ParentNotFound {
+                    parent: parent.to_string(),
+                }),
+                "{label}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_parent_for_new_task_cycle_or_too_deep_cases() {
+        let chain_20 = parent_chain_with_edge_count(20);
+        let cycle_pair = vec![
+            task_with_parent("tasks/a.md", "tasks/b.md"),
+            task_with_parent("tasks/b.md", "tasks/a.md"),
+        ];
+
+        let cases: Vec<(&str, &[Task], ParentHierarchyErrorReason, &str)> = vec![
+            (
+                "tasks/0.md",
+                chain_20.as_slice(),
+                ParentHierarchyErrorReason::TooDeep,
+                "edge 20 chain (total 21 exceeds MAX)",
+            ),
+            (
+                "tasks/a.md",
+                cycle_pair.as_slice(),
+                ParentHierarchyErrorReason::Cycle,
+                "two-node cycle a <-> b",
+            ),
+        ];
+        for (parent, tasks, expected_reason, label) in cases {
+            assert_eq!(
+                validate_parent_for_new_task(Some(parent), tasks),
+                Err(CreateTaskError::ParentCycleOrTooDeep {
+                    parent: parent.to_string(),
+                    reason: expected_reason,
+                }),
+                "{label}"
+            );
         }
     }
 }

--- a/src-tauri/src/task_index.rs
+++ b/src-tauri/src/task_index.rs
@@ -379,6 +379,63 @@ fn validate_parent_chain(
     }
 }
 
+/// 新規タスクが受け取る parent 文字列を正規化し、既存タスク群の中から index を解決する。
+///
+/// 空文字 / 絶対パス / Windows drive prefix / 不一致パス のいずれかは `None` を返す。
+/// 自己参照（新規タスク自身の想定 file_path を parent に渡すケース）も既存タスク集合に
+/// 未登録のため、自然に `None` となる。
+///
+/// @param parent 新規タスクの parent 引数文字列（プロジェクトルート相対 / `.md` 込み）。
+/// @param tasks 既存タスクスナップショット。
+/// @returns 一致する Task の入力配列内 index。一致しない場合は `None`。
+pub(crate) fn resolve_parent_for_new_task(parent: &str, tasks: &[Task]) -> Option<usize> {
+    let normalized = normalize_parent_path_for_lookup(parent)?;
+    tasks
+        .iter()
+        .position(|task| normalize_task_path_for_lookup(&task.file_path) == normalized)
+}
+
+/// parent 起点に新規タスクを末端へ 1 edge 追加した chain の循環/深さ超過を検出する。
+///
+/// `depth` は「新規タスクから上に向かって辿った edge 累計」を表す。初期 `depth = 1` は
+/// 新規タスク → 起点 parent の 1 edge ぶんで、parent の上方向に 1 つ進めるたびに `depth += 1` する。
+/// 判定は親辺取得の **前** に `depth > MAX_PARENT_DEPTH` を確認するため、
+/// parent 側 chain の edge 数 19 → `Ok(())`（合計 20 = `MAX_PARENT_DEPTH`）、
+/// 20 → `TooDeep`（合計 21 で上限超過）となる。
+///
+/// 事前条件: `parent_index < tasks.len()`。`resolve_parent_for_new_task` が `Some(idx)` を返した
+/// 直後にのみ呼ぶこと。範囲外の場合は caller の不変条件違反として panic する。
+///
+/// @param parent_index 起点 parent の `tasks` 内 index。
+/// @param tasks 既存タスクスナップショット。
+/// @returns Ok(()) / `ParentHierarchyErrorReason::Cycle` / `ParentHierarchyErrorReason::TooDeep`。
+pub(crate) fn validate_chain_from_parent(
+    parent_index: usize,
+    tasks: &[Task],
+) -> Result<(), ParentHierarchyErrorReason> {
+    let parent_task = tasks
+        .get(parent_index)
+        .expect("validate_chain_from_parent: parent_index must be in range (caller invariant)");
+    let lookup = parent_lookup_index(tasks);
+    let mut visited = HashSet::new();
+    let mut current = normalize_task_path_for_lookup(&parent_task.file_path);
+    let mut depth: usize = 1;
+
+    loop {
+        if !visited.insert(current.clone()) {
+            return Err(ParentHierarchyErrorReason::Cycle);
+        }
+        if depth > MAX_PARENT_DEPTH {
+            return Err(ParentHierarchyErrorReason::TooDeep);
+        }
+        let Some(Some(next)) = lookup.get(&current) else {
+            return Ok(());
+        };
+        depth += 1;
+        current = next.clone();
+    }
+}
+
 /// parent 参照が解決できない Task に `ParentNotFound` warning を追加する。
 ///
 /// @param task parent 存在検証の対象 Task。
@@ -1592,5 +1649,80 @@ mod tests {
             invalid_encoding,
             Err(TaskParseError::Frontmatter(_))
         ));
+    }
+
+    #[test]
+    fn resolve_parent_for_new_task_hit_cases() {
+        let tasks = vec![task_without_parent("tasks/a.md")];
+        let cases: Vec<(&str, &str)> = vec![
+            ("tasks/a.md", "exact match"),
+            ("./tasks/a.md", "leading ./ normalized"),
+            ("tasks\\a.md", "backslash separator"),
+        ];
+        for (parent, label) in cases {
+            assert_eq!(
+                resolve_parent_for_new_task(parent, &tasks),
+                Some(0),
+                "{label}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_parent_for_new_task_miss_cases_with_existing_task() {
+        let tasks = vec![task_without_parent("tasks/a.md")];
+        let cases: Vec<(&str, &str)> = vec![
+            ("tasks/missing.md", "no matching path"),
+            ("", "empty parent string"),
+            ("/abs/path.md", "absolute path"),
+            ("C:\\foo.md", "windows drive prefix"),
+        ];
+        for (parent, label) in cases {
+            assert_eq!(resolve_parent_for_new_task(parent, &tasks), None, "{label}");
+        }
+    }
+
+    #[test]
+    fn resolve_parent_for_new_task_returns_none_for_empty_tasks() {
+        let tasks: Vec<Task> = Vec::new();
+
+        assert_eq!(resolve_parent_for_new_task("tasks/a.md", &tasks), None);
+    }
+
+    #[test]
+    fn validate_chain_from_parent_single_root_returns_ok() {
+        let tasks = vec![task_without_parent("tasks/a.md")];
+
+        assert_eq!(validate_chain_from_parent(0, &tasks), Ok(()));
+    }
+
+    #[test]
+    fn validate_chain_from_parent_edge_19_is_allowed() {
+        let tasks = parent_chain_with_edge_count(19);
+
+        assert_eq!(validate_chain_from_parent(0, &tasks), Ok(()));
+    }
+
+    #[test]
+    fn validate_chain_from_parent_edge_20_returns_too_deep() {
+        let tasks = parent_chain_with_edge_count(20);
+
+        assert_eq!(
+            validate_chain_from_parent(0, &tasks),
+            Err(ParentHierarchyErrorReason::TooDeep),
+        );
+    }
+
+    #[test]
+    fn validate_chain_from_parent_detects_cycle() {
+        let tasks = vec![
+            task_with_parent("tasks/a.md", "tasks/b.md"),
+            task_with_parent("tasks/b.md", "tasks/a.md"),
+        ];
+
+        assert_eq!(
+            validate_chain_from_parent(0, &tasks),
+            Err(ParentHierarchyErrorReason::Cycle),
+        );
     }
 }


### PR DESCRIPTION
## 概要

`create_task` Tauri command の前提となる、新規タスクの `parent` 引数を検証する純粋関数を追加する。`task_index.rs` に `pub(crate)` の高レベル API を新設し、`create_task.rs` から薄くラップする形で `validate_parent_for_new_task` を公開した。本 PR は純粋関数追加のみで `#[tauri::command]` 本体は対象外（後続 Issue で実装予定）。

## 変更の種類

- ✨ New Feature

## 追加した内容

- `task_index.rs`
  - `pub(crate) fn resolve_parent_for_new_task(parent: &str, tasks: &[Task]) -> Option<usize>`
    - parent 文字列を `normalize_parent_path_for_lookup` で正規化し、既存タスク群から index を解決する
    - 空文字 / 絶対パス / Windows drive prefix / 不一致パス / 自己参照（未登録）はすべて `None`
  - `pub(crate) fn validate_chain_from_parent(parent_index: usize, tasks: &[Task]) -> Result<(), ParentHierarchyErrorReason>`
    - parent 起点の chain を辿り、新規タスク 1 edge を加えた合計が `MAX_PARENT_DEPTH (=20)` を超えないか / 循環していないかを検出
    - 初期 `depth = 1`（新規 → parent の 1 edge ぶん）からループする境界条件
- `create_task.rs`
  - `CreateTaskError::ParentNotFound { parent }` バリアント
  - `CreateTaskError::ParentCycleOrTooDeep { parent, reason: ParentHierarchyErrorReason }` バリアント
  - `pub fn validate_parent_for_new_task(parent: Option<&str>, existing_tasks: &[Task]) -> Result<(), CreateTaskError>`

## 変更した内容

- `create_task.rs`
  - モジュール doc コメントに `validate_parent_for_new_task` を追記し、「parent 検証は後続 Issue」表現を「Tauri command 本体は後続 Issue」に更新（実装後の状態と整合）
  - `CreateTaskArgs.parent` フィールド doc を「存在 + 循環/深さの検証は `validate_parent_for_new_task` で行う」に更新
- `task_index.rs` の private helper（`MAX_PARENT_DEPTH` / `parent_lookup_index` / `validate_parent_chain` / `normalize_*_for_lookup`）の可視性は維持（隠したまま）

## 仕様ドキュメント更新

不要（純粋なバックエンド内部 API 追加。公開 Tauri command や FE 連携 / データ形式 / 画面挙動 / 設定項目への変更なし）。`docs/spec-board/` 配下の更新は不要。

## システム図

```mermaid
flowchart TD
    A[validate_parent_for_new_task<br/>parent: Option&lt;&str&gt;, existing_tasks: &[Task]]
    A -->|None| OK1[Ok ・親なし]
    A -->|Some s| B[resolve_parent_for_new_task<br/>NEW pub crate]
    B -->|None ・空/絶対/drive prefix/不一致/自己参照| E1[Err ParentNotFound]
    B -->|Some idx| C[validate_chain_from_parent idx, tasks<br/>NEW pub crate]
    C -->|Ok ・合計 edge ≤ 20| OK2[Ok]
    C -->|Err TooDeep ・合計 edge ≥ 21| E2[Err ParentCycleOrTooDeep TooDeep]
    C -->|Err Cycle ・visited 重複| E3[Err ParentCycleOrTooDeep Cycle]

    style B fill:#dbeafe,stroke:#1d4ed8
    style C fill:#dbeafe,stroke:#1d4ed8
    style E1 fill:#fee2e2,stroke:#b91c1c
    style E2 fill:#fee2e2,stroke:#b91c1c
    style E3 fill:#fee2e2,stroke:#b91c1c
```

境界条件: parent 側 edge 数 19 → Ok（合計 20 = MAX_PARENT_DEPTH）/ 20 → TooDeep（合計 21）。

## 関連Issue

Refs #81

## テスト

`/workspace/.claude/worktrees/issues81_be/src-tauri/` で実行:

- ✅ `cargo test` — 375 passed / 0 failed / 2 ignored（既存 doc-test）
  - 新規 `task_index::tests`（7 件）: `resolve_parent_for_new_task_*` 3 件 / `validate_chain_from_parent_*` 4 件
  - 新規 `create_task::tests`（3 件、パラメータ化集約後）: `validate_parent_for_new_task_ok_cases` / `_not_found_cases` / `_cycle_or_too_deep_cases`
  - 既存テストへのリグレッションなし
- ✅ `cargo fmt --check` — 差分なし
- ✅ `cargo clippy --all-targets -- -D warnings` — 警告ゼロ
- ✅ `cargo check --all-targets` — エラー / 警告ともにゼロ

UI 変更なしのためブラウザ / Tauri アプリでの動作確認は対象外。

Codex CLI レビュー（2 ラウンド）も実施: 1 ラウンド目で指摘されたモジュール doc の陳腐化を修正し、2 ラウンド目で「問題なし」を確認。

## レビューポイント

- `validate_chain_from_parent` の境界セマンティクス: `depth` 初期値を `1`（新規 → parent の 1 edge）にし、判定順を「visited 検査 → `depth > MAX_PARENT_DEPTH` 判定 → 親辺取得 → `depth += 1`」とした。これにより既存 `validate_parent_chain`（initial depth=0、parent 辺取得後に increment）と `MAX_PARENT_DEPTH = 20` の意味を保ちつつ、新規 1 edge を表現している
- `validate_chain_from_parent` の `parent_index` は `pub(crate)` の caller 不変条件として `< tasks.len()` を要求し、`tasks.get(parent_index).expect("caller invariant")` で意図を明示している（呼び出し元 `validate_parent_for_new_task` は `resolve_parent_for_new_task` が `Some(idx)` を返した直後にのみ呼ぶ）
- 自己参照は専用ロジックを設けず、新規タスクが `tasks_cache` に未登録のため自然に `ParentNotFound` となる挙動を採用（探索論点 2: A）
- `CreateTaskError` の Display 文字列は日本語のままで FE の `TauriError.PATTERNS` 整備は本 PR では行わない（探索論点 4: A、UNKNOWN 分類のまま）