### PR TITLE
♻️ [Refactoring]: #206 [BE] open_project IPC 境界に Intent + WatcherFactory 層を導入

### DIFF
--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -1,5 +1,7 @@
 pub mod intent;
 pub mod open;
 pub mod project_root;
+pub mod watcher_factory;
 
 pub use intent::OpenProjectIntent;
+pub use watcher_factory::{TauriWatcherFactory, WatcherFactory};

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -1,2 +1,5 @@
+pub mod intent;
 pub mod open;
 pub mod project_root;
+
+pub use intent::OpenProjectIntent;

--- a/src-tauri/src/project/intent.rs
+++ b/src-tauri/src/project/intent.rs
@@ -1,0 +1,79 @@
+//! `open_project` Tauri command の IPC 境界 (`path: String`) を application 層で
+//! 詰め直す Intent 型。
+//!
+//! FE から渡される未検証文字列を `TryFrom<String>` で本 Intent に詰め直し、
+//! 以降の effect 層 (`open_project_impl`) は `&OpenProjectIntent` のみを取る。
+//! empty path の境界拒否はここで完結する。
+//!
+//! # 非 UTF-8 path の扱い
+//!
+//! 本 Intent は `String` 入力経由でのみ構築される。Rust の `String` は UTF-8
+//! 確定であるため、`as_path_str()` が呼ばれる時点で内部 `raw` は常に UTF-8。
+//! 非 UTF-8 path を IPC 境界から受け取るケースは型システムレベルで到達不能で
+//! あり、`PathBuf::from(&str).to_str()` が失敗する経路も存在しない。将来
+//! `From<OsString>` 等を追加する場合は別 API として設計する。
+//!
+//! # `raw: String` を保持する理由
+//!
+//! `OpenProjectError::DirectoryNotFound { path }` 等の Display 表示は FE 側
+//! `TauriError.from` の正規表現分類に直結する。`ProjectRoot::Display`
+//! (`to_string_lossy()`) で復元すると lossy 変換が混入する可能性があるため、
+//! 元 `String` をそのまま保持して FE 互換を担保する。
+
+use std::path::Path;
+
+use crate::project::open::OpenProjectError;
+use crate::project::project_root::ProjectRoot;
+
+/// `open_project` の application 層エントリ。
+///
+/// 構築時に `root: ProjectRoot` が非空であることを保証する（empty path は
+/// `TryFrom` で拒否済み）。effect 層は `as_path()` / `as_path_str()` で
+/// `&Path` / `&str` を取り出し、既存 helper（`validate_directory` 等）に
+/// 渡せる。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenProjectIntent {
+    root: ProjectRoot,
+    raw: String,
+}
+
+impl OpenProjectIntent {
+    /// 内部の `ProjectRoot` を `&Path` として参照する。
+    pub fn as_path(&self) -> &Path {
+        self.root.as_path()
+    }
+
+    /// 内部 path を `&str` として参照する。
+    ///
+    /// 元 `String` をそのまま返すため `to_str()` を呼ばず構造的に成功する。
+    pub fn as_path_str(&self) -> &str {
+        &self.raw
+    }
+
+    /// 内部の `ProjectRoot` を消費して取り出す。
+    pub fn into_root(self) -> ProjectRoot {
+        self.root
+    }
+
+    /// 内部の `ProjectRoot` を参照する。
+    pub fn root(&self) -> &ProjectRoot {
+        &self.root
+    }
+}
+
+impl TryFrom<String> for OpenProjectIntent {
+    type Error = OpenProjectError;
+
+    fn try_from(path: String) -> Result<Self, Self::Error> {
+        // empty 判定は ProjectRoot::try_from_str に委譲し、Intent 層では
+        // map_err で元 `path` を `DirectoryNotFound { path }` に詰め直す。
+        // これにより empty 判定ロジックが二重実装にならない。
+        let root = ProjectRoot::try_from_str(&path)
+            .map_err(|_| OpenProjectError::DirectoryNotFound { path: path.clone() })?;
+        Ok(Self { root, raw: path })
+    }
+}
+
+#[cfg(test)]
+#[path = "intent_tests.rs"]
+mod intent_tests;

--- a/src-tauri/src/project/intent_tests.rs
+++ b/src-tauri/src/project/intent_tests.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::OpenProjectIntent;
 use crate::project::open::OpenProjectError;
 
@@ -6,7 +8,9 @@ fn try_from_normal_path_succeeds() {
     let intent = OpenProjectIntent::try_from("/abs/proj".to_string())
         .expect("non-empty path should succeed");
     assert_eq!(intent.as_path_str(), "/abs/proj");
-    assert_eq!(intent.as_path().to_string_lossy(), "/abs/proj");
+    // Path 値として比較し、`to_string_lossy()` の OS 依存（Windows のパス区切り
+    // 正規化）を避ける。
+    assert_eq!(intent.as_path(), Path::new("/abs/proj"));
 }
 
 #[test]

--- a/src-tauri/src/project/intent_tests.rs
+++ b/src-tauri/src/project/intent_tests.rs
@@ -1,0 +1,33 @@
+use super::OpenProjectIntent;
+use crate::project::open::OpenProjectError;
+
+#[test]
+fn try_from_normal_path_succeeds() {
+    let intent = OpenProjectIntent::try_from("/abs/proj".to_string())
+        .expect("non-empty path should succeed");
+    assert_eq!(intent.as_path_str(), "/abs/proj");
+    assert_eq!(intent.as_path().to_string_lossy(), "/abs/proj");
+}
+
+#[test]
+fn try_from_empty_string_maps_to_directory_not_found_with_empty_path() {
+    // 旧 effect 層 (`validate_directory`) 経路で empty path が
+    // `DirectoryNotFound { path: "" }` に倒れていた等価性を Intent 層が引き継ぐ
+    // ことを担保する境界テスト。
+    let err = OpenProjectIntent::try_from(String::new()).expect_err("empty path must fail");
+    assert!(matches!(
+        &err,
+        OpenProjectError::DirectoryNotFound { path } if path.is_empty()
+    ));
+    assert_eq!(err.to_string(), "ディレクトリが見つかりません: ");
+}
+
+#[test]
+fn try_from_preserves_raw_path_for_directory_not_found_display() {
+    // 実在性チェックは effect 層の責務であり、TryFrom 自体は実在しないパスでも
+    // 通る。`as_path_str()` が `to_str()` ではなく保持中の `raw: String` を
+    // そのまま返す回帰テスト。
+    let intent = OpenProjectIntent::try_from("/nonexistent/path/xyz".to_string())
+        .expect("non-empty path should succeed");
+    assert_eq!(intent.as_path_str(), "/nonexistent/path/xyz");
+}

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -394,7 +394,7 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 /// が単一スレッドで直列処理されることを前提に pre-flight ベースの「best-effort 防御」
 /// に留める。
 ///
-/// `open_project_with_factories` 冒頭の `check_app_state_locks` でも同じ probe を行うが、
+/// `open_project_impl` 冒頭の `check_app_state_locks` でも同じ probe を行うが、
 /// これは scan / parse / GUIDE 副作用の前に poison を検出して無駄な計算を
 /// 避けるためであり、commit 直前の probe は pre-flight 後 / commit 前に
 /// 他スレッドで poison が発生する稀なケースの取り逃しを減らすための念押し。
@@ -402,7 +402,7 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 /// 1. **pre-flight**: `project_path` / `config` / `tasks_cache` /
 ///    `watcher_handle` / `write_ignore` の各 lock を順に probe し、
 ///    開始時点で既に poison していれば早期に `Err(StateLockPoisoned)` を返す。
-///    この時点ではまだ何も書き換えていないため、`open_project_with_factories` の
+///    この時点ではまだ何も書き換えていないため、`open_project_impl` の
 ///    「失敗時は旧プロジェクト state を保持する」契約が守られる。
 /// 2. **書き込み**: 副作用を以下の順で実行する。
 ///    - `set_project_path` / `replace_config` / `replace_tasks_cache`: 値の swap のみ
@@ -419,7 +419,7 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 /// `open_project` の commit 段階の一般化版。
 ///
 /// `prepare` の実行と GUIDE.md 書き込みは呼び出し側
-/// （`open_project_with_factories`）で順序を制御するため、本関数には
+/// （`open_project_impl`）で順序を制御するため、本関数には
 /// **既に確保済みの `prepared`** を直接渡す。これにより watcher 起動失敗時に
 /// `.spec-board/GUIDE.md` を新 dir に書き込んでしまう副作用を避けられる。
 ///

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -9,10 +9,11 @@
 //!
 //! - `OpenProjectPayload` / `OpenProjectError`: FE へ返す値・エラー
 //! - `open_project`: `#[tauri::command]` 薄層（thin layer）。`tauri::AppHandle`
-//!   を保持するのはここだけで、effect 層へは closure capture 経由でのみ渡す
-//! - `open_project_with_factories`: 単体テストの境界となる effect 層本体
-//!   （`tauri::AppHandle` を受け取らず、watcher の prepare / spawn を closure で
-//!   注入することでテスト容易性を確保する）
+//!   は本層で構築する `TauriWatcherFactory` のフィールドへ閉じ込め、effect 層
+//!   へは漏出させない
+//! - `open_project_impl`: 単体テストの境界となる effect 層本体
+//!   （`tauri::AppHandle` を受け取らず、watcher の prepare / spawn を
+//!   `WatcherFactory` trait で注入することでテスト容易性を確保する）
 //!
 //! # エラー文字列の契約
 //!
@@ -71,8 +72,9 @@ use crate::config::column_name::ColumnName;
 use crate::config::{
     load_or_default, write_guide_markdown_best_effort, Column, Config, LoadConfigError,
 };
-use crate::project::project_root::ProjectRoot;
-use crate::state::{AppState, AppStateError, BoxedWatcherHandle};
+use crate::project::watcher_factory::{TauriWatcherFactory, WatcherFactory};
+use crate::project::OpenProjectIntent;
+use crate::state::{AppState, AppStateError};
 use crate::task::parse::{
     default_status_for, task_from_markdown, TaskParseContext, TaskParseError,
 };
@@ -156,11 +158,12 @@ impl From<WriteIgnoreError> for OpenProjectError {
     }
 }
 
-/// Tauri command 薄層。`open_project_with_factories` を直接呼び、エラーを
-/// 文字列化して返す。
+/// Tauri command 薄層。`open_project_impl` を直接呼び、エラーを文字列化して返す。
 ///
-/// `tauri::AppHandle` はこの薄層のみで保持し、effect 層
-/// (`open_project_with_factories`) へは closure capture 経由でのみ渡す。
+/// `tauri::AppHandle` はこの薄層で構築する `TauriWatcherFactory` のフィールドに
+/// 閉じ込めて effect 層へは漏出させない。empty path 拒否は `OpenProjectIntent`
+/// 構築時 (`TryFrom<String>`) に集約済みのため、本層では `intent` 構築失敗時の
+/// `DirectoryNotFound { path: "" }` を文字列化してそのまま返す。
 ///
 /// 戻り値の `Result<_, String>` の Err 文字列は `OpenProjectError` の Display 文字列であり、
 /// FE 側でパターンマッチして `TauriError` に変換される。
@@ -170,66 +173,28 @@ pub fn open_project(
     state: State<'_, Arc<AppState>>,
     path: String,
 ) -> Result<OpenProjectPayload, String> {
-    // FE から渡された path を最初に ProjectRoot VO へ詰め直し、空文字を境界で
-    // 弾く。実在性チェックは `validate_directory` の責務。
-    //
-    // 旧経路では empty path は `validate_directory` の `fs::metadata("")` で
-    // ENOENT が返り `DirectoryNotFound { path: "" }` に倒れていた。本シンでも
-    // 同じ `DirectoryNotFound { path: "" }` に map するため、FE から見た
-    // Display 文字列・`TauriError` 分類は不変
-    // （`empty_path_maps_to_directory_not_found_at_validate_directory_layer`
-    //  テストで等価性を担保）。
-    let root = ProjectRoot::try_from_str(&path)
-        .map_err(|_| OpenProjectError::DirectoryNotFound { path: path.clone() }.to_string())?;
-    let root_str = root.as_path().to_str().ok_or_else(|| {
-        OpenProjectError::DirectoryNotFound {
-            path: root.to_string(),
-        }
-        .to_string()
-    })?;
-    open_project_with_factories(
-        state.inner().clone(),
-        root_str,
-        |root| {
-            crate::watcher_event::prepare_watcher(root)
-                .map_err(|source| OpenProjectError::WatcherInitFailed { source })
-        },
-        move |(watcher, rx), state, root, config| {
-            let handle = crate::watcher_event::spawn_adapter(
-                &app,
-                root,
-                config,
-                Arc::clone(state),
-                watcher,
-                rx,
-            );
-            Box::new(handle) as BoxedWatcherHandle
-        },
-    )
-    .map_err(|e| e.to_string())
+    let intent = OpenProjectIntent::try_from(path).map_err(|e| e.to_string())?;
+    let watcher = TauriWatcherFactory { app };
+    open_project_impl(state.inner(), &intent, &watcher).map_err(|e| e.to_string())
 }
 
 /// `open_project` Tauri command の effect 層本体（テスト容易性のための一般化版）。
 ///
-/// `prepare` / `spawn` を closure で注入することで、`AppHandle` を持たない
-/// テストでも実装本体を直接駆動できる。
-pub(crate) fn open_project_with_factories<P, S, T>(
-    state: Arc<AppState>,
-    path: &str,
-    prepare: P,
-    spawn: S,
-) -> Result<OpenProjectPayload, OpenProjectError>
-where
-    P: FnOnce(&Path) -> Result<T, OpenProjectError>,
-    S: FnOnce(T, &Arc<AppState>, &Path, &Config) -> BoxedWatcherHandle,
-{
-    let root = Path::new(path);
-    validate_directory(root, path)?;
-    check_app_state_locks(&state)?;
+/// `tauri::AppHandle` を受け取らず、watcher の prepare / spawn を
+/// `WatcherFactory` trait で注入することでテスト容易性を確保する。
+pub(crate) fn open_project_impl<W: WatcherFactory>(
+    state: &Arc<AppState>,
+    intent: &OpenProjectIntent,
+    watcher: &W,
+) -> Result<OpenProjectPayload, OpenProjectError> {
+    let root = intent.as_path();
+    let raw_path = intent.as_path_str();
+    validate_directory(root, raw_path)?;
+    check_app_state_locks(state)?;
 
     let config = load_or_default(root).map_err(map_load_config_error)?;
 
-    let md_paths = scan_md_files(root).map_err(|e| map_scan_error(e, path))?;
+    let md_paths = scan_md_files(root).map_err(|e| map_scan_error(e, raw_path))?;
 
     let default_status = default_status_for(&config);
     let tasks = collect_tasks(root, &md_paths, &default_status);
@@ -243,11 +208,11 @@ where
     // GUIDE.md 書き込みより **前に** prepare を実行する。watcher 初期化失敗で
     // 復帰する場合に新 dir 配下の `.spec-board/GUIDE.md` が副作用として残らない
     // ようにするため。prepare 自体は AppState を一切更新しない。
-    let prepared = prepare(root)?;
+    let prepared = watcher.prepare(root)?;
 
     write_guide_markdown_best_effort(root, &config);
 
-    commit_app_state_with_prepared(&state, root, &config, &tasks, prepared, spawn)?;
+    commit_app_state_with_prepared(state, root, &config, &tasks, prepared, watcher)?;
 
     Ok(build_payload(tasks, &config))
 }
@@ -464,20 +429,17 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 ///    書かれる前に旧 watcher を必ず停止して race を防ぐ）
 /// 2. project_path / config / tasks_cache / write_ignore.clear の commit を
 ///    1 ステップずつ実行
-/// 3. `spawn(prepared, state, root, config)` で adapter スレッドを起動し、
+/// 3. `watcher.spawn(prepared, state, root, config)` で adapter スレッドを起動し、
 ///    返り値を `install_watcher_handle` で AppState に格納する。spawn は panic
 ///    以外で失敗しない契約。
-pub(crate) fn commit_app_state_with_prepared<S, T>(
+pub(crate) fn commit_app_state_with_prepared<W: WatcherFactory>(
     state: &Arc<AppState>,
     root: &Path,
     config: &Config,
     tasks: &[Task],
-    prepared: T,
-    spawn: S,
-) -> Result<(), OpenProjectError>
-where
-    S: FnOnce(T, &Arc<AppState>, &Path, &Config) -> BoxedWatcherHandle,
-{
+    prepared: W::Prepared,
+    watcher: &W,
+) -> Result<(), OpenProjectError> {
     state.check_all_locks()?;
     state.write_ignore().is_empty()?;
 
@@ -495,7 +457,7 @@ where
     state.replace_tasks_cache(cache)?;
     state.write_ignore().clear()?;
 
-    let handle = spawn(prepared, state, root, config);
+    let handle = watcher.spawn(prepared, state, root, config);
     state.install_watcher_handle(handle)?;
     Ok(())
 }

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -174,7 +174,7 @@ pub fn open_project(
     path: String,
 ) -> Result<OpenProjectPayload, String> {
     let intent = OpenProjectIntent::try_from(path).map_err(|e| e.to_string())?;
-    let watcher = TauriWatcherFactory { app };
+    let watcher = TauriWatcherFactory::new(app);
     open_project_impl(state.inner(), &intent, &watcher).map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/project/open_tests.rs
+++ b/src-tauri/src/project/open_tests.rs
@@ -1,8 +1,11 @@
-use super::{open_project_with_factories, OpenProjectError, OpenProjectPayload};
+use super::{open_project_impl, OpenProjectError, OpenProjectPayload};
 
 use crate::config::{CardOrder, Column, Config};
+use crate::project::watcher_factory::{NoopWatcherFactory, WatcherFactory};
+use crate::project::OpenProjectIntent;
 use crate::state::{AppState, BoxedWatcherHandle};
 use crate::task::task_index::Task;
+use spec_board_fs::watcher::core::WatcherError;
 use spec_board_fs::watcher::handle::{NoopWatcherHandle, WatcherHandle};
 
 use std::fs;
@@ -17,17 +20,80 @@ fn tempdir() -> TempDir {
 }
 
 /// 4 段階手順を保ったまま、`AppHandle` / `Watcher::start` を使わずに
-/// `open_project_with_factories` を駆動するための shorthand。
+/// `open_project_impl` を駆動するための shorthand。
+///
+/// 外側シグネチャは `(state: Arc<AppState>, path: &str)` を温存し、内部で
+/// `OpenProjectIntent` 構築 + `NoopWatcherFactory` 注入を行う。
 fn open_with_noop(
     state: Arc<AppState>,
     path: &str,
 ) -> Result<OpenProjectPayload, OpenProjectError> {
-    open_project_with_factories(
-        state,
-        path,
-        |_root| Ok::<(), OpenProjectError>(()),
-        |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
-    )
+    let intent = OpenProjectIntent::try_from(path.to_string())?;
+    open_project_impl(&state, &intent, &NoopWatcherFactory)
+}
+
+/// `prepare` で `WatcherInitFailed` を返すテスト用 factory。
+/// `spawn` は呼ばれない契約のため panic でガードする。
+struct FailingPrepareFactory {
+    init_message: String,
+}
+
+impl FailingPrepareFactory {
+    fn new(init_message: &str) -> Self {
+        Self {
+            init_message: init_message.to_string(),
+        }
+    }
+}
+
+impl WatcherFactory for FailingPrepareFactory {
+    type Prepared = ();
+
+    fn prepare(&self, _root: &Path) -> Result<(), OpenProjectError> {
+        Err(OpenProjectError::WatcherInitFailed {
+            source: WatcherError::Init(self.init_message.clone()),
+        })
+    }
+
+    fn spawn(
+        &self,
+        _prepared: (),
+        _state: &Arc<AppState>,
+        _root: &Path,
+        _config: &Config,
+    ) -> BoxedWatcherHandle {
+        panic!("spawn should not be invoked when prepare fails");
+    }
+}
+
+/// `spawn` 段階で旧 watcher の停止と AppState commit が完了していることを
+/// 検証するためのテスト用 factory。
+struct CountingFactory {
+    stop_calls: Arc<AtomicUsize>,
+    state: Arc<AppState>,
+}
+
+impl WatcherFactory for CountingFactory {
+    type Prepared = ();
+
+    fn prepare(&self, _root: &Path) -> Result<(), OpenProjectError> {
+        Ok(())
+    }
+
+    fn spawn(
+        &self,
+        _prepared: (),
+        _state: &Arc<AppState>,
+        _root: &Path,
+        _config: &Config,
+    ) -> BoxedWatcherHandle {
+        // spawn 段階では旧 stop が既に呼ばれており、cache も新値で commit 済み。
+        assert_eq!(1, self.stop_calls.load(Ordering::SeqCst));
+        let snapshot = self.state.tasks_snapshot().expect("readable");
+        assert_eq!(1, snapshot.len());
+        assert_eq!("tasks/a.md", snapshot[0].file_path);
+        Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle
+    }
 }
 
 fn write_md(root: &Path, rel: &str, body: &str) {
@@ -504,19 +570,10 @@ fn watcher_init_failure_keeps_app_state_completely_unchanged() {
     // 2 回目: prepare で WatcherInitFailed を返すスタブを使う。
     let other_dir = tempdir();
     let other_raw = other_dir.path().to_str().expect("utf-8").to_string();
-    let err = open_project_with_factories(
-        Arc::clone(&state),
-        &other_raw,
-        |_root| -> Result<(), OpenProjectError> {
-            Err(OpenProjectError::WatcherInitFailed {
-                source: spec_board_fs::watcher::core::WatcherError::Init(
-                    "synthetic init failure".to_string(),
-                ),
-            })
-        },
-        |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
-    )
-    .expect_err("watcher init failure should be returned");
+    let intent = OpenProjectIntent::try_from(other_raw.clone()).expect("non-empty path");
+    let factory = FailingPrepareFactory::new("synthetic init failure");
+    let err = open_project_impl(&state, &intent, &factory)
+        .expect_err("watcher init failure should be returned");
     assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
 
     // AppState の全フィールドが 1 回目の状態のまま残ることを確認する。
@@ -541,19 +598,9 @@ fn watcher_init_failure_does_not_write_guide_md_in_new_dir() {
     let dir = tempdir();
     let raw = dir.path().to_str().expect("utf-8").to_string();
 
-    let err = open_project_with_factories(
-        Arc::clone(&state),
-        &raw,
-        |_root| -> Result<(), OpenProjectError> {
-            Err(OpenProjectError::WatcherInitFailed {
-                source: spec_board_fs::watcher::core::WatcherError::Init(
-                    "synthetic init failure".to_string(),
-                ),
-            })
-        },
-        |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
-    )
-    .expect_err("watcher init failure");
+    let intent = OpenProjectIntent::try_from(raw.clone()).expect("non-empty path");
+    let factory = FailingPrepareFactory::new("synthetic init failure");
+    let err = open_project_impl(&state, &intent, &factory).expect_err("watcher init failure");
     assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
 
     let guide = dir.path().join(".spec-board").join("GUIDE.md");
@@ -575,17 +622,9 @@ fn watcher_init_failure_does_not_invoke_old_watcher_stop() {
     let dir = tempdir();
     let raw = dir.path().to_str().expect("utf-8").to_string();
 
-    let err = open_project_with_factories(
-        Arc::clone(&state),
-        &raw,
-        |_root| -> Result<(), OpenProjectError> {
-            Err(OpenProjectError::WatcherInitFailed {
-                source: spec_board_fs::watcher::core::WatcherError::Init("synth".to_string()),
-            })
-        },
-        |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
-    )
-    .expect_err("watcher init failure");
+    let intent = OpenProjectIntent::try_from(raw.clone()).expect("non-empty path");
+    let factory = FailingPrepareFactory::new("synth");
+    let err = open_project_impl(&state, &intent, &factory).expect_err("watcher init failure");
     assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
 }
 
@@ -607,22 +646,12 @@ fn old_watcher_is_stopped_before_state_commit() {
     write_md(dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
     let raw = dir.path().to_str().expect("utf-8").to_string();
 
-    let observed_counter = Arc::clone(&stop_counter);
-    let observed_state = Arc::clone(&state);
-    open_project_with_factories(
-        Arc::clone(&state),
-        &raw,
-        |_root| Ok::<(), OpenProjectError>(()),
-        move |(), _state, _root, _config| {
-            // spawn 段階では旧 stop が既に呼ばれており、cache も新値で commit 済み。
-            assert_eq!(1, observed_counter.load(Ordering::SeqCst));
-            let snapshot = observed_state.tasks_snapshot().expect("readable");
-            assert_eq!(1, snapshot.len());
-            assert_eq!("tasks/a.md", snapshot[0].file_path);
-            Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle
-        },
-    )
-    .expect("open should succeed");
+    let intent = OpenProjectIntent::try_from(raw.clone()).expect("non-empty path");
+    let factory = CountingFactory {
+        stop_calls: Arc::clone(&stop_counter),
+        state: Arc::clone(&state),
+    };
+    open_project_impl(&state, &intent, &factory).expect("open should succeed");
 
     assert_eq!(1, stop_counter.load(Ordering::SeqCst));
 }
@@ -784,26 +813,4 @@ fn open_project_payload_round_trip() {
     };
     let serialized = serde_json::to_string(&payload).unwrap();
     assert_eq!(serialized, r#"{"tasks":[],"columns":["Todo","Done"]}"#);
-}
-
-#[test]
-fn empty_path_maps_to_directory_not_found_at_validate_directory_layer() {
-    // open_project Tauri command 入口で `ProjectRoot::try_from_str("")` を
-    // 呼ぶ前後で empty path 入力の挙動が同一であることを文書化する。
-    //
-    // 旧挙動: empty path は `validate_directory` の `fs::metadata("")` で
-    //   ENOENT が返り、`DirectoryNotFound { path: "" }` に詰め直されていた。
-    // 新挙動: command シンの `ProjectRoot::try_from_str("")` が
-    //   `ProjectRootError::Empty` を返し、同じ `DirectoryNotFound { path: "" }`
-    //   へ map される。
-    // → FE 視点では Display 文字列も `TauriError` 分類も同一。
-    //
-    // 本テストは旧経路（`open_project_with_factories`）を直接駆動して
-    // empty path が `DirectoryNotFound` に倒れることを確認する。
-    let state = Arc::new(AppState::new());
-    let err = open_with_noop(Arc::clone(&state), "").expect_err("empty path must yield error");
-    match err {
-        OpenProjectError::DirectoryNotFound { path } => assert_eq!(path, ""),
-        other => panic!("expected DirectoryNotFound, got {other:?}"),
-    }
 }

--- a/src-tauri/src/project/project_root.rs
+++ b/src-tauri/src/project/project_root.rs
@@ -1,9 +1,13 @@
 //! プロジェクトルートディレクトリの絶対 / 相対パスを表す Value Object。
 //!
-//! Tauri command (`open_project`) の引数 `path: String` を Rust 側で受け取った
-//! 直後に `try_from_str` で本 VO に詰め直し、以降の本体ロジックは `&ProjectRoot`
-//! を引数に取る。serde 不要（FE → Rust の引数として直接 deserialize される
-//! ことはなく、command シン関数で明示的に変換するため）。
+//! IPC 境界の DTO として直接利用するのではなく、`OpenProjectIntent` の内部で
+//! `try_from_str` により詰め直される VO として扱う。`open_project` Tauri
+//! command は引数 `path: String` を `OpenProjectIntent::try_from(path)` に渡し、
+//! Intent 構築時に本 VO への変換と empty path 拒否がまとめて行われる。
+//! 以降の effect 層 (`open_project_impl`) は `&OpenProjectIntent` のみを取る。
+//!
+//! serde 不要（FE → Rust の引数として直接 deserialize されることはなく、
+//! Intent 経由で明示的に変換するため）。
 
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/src-tauri/src/project/watcher_factory.rs
+++ b/src-tauri/src/project/watcher_factory.rs
@@ -42,9 +42,16 @@ pub trait WatcherFactory {
 /// `spawn_adapter` に委譲する。
 ///
 /// `AppHandle` は本構造体のフィールドに閉じ込め、effect 層
-/// (`open_project_impl`) には漏出させない。
+/// (`open_project_impl`) には漏出させない。フィールド自体も非公開とし、
+/// 外部からの取り出しを `new` 経由のみに制限する。
 pub struct TauriWatcherFactory {
-    pub app: tauri::AppHandle,
+    app: tauri::AppHandle,
+}
+
+impl TauriWatcherFactory {
+    pub fn new(app: tauri::AppHandle) -> Self {
+        Self { app }
+    }
 }
 
 impl WatcherFactory for TauriWatcherFactory {

--- a/src-tauri/src/project/watcher_factory.rs
+++ b/src-tauri/src/project/watcher_factory.rs
@@ -1,0 +1,104 @@
+//! watcher の prepare / spawn を effect 層へ注入するための port abstraction。
+//!
+//! 本番実装 `TauriWatcherFactory` は `tauri::AppHandle` を保持し、
+//! `crate::watcher_event::spawn_adapter` 経由で Tauri IPC emit を行う。
+//! テストでは `NoopWatcherFactory` 等の手書きフェイクを差し込む。
+//!
+//! port 化の意図:
+//! - effect 層 (`open_project_impl`) からは `tauri::AppHandle` を完全に隠蔽し、
+//!   thin layer 側でのみ `AppHandle` を保持する契約を保つ
+//! - prepare / spawn の 2 closure を `WatcherFactory` trait 1 つに集約することで、
+//!   effect 層シグネチャの引数数とジェネリック数を削減する
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::config::Config;
+use crate::project::open::OpenProjectError;
+use crate::state::{AppState, BoxedWatcherHandle};
+
+/// watcher 準備 / 起動の port。
+///
+/// `prepare` は GUIDE.md 書き込みより前に呼ばれ、失敗時は effect 層が
+/// 副作用ゼロで `Err` 復帰する契約。`spawn` は AppState commit 完了後に
+/// 呼ばれ、adapter スレッドを起動して `BoxedWatcherHandle` を返す。
+pub trait WatcherFactory {
+    /// `prepare` の結果型。本番では `(Watcher, Receiver<FsEvent>)` 相当、
+    /// テストでは `()` 等の軽量な値で代替する。
+    type Prepared;
+
+    fn prepare(&self, root: &Path) -> Result<Self::Prepared, OpenProjectError>;
+
+    fn spawn(
+        &self,
+        prepared: Self::Prepared,
+        state: &Arc<AppState>,
+        root: &Path,
+        config: &Config,
+    ) -> BoxedWatcherHandle;
+}
+
+/// 本番実装。`AppHandle` を保持し、`watcher_event::prepare_watcher` /
+/// `spawn_adapter` に委譲する。
+///
+/// `AppHandle` は本構造体のフィールドに閉じ込め、effect 層
+/// (`open_project_impl`) には漏出させない。
+pub struct TauriWatcherFactory {
+    pub app: tauri::AppHandle,
+}
+
+impl WatcherFactory for TauriWatcherFactory {
+    type Prepared = (
+        spec_board_fs::watcher::core::Watcher,
+        std::sync::mpsc::Receiver<spec_board_fs::watcher::core::FsEvent>,
+    );
+
+    fn prepare(&self, root: &Path) -> Result<Self::Prepared, OpenProjectError> {
+        crate::watcher_event::prepare_watcher(root)
+            .map_err(|source| OpenProjectError::WatcherInitFailed { source })
+    }
+
+    fn spawn(
+        &self,
+        prepared: Self::Prepared,
+        state: &Arc<AppState>,
+        root: &Path,
+        config: &Config,
+    ) -> BoxedWatcherHandle {
+        let (watcher, rx) = prepared;
+        let handle = crate::watcher_event::spawn_adapter(
+            &self.app,
+            root,
+            config,
+            Arc::clone(state),
+            watcher,
+            rx,
+        );
+        Box::new(handle) as BoxedWatcherHandle
+    }
+}
+
+/// テスト共有の no-op 実装。`prepare` は常に `Ok(())`、`spawn` は
+/// `NoopWatcherHandle` を返す。`open_tests.rs` / `task/get_tests.rs` /
+/// `task/create/command_tests.rs` から共用する。
+#[cfg(test)]
+pub(crate) struct NoopWatcherFactory;
+
+#[cfg(test)]
+impl WatcherFactory for NoopWatcherFactory {
+    type Prepared = ();
+
+    fn prepare(&self, _root: &Path) -> Result<(), OpenProjectError> {
+        Ok(())
+    }
+
+    fn spawn(
+        &self,
+        _prepared: (),
+        _state: &Arc<AppState>,
+        _root: &Path,
+        _config: &Config,
+    ) -> BoxedWatcherHandle {
+        Box::new(spec_board_fs::watcher::handle::NoopWatcherHandle::new()) as BoxedWatcherHandle
+    }
+}

--- a/src-tauri/src/task/create/command_tests.rs
+++ b/src-tauri/src/task/create/command_tests.rs
@@ -7,24 +7,21 @@ use tempfile::TempDir;
 use super::super::args::CreateTaskArgs;
 use super::super::error::{ContentRejectReason, CreateTaskCommandError, CreateTaskError};
 use super::create_task_impl;
-use crate::project::open::open_project_with_factories;
-use crate::state::{AppState, BoxedWatcherHandle};
+use crate::project::open::open_project_impl;
+use crate::project::watcher_factory::NoopWatcherFactory;
+use crate::project::OpenProjectIntent;
+use crate::state::AppState;
 use crate::task::io::FsTaskIo;
 use crate::task::task_index::ParentHierarchyErrorReason;
-use spec_board_fs::watcher::handle::NoopWatcherHandle;
 
 fn tempdir() -> TempDir {
     tempfile::tempdir().expect("create temp dir")
 }
 
 fn open_with_noop(state: Arc<AppState>, path: &Path) {
-    open_project_with_factories(
-        state,
-        path.to_str().expect("utf-8"),
-        |_root| Ok::<(), crate::project::open::OpenProjectError>(()),
-        |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
-    )
-    .expect("open should succeed");
+    let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
+        .expect("non-empty path");
+    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
 }
 
 fn args_with_title(title: &str) -> CreateTaskArgs {

--- a/src-tauri/src/task/get_tests.rs
+++ b/src-tauri/src/task/get_tests.rs
@@ -5,18 +5,13 @@ use std::sync::Arc;
 use tempfile::TempDir;
 
 use super::*;
-use crate::project::open::open_project_with_factories;
-use crate::state::BoxedWatcherHandle;
-use spec_board_fs::watcher::handle::NoopWatcherHandle;
+use crate::project::open::open_project_impl;
+use crate::project::watcher_factory::NoopWatcherFactory;
+use crate::project::OpenProjectIntent;
 
 fn open_with_noop(state: Arc<AppState>, path: &str) {
-    open_project_with_factories(
-        state,
-        path,
-        |_root| Ok::<(), crate::project::open::OpenProjectError>(()),
-        |(), _state, _root, _config| Box::new(NoopWatcherHandle::new()) as BoxedWatcherHandle,
-    )
-    .expect("open should succeed");
+    let intent = OpenProjectIntent::try_from(path.to_string()).expect("non-empty path");
+    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
 }
 
 fn tempdir() -> TempDir {

--- a/src-tauri/src/watcher_event.rs
+++ b/src-tauri/src/watcher_event.rs
@@ -5,7 +5,7 @@
 //! # モジュール構成
 //!
 //! - `prepare_watcher(root)`: `Watcher::start` を呼んで `(Watcher, Receiver)`
-//!   を確保するだけ。`open_project_with_factories` の AppState commit より前に
+//!   を確保するだけ。`open_project_impl` の AppState commit より前に
 //!   実行される 1 段目。
 //! - `spawn_adapter(app, root, config, state, watcher, rx)`: 既に確保済みの
 //!   watcher / rx から adapter スレッドを spawn し、`EmittingWatcherHandle` を
@@ -84,7 +84,7 @@ impl WatcherHandle for EmittingWatcherHandle {
     }
 }
 
-/// `open_project_with_factories` の **AppState commit より前に**呼び出される 1 段目。
+/// `open_project_impl` の **AppState commit より前に**呼び出される 1 段目。
 ///
 /// `Watcher::start` を試みて Watcher と Receiver を確保するだけで、adapter は
 /// まだ spawn しない。失敗時はこの段階で `WatcherError` を返し、呼び出し側は
@@ -93,7 +93,7 @@ pub(crate) fn prepare_watcher(root: &Path) -> Result<(Watcher, Receiver<FsEvent>
     Watcher::start(root)
 }
 
-/// `open_project_with_factories` の **AppState commit 完了後**に呼び出される 2 段目。
+/// `open_project_impl` の **AppState commit 完了後**に呼び出される 2 段目。
 ///
 /// 確保済みの `(watcher, rx)` から adapter スレッドを spawn し、実
 /// `EmittingWatcherHandle` を組み立てる。spawn は panic 以外で失敗しないため


### PR DESCRIPTION
## 概要

`open_project` Tauri command の IPC 境界 (`path: String`) を `OpenProjectIntent` に詰め直す責務を application 層に切り出し、watcher の prepare / spawn を `WatcherFactory` trait の port abstraction に集約する。effect 層を `open_project_with_factories` → `open_project_impl` にリネームしてシグネチャを 4 引数 → 3 引数 / generic 3 → 1 に削減する。FE 側 wire format（`{ path: string }` 引数 / `OpenProjectPayload` 戻り値 / `OpenProjectError` Display 文字列）は不変。

PR #205 の `create_task` ports & adapters 境界の方針を `open_project` にも適用する純粋なリファクタリング。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 追加した内容

- `src-tauri/src/project/intent.rs` — `OpenProjectIntent { root: ProjectRoot, raw: String }` + `TryFrom<String>`（empty path 拒否を集約）+ `as_path` / `as_path_str` / `into_root` / `root` API
- `src-tauri/src/project/intent_tests.rs` — Intent 単体テスト 3 件（empty / 通常パス / raw 文字列保持）
- `src-tauri/src/project/watcher_factory.rs` — `WatcherFactory` trait + 本番実装 `TauriWatcherFactory` + `#[cfg(test)] NoopWatcherFactory`
- `open_tests.rs` 内のローカルテスト用 factory 構造体（`FailingPrepareFactory` / `CountingFactory`）

## 変更した内容

- `src-tauri/src/project/open.rs`
  - effect 層 `open_project_with_factories` → **`open_project_impl`** にリネーム
  - シグネチャを `<W: WatcherFactory>(state: &Arc<AppState>, intent: &OpenProjectIntent, watcher: &W)` に変更（引数 4 → 3、generic 3 → 1）
  - `commit_app_state_with_prepared` も `WatcherFactory` 経由に置換
  - thin layer `open_project` を `OpenProjectIntent` + `TauriWatcherFactory` 経由の実質 3 行に薄化（旧 `state.inner().clone()` と `to_str()` 防御的死コード削除）
- `src-tauri/src/project/open_tests.rs`
  - `open_with_noop` ヘルパー内部を `NoopWatcherFactory` 経由に書換（外側シグネチャ温存で 22 件のテストは無変更で通る）
  - 直接呼び出し 4 か所をローカル factory（`FailingPrepareFactory` / `CountingFactory`）経由に書換
  - `empty_path_maps_to_directory_not_found_at_validate_directory_layer` テストは Intent 化により effect 層に到達しなくなったため削除し、`intent_tests.rs` 側で吸収
- `src-tauri/src/task/get_tests.rs` / `task/create/command_tests.rs` — ヘルパーを `OpenProjectIntent` + `NoopWatcherFactory` 経由に書換
- `src-tauri/src/project/project_root.rs` — module doc を Intent 経由文脈に更新（コード本体は無変更）
- `src-tauri/src/project.rs` — `pub mod intent; pub mod watcher_factory;` + `pub use` 追加
- `src-tauri/src/watcher_event.rs` — module doc 内の旧関数名 `open_project_with_factories` を `open_project_impl` に置換

## システム図

```mermaid
flowchart TD
    FE["FE (TypeScript)<br/>invokeWrapped('open_project', { path })"] --> ThinLayer
    ThinLayer["thin layer<br/>#[tauri::command] open_project"]
    ThinLayer -->|"OpenProjectIntent::try_from(path)"| Intent
    ThinLayer -->|"TauriWatcherFactory { app }"| Factory
    Intent["OpenProjectIntent<br/>{ root, raw }<br/><b>[NEW]</b>"]
    Factory["TauriWatcherFactory<br/><b>[NEW]</b>"]
    Intent --> Impl
    Factory --> Impl
    Impl["effect 層<br/>open_project_impl<br/>(&Arc&lt;AppState&gt;, &OpenProjectIntent, &W: WatcherFactory)<br/><b>[RENAMED + 3 引数化]</b>"]
    Impl --> Domain["domain / fs<br/>config / task / TaskIndex / scan_md_files / watcher"]

    style Intent fill:#dfd,stroke:#080
    style Factory fill:#dfd,stroke:#080
    style Impl fill:#ffd,stroke:#880
```

## 仕様ドキュメント更新

不要（純粋なリファクタリング / 内部実装）。FE wire format（`{ path: string }` / `OpenProjectPayload` / `OpenProjectError` Display 文字列）は完全に不変のため、`docs/spec-board/` の仕様変更は発生しない。

## 関連Issue

Closes #206

## テスト

### バックエンド

- `cd src-tauri && cargo fmt --all -- --check` — 差分なし
- `cd src-tauri && cargo clippy --workspace --all-targets -- -D warnings` — warning なし
- `cd src-tauri && cargo test --workspace` — green
  - `project::intent::intent_tests` 3 件 green（新規）
  - `project::open_tests` 既存 30 件 → 29 件 green（empty テスト 1 件を Intent 側へ移管）
  - `task::get_tests` / `task::create::command_tests` 既存件数 green
  - workspace 全体: spec-board lib 425 件 + spec-board-fs 116 件すべて green

### フロントエンド

- FE wire format 不変のため変更なし。`src/lib/tauri/taskCommands/openProject/` は無修正。

### AI レビュー

- Codex CLI による 2 ラウンドレビュー実施
  - review-001: ドキュメント内の旧関数名残存を指摘 → 修正コミットで対応
  - review-002: 「問題なし」承認

## レビューポイント

1. **`OpenProjectIntent` の `raw: String` 保持理由** — `OpenProjectError::DirectoryNotFound { path }` Display は FE 側 `TauriError.from` の正規表現分類に直結するため、`ProjectRoot::Display` の lossy 変換を避けて元 `String` をそのまま保持している（`intent.rs` module doc 参照）
2. **`WatcherFactory::Prepared` を associated type にした設計判断** — 本番では `(Watcher, Receiver<FsEvent>)` 相当、テストでは `()` で代替できる。closure 注入を捨てて trait + struct 方式にした理由は implementation-plan §3.6 参照
3. **エラー文字列の不変契約** — empty / 通常パスの 2 ケースで現行と完全一致することを担保（implementation-plan §5 参照）。empty path は Intent 化後 effect 層に到達しなくなるが、Intent 側の境界テストで等価性を担保

🤖 Generated with [Claude Code](https://claude.com/claude-code)