### PR TITLE
✨ [New Feature]: #74 [BE] watcher Remove を task-deleted IPC として配信

### DIFF
--- a/docs/impl/watcher.md
+++ b/docs/impl/watcher.md
@@ -745,7 +745,7 @@ emit は `handle_event(event, &ctx)` に集約する。emit は `EmitFn` closure
 |:----|:----|
 | `Created(p)` / `Modified(p)` | tasks_cache に key 不在なら `task-created`、存在すれば `task-updated`（atomic save の Created でも判定が変わらない） |
 | `Renamed { from, to }` | from で `task-deleted`（cache に存在した場合のみ）、to で `task-created` を順に emit |
-| `Removed(_)` | 本 PR では何もしない（log::trace のみ）。`task-deleted` は別 Issue で対応 |
+| `Removed(p)` | `handle_delete(p)` を呼び、cache 登録済みなら `task-deleted` emit + cache 消去。write_ignore 登録済みは skip。 |
 | `Other(_)` / `Rescan` / `Error(_)` | log::trace / warn のみ。FE への通知はしない |
 
 副作用は `tasks_cache` の差分書き込み + emit のみ。**emit より先に cache を更新**

--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -246,7 +246,7 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | 監視ライブラリ | `notify` crate（Rust） |
 | モジュール配置 | サブクレート `spec-board-fs`（`src-tauri/crates/fs/`）配下に置く（重い外部 crate を集約する規約。CLAUDE.md「Rust バックエンド構成ルール」参照）。公開 API には `notify::*` の型を漏らさず、`std` の型と独自エラー型のみで構成する |
 | 監視対象 | プロジェクトディレクトリ以下の `.md` ファイル |
-| 監視イベント | Create / Modify / Remove / Rename。**現時点で FE に配信されるのは Create / Modify / Rename のみ**で、`Remove` は本体クレート側 adapter で `log::trace!` のみとする。Remove → `task-deleted` 配線は別 Issue で対応する |
+| 監視イベント | Create / Modify / Remove / Rename。いずれも本体クレート側 adapter で `tasks_cache` を差分更新後、Tauri IPC で FE に配信される。Remove は cache 登録済みパスのみ `task-deleted` を発火し、`WriteIgnoreRegistry` に登録された自前 delete はスキップする |
 | デバウンス | 後述の「デバウンス（スライディングウィンドウ集約）」セクション参照 |
 | 自己書き込み抑制 | 後述の「自己書き込み抑制」セクション参照 |
 | フロントエンドへの通知 | Tauri のイベントシステム（`emit`）を使用 |
@@ -271,7 +271,7 @@ flowchart TD
     B --> C{イベント種別}
     C -->|Create| D[ファイルを読み込み・パース]
     C -->|Modify| D
-    C -->|Remove| E[本体 adapter で log::trace のみ。FE への通知は別 Issue]
+    C -->|Remove| E[cache 登録済みなら task-deleted を発火。write_ignore 登録済みは skip]
     C -->|Rename| R[旧パスで task-deleted + 新パスで読み込み・パース]
     D --> F{パース成功?}
     R --> F
@@ -485,7 +485,6 @@ pub enum WatcherError {
 
 - 監視対象パスの動的追加・削除
 - root が symlink ディレクトリの場合の追加検査（現状は notify に委ねる）
-- `FsEvent::Removed` を受けた `task-deleted` 配信（Issue #74）
 
 ## カラム設定・カード並び順の永続化
 

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -66,11 +66,7 @@ pub(crate) fn handle_event(event: &FsEvent, ctx: &AdapterContext) -> Result<(), 
             handle_delete(from, ctx)?;
             handle_upsert(to, ctx, UpsertMode::ForceCreated)
         }
-        FsEvent::Removed(_) => {
-            // 別 Issue で対応する。本ハンドラでは何もしない。
-            log::trace!("watcher_event: ignoring Removed event");
-            Ok(())
-        }
+        FsEvent::Removed(p) => handle_delete(p, ctx),
         FsEvent::Other(p) => {
             log::trace!("watcher_event: ignoring Other event for {}", p.display());
             Ok(())
@@ -197,11 +193,12 @@ fn handle_upsert(
     Ok(())
 }
 
-/// 削除系（Rename の `from` 側）。`tasks_cache` から実際に entry を remove
-/// できた場合のみ `task-deleted` を emit する。エディタの atomic save 時に
-/// 出る一時ファイル rename で偽 delete が飛ばないようにするための運用。
+/// 削除系（Rename の `from` 側 / 単独 Remove イベント）。`tasks_cache` から
+/// 実際に entry を remove できた場合のみ `task-deleted` を emit する。
+/// エディタの atomic save 時に出る一時ファイル rename / 削除で偽 delete が
+/// 飛ばないようにするための運用。
 ///
-/// from 側のファイルは既に削除済み（metadata 取得不可）なケースが多いため、
+/// 対象ファイルは既に削除済み（metadata 取得不可）なケースが多いため、
 /// metadata に依存しない `rel_md_path_lenient` を使う。
 fn handle_delete(abs_path: &Path, ctx: &AdapterContext) -> Result<(), HandleError> {
     let Some(rel_path) = rel_md_path_lenient(abs_path, &ctx.root) else {

--- a/src-tauri/src/watcher_event/tests.rs
+++ b/src-tauri/src/watcher_event/tests.rs
@@ -433,13 +433,138 @@ fn non_markdown_extension_is_ignored() {
 }
 
 #[test]
-fn removed_other_rescan_error_variants_are_no_op() {
+fn removed_event_for_cached_path_emits_task_deleted_and_removes_from_cache() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("seed create");
+    drain_log(&log);
+
+    std::fs::remove_file(&abs).expect("remove file");
+
+    handle_event(&FsEvent::Removed(abs), &ctx).expect("removed ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len(), "one task-deleted expected");
+    assert_eq!("task-deleted", entries[0].0);
+    assert_eq!("tasks/a.md", entries[0].1["filePath"]);
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn removed_event_payload_uses_forward_slash_relative_path() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/sub/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("seed create");
+    drain_log(&log);
+
+    std::fs::remove_file(&abs).ok();
+    handle_event(&FsEvent::Removed(abs), &ctx).expect("removed ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len());
+    assert_eq!("task-deleted", entries[0].0);
+    assert_eq!(json!("tasks/sub/a.md"), entries[0].1["filePath"]);
+}
+
+#[test]
+fn removed_event_for_uncached_path_does_not_emit() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = dir.path().join("tasks/ghost.md");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Removed(abs), &ctx).expect("removed ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn write_ignore_consume_skips_emit_for_self_originated_remove() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("seed create");
+    drain_log(&log);
+
+    state
+        .write_ignore()
+        .register(&abs)
+        .expect("register write_ignore");
+
+    std::fs::remove_file(&abs).ok();
+    handle_event(&FsEvent::Removed(abs), &ctx).expect("removed ok");
+
+    assert!(drain_log(&log).is_empty(), "self delete should not emit");
+    assert_eq!(vec!["tasks/a.md".to_string()], snapshot_paths(&state));
+    assert!(state.write_ignore().is_empty().expect("readable"));
+}
+
+#[test]
+fn removed_event_for_non_markdown_is_ignored() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = write_md(dir.path(), "tasks/a.txt", "plain text");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Removed(abs), &ctx).expect("removed ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn removed_event_for_dotfile_is_ignored() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = dir.path().join(".spec-board/x.md");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Removed(abs), &ctx).expect("removed ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn removed_event_for_node_modules_is_ignored() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+    let abs = dir.path().join("node_modules/x/y.md");
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Removed(abs), &ctx).expect("removed ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn removed_event_for_path_outside_root_is_ignored() {
+    let root = TempDir::new().expect("root tempdir");
+    let other = TempDir::new().expect("other tempdir");
+    let state = Arc::new(AppState::new());
+    let outside = other.path().join("tasks/x.md");
+    let (ctx, log) = build_ctx(root.path().to_path_buf(), Arc::clone(&state));
+
+    handle_event(&FsEvent::Removed(outside), &ctx).expect("removed ok");
+
+    assert!(drain_log(&log).is_empty());
+    assert!(snapshot_paths(&state).is_empty());
+}
+
+#[test]
+fn other_rescan_error_variants_are_no_op() {
     let dir = TempDir::new().expect("tempdir");
     let state = Arc::new(AppState::new());
     let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
     let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
 
-    handle_event(&FsEvent::Removed(abs.clone()), &ctx).expect("ok");
     handle_event(&FsEvent::Other(abs), &ctx).expect("ok");
     handle_event(&FsEvent::Rescan, &ctx).expect("ok");
     handle_event(&FsEvent::Error("backend boom".to_string()), &ctx).expect("ok");


### PR DESCRIPTION
## 概要

ファイルシステムの `FsEvent::Removed` をフロントエンドへ `task-deleted` IPC イベントとして配信する。これにより外部エディタ・ターミナル等で `.md` ファイルを削除した際、ボード上のカードがリロード無しで自動消失する。Create / Modify / Rename は既配線済みで、Remove だけが `log::trace` のスタブとして残っていた状態を解消する。

## 変更の種類

- ✨ 新機能（`Removed` イベントの IPC 配信を新規配線）
- 🧪 テスト追加（Removed 単独テスト 8 件）
- 📝 ドキュメント更新（file-system-spec / impl-watcher）

## 追加した内容

- `src-tauri/src/watcher_event/tests.rs` に Removed 単独テスト 8 件
  - 正常系: cache 登録済み + `.md` → `task-deleted` emit + cache 消去
  - payload 形式: `{ filePath: "tasks/sub/a.md" }` の forward-slash 正規化
  - 境界値: cache 未登録 → emit 0 件（atomic save 互換）
  - 境界値: `write_ignore` 登録済み → emit 0 件 + cache 残存 + registry consume
  - 異常系: 非 `.md` → 早期 return
  - エッジケース: dotfile / `node_modules` / root 外パス → スキップ

## 変更した内容

- `src-tauri/src/watcher_event/handler.rs`
  - `FsEvent::Removed(_) => log::trace ...` を `FsEvent::Removed(p) => handle_delete(p, ctx)` に置換
  - `handle_delete` の doc コメントを「Rename の `from` 側 / 単独 Remove イベント」両対応の表現に更新
- 既存テスト `removed_other_rescan_error_variants_are_no_op` を `other_rescan_error_variants_are_no_op` にリネームし、Removed 検証を除去（Other/Rescan/Error の no-op 検証は維持）

## 削除した内容

- `docs/spec-board/file-system-spec.md` の「既知 / TODO」節から `FsEvent::Removed を受けた task-deleted 配信（Issue #74）` を削除（実装完了）

## 仕様ドキュメント更新

- `docs/spec-board/file-system-spec.md`: 監視イベント表 / 処理フロー mermaid / 既知-TODO 節を Remove 配線済みに更新
- `docs/impl/watcher.md`: `handle_event` 表 14.4 の `Removed(_)` 行を「`handle_delete(p)` を呼び、cache 登録済みなら `task-deleted` emit + cache 消去。`write_ignore` 登録済みは skip。」に更新

## システム図

```mermaid
flowchart TD
    A[notify backend] --> B[spec_board_fs::watcher::core]
    B --> C[FsEvent::Removed p]
    C --> D[handle_event]
    D --> E[handle_delete p, ctx]
    E --> F{rel_md_path_lenient}
    F -->|None| G[早期 return<br/>非 .md / dotfile /<br/>node_modules / root 外]
    F -->|Some rel| H{try_consume_write_ignore}
    H -->|true 自前 delete| I[早期 return]
    H -->|false| J[tasks_cache.remove key]
    J -->|removed=true| K["emit task-deleted<br/>filePath: rel"]
    J -->|removed=false| L[log::trace<br/>cache 未登録]
    K --> M[FE reducer<br/>tasks.filter ボード再描画]

    style C fill:#ffe4b5
    style E fill:#ffe4b5
    style K fill:#90ee90
```

## 関連Issue

Closes #74

## テスト

### 自動テスト

- `cd src-tauri && cargo test --workspace watcher_event` ✅ 32 tests pass（既存 24 + Removed 8 新規）
- `cd src-tauri && cargo test --workspace` ✅ 479 tests pass（本体 363 + spec-board-fs 116、リグレッション無し）
- `cd src-tauri && cargo fmt --all -- --check` ✅
- `cd src-tauri && cargo clippy --workspace --all-targets -- -D warnings` ✅

### Codex レビュー

Codex CLI による全変更の一括レビュー: **「問題なし」**（1 回で完了）。`code-review/review-001.md` 参照。

### 手動検証（未実施 / レビュアー任意）

implementation-plan.md「手動検証」手順 1-6 を参照:

1. `pnpm tauri dev` で起動 → 任意プロジェクトを開く
2. 外部ターミナルで `rm tasks/<column>/<task>.md` → ボード上の該当カードが自動消失することを確認
3. Rename (`mv old.md new.md`) で `task-deleted` + `task-created` の 2 イベントが流れることを確認（既存挙動のリグレッション無し）

## レビューポイント

- **既存 `handle_delete` の流用判断**: Rename の `from` 側用に既存実装されている `handle_delete(abs_path, ctx)` が、`rel_md_path_lenient` + `try_consume_write_ignore` + `tasks_cache.remove` + `emit("task-deleted")` のロジックを hearing 仕様と完全一致で満たすため、Remove 専用関数を新設せずそのまま流用した。
- **payload キー名 `filePath`**: hearing-notes 当初は `{ task_id: string }` 案だったが、既存実装（Rename `from` 側 emit / spec doc / FE reducer / FE behavior test）が全て `{ filePath: string }` で統一されているため、整合性と FE 改修ゼロを優先して採用。
- **サブクレート `crates/fs/` への変更なし**: `FsEvent::Removed(PathBuf)` バリアント・`convert_event` での生成・debounce 集約・`WriteIgnoreRegistry::consume` API はすべて完備済み。境界の漏出無し（`git diff --name-only` で確認済み）。
- **破壊的変更なし**: 既存 IPC イベント名・payload 形式・公開 API シグネチャの変更はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)