### PR TITLE
✨ [New Feature]: #82 [BE] create_task Tauri command の effect 層を実装

### DIFF
--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -119,11 +119,31 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | body | `String` | いいえ | Markdown本文 |
 
 **振る舞い**:
-1. タイトルをkebab-caseに変換してファイル名を生成（例: `fix-login-bug.md`）
-2. 同名ファイルが存在する場合はサフィックスを付与（`fix-login-bug-1.md`）
-3. `parent` が指定されている場合、対象ファイルの存在と循環参照がないことを検証
-4. フロントマター + 本文の形式でmdファイルを書き出し
-5. 作成したタスク情報を返却（`children` と `reverseLinks` を含む）
+1. タイトルを kebab-case に変換してファイル名を生成（例: `fix-login-bug.md`）
+2. **配置先ディレクトリの決定**:
+   - `parent` 未指定 → プロジェクトルート直下の `tasks/`（必要なら自動作成）
+   - `parent` 指定 → 解決済み親 Task の `file_path` の dirname に同居（raw 入力の `./tasks/x.md` や `tasks\\x.md` 表記揺れではなく、正規化済み親パス由来）
+3. **ファイル名衝突回避**:
+   - in-memory `tasks_cache` の同一配置先ディレクトリ内に同名 Task があればサフィックス付与（`fix-login-bug-1.md` / `-2.md` ...）
+   - cache に未反映の disk 上 stale ファイルや並行 create との衝突は `OpenOptions::create_new(true)` で検出され `Io(AlreadyExists)` エラー（上書きはしない）
+4. **入力検証**:
+   - `parent` 指定時は対象 Task の存在 + 親 chain 循環 + 深さ上限（MAX=20）を検証
+   - 既存 cache 内の dangling parent / links が新規 Task で解決されるケース（augmented hierarchy）も検証対象に含める
+   - `title` が空、または kebab-case 化結果が空文字列なら `InvalidTitle` エラー
+5. **frontmatter 構築**:
+   - `priority` は `High` / `Medium` / `Low` に ASCII 大小文字非区別で正規化、`Some` だけ書き出す（無効値 / 空文字 / 未指定は frontmatter から省略）
+   - `labels` は空配列なら省略
+   - `parent` は解決済み Task の `file_path` 文字列をそのまま書き出す
+6. **書き込み + cache 差分更新**:
+   - watcher 起動状態でのみ `write_ignore` レジストリに自前 write path を登録 → 監視 thread 側で `task-created` IPC emit を抑止
+   - 書き込み成功後、`tasks_cache` に新規 Task を挿入し、親の `children` および link 先の `reverse_links` を差分更新
+   - 既存 cache 内で dangling parent / links が新規 Task を参照していた場合、新規 Task 側の `children` / `reverse_links` にも反映
+7. **戻り値**: 挿入後の Task（`children` / `reverseLinks` 解決済み）
+
+**Atomic 性 (部分 atomic)**:
+- 入力検証 / 配置先決定は副作用前に完了する。失敗時は FS / state を一切変更しない
+- FS write 中の失敗（`write_all` 途中失敗）は best-effort で `remove_file` を試み、`write_ignore` を解除して `Io` エラーを返す
+- FS write 成功後の cache 更新失敗（lock poison 等）はファイルが残る（次回 open / watcher rescan で拾われる）
 
 ---
 
@@ -150,11 +170,12 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 4. フロントマター + 本文を再構成して書き出し
 5. **`title` を変更してもファイル名はリネームしない**（`parent` や `links` での参照が壊れるため）
 
-> Implementation notes (2026-05-05): parent 循環検証は
-> `task_index::validate_parent_hierarchy` で行う。PL-008 の初期実装は
-> task_index の純粋 validation API を提供する段階であり、`create_task` /
-> `update_task` command を実装または接続する変更では、この note を更新し、
-> command 側で index 確定前に同 API を呼び出す。
+> Implementation notes (2026-05-11): parent 循環検証は
+> `task_index::validate_parent_hierarchy` / `validate_chain_from_parent` で行う。
+> `create_task` command は本ドキュメントの振る舞いを実装済み。dangling parent
+> 解決による cycle / too-deep は `validate_parent_hierarchy` を augmented snapshot
+> に対して呼ぶことで検出する。`update_task` command は未実装で、接続時に
+> 同様の augmented 検証を行う前提。
 
 ---
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,7 +32,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             greet,
             project::open::open_project,
-            task::get::get_tasks
+            task::get::get_tasks,
+            task::create::create_task
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -173,6 +173,15 @@ impl AppState {
         Ok(guard.take())
     }
 
+    /// `watcher_handle` が install 済みかを返す非破壊 accessor。
+    ///
+    /// `take_watcher_handle` と異なり handle を取り出さず、`Mutex` 内の
+    /// `Option<BoxedWatcherHandle>` の `is_some()` のみを返す。
+    pub fn is_watcher_installed(&self) -> Result<bool, AppStateError> {
+        let guard = lock(&self.watcher_handle)?;
+        Ok(guard.is_some())
+    }
+
     /// `project_path` 用 `Mutex` の健全性をチェックする副作用なしの probe。
     ///
     /// `project_path()` と異なりクローンを行わないため、pre-flight 用途で

--- a/src-tauri/src/task/create.rs
+++ b/src-tauri/src/task/create.rs
@@ -292,8 +292,7 @@ pub(crate) fn create_task_impl(
     //         拾えなくなる。したがって post-write phase の Err では
     //         `write_ignore.unregister` を呼んで watcher の自然回復経路に戻す
     //         （成功時はそのまま残し、watcher event を consume させる）。
-    let result =
-        parse_and_insert_into_cache(state, &content, &rel_path, args.status.clone());
+    let result = parse_and_insert_into_cache(state, &content, &rel_path, args.status.clone());
     if result.is_err() && watcher_active {
         let _ = state.write_ignore().unregister(&abs_path);
     }

--- a/src-tauri/src/task/create.rs
+++ b/src-tauri/src/task/create.rs
@@ -81,6 +81,31 @@ pub enum CreateTaskError {
         parent: String,
         reason: ParentHierarchyErrorReason,
     },
+    /// 生成 content が scanner の eligible 条件を満たさない（1 MiB 超 / 先頭 8 KB に
+    /// NUL byte を含む）。書き込み後 reopen / 再 scan 時に scanner で除外されて
+    /// state 不整合が起きるため、書込み前にこの段階で弾く。
+    #[error("作成しようとしたタスク本文が scanner の対象外です: {reason}")]
+    ContentNotScannerEligible { reason: ContentRejectReason },
+}
+
+/// `ContentNotScannerEligible` の理由バリアント。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentRejectReason {
+    /// scanner の `MAX_FILE_SIZE` (1 MiB) を超える。
+    TooLarge { size: u64 },
+    /// scanner の `BINARY_PROBE_LEN` (8 KiB) 範囲に NUL byte が含まれる。
+    BinaryDetected,
+}
+
+impl std::fmt::Display for ContentRejectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLarge { size } => {
+                write!(f, "本文サイズが 1 MiB を超えています ({size} byte)")
+            }
+            Self::BinaryDetected => write!(f, "本文の先頭 8 KiB に NUL byte が含まれています"),
+        }
+    }
 }
 
 /// title と既存ファイル名集合から、衝突しない md ファイル名を生成する。
@@ -234,6 +259,12 @@ pub(crate) fn create_task_impl(
     // 7. frontmatter + body 文字列を組み立て
     let resolved_parent_path = parent_index.map(|i| snapshot[i].file_path.as_str().to_string());
     let content = build_task_content(&args, resolved_parent_path.as_deref());
+
+    // 7.5 生成 content が scanner の eligible 条件を満たすか検証する。
+    //     `spec_board_fs::task::file_scanner` は 1 MiB 超や先頭 8 KiB に NUL byte を
+    //     含むファイルを除外するため、create 直後は cache にあっても reopen 後に
+    //     scanner で消える状態不整合が起きる。書込み前にこの段階で弾く。
+    validate_content_scanner_eligibility(&content)?;
 
     // 8. augmented hierarchy 検証（FS write 前に dangling 解決 cycle / too deep を弾く）
     let provisional =
@@ -486,6 +517,35 @@ fn validate_augmented_hierarchy(
             })
         }
     }
+}
+
+/// 生成 content を `spec_board_fs::task::file_scanner` 互換の eligible 条件で検証する。
+///
+/// - 1 MiB (1_048_576 byte) を超える content は `TooLarge` で弾く
+/// - 先頭 8 KiB 範囲に NUL byte (0x00) を含む場合は `BinaryDetected` で弾く
+///
+/// scanner 側の閾値（`MAX_FILE_SIZE` / `BINARY_PROBE_LEN`）と揃えることで、
+/// 作成直後に cache へ反映された Task が reopen / 再 scan 時に消えて state
+/// 不整合が起きることを防ぐ。
+fn validate_content_scanner_eligibility(content: &str) -> Result<(), CreateTaskError> {
+    const MAX_FILE_SIZE: usize = 1024 * 1024;
+    const BINARY_PROBE_LEN: usize = 8 * 1024;
+
+    let bytes = content.as_bytes();
+    if bytes.len() > MAX_FILE_SIZE {
+        return Err(CreateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::TooLarge {
+                size: bytes.len() as u64,
+            },
+        });
+    }
+    let probe_len = bytes.len().min(BINARY_PROBE_LEN);
+    if bytes[..probe_len].contains(&0u8) {
+        return Err(CreateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::BinaryDetected,
+        });
+    }
+    Ok(())
 }
 
 /// `target_dir.join(filename)` だが、`target_dir` が空 PathBuf の場合に

--- a/src-tauri/src/task/create.rs
+++ b/src-tauri/src/task/create.rs
@@ -271,11 +271,12 @@ pub(crate) fn create_task_impl(
         build_provisional_task_for_validation(&rel_path, &args, resolved_parent_path.as_deref());
     validate_augmented_hierarchy(&snapshot, &provisional, args.parent.as_deref())?;
 
-    // 9. ディレクトリ確保（register 前なので失敗時 rollback 不要）
-    std::fs::create_dir_all(&target_dir_abs)?;
-
-    // 10. watcher 起動有無を probe
+    // 9. watcher 起動有無を probe（state lock エラー時に FS 副作用を残さないため
+    //    `create_dir_all` より前に行う）
     let watcher_active = state.is_watcher_installed()?;
+
+    // 10. ディレクトリ確保（register 前なので失敗時 rollback 不要）
+    std::fs::create_dir_all(&target_dir_abs)?;
 
     // 11. write_ignore 登録 → 排他 create write
     //     `open` で create_new=true により既存ファイル衝突を弾き、`write_all` で

--- a/src-tauri/src/task/create.rs
+++ b/src-tauri/src/task/create.rs
@@ -1,26 +1,38 @@
-//! `create_task` Tauri command の引数受け取り型・入力検証純粋関数群。
+//! `create_task` Tauri command の引数受け取り型・入力検証純粋関数群と effect 層。
 //!
-//! 本モジュールは現時点では以下を提供する:
+//! 本モジュールは以下を提供する:
 //! - [`CreateTaskArgs`][] : FE から受け取る引数 DTO
 //! - [`CreateTaskError`][]: 入力検証エラー
 //! - [`build_new_filename`][]: title と既存ファイル名集合からユニークな
 //!   md ファイル名を生成する純粋関数
 //! - [`validate_parent_for_new_task`][]: 新規タスクの parent 引数を既存タスク
 //!   スナップショットに対して検証する純粋関数（存在 + 循環/深さ）
-//!
-//! `#[tauri::command]` シン本体・AppState 反映・FS 書込みは本モジュールには含まれず、
-//! 後続 Issue で追加される（本モジュールの純粋関数を組み合わせて使う想定）。
+//! - [`create_task`][] / [`create_task_impl`][]: Tauri command 薄層 + effect 層実装
 
 use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use serde::Deserialize;
 use spec_board_fs::task::kebab_case::to_kebab_case;
 use spec_board_fs::task::unique_filename::build_unique_filename;
+use spec_board_fs::watcher::write_ignore::WriteIgnoreError;
+use tauri::State;
 use thiserror::Error;
 
-use super::index::{
-    resolve_parent_for_new_task, validate_chain_from_parent, ParentHierarchyErrorReason, Task,
+use super::frontmatter::{
+    parse as parse_frontmatter, serialize as serialize_frontmatter, Frontmatter, FrontmatterError,
+    Parsed, Priority,
 };
+use super::index::{
+    resolve_parent_for_new_task, task_from_parsed, validate_chain_from_parent,
+    validate_parent_hierarchy, ParentHierarchyErrorReason, Task, TaskExtras, TaskIndex,
+    TaskParseContext, TaskParseError, TaskWarning,
+};
+use super::task_file_path::TaskFilePath;
+use super::task_title::TaskTitle;
+use crate::config::column_name::ColumnName;
+use crate::state::{AppState, AppStateError};
 
 /// `create_task` Tauri command の引数 DTO。
 ///
@@ -144,6 +156,326 @@ pub fn validate_parent_for_new_task(
             reason,
         }
     })
+}
+
+/// `create_task` Tauri command 全体のエラー。
+///
+/// FE には `to_string()` で文字列化されて伝わる。
+#[derive(Debug, Error)]
+pub enum CreateTaskCommandError {
+    /// 入力検証エラー（既存純粋関数経由）。
+    #[error(transparent)]
+    Validation(#[from] CreateTaskError),
+    /// プロジェクト未 open（`AppState.project_path` が `None`）。
+    #[error("project is not opened")]
+    NoProjectOpen,
+    /// `AppState` 内部 Mutex の lock 取得失敗。
+    #[error("内部状態のロックが破損しました")]
+    AppState(#[from] AppStateError),
+    /// `WriteIgnoreRegistry` の lock 取得失敗等。
+    #[error(transparent)]
+    WriteIgnore(#[from] WriteIgnoreError),
+    /// ファイル I/O 失敗（`create_dir_all` / `OpenOptions::open` / `write_all`）。
+    #[error("failed to write task file: {0}")]
+    Io(#[from] std::io::Error),
+    /// 生成した frontmatter の再 parse 失敗（通常運用では発生しない）。
+    #[error(transparent)]
+    Frontmatter(#[from] FrontmatterError),
+}
+
+/// `create_task` Tauri command 薄層。
+///
+/// `create_task_impl` を呼び、エラーは Display 文字列化して FE へ返す。
+#[tauri::command]
+pub fn create_task(state: State<'_, Arc<AppState>>, args: CreateTaskArgs) -> Result<Task, String> {
+    create_task_impl(state.inner(), args).map_err(|e| e.to_string())
+}
+
+/// `create_task` の effect 層本体（テスト境界）。
+///
+/// 全体フロー:
+/// 1. preflight lock probe（tasks_cache + write_ignore）
+/// 2. project_path / tasks_snapshot 取得
+/// 3. parent 解決 + chain 検証
+/// 4. 配置先 dir / filename / content の決定
+/// 5. augmented hierarchy 検証（dangling parent 解決による cycle/too deep 防止）
+/// 6. `create_dir_all` → `write_ignore.register`（watcher 起動時のみ）
+///    → `OpenOptions::create_new(true).write(true)`
+/// 7. cache 差分更新 (`TaskIndex::insert_new_task_into_cache`)
+pub(crate) fn create_task_impl(
+    state: &AppState,
+    args: CreateTaskArgs,
+) -> Result<Task, CreateTaskCommandError> {
+    // 1. preflight (side effect 前の lock 健全性確認)
+    state.check_tasks_cache_lock()?;
+    let _ = state.write_ignore().is_empty()?;
+
+    // 2. snapshot + project root
+    let project_root = state
+        .project_path()?
+        .ok_or(CreateTaskCommandError::NoProjectOpen)?;
+    let snapshot = state.tasks_snapshot()?;
+
+    // 3. parent 解決 + chain 検証
+    let parent_index = resolve_parent_and_validate(args.parent.as_deref(), &snapshot)?;
+
+    // 4. 配置先ディレクトリ（raw 入力ではなく解決済み Task.file_path から導出）
+    let target_dir = resolve_target_dir(parent_index, &snapshot);
+
+    // 5. 同ディレクトリ内の既存ファイル名集合 → 衝突回避ファイル名
+    let existing = build_existing_filenames_in_dir(&snapshot, &target_dir);
+    let filename = build_new_filename(&args.title, &existing)?;
+
+    // 6. relative / absolute path
+    let rel_path = join_rel_path(&target_dir, &filename);
+    let abs_path = project_root.join(&rel_path);
+    let target_dir_abs = project_root.join(&target_dir);
+
+    // 7. frontmatter + body 文字列を組み立て
+    let resolved_parent_path = parent_index.map(|i| snapshot[i].file_path.as_str().to_string());
+    let content = build_task_content(&args, resolved_parent_path.as_deref());
+
+    // 8. augmented hierarchy 検証（FS write 前に dangling 解決 cycle / too deep を弾く）
+    let provisional =
+        build_provisional_task_for_validation(&rel_path, &args, resolved_parent_path.as_deref());
+    validate_augmented_hierarchy(&snapshot, &provisional, args.parent.as_deref())?;
+
+    // 9. ディレクトリ確保（register 前なので失敗時 rollback 不要）
+    std::fs::create_dir_all(&target_dir_abs)?;
+
+    // 10. watcher 起動有無を probe
+    let watcher_active = state.is_watcher_installed()?;
+
+    // 11. write_ignore 登録 → 排他 create write
+    //     `open` で create_new=true により既存ファイル衝突を弾き、`write_all` で
+    //     本文を書き込む。`write_all` が途中で失敗した場合のみ、本関数が作った
+    //     ファイル（自前で確実に所有している）を `remove_file` で巻き戻す。
+    //     open 自体の失敗時には本関数はファイルを作成していないため `remove_file`
+    //     してはならない（race condition で他プロセスが作った同 path を消して
+    //     しまう恐れがある）。
+    if watcher_active {
+        state.write_ignore().register(&abs_path)?;
+    }
+    let mut file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&abs_path)
+    {
+        Ok(f) => f,
+        Err(err) => {
+            if watcher_active {
+                let _ = state.write_ignore().unregister(&abs_path);
+            }
+            return Err(CreateTaskCommandError::Io(err));
+        }
+    };
+    if let Err(err) = std::io::Write::write_all(&mut file, content.as_bytes()) {
+        drop(file);
+        if let Err(rm_err) = std::fs::remove_file(&abs_path) {
+            if rm_err.kind() != std::io::ErrorKind::NotFound {
+                log::warn!(
+                    "create_task: failed to clean up partial file `{}`: {rm_err}",
+                    abs_path.display()
+                );
+            }
+        }
+        if watcher_active {
+            let _ = state.write_ignore().unregister(&abs_path);
+        }
+        return Err(CreateTaskCommandError::Io(err));
+    }
+    drop(file);
+
+    // 12. 書き込んだ md を再 parse → Task に変換
+    let parsed = parse_frontmatter(&content)?.expect("just-written frontmatter must parse");
+    let ctx = TaskParseContext {
+        file_path: rel_path.clone(),
+        default_status: ColumnName::from_lenient(args.status.clone()),
+    };
+    let task = task_from_parsed(parsed, &ctx);
+
+    // 13. cache 差分更新 (lock 内)
+    let final_task =
+        state.with_tasks_cache_mut(|cache| TaskIndex::insert_new_task_into_cache(cache, task))?;
+
+    Ok(final_task)
+}
+
+/// parent 文字列を解決し、chain 検証まで実行する。
+///
+/// `None` の場合は `Ok(None)`（親なし）。`Some` の場合は既存 snapshot 内の index を返すか、
+/// 既存純粋関数のエラーを `CreateTaskError` に詰め直す。
+pub(crate) fn resolve_parent_and_validate(
+    parent: Option<&str>,
+    snapshot: &[Task],
+) -> Result<Option<usize>, CreateTaskError> {
+    let Some(parent_str) = parent else {
+        return Ok(None);
+    };
+    let parent_index = resolve_parent_for_new_task(parent_str, snapshot).ok_or_else(|| {
+        CreateTaskError::ParentNotFound {
+            parent: parent_str.to_string(),
+        }
+    })?;
+    validate_chain_from_parent(parent_index, snapshot).map_err(|reason| {
+        CreateTaskError::ParentCycleOrTooDeep {
+            parent: parent_str.to_string(),
+            reason,
+        }
+    })?;
+    Ok(Some(parent_index))
+}
+
+/// parent_index から配置先ディレクトリを決める。
+///
+/// 親未指定なら `tasks`、指定ありなら親 Task の `file_path` の dirname。
+/// 親 Task が root 配下にある場合は空 `PathBuf`（=ルート直下）になる。
+pub(crate) fn resolve_target_dir(parent_index: Option<usize>, snapshot: &[Task]) -> PathBuf {
+    match parent_index {
+        Some(i) => {
+            let p = Path::new(snapshot[i].file_path.as_str());
+            p.parent().map(Path::to_path_buf).unwrap_or_default()
+        }
+        None => PathBuf::from("tasks"),
+    }
+}
+
+/// target_dir 直下に存在する Task のファイル名（basename）の集合を作る。
+///
+/// `Task.file_path` は forward slash 正規化済み相対パス前提。snapshot 内で
+/// 同一 dirname の Task のみを拾い、basename のみを取り出して `HashSet` に詰める。
+/// 比較は `Path::parent()` の `Path` 単位で行うため slash 表記揺れに耐性がある。
+pub(crate) fn build_existing_filenames_in_dir(
+    tasks: &[Task],
+    target_dir: &Path,
+) -> HashSet<String> {
+    let mut out: HashSet<String> = HashSet::new();
+    for task in tasks {
+        let path = Path::new(task.file_path.as_str());
+        let parent = path.parent().unwrap_or_else(|| Path::new(""));
+        if parent != target_dir {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        out.insert(name.to_string());
+    }
+    out
+}
+
+/// frontmatter + body を md 文字列に組み立てる。
+///
+/// - title / status は `extras` に詰めて typed 位置（先頭）に出る
+/// - priority は `Priority::from_ascii_ci` で正規化、`Some` のみ出力
+/// - labels は空なら省略
+/// - parent は解決済みの `Task.file_path` 文字列をそのまま入れる（未指定なら省略）
+/// - body は `args.body` を本文として末尾に追加（前に空行 1 行を挟む）
+pub(crate) fn build_task_content(
+    args: &CreateTaskArgs,
+    resolved_parent_path: Option<&str>,
+) -> String {
+    use serde_yaml_ng::{Mapping, Value};
+
+    let mut extras = Mapping::new();
+    extras.insert(
+        Value::String("title".into()),
+        Value::String(args.title.clone()),
+    );
+    extras.insert(
+        Value::String("status".into()),
+        Value::String(args.status.clone()),
+    );
+    if let Some(parent_path) = resolved_parent_path {
+        extras.insert(
+            Value::String("parent".into()),
+            Value::String(parent_path.to_string()),
+        );
+    }
+
+    let priority = args.priority.as_deref().and_then(Priority::from_ascii_ci);
+
+    let frontmatter = Frontmatter {
+        priority,
+        labels: args.labels.clone(),
+        links: Vec::new(),
+        extras,
+    };
+
+    let body = match args.body.as_deref() {
+        Some(b) if !b.is_empty() => format!("\n{b}"),
+        _ => String::new(),
+    };
+
+    serialize_frontmatter(&Parsed { frontmatter, body })
+}
+
+/// hierarchy 検証用に最低限のフィールドだけ埋めた Task を作る。
+fn build_provisional_task_for_validation(
+    rel_path: &Path,
+    args: &CreateTaskArgs,
+    resolved_parent_path: Option<&str>,
+) -> Task {
+    let file_path = TaskFilePath::from_lenient(rel_path.to_string_lossy().replace('\\', "/"));
+    let parent = resolved_parent_path.map(TaskFilePath::from_lenient);
+    Task {
+        id: file_path.clone(),
+        file_path,
+        title: TaskTitle::from_lenient(args.title.clone()),
+        status: ColumnName::from_lenient(args.status.clone()),
+        priority: None,
+        labels: Vec::new(),
+        parent,
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: TaskExtras::new(),
+        warnings: Vec::<TaskWarning>::new(),
+    }
+}
+
+/// snapshot に provisional な new_task を足した状態で parent chain を一括検証し、
+/// dangling parent 解決による cycle / too deep を検出する。
+///
+/// 既存 snapshot は open_project 時点で検証済みなので、新規発生し得る違反は
+/// new_task の挿入で初めて成立するもののみ。`TaskParseError::CycleOrTooDeep` を
+/// `CreateTaskError::ParentCycleOrTooDeep` にマップして返す。
+fn validate_augmented_hierarchy(
+    snapshot: &[Task],
+    new_task: &Task,
+    raw_parent_input: Option<&str>,
+) -> Result<(), CreateTaskError> {
+    let mut augmented: Vec<Task> = snapshot.to_vec();
+    augmented.push(new_task.clone());
+    match validate_parent_hierarchy(augmented) {
+        Ok(_) => Ok(()),
+        Err(TaskParseError::CycleOrTooDeep { reason, .. }) => {
+            Err(CreateTaskError::ParentCycleOrTooDeep {
+                parent: raw_parent_input.unwrap_or("").to_string(),
+                reason,
+            })
+        }
+        Err(other) => {
+            // build_children 経由ではない経路で他 variant が来た場合は伝播理由
+            // を `Cycle` 相当に詰め直す（通常運用では到達しない）。
+            log::warn!("validate_augmented_hierarchy: unexpected error: {other}");
+            Err(CreateTaskError::ParentCycleOrTooDeep {
+                parent: raw_parent_input.unwrap_or("").to_string(),
+                reason: ParentHierarchyErrorReason::Cycle,
+            })
+        }
+    }
+}
+
+/// `target_dir.join(filename)` だが、`target_dir` が空 PathBuf の場合に
+/// `Path::new("").join("x.md")` が `"x.md"` を返す挙動を活かしてルート直下を扱う。
+fn join_rel_path(target_dir: &Path, filename: &str) -> PathBuf {
+    if target_dir.as_os_str().is_empty() {
+        PathBuf::from(filename)
+    } else {
+        target_dir.join(filename)
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task/create.rs
+++ b/src-tauri/src/task/create.rs
@@ -286,18 +286,39 @@ pub(crate) fn create_task_impl(
     }
     drop(file);
 
-    // 12. 書き込んだ md を再 parse → Task に変換
-    let parsed = parse_frontmatter(&content)?.expect("just-written frontmatter must parse");
+    // 12-13. 書き込んだ md を再 parse → Task に変換 → cache 差分更新。
+    //         ここで失敗（lock poison / parse 失敗）すると、cache には新規 Task が
+    //         反映されないため、`write_ignore` を残したままだと watcher 経由でも
+    //         拾えなくなる。したがって post-write phase の Err では
+    //         `write_ignore.unregister` を呼んで watcher の自然回復経路に戻す
+    //         （成功時はそのまま残し、watcher event を consume させる）。
+    let result =
+        parse_and_insert_into_cache(state, &content, &rel_path, args.status.clone());
+    if result.is_err() && watcher_active {
+        let _ = state.write_ignore().unregister(&abs_path);
+    }
+    result
+}
+
+/// FS write 成功後に呼ぶ post-write phase 本体。
+///
+/// 再 parse → Task 構築 → `tasks_cache` への差分挿入をまとめる。失敗時は
+/// caller が `write_ignore.unregister` を行うことで、watcher の自然回復に
+/// 委ねる前提（部分 atomic）。
+fn parse_and_insert_into_cache(
+    state: &AppState,
+    content: &str,
+    rel_path: &Path,
+    status: String,
+) -> Result<Task, CreateTaskCommandError> {
+    let parsed = parse_frontmatter(content)?.expect("just-written frontmatter must parse");
     let ctx = TaskParseContext {
-        file_path: rel_path.clone(),
-        default_status: ColumnName::from_lenient(args.status.clone()),
+        file_path: rel_path.to_path_buf(),
+        default_status: ColumnName::from_lenient(status),
     };
     let task = task_from_parsed(parsed, &ctx);
-
-    // 13. cache 差分更新 (lock 内)
     let final_task =
         state.with_tasks_cache_mut(|cache| TaskIndex::insert_new_task_into_cache(cache, task))?;
-
     Ok(final_task)
 }
 

--- a/src-tauri/src/task/create_tests.rs
+++ b/src-tauri/src/task/create_tests.rs
@@ -718,6 +718,53 @@ fn create_task_create_dir_all_failure_leaves_state_clean() {
 }
 
 #[test]
+fn create_task_rejects_body_larger_than_scanner_max_size() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // 1 MiB を確実に超える body を生成する。
+    let huge_body = "a".repeat(1024 * 1024 + 1);
+    let mut args = args_with_title("Huge");
+    args.body = Some(huge_body);
+    let err = create_task_impl(&state, args).expect_err("should fail");
+    match err {
+        CreateTaskCommandError::Validation(CreateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::TooLarge { .. },
+        }) => {}
+        other => panic!("expected ContentNotScannerEligible(TooLarge), got {other:?}"),
+    }
+    // FS / state 不変
+    assert!(!dir.path().join("tasks/huge.md").exists());
+    assert!(state.tasks_snapshot().unwrap().is_empty());
+    assert!(state.write_ignore().is_empty().unwrap());
+}
+
+#[test]
+fn create_task_rejects_body_with_nul_byte_in_first_8kb() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // 先頭 8 KiB 範囲に NUL byte を含む body を生成する。
+    let mut bad_body = String::from("hello");
+    bad_body.push('\u{0000}');
+    bad_body.push_str("world");
+    let mut args = args_with_title("Nul");
+    args.body = Some(bad_body);
+    let err = create_task_impl(&state, args).expect_err("should fail");
+    match err {
+        CreateTaskCommandError::Validation(CreateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::BinaryDetected,
+        }) => {}
+        other => panic!("expected ContentNotScannerEligible(BinaryDetected), got {other:?}"),
+    }
+    assert!(!dir.path().join("tasks/nul.md").exists());
+    assert!(state.tasks_snapshot().unwrap().is_empty());
+    assert!(state.write_ignore().is_empty().unwrap());
+}
+
+#[test]
 fn create_task_detects_augmented_cycle_via_dangling_parent_resolution() {
     let dir = tempdir();
     let state = Arc::new(AppState::new());

--- a/src-tauri/src/task/create_tests.rs
+++ b/src-tauri/src/task/create_tests.rs
@@ -1,6 +1,15 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
 use super::super::frontmatter::Priority;
 use super::super::index::{TaskExtras, TaskWarning};
 use super::*;
+use crate::project::open::open_project_with_factories;
+use crate::state::{AppState, BoxedWatcherHandle};
+use spec_board_fs::watcher::handle::NoopWatcherHandle;
 
 fn set_of(items: &[&str]) -> HashSet<String> {
     items.iter().map(|s| (*s).to_string()).collect()
@@ -234,4 +243,501 @@ fn validate_parent_for_new_task_cycle_or_too_deep_cases() {
             "{label}"
         );
     }
+}
+
+// ============================================================================
+// Pure helpers: resolve_target_dir / build_existing_filenames_in_dir / build_task_content
+// ============================================================================
+
+#[test]
+fn resolve_target_dir_returns_tasks_when_parent_none() {
+    let snapshot: Vec<Task> = Vec::new();
+    assert_eq!(PathBuf::from("tasks"), resolve_target_dir(None, &snapshot));
+}
+
+#[test]
+fn resolve_target_dir_returns_tasks_when_parent_in_tasks_dir() {
+    let snapshot = vec![task_without_parent("tasks/parent.md")];
+    assert_eq!(
+        PathBuf::from("tasks"),
+        resolve_target_dir(Some(0), &snapshot)
+    );
+}
+
+#[test]
+fn resolve_target_dir_returns_parent_dirname_for_nested_parent() {
+    let snapshot = vec![task_without_parent("issues/82/parent.md")];
+    assert_eq!(
+        PathBuf::from("issues/82"),
+        resolve_target_dir(Some(0), &snapshot)
+    );
+}
+
+#[test]
+fn build_existing_filenames_collects_only_files_in_target_dir() {
+    let snapshot = vec![
+        task_without_parent("tasks/a.md"),
+        task_without_parent("tasks/b.md"),
+        task_without_parent("issues/x.md"),
+    ];
+    let names = build_existing_filenames_in_dir(&snapshot, Path::new("tasks"));
+    assert_eq!(set_of(&["a.md", "b.md"]), names);
+}
+
+#[test]
+fn build_existing_filenames_excludes_other_directories() {
+    let snapshot = vec![
+        task_without_parent("tasks/a.md"),
+        task_without_parent("notes/a.md"),
+    ];
+    let names = build_existing_filenames_in_dir(&snapshot, Path::new("notes"));
+    assert_eq!(set_of(&["a.md"]), names);
+}
+
+#[test]
+fn build_task_content_renders_title_and_status_in_fixed_order() {
+    let args = CreateTaskArgs {
+        title: "Foo Bar".into(),
+        status: "Todo".into(),
+        priority: None,
+        labels: Vec::new(),
+        parent: None,
+        body: None,
+    };
+    let content = build_task_content(&args, None);
+    assert!(content.starts_with("---\ntitle: Foo Bar\nstatus: Todo\n"));
+    // priority / labels / parent / links は省略
+    assert!(!content.contains("priority:"));
+    assert!(!content.contains("labels:"));
+    assert!(!content.contains("parent:"));
+}
+
+#[test]
+fn build_task_content_normalizes_priority_case_insensitively() {
+    let cases: Vec<(&str, &str)> = vec![("high", "High"), ("HIGH", "High"), ("MeDiUm", "Medium")];
+    for (input, expected) in cases {
+        let args = CreateTaskArgs {
+            title: "T".into(),
+            status: "Todo".into(),
+            priority: Some(input.to_string()),
+            labels: Vec::new(),
+            parent: None,
+            body: None,
+        };
+        let content = build_task_content(&args, None);
+        assert!(
+            content.contains(&format!("priority: {expected}")),
+            "priority {input} → {expected} expected, got:\n{content}"
+        );
+    }
+}
+
+#[test]
+fn build_task_content_omits_priority_for_invalid_string() {
+    let args = CreateTaskArgs {
+        title: "T".into(),
+        status: "Todo".into(),
+        priority: Some("urgent".into()),
+        labels: Vec::new(),
+        parent: None,
+        body: None,
+    };
+    let content = build_task_content(&args, None);
+    assert!(
+        !content.contains("priority:"),
+        "invalid priority should be omitted, got:\n{content}"
+    );
+}
+
+#[test]
+fn build_task_content_renders_labels_and_parent_and_body() {
+    let args = CreateTaskArgs {
+        title: "T".into(),
+        status: "Todo".into(),
+        priority: Some("High".into()),
+        labels: vec!["bug".into(), "api".into()],
+        parent: Some("tasks/p.md".into()),
+        body: Some("hello body".into()),
+    };
+    let content = build_task_content(&args, Some("tasks/p.md"));
+    assert!(content.contains("title: T"));
+    assert!(content.contains("status: Todo"));
+    assert!(content.contains("priority: High"));
+    assert!(content.contains("labels:"));
+    assert!(content.contains("- bug"));
+    assert!(content.contains("- api"));
+    assert!(content.contains("parent: tasks/p.md"));
+    assert!(
+        content.ends_with("hello body\n"),
+        "body trailing:\n{content}"
+    );
+}
+
+// ============================================================================
+// Effect layer: create_task_impl integration tests
+// ============================================================================
+
+fn tempdir() -> TempDir {
+    tempfile::tempdir().expect("create temp dir")
+}
+
+fn open_with_noop(state: Arc<AppState>, path: &Path) {
+    open_project_with_factories(
+        state,
+        path.to_str().expect("utf-8"),
+        |_root| Ok::<(), crate::project::open::OpenProjectError>(()),
+        |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
+    )
+    .expect("open should succeed");
+}
+
+fn args_with_title(title: &str) -> CreateTaskArgs {
+    CreateTaskArgs {
+        title: title.into(),
+        status: "Todo".into(),
+        priority: None,
+        labels: Vec::new(),
+        parent: None,
+        body: None,
+    }
+}
+
+#[test]
+fn create_task_writes_md_and_inserts_into_cache_for_empty_project() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let args = args_with_title("Fix Login Bug");
+    let task = create_task_impl(&state, args).expect("create succeeds");
+
+    assert_eq!(task.file_path, "tasks/fix-login-bug.md");
+    let abs = dir.path().join("tasks/fix-login-bug.md");
+    assert!(abs.exists(), "md file should be written");
+    let content = fs::read_to_string(&abs).expect("read");
+    assert!(content.contains("title: Fix Login Bug"));
+    assert!(content.contains("status: Todo"));
+
+    let snap = state.tasks_snapshot().expect("snapshot");
+    assert_eq!(1, snap.len());
+    assert_eq!("tasks/fix-login-bug.md", snap[0].file_path);
+}
+
+#[test]
+fn create_task_with_priority_and_labels_and_body_renders_full_frontmatter() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let args = CreateTaskArgs {
+        title: "Implement Feature".into(),
+        status: "Doing".into(),
+        priority: Some("high".into()),
+        labels: vec!["bug".into(), "api".into()],
+        parent: None,
+        body: Some("Detailed description.".into()),
+    };
+    let task = create_task_impl(&state, args).expect("create succeeds");
+
+    let abs = dir.path().join(task.file_path.as_str());
+    let content = fs::read_to_string(&abs).expect("read");
+    assert!(content.contains("priority: High"));
+    assert!(content.contains("- bug"));
+    assert!(content.contains("- api"));
+    assert!(content.contains("Detailed description."));
+}
+
+#[test]
+fn create_task_under_parent_places_into_parent_dir_and_updates_children() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+
+    // 事前に親 task を直接書き込んで open する。
+    let parent_rel = "issues/82/parent.md";
+    let parent_md = "---\ntitle: Parent\nstatus: Todo\n---\n";
+    let parent_abs = dir.path().join(parent_rel);
+    fs::create_dir_all(parent_abs.parent().unwrap()).unwrap();
+    fs::write(&parent_abs, parent_md).unwrap();
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let args = CreateTaskArgs {
+        title: "Child Task".into(),
+        status: "Todo".into(),
+        priority: None,
+        labels: Vec::new(),
+        parent: Some("issues/82/parent.md".into()),
+        body: None,
+    };
+    let task = create_task_impl(&state, args).expect("create succeeds");
+
+    assert_eq!(task.file_path, "issues/82/child-task.md");
+    let abs = dir.path().join("issues/82/child-task.md");
+    assert!(abs.exists());
+
+    // 親 children 更新確認
+    let snap = state.tasks_snapshot().expect("snapshot");
+    let parent_task = snap
+        .iter()
+        .find(|t| t.file_path == "issues/82/parent.md")
+        .expect("parent in cache");
+    assert!(
+        parent_task
+            .children
+            .iter()
+            .any(|c| c.as_str() == "issues/82/child-task.md"),
+        "child should be appended to parent.children",
+    );
+}
+
+#[test]
+fn create_task_normalizes_raw_parent_path_to_resolved_dir() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    let parent_md = "---\ntitle: Parent\nstatus: Todo\n---\n";
+    let parent_abs = dir.path().join("tasks/parent.md");
+    fs::create_dir_all(parent_abs.parent().unwrap()).unwrap();
+    fs::write(&parent_abs, parent_md).unwrap();
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let cases = vec!["./tasks/parent.md", "tasks\\parent.md"];
+    for (i, raw) in cases.into_iter().enumerate() {
+        let args = CreateTaskArgs {
+            title: format!("Child {i}"),
+            status: "Todo".into(),
+            priority: None,
+            labels: Vec::new(),
+            parent: Some(raw.to_string()),
+            body: None,
+        };
+        let task = create_task_impl(&state, args).expect("create succeeds");
+        assert!(
+            task.file_path.as_str().starts_with("tasks/"),
+            "raw parent {raw} should resolve to tasks/, got {}",
+            task.file_path
+        );
+    }
+}
+
+#[test]
+fn create_task_collision_appends_suffix() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    create_task_impl(&state, args_with_title("Foo")).expect("first");
+    let second = create_task_impl(&state, args_with_title("Foo")).expect("second");
+
+    assert_eq!(second.file_path, "tasks/foo-1.md");
+}
+
+#[test]
+fn create_task_returns_no_project_open_when_project_not_opened() {
+    let state = AppState::new();
+    let err = create_task_impl(&state, args_with_title("X")).expect_err("should fail");
+    assert!(matches!(err, CreateTaskCommandError::NoProjectOpen));
+}
+
+#[test]
+fn create_task_returns_parent_not_found_for_missing_parent() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_with_title("X");
+    args.parent = Some("tasks/missing.md".into());
+    let err = create_task_impl(&state, args).expect_err("should fail");
+    match err {
+        CreateTaskCommandError::Validation(CreateTaskError::ParentNotFound { parent }) => {
+            assert_eq!("tasks/missing.md", parent);
+        }
+        other => panic!("expected ParentNotFound, got {other:?}"),
+    }
+    // cache / FS が不変
+    assert!(state.tasks_snapshot().unwrap().is_empty());
+}
+
+#[test]
+fn create_task_returns_invalid_title_for_empty_title() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_with_title("");
+    args.title.clear();
+    let err = create_task_impl(&state, args).expect_err("should fail");
+    assert!(matches!(
+        err,
+        CreateTaskCommandError::Validation(CreateTaskError::InvalidTitle)
+    ));
+}
+
+#[test]
+fn create_task_succeeds_when_watcher_not_installed_and_does_not_register_write_ignore() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    // open は state を最低限初期化するだけ。watcher を install しない。
+    state
+        .set_project_path(Some(dir.path().to_path_buf()))
+        .unwrap();
+
+    let task = create_task_impl(&state, args_with_title("No Watcher")).expect("succeeds");
+    let abs = dir.path().join(task.file_path.as_str());
+    assert!(abs.exists());
+    assert!(
+        state.write_ignore().is_empty().unwrap(),
+        "write_ignore must stay empty when watcher is not installed"
+    );
+}
+
+#[test]
+fn create_task_registers_write_ignore_when_watcher_installed_and_consumed_on_event() {
+    use crate::watcher_event::handler::handle_event;
+    use crate::watcher_event::AdapterContext;
+    use crate::watcher_event::EmitFn;
+    use spec_board_fs::watcher::core::FsEvent;
+    use std::sync::Mutex;
+
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let task = create_task_impl(&state, args_with_title("Watched")).expect("create");
+    let abs = dir.path().join(task.file_path.as_str());
+
+    // create 後は write_ignore に 1 件登録されているはず（NoopWatcherHandle 経由でも install 済み判定）。
+    assert_eq!(1, state.write_ignore().len().expect("len"));
+
+    // 自前 write 由来の Created event を流し、emit が抑止され write_ignore も空になることを確認する。
+    let log: Arc<Mutex<Vec<(String, serde_json::Value)>>> = Arc::new(Mutex::new(Vec::new()));
+    let log_clone = Arc::clone(&log);
+    let emit: EmitFn = Box::new(move |ev, payload| {
+        log_clone.lock().unwrap().push((ev.to_string(), payload));
+    });
+    let ctx = AdapterContext {
+        root: dir.path().to_path_buf(),
+        default_status: "Todo".into(),
+        state: Arc::clone(&state),
+        emit,
+    };
+    handle_event(&FsEvent::Created(abs), &ctx).expect("handle ok");
+
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "self-write should not emit IPC"
+    );
+    assert!(state.write_ignore().is_empty().unwrap());
+}
+
+#[test]
+fn create_task_with_existing_file_returns_already_exists_and_leaves_state_clean() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // cache 未反映の stale ファイルを直接配置する。
+    let stale = dir.path().join("tasks/stale.md");
+    fs::create_dir_all(stale.parent().unwrap()).unwrap();
+    fs::write(&stale, "---\ntitle: Stale\nstatus: Todo\n---\n").unwrap();
+
+    let err = create_task_impl(&state, args_with_title("Stale")).expect_err("should fail");
+    match err {
+        CreateTaskCommandError::Io(e) => {
+            assert_eq!(std::io::ErrorKind::AlreadyExists, e.kind());
+        }
+        other => panic!("expected Io(AlreadyExists), got {other:?}"),
+    }
+    // write_ignore は巻き戻されて空、cache は空のまま。
+    assert!(state.write_ignore().is_empty().unwrap());
+    assert!(state.tasks_snapshot().unwrap().is_empty());
+}
+
+#[test]
+fn create_task_detects_augmented_too_deep_when_descendant_chain_exceeds_limit() {
+    // 既存タスクが個別では MAX 以下だが、新規 task の追加で dangling parent が
+    // 解決されて累計 chain が MAX を超えるケースを検証する。
+    //
+    // 構成:
+    //   tasks/a.md → parent: tasks/new.md (dangling)
+    //   tasks/B0.md → tasks/B1.md → ... → tasks/B19.md (19 edges, B19 が root)
+    //   新規: tasks/new.md → parent: tasks/B0.md
+    // → 追加後の augmented chain (from tasks/a.md):
+    //   a → new → B0 → B1 → ... → B19 = 21 edges = TooDeep
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+
+    let make = |parent: Option<&str>| {
+        let mut s = String::from("---\ntitle: T\nstatus: Todo\n");
+        if let Some(p) = parent {
+            s.push_str(&format!("parent: {p}\n"));
+        }
+        s.push_str("---\n");
+        s
+    };
+    let tasks_dir = dir.path().join("tasks");
+    fs::create_dir_all(&tasks_dir).unwrap();
+    fs::write(tasks_dir.join("a.md"), make(Some("tasks/new.md"))).unwrap();
+    // B0.md → B1.md → ... → B19.md, B19 が root（19 edge）
+    for i in 0..19 {
+        let parent = format!("tasks/B{}.md", i + 1);
+        fs::write(tasks_dir.join(format!("B{i}.md")), make(Some(&parent))).unwrap();
+    }
+    fs::write(tasks_dir.join("B19.md"), make(None)).unwrap();
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_with_title("New");
+    args.parent = Some("tasks/B0.md".into());
+    let err = create_task_impl(&state, args).expect_err("should fail");
+    match err {
+        CreateTaskCommandError::Validation(CreateTaskError::ParentCycleOrTooDeep {
+            reason,
+            ..
+        }) => {
+            assert_eq!(reason, ParentHierarchyErrorReason::TooDeep);
+        }
+        other => panic!("expected ParentCycleOrTooDeep(TooDeep), got {other:?}"),
+    }
+    assert!(!dir.path().join("tasks/new.md").exists());
+}
+
+#[test]
+fn create_task_create_dir_all_failure_leaves_state_clean() {
+    // create_dir_all は親 dir が file の場合に失敗する。
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // tasks/ をファイルとして作る → create_dir_all が失敗する。
+    let tasks_path = dir.path().join("tasks");
+    fs::write(&tasks_path, "stub").unwrap();
+
+    let err = create_task_impl(&state, args_with_title("X")).expect_err("should fail");
+    assert!(matches!(err, CreateTaskCommandError::Io(_)));
+    // register / write どちらも未実行で state は不変。
+    assert!(state.write_ignore().is_empty().unwrap());
+    assert!(state.tasks_snapshot().unwrap().is_empty());
+}
+
+#[test]
+fn create_task_detects_augmented_cycle_via_dangling_parent_resolution() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    // 既存 a.md は parent: tasks/new.md（dangling）。new.md は未存在。
+    let a_md = "---\ntitle: A\nstatus: Todo\nparent: tasks/new.md\n---\n";
+    let a_abs = dir.path().join("tasks/a.md");
+    fs::create_dir_all(a_abs.parent().unwrap()).unwrap();
+    fs::write(&a_abs, a_md).unwrap();
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // 新規 tasks/new.md を parent=tasks/a.md で作る → 解決後 a -> new -> a の cycle。
+    let mut args = args_with_title("New");
+    args.parent = Some("tasks/a.md".into());
+    let err = create_task_impl(&state, args).expect_err("should fail");
+    match err {
+        CreateTaskCommandError::Validation(CreateTaskError::ParentCycleOrTooDeep { .. }) => {}
+        other => panic!("expected ParentCycleOrTooDeep, got {other:?}"),
+    }
+    // FS / state 不変（a.md だけが残っている、new.md は書かれていない）。
+    assert!(!dir.path().join("tasks/new.md").exists());
+    let snap = state.tasks_snapshot().unwrap();
+    assert_eq!(1, snap.len());
 }

--- a/src-tauri/src/task/index.rs
+++ b/src-tauri/src/task/index.rs
@@ -912,16 +912,15 @@ impl TaskIndex {
 
 /// `cache` から、正規化済み path で一致する Task の可変参照を見つける。
 ///
-/// `cache` の key は `PathBuf::from(task.file_path.as_str())` で構築されている
-/// 前提だが、表記揺れ吸収のため値側の `file_path` を `normalize_task_path_for_lookup`
-/// で比較する。
+/// `cache` の key は常に `PathBuf::from(task.file_path.as_str())`、かつ
+/// `task.file_path` は `normalized_task_file_path` 経由で常に正規化済み（forward
+/// slash / drive prefix 除去 / `.` セグメント除去）。したがって正規化済み path
+/// 文字列をそのまま `PathBuf` 化して `HashMap::get_mut` で O(1) 引き当てできる。
 fn find_task_mut<'a>(
     cache: &'a mut HashMap<PathBuf, Task>,
     normalized: &str,
 ) -> Option<&'a mut Task> {
-    cache
-        .values_mut()
-        .find(|task| normalize_task_path_for_lookup(task.file_path.as_str()) == normalized)
+    cache.get_mut(&PathBuf::from(normalized))
 }
 
 impl From<Vec<Task>> for TaskIndex {

--- a/src-tauri/src/task/index.rs
+++ b/src-tauri/src/task/index.rs
@@ -700,7 +700,7 @@ pub(crate) fn default_status_for(config: &Config) -> ColumnName {
 ///
 /// @param path lookup key に変換する Task file path。
 /// @returns lookup 用の正規化済み path。
-fn normalize_task_path_for_lookup(path: &str) -> String {
+pub(crate) fn normalize_task_path_for_lookup(path: &str) -> String {
     let path_text = path.replace('\\', "/");
     normalize_path_parts(&path_text, true)
 }
@@ -711,7 +711,7 @@ fn normalize_task_path_for_lookup(path: &str) -> String {
 ///
 /// @param parent 正規化する parent 参照文字列。
 /// @returns lookup 用の正規化済み相対 path。task graph 対象外の場合は `None`。
-fn normalize_parent_path_for_lookup(parent: &str) -> Option<String> {
+pub(crate) fn normalize_parent_path_for_lookup(parent: &str) -> Option<String> {
     if parent.is_empty() || parent.starts_with('/') || parent.starts_with('\\') {
         return None;
     }
@@ -809,6 +809,119 @@ impl TaskIndex {
     ) -> Result<(), ParentHierarchyErrorReason> {
         validate_chain_from_parent(parent_index, &self.tasks)
     }
+
+    /// 差分追加: 新規 Task を cache に挿入し、親 `children` と link 先
+    /// `reverse_links` を局所更新する。さらに既存 cache 内の dangling parent /
+    /// links（新規タスクの file_path を参照しているもの）を解決して新規タスク側の
+    /// `children` / `reverse_links` を埋めることで、全件再スキャン
+    /// （`build_children` / `build_reverse_links`）と**集合として等価**な状態を
+    /// 再現する。
+    ///
+    /// # 順序仕様
+    /// `children` / `reverse_links` の **配列順序自体は spec として固定しない**。
+    /// 差分挿入は次の不変条件で決定的に動作する:
+    /// - outgoing 更新: 既存 parent / target の `children` / `reverse_links` の
+    ///   末尾に新規 task を `push` する。
+    /// - incoming 更新: 既存 cache を `file_path` 昇順で走査して新規 task の
+    ///   `children` / `reverse_links` を埋める。
+    ///
+    /// 一方、全件再構築 (`build_children` / `build_reverse_links`) は入力 task 順
+    /// （walkdir 由来）に依存するため、両者の結果は集合としては一致するが
+    /// 配列順までは一致しないことがある。FE 側で表示順が必要な場合は別途
+    /// 並び替える前提。
+    ///
+    /// 重複除去: 同一 source 内の `links` で複数 entry が同じ正規化 target を
+    /// 指す場合、`build_reverse_links` の既存挙動と揃え、最初の参照だけを採用する。
+    ///
+    /// @param cache `tasks_cache` の可変参照（lock 内）。
+    /// @param new_task 挿入する Task（children / reverse_links は空想定）。
+    /// @returns 挿入後の Task（children / reverse_links 反映済み）。
+    pub fn insert_new_task_into_cache(
+        cache: &mut HashMap<PathBuf, Task>,
+        mut new_task: Task,
+    ) -> Task {
+        let key = PathBuf::from(new_task.file_path.as_str());
+        let new_normalized = normalize_task_path_for_lookup(new_task.file_path.as_str());
+
+        // (A) outgoing: 親があれば親の children に append
+        if let Some(parent_ref) = new_task.parent.as_ref() {
+            if let Some(pn) = normalize_parent_path_for_lookup(parent_ref.as_str()) {
+                if let Some(parent_task) = find_task_mut(cache, &pn) {
+                    parent_task.children.push(new_task.file_path.clone());
+                }
+            }
+        }
+
+        // (B) outgoing: links 先 task の reverse_links に append（重複 target 除外）
+        let mut seen_link_targets: HashSet<String> = HashSet::new();
+        for link in new_task.links.clone() {
+            let Some(normalized) = normalize_link_path_for_lookup(link.as_str()) else {
+                continue;
+            };
+            if !seen_link_targets.insert(normalized.clone()) {
+                continue;
+            }
+            if let Some(target_task) = find_task_mut(cache, &normalized) {
+                target_task.reverse_links.push(new_task.file_path.clone());
+            }
+        }
+
+        // incoming 走査は cache (HashMap) の走査順が不定なため、`file_path` 昇順で
+        // 決定的に並べてから集計する。これで差分挿入結果の `children` /
+        // `reverse_links` 順序が再現可能になる（全件再構築との等価比較も sort 不要で
+        // 安定する）。
+        let mut existing_sorted: Vec<&Task> = cache.values().collect();
+        existing_sorted.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+
+        // (C) incoming parent: 既存 cache の task で parent が new_task を指すもの
+        //     → new_task.children へ追加
+        for existing in &existing_sorted {
+            let Some(parent_ref) = existing.parent.as_ref() else {
+                continue;
+            };
+            let Some(pn) = normalize_parent_path_for_lookup(parent_ref.as_str()) else {
+                continue;
+            };
+            if pn == new_normalized {
+                new_task.children.push(existing.file_path.clone());
+            }
+        }
+
+        // (D) incoming links: 既存 cache の task の links が new_task を指すもの
+        //     → new_task.reverse_links へ追加（同一 source 内の重複 target は除外）
+        for existing in &existing_sorted {
+            let mut seen_in_source: HashSet<String> = HashSet::new();
+            for link in &existing.links {
+                let Some(ln) = normalize_link_path_for_lookup(link.as_str()) else {
+                    continue;
+                };
+                if !seen_in_source.insert(ln.clone()) {
+                    continue;
+                }
+                if ln == new_normalized {
+                    new_task.reverse_links.push(existing.file_path.clone());
+                    break;
+                }
+            }
+        }
+
+        cache.insert(key, new_task.clone());
+        new_task
+    }
+}
+
+/// `cache` から、正規化済み path で一致する Task の可変参照を見つける。
+///
+/// `cache` の key は `PathBuf::from(task.file_path.as_str())` で構築されている
+/// 前提だが、表記揺れ吸収のため値側の `file_path` を `normalize_task_path_for_lookup`
+/// で比較する。
+fn find_task_mut<'a>(
+    cache: &'a mut HashMap<PathBuf, Task>,
+    normalized: &str,
+) -> Option<&'a mut Task> {
+    cache
+        .values_mut()
+        .find(|task| normalize_task_path_for_lookup(task.file_path.as_str()) == normalized)
 }
 
 impl From<Vec<Task>> for TaskIndex {

--- a/src-tauri/src/task/index.rs
+++ b/src-tauri/src/task/index.rs
@@ -833,10 +833,15 @@ impl TaskIndex {
     /// 重複除去: 同一 source 内の `links` で複数 entry が同じ正規化 target を
     /// 指す場合、`build_reverse_links` の既存挙動と揃え、最初の参照だけを採用する。
     ///
+    /// # 可視性
+    /// `tasks_cache` の内部表現 (`HashMap<PathBuf, Task>`) と
+    /// 「`AppState::with_tasks_cache_mut` の closure 内 = lock 保持中に呼ぶ」
+    /// 前提を crate 外へ漏らさないよう `pub(crate)` に制限する。
+    ///
     /// @param cache `tasks_cache` の可変参照（lock 内）。
     /// @param new_task 挿入する Task（children / reverse_links は空想定）。
     /// @returns 挿入後の Task（children / reverse_links 反映済み）。
-    pub fn insert_new_task_into_cache(
+    pub(crate) fn insert_new_task_into_cache(
         cache: &mut HashMap<PathBuf, Task>,
         mut new_task: Task,
     ) -> Task {

--- a/src-tauri/src/task/index_tests.rs
+++ b/src-tauri/src/task/index_tests.rs
@@ -1082,3 +1082,234 @@ fn task_json_round_trip_omits_none_optional_fields() {
     let serialized = serde_json::to_string(&parsed).unwrap();
     assert_eq!(serialized, json);
 }
+
+// ============================================================================
+// TaskIndex::insert_new_task_into_cache
+// ============================================================================
+
+fn cache_from(tasks: Vec<Task>) -> HashMap<PathBuf, Task> {
+    let mut cache = HashMap::new();
+    for task in tasks {
+        cache.insert(PathBuf::from(task.file_path.as_str()), task);
+    }
+    cache
+}
+
+fn task_with_links_and_parent(path: &str, parent: Option<&str>, links: &[&str]) -> Task {
+    let mut s = String::from("---\ntitle: Task\nstatus: Todo\n");
+    if let Some(p) = parent {
+        s.push_str(&format!("parent: {p}\n"));
+    }
+    if !links.is_empty() {
+        s.push_str("links:\n");
+        for l in links {
+            s.push_str(&format!("  - {l}\n"));
+        }
+    }
+    s.push_str("---\n");
+    task_from(&s, path)
+}
+
+#[test]
+fn insert_new_task_into_empty_cache_adds_one_entry() {
+    let mut cache = HashMap::new();
+    let new_task = task_without_parent("tasks/new.md");
+
+    let returned = TaskIndex::insert_new_task_into_cache(&mut cache, new_task.clone());
+
+    assert_eq!(1, cache.len());
+    assert!(returned.children.is_empty());
+    assert!(returned.reverse_links.is_empty());
+    assert_eq!(returned.file_path, "tasks/new.md");
+    assert!(cache.contains_key(&PathBuf::from("tasks/new.md")));
+}
+
+#[test]
+fn insert_new_task_appends_to_parent_children_when_parent_exists() {
+    let parent = task_without_parent("tasks/parent.md");
+    let mut cache = cache_from(vec![parent]);
+    let new_task = task_with_parent("tasks/child.md", "tasks/parent.md");
+
+    TaskIndex::insert_new_task_into_cache(&mut cache, new_task);
+
+    let updated_parent = cache.get(&PathBuf::from("tasks/parent.md")).unwrap();
+    assert_eq!(
+        vec![TaskFilePath::from("tasks/child.md")],
+        updated_parent.children
+    );
+}
+
+#[test]
+fn insert_new_task_appends_to_target_reverse_links_when_link_exists() {
+    let target = task_without_parent("tasks/target.md");
+    let mut cache = cache_from(vec![target]);
+    let new_task = task_with_links_and_parent("tasks/source.md", None, &["tasks/target.md"]);
+
+    TaskIndex::insert_new_task_into_cache(&mut cache, new_task);
+
+    let updated_target = cache.get(&PathBuf::from("tasks/target.md")).unwrap();
+    assert_eq!(
+        vec![TaskFilePath::from("tasks/source.md")],
+        updated_target.reverse_links
+    );
+}
+
+#[test]
+fn insert_new_task_resolves_incoming_parent_into_new_task_children() {
+    // 既存 task が new_task を parent として指している（dangling parent）→
+    // 解決して new_task.children に入る。
+    let existing = task_with_parent("tasks/a.md", "tasks/new.md");
+    let mut cache = cache_from(vec![existing]);
+    let new_task = task_without_parent("tasks/new.md");
+
+    let returned = TaskIndex::insert_new_task_into_cache(&mut cache, new_task);
+
+    assert_eq!(vec![TaskFilePath::from("tasks/a.md")], returned.children);
+    // cache 側も同じ children を持つ
+    let cached_new = cache.get(&PathBuf::from("tasks/new.md")).unwrap();
+    assert_eq!(vec![TaskFilePath::from("tasks/a.md")], cached_new.children);
+}
+
+#[test]
+fn insert_new_task_resolves_incoming_links_into_new_task_reverse_links() {
+    let existing = task_with_links_and_parent("tasks/source.md", None, &["tasks/new.md"]);
+    let mut cache = cache_from(vec![existing]);
+    let new_task = task_without_parent("tasks/new.md");
+
+    let returned = TaskIndex::insert_new_task_into_cache(&mut cache, new_task);
+
+    assert_eq!(
+        vec![TaskFilePath::from("tasks/source.md")],
+        returned.reverse_links
+    );
+}
+
+#[test]
+fn insert_new_task_leaves_cache_unchanged_when_parent_and_links_dangling() {
+    let mut cache = HashMap::new();
+    let new_task = task_with_links_and_parent(
+        "tasks/new.md",
+        Some("tasks/missing-parent.md"),
+        &["tasks/missing-link.md"],
+    );
+
+    let returned = TaskIndex::insert_new_task_into_cache(&mut cache, new_task);
+
+    assert_eq!(1, cache.len(), "only new_task inserted");
+    assert!(returned.children.is_empty());
+    assert!(returned.reverse_links.is_empty());
+}
+
+#[test]
+fn insert_new_task_dedups_repeated_link_target_into_single_reverse_link() {
+    let target = task_without_parent("tasks/target.md");
+    let mut cache = cache_from(vec![target]);
+    // links に同じ target が 2 回登場（既存 lenient deserializer により dedupe 済みになるが、
+    // ここでは仕様確認のため両方持つ Task を直接組み立てる）。
+    let mut new_task = task_without_parent("tasks/source.md");
+    new_task.links = vec![
+        TaskFilePath::from("tasks/target.md"),
+        TaskFilePath::from("tasks/target.md"),
+    ];
+
+    TaskIndex::insert_new_task_into_cache(&mut cache, new_task);
+
+    let updated_target = cache.get(&PathBuf::from("tasks/target.md")).unwrap();
+    assert_eq!(
+        vec![TaskFilePath::from("tasks/source.md")],
+        updated_target.reverse_links,
+        "duplicate link target should produce only one reverse_link"
+    );
+}
+
+#[test]
+fn insert_new_task_appends_to_existing_children_at_end_regardless_of_lex_order() {
+    // 順序の不変条件: 差分挿入は既存 parent.children の末尾に新規 task を push する
+    // （`file_path` の辞書順では新規が先頭に来てしまうケースでも変わらない）。
+    let parent = task_without_parent("tasks/zzz-parent.md");
+    // 既存 child a が parent の children に登録済み（pre-resolved 状態を再現）。
+    let mut a = task_with_parent("tasks/m-child.md", "tasks/zzz-parent.md");
+    a.children = Vec::new();
+    let mut parent_pre = parent;
+    parent_pre.children = vec![TaskFilePath::from("tasks/m-child.md")];
+    let mut cache = cache_from(vec![parent_pre, a]);
+
+    // 新規 a-child (辞書順で m-child より前) を追加。
+    let new_task = task_with_parent("tasks/a-child.md", "tasks/zzz-parent.md");
+    TaskIndex::insert_new_task_into_cache(&mut cache, new_task);
+
+    let parent_now = cache.get(&PathBuf::from("tasks/zzz-parent.md")).unwrap();
+    assert_eq!(
+        vec![
+            TaskFilePath::from("tasks/m-child.md"),
+            TaskFilePath::from("tasks/a-child.md"),
+        ],
+        parent_now.children,
+        "new child should be appended at end, not lex-sorted"
+    );
+}
+
+#[test]
+fn insert_new_task_matches_full_rebuild_with_build_children_and_build_reverse_links() {
+    // 差分挿入後の cache snapshot が、全件再構築の結果と等価であることを確認する。
+    // 前提: open_project の挙動と同じく、既存 cache は children/reverse_links を
+    //       既に解決済みの状態から始める。create_task はそこに新規 Task を 1 件追加する。
+    let existing = vec![
+        task_with_links_and_parent("tasks/a.md", Some("tasks/new.md"), &["tasks/new.md"]),
+        task_without_parent("tasks/b.md"),
+        task_with_links_and_parent("tasks/c.md", None, &["tasks/new.md", "tasks/b.md"]),
+    ];
+    let new_task = task_with_links_and_parent("tasks/new.md", Some("tasks/b.md"), &["tasks/c.md"]);
+
+    // 差分挿入経路: 既存 cache は build_children + build_reverse_links 済みから出発
+    let prebuilt = TaskIndex::new(existing.clone())
+        .build_children()
+        .expect("no cycle")
+        .build_reverse_links()
+        .into_tasks();
+    let mut cache = cache_from(prebuilt);
+    TaskIndex::insert_new_task_into_cache(&mut cache, new_task.clone());
+    let mut diff_tasks: Vec<Task> = cache.values().cloned().collect();
+    diff_tasks.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+
+    // 全件再構築経路
+    let mut all = existing.clone();
+    all.push(new_task);
+    let rebuilt = TaskIndex::new(all)
+        .build_children()
+        .expect("no cycle")
+        .build_reverse_links()
+        .into_tasks();
+    let mut full_tasks = rebuilt;
+    full_tasks.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+
+    // `children` / `reverse_links` は集合としての等価性のみを保証する仕様。
+    // - 差分挿入: 既存 parent/target の末尾に新規 task を `push` する（incoming は
+    //   `file_path` 昇順で安定）
+    // - 全件再構築: 入力 task 順に build_children / build_reverse_links が走る
+    //   （walkdir 由来の入力順次第で順序が決まる）
+    // どちらも内部表現で順序自体は spec として固定していない（FE 側で必要なら
+    // 表示順を別途決める）。等価性検証は sort 後比較で行う。
+    assert_eq!(full_tasks.len(), diff_tasks.len());
+    for (a, b) in full_tasks.iter().zip(diff_tasks.iter()) {
+        assert_eq!(a.file_path, b.file_path);
+        let mut a_children = a.children.clone();
+        let mut b_children = b.children.clone();
+        a_children.sort();
+        b_children.sort();
+        assert_eq!(
+            a_children, b_children,
+            "children for {} mismatched (as set)",
+            a.file_path
+        );
+        let mut a_rl = a.reverse_links.clone();
+        let mut b_rl = b.reverse_links.clone();
+        a_rl.sort();
+        b_rl.sort();
+        assert_eq!(
+            a_rl, b_rl,
+            "reverse_links for {} mismatched (as set)",
+            a.file_path
+        );
+    }
+}


### PR DESCRIPTION
## 概要

#81 で追加した parent 検証純粋関数の上に effect 層を実装し、`create_task` Tauri command を完成させた。`.md` ファイル書き込み + `tasks_cache` の差分更新 + watcher self-write 抑止 + 親 children / link 先 reverse_links の解決を 1 つの command に統合し、`lib.rs::run()` に登録した。

## 変更の種類

- ✨ 新機能（BE: `create_task` の effect 層）
- 📝 ドキュメント（`docs/spec-board/file-system-spec.md`）

## 追加した内容

- `AppState::is_watcher_installed`: watcher 起動有無の非破壊 probe
- `TaskIndex::insert_new_task_into_cache`: cache への差分挿入 Aggregate API（outgoing parent / links + incoming dangling 解決）
- `task::create::create_task` Tauri command + `create_task_impl` effect 層本体
- 純粋ヘルパー: `resolve_parent_and_validate` / `resolve_target_dir` / `build_existing_filenames_in_dir` / `build_task_content` / `validate_augmented_hierarchy`
- 結合テスト 17 件 + Aggregate テスト 9 件

## 変更した内容

- `lib.rs::run()` の `invoke_handler` に `task::create::create_task` を登録
- `task::index` の `normalize_task_path_for_lookup` / `normalize_parent_path_for_lookup` を `pub(crate)` 化（effect 層から再利用）

## 仕様ドキュメント更新

- `docs/spec-board/file-system-spec.md` の `create_task` 節を本実装に追従して詳細化（配置先決定 / 衝突回避 / 入力検証 / frontmatter 構築 / watcher 抑止 / 戻り値 / Atomic 性）
- 末尾 Implementation notes を 2026-05-11 時点に更新

## システム図

```mermaid
flowchart TD
    A[FE invoke create_task] --> B[create_task command]
    B --> C[preflight lock probe]
    C --> D{project_path?}
    D -->|None| E[Err NoProjectOpen]
    D -->|Some root| F[tasks_snapshot]
    F --> G[resolve_parent_and_validate]
    G -->|Err| H[Err ParentNotFound or CycleOrTooDeep]
    G -->|Ok parent_index| I[resolve_target_dir]
    I --> J[build_existing_filenames_in_dir + build_new_filename]
    J -->|Err InvalidTitle| H
    J -->|Ok filename| K[build_task_content]
    K --> L[validate_augmented_hierarchy]
    L -->|Err| H
    L -->|Ok| M[create_dir_all]
    M --> N{watcher installed?}
    N -->|yes| O[write_ignore.register]
    N -->|no| P[OpenOptions create_new write]
    O --> P
    P -->|open Err| Q[unregister + Err Io]
    P -->|write_all Err| R[remove_file + unregister + Err Io]
    P -->|Ok| S[task_from_parsed]
    S --> T["TaskIndex::insert_new_task_into_cache"]
    T --> U[Return Task]

    style B fill:#e1f5ff
    style T fill:#fff4e1
    style O fill:#fff4e1
```

```mermaid
flowchart LR
    subgraph cache[tasks_cache HashMap]
        EA[Existing A]
        EB[Existing B parent: new.md]
        EC[Existing C links: new.md]
    end
    NT["[NEW] new_task<br/>parent: A<br/>links: -"]
    NT -.->|outgoing parent push| EA
    EB -.->|incoming parent resolve| NT
    EC -.->|incoming links resolve| NT
    style NT fill:#e1f5ff
```

## 関連Issue

Refs #82

## テスト

- `cargo test -p spec-board --lib`: **395 passed** (新規追加 26 件含む)
- `cargo test -p spec-board-fs --lib`: **116 passed**
- `cargo clippy --workspace --all-targets -- -D warnings`: クリーン
- `cargo fmt`: クリーン
- Codex CLI による多段コードレビュー（5 ラウンド）で指摘事項をすべて解消し最終回答「問題なし」を取得
- UI 操作確認は FE 側 invoke 実装が別 PR スコープのためスキップ

## レビューポイント

- **Atomic 契約**: `write_all` 途中失敗時は `remove_file` で巻き戻すが、`open` 失敗時は本関数が作成していないため `remove_file` しない設計（race condition で他プロセスのファイルを消さない）。FS write 成功後の cache 更新失敗は部分 atomic として明示。
- **順序仕様**: `children` / `reverse_links` の配列順は spec として固定しない（FE 側で表示順が必要なら別途 sort する前提）。差分挿入は outgoing 末尾 push + incoming `file_path` 昇順で決定的に動作。全件再構築との等価性は集合として保証。
- **augmented hierarchy 検証**: 既存 cache の dangling parent / links が新規 Task の追加で初めて解決されるケース（cycle / too-deep）を FS write 前に検出。
- **path 正規化**: `write_ignore` は exact `PathBuf` 比較。`canonicalize` は行わず、`open_project` 時の root 表記をそのまま使用することで watcher 側の path と一致させている。

## チェックリスト

- [x] セルフレビューを実施した
- [x] `cargo test` / `cargo clippy` / `cargo fmt` が通る
- [x] 仕様変更があるため `docs/spec-board/file-system-spec.md` を更新した
- [x] 関連 Issue (#82) を PR にリンクした
- [x] 破壊的変更なし