### PR TITLE
✨ [New Feature]: #106 [FE] useProject に task-created IPC listener を追加

### DIFF
--- a/src/__tests__/App.interaction.test.tsx
+++ b/src/__tests__/App.interaction.test.tsx
@@ -39,6 +39,10 @@ vi.mock("@/lib/tauri", async () => {
   };
 });
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
 const openDirectoryDialogMock = vi.mocked(openDirectoryDialog);
 const openProjectMock = vi.mocked(openProjectInvoke);
 const getColumnsMock = vi.mocked(getColumnsInvoke);

--- a/src/features/board/hooks/useProject/__tests__/useProject.interaction.test.tsx
+++ b/src/features/board/hooks/useProject/__tests__/useProject.interaction.test.tsx
@@ -1,3 +1,7 @@
+import {
+  listen as listenInvoke,
+  type UnlistenFn as UnlistenFnT,
+} from "@tauri-apps/api/event";
 import { act, createElement, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
@@ -23,7 +27,7 @@ import {
   updateColumns as updateColumnsInvoke,
   updateTask as updateTaskInvoke,
 } from "@/lib/tauri";
-import { Task } from "@/types/task";
+import { Task, type TaskPayload } from "@/types/task";
 import { Result, type Result as ResultT } from "@/utils/result";
 import { type UseProjectOptions, type UseProjectResult, useProject } from "..";
 
@@ -42,6 +46,10 @@ vi.mock("@/lib/tauri", async () => {
   };
 });
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
 const openDirectoryDialogMock = vi.mocked(openDirectoryDialog);
 const openProjectMock = vi.mocked(openProjectInvoke);
 const getColumnsMock = vi.mocked(getColumnsInvoke);
@@ -49,6 +57,26 @@ const createTaskMock = vi.mocked(createTaskInvoke);
 const updateTaskMock = vi.mocked(updateTaskInvoke);
 const deleteTaskMock = vi.mocked(deleteTaskInvoke);
 const updateColumnsMock = vi.mocked(updateColumnsInvoke);
+const listenMock = vi.mocked(listenInvoke);
+
+type TaskCreatedHandler = (event: { payload: { task: TaskPayload } }) => void;
+
+type CaptureListenResult = {
+  handlers: TaskCreatedHandler[];
+  unlistenFns: ReturnType<typeof vi.fn>[];
+};
+
+const captureListen = (): CaptureListenResult => {
+  const handlers: TaskCreatedHandler[] = [];
+  const unlistenFns: ReturnType<typeof vi.fn>[] = [];
+  listenMock.mockImplementation(((_event, handler) => {
+    handlers.push(handler as TaskCreatedHandler);
+    const unlisten = vi.fn();
+    unlistenFns.push(unlisten);
+    return Promise.resolve(unlisten);
+  }) as typeof listenInvoke);
+  return { handlers, unlistenFns };
+};
 
 const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -100,6 +128,8 @@ beforeEach(() => {
   updateTaskMock.mockReset();
   deleteTaskMock.mockReset();
   updateColumnsMock.mockReset();
+  listenMock.mockReset();
+  listenMock.mockResolvedValue(vi.fn());
 });
 
 afterEach(() => {
@@ -988,4 +1018,252 @@ test("createTask: projectCommandQueue により再 open は createTask 完了を
   });
   expect(result.ok).toBe(true);
   expect(probe.latest.state.kind).toBe("loaded");
+});
+
+// === task-created IPC listener ===
+
+test("loaded 状態で task-created の listen が登録される", async () => {
+  const { handlers } = captureListen();
+  const probe = renderHook();
+  await openLoaded(probe);
+  expect(listenMock).toHaveBeenCalledWith("task-created", expect.any(Function));
+  expect(handlers).toHaveLength(1);
+});
+
+test("task-created callback を invoke すると state.data.tasks に追加される", async () => {
+  const { handlers } = captureListen();
+  const probe = renderHook();
+  await openLoaded(probe);
+  act(() => {
+    handlers[0]({
+      payload: {
+        task: {
+          id: "b",
+          title: "B",
+          status: "Todo",
+          labels: [],
+          links: [],
+          children: [],
+          reverseLinks: [],
+          body: "",
+          filePath: "tasks/b.md",
+          extras: {},
+          warnings: [],
+        },
+      },
+    });
+  });
+  const tasks = (probe.latest.state as { data: { tasks: Task[] } }).data.tasks;
+  expect(tasks.map((t) => t.filePath)).toEqual(["tasks/a.md", "tasks/b.md"]);
+});
+
+test("parent あり task-created で親の hierarchy.childFilePaths に追加される", async () => {
+  const { handlers } = captureListen();
+  const probe = renderHook();
+  await openLoaded(probe);
+  act(() => {
+    handlers[0]({
+      payload: {
+        task: {
+          id: "c",
+          title: "C",
+          status: "Todo",
+          labels: [],
+          parent: "tasks/a.md",
+          links: [],
+          children: [],
+          reverseLinks: [],
+          body: "",
+          filePath: "tasks/c.md",
+          extras: {},
+          warnings: [],
+        },
+      },
+    });
+  });
+  const tasks = (probe.latest.state as { data: { tasks: Task[] } }).data.tasks;
+  const parent = tasks.find((t) => t.filePath === "tasks/a.md");
+  expect(parent?.hierarchy.childFilePaths).toEqual(["tasks/c.md"]);
+});
+
+test("unmount で task-created の unlisten が呼ばれる", async () => {
+  const { unlistenFns } = captureListen();
+  const probe = renderHook();
+  await openLoaded(probe);
+  expect(unlistenFns).toHaveLength(1);
+  await act(async () => {
+    root?.unmount();
+    root = null;
+    await Promise.resolve();
+  });
+  expect(unlistenFns[0]).toHaveBeenCalled();
+});
+
+test("mount 直後 (idle) では listen が呼ばれない", async () => {
+  captureListen();
+  renderHook();
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(listenMock).not.toHaveBeenCalled();
+});
+
+test("openProject 進行中 (loading) では listen が呼ばれない", async () => {
+  captureListen();
+  let resolveDialog!: (r: ResultT<string | null, TauriError>) => void;
+  openDirectoryDialogMock.mockReturnValueOnce(
+    new Promise<ResultT<string | null, TauriError>>((res) => {
+      resolveDialog = res;
+    }),
+  );
+  const probe = renderHook();
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProject();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(listenMock).not.toHaveBeenCalled();
+  // teardown
+  await act(async () => {
+    resolveDialog(Result.ok(null));
+    await pending;
+  });
+});
+
+test("openProject 失敗 (error 状態) では listen が呼ばれない", async () => {
+  captureListen();
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  openProjectMock.mockResolvedValueOnce(
+    Result.err(new TauriError("NOT_FOUND", "no")),
+  );
+  const probe = renderHook({ onError: () => {} });
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProject();
+  });
+  await act(async () => {
+    await pending;
+  });
+  expect(probe.latest.state.kind).toBe("error");
+  expect(listenMock).not.toHaveBeenCalled();
+});
+
+test("プロジェクト切替で旧 listen が unlisten され、新 listen が再登録される", async () => {
+  const { unlistenFns } = captureListen();
+  const probe = renderHook();
+  await openLoaded(probe);
+  expect(listenMock).toHaveBeenCalledTimes(1);
+
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/q"));
+  openProjectMock.mockResolvedValueOnce(
+    Result.ok({ tasks: [taskB], columns: ["Done"] }),
+  );
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProject();
+  });
+  await act(async () => {
+    await pending;
+  });
+
+  expect(unlistenFns[0]).toHaveBeenCalled();
+  expect(listenMock).toHaveBeenCalledTimes(2);
+});
+
+test("open-start 直後の race: loading 中に旧 callback が発火しても previousLoaded が変化しない", async () => {
+  const { handlers } = captureListen();
+  const probe = renderHook();
+  await openLoaded(probe);
+  expect(handlers).toHaveLength(1);
+  const oldHandler = handlers[0];
+
+  // openProject(P2) を発行して loading 状態に遷移させ、invoke を pending にしておく
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/q"));
+  let resolveInvoke!: (r: ResultT<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockReturnValueOnce(
+    new Promise<ResultT<OpenProjectPayload, TauriError>>((resolve) => {
+      resolveInvoke = resolve;
+    }),
+  );
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProject();
+  });
+  // dialog 解決 + dispatch(open-start) まで進めて loading にする
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  expect(probe.latest.state.kind).toBe("loading");
+
+  // 旧 listener の callback を invoke する (cleanup 前の race を模擬)
+  act(() => {
+    oldHandler({
+      payload: {
+        task: {
+          id: "z",
+          title: "Z",
+          status: "Todo",
+          labels: [],
+          links: [],
+          children: [],
+          reverseLinks: [],
+          body: "",
+          filePath: "tasks/z.md",
+          extras: {},
+          warnings: [],
+        },
+      },
+    });
+  });
+
+  // loading.previousLoaded.data.tasks が汚染されていないこと
+  const loadingState = probe.latest.state as {
+    kind: "loading";
+    previousLoaded?: { data: { tasks: Task[] } };
+  };
+  expect(
+    loadingState.previousLoaded?.data.tasks.map((t) => t.filePath),
+  ).toEqual(["tasks/a.md"]);
+
+  // teardown: invoke を成功させる
+  await act(async () => {
+    resolveInvoke(Result.ok({ tasks: [taskB], columns: ["Done"] }));
+    await pending;
+  });
+});
+
+test("listen Promise pending 中の unmount でも解決後 UnlistenFn が呼ばれる", async () => {
+  let resolveListen!: (fn: UnlistenFnT) => void;
+  const unlistenLate = vi.fn();
+  listenMock.mockImplementation((() => {
+    return new Promise<UnlistenFnT>((resolve) => {
+      resolveListen = resolve;
+    });
+  }) as typeof listenInvoke);
+
+  const probe = renderHook();
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  openProjectMock.mockResolvedValueOnce(Result.ok(payload));
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProject();
+  });
+  await act(async () => {
+    await pending;
+  });
+  // listen は呼ばれたが Promise はまだ pending
+  expect(listenMock).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    root?.unmount();
+    root = null;
+  });
+  // 後から listen の Promise を resolve
+  resolveListen(unlistenLate);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(unlistenLate).toHaveBeenCalled();
 });

--- a/src/features/board/hooks/useProject/index.ts
+++ b/src/features/board/hooks/useProject/index.ts
@@ -1,10 +1,11 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import type {
   CreateTaskParams,
   DeleteTaskParams,
   UpdateTaskParams,
 } from "@/lib/tauri";
-import type { Task } from "@/types/task";
+import { Task, type TaskPayload } from "@/types/task";
 import type { Result as ResultT } from "@/utils/result";
 import { openProjectAction } from "./actions/openProject";
 import {
@@ -79,6 +80,46 @@ export const useProject = (
     latestStateRef.current = reducer(latestStateRef.current, action);
     dispatch(action);
   }, []);
+
+  const loadedPath = state.kind === "loaded" ? state.path : null;
+  useEffect(() => {
+    if (loadedPath == null) {
+      return;
+    }
+    let unlistened = false;
+    let unlistenFn: UnlistenFn | null = null;
+    const capturedPath = loadedPath;
+    listen<{ task: TaskPayload }>("task-created", (event) => {
+      const payload = event.payload;
+      if (!payload?.task) {
+        return;
+      }
+      const current = latestStateRef.current;
+      if (current.kind !== "loaded" || current.path !== capturedPath) {
+        return;
+      }
+      const task = Task.fromPayload(payload.task);
+      dispatchSync({ type: "task-created", task });
+    })
+      .then((fn) => {
+        if (unlistened) {
+          fn();
+          return;
+        }
+        unlistenFn = fn;
+      })
+      .catch(() => {
+        // listen 登録自体が失敗した場合は購読を諦める。
+        // 失敗は user action と紐づかないため onError で通知せず黙殺する。
+      });
+    return () => {
+      unlistened = true;
+      if (unlistenFn) {
+        unlistenFn();
+        unlistenFn = null;
+      }
+    };
+  }, [loadedPath, dispatchSync]);
 
   const openProject = useCallback(
     (): Promise<void> =>


### PR DESCRIPTION
## 概要

backend watcher が emit する `task-created` IPC イベントを `useProject` で購読し、`Task.fromPayload` で正規化したうえで reducer に dispatch する。これにより、外部エディタや watcher 経由で新規追加された `.md` タスクがボード UI に即時反映される。

## 変更の種類

- ✨ [New Feature]: useProject への task-created IPC 購読の追加

## 追加した内容

- `useProject/index.ts`: `@tauri-apps/api/event#listen` による `task-created` 購読 useEffect
- `useProject.interaction.test.tsx`: `task-created` listener の振る舞いを TDD で網羅する 9 件のテスト
- `App.interaction.test.tsx`: `@tauri-apps/api/event` の `listen` mock 追加（useProject が listen を呼ぶようになったため）

## 変更した内容

- `useProject` 内部の useEffect 群に listen ライフサイクル管理を追加
  - `loaded` 状態のときだけ listen を仕掛け、`idle` / `loading` / `error` 中は購読しない
  - プロジェクト切替 (`loadedPath` 変化) で旧 listen を unlisten し新規登録
  - listen Promise pending 中の unmount でも、解決後に必ず UnlistenFn を呼ぶ
  - open-start 直後の race で旧 callback が発火しても、`latestStateRef.current` の `kind === "loaded" && path === capturedPath` のときだけ dispatch
  - listen 登録失敗時は `.catch` で購読を諦め unhandled rejection を防ぐ

`useProject` の public API (`UseProjectResult`) は無変更。

## 仕様ドキュメント更新

不要（既存仕様の整合補完。watcher → frontend の task-created 反映は既存仕様の延長で、`docs/spec-board/` 配下に新規仕様変更なし）。

## システム図

```mermaid
flowchart LR
    A[filesystem<br/>.md create] --> B[notify watcher<br/>FsEvent::Created]
    B --> C[watcher_event/handler.rs<br/>emit task-created]
    C --> D[Tauri IPC]
    D --> E["@tauri-apps/api/event<br/>listen callback"]
    E --> F{"latestStateRef<br/>loaded &&<br/>path 一致?"}
    F -- No --> G[drop]
    F -- Yes --> H["Task.fromPayload"]
    H --> I["dispatchSync<br/>task-created"]
    I --> J[reducer<br/>applyTaskCreated]
    J --> K[Board UI 反映]

    style E fill:#ffefc1
    style F fill:#ffefc1
    style H fill:#ffefc1
    style I fill:#ffefc1
```

NEW: useProject 内の listen useEffect 〜 dispatch までを追加。

## 関連Issue

Closes #106

後続:
- Refs #107 (task-updated 購読)
- Refs #108 (task-deleted 購読)

## テスト

- `pnpm test:run`: **78 files / 636 tests passed**（既存テスト破壊なし + 新規 9 件追加）
- `pnpm typecheck`: エラーなし
- `pnpm lint`: 0 errors / 0 warnings
- Codex review: 1 round の修正後「問題なし」
  - 指摘: listen Promise に `.catch` が無く unhandled rejection の懸念 → 修正済み

### 新規テストケース

- loaded 状態で listen 登録
- callback invoke で `state.data.tasks` に追加
- parent あり task-created で親の `hierarchy.childFilePaths` に追加
- unmount で unlisten 呼び出し
- プロジェクト切替で旧 unlisten + 新 listen
- mount 直後 (idle) / openProject 進行中 (loading) / openProject 失敗 (error) で listen 呼ばれない
- listen Promise pending 中の unmount でも解決後 UnlistenFn 呼び出し
- open-start 直後の race で `loading.previousLoaded` が汚染されない

## レビューポイント

- `latestStateRef.current.kind === "loaded" && current.path === capturedPath` での race ガード設計（`useProject/index.ts:97-100`）
- listen Promise pending 中の unmount に対する `unlistened` フラグ + `.then` ハンドラの組み合わせ（`useProject/index.ts:104-117`）
- listen 失敗時の `.catch` を黙殺している判断（user action ではないため onError 通知しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)