### PR TITLE
♻️ [Refactoring]: #207 [BE] get_tasks の sort ロジックを TaskIndex::sorted_by_id に吸収

### DIFF
--- a/src-tauri/src/task/get.rs
+++ b/src-tauri/src/task/get.rs
@@ -1,8 +1,9 @@
 //! `get_tasks` Tauri command 本体。
 //!
-//! `AppState.tasks_cache` に格納済みの `Task` 一覧を `id` 昇順でクローンして返す
-//! 純粋な読み取り専用 command。`open_project` で commit された state を消費する
-//! 後続 API としての位置付け。
+//! `AppState.tasks_cache` に格納済みの `Task` 一覧を取得し、`TaskIndex` aggregate
+//! に並び順の決定を委譲して返す純粋な読み取り専用 command。`open_project` で
+//! commit された state を消費する後続 API としての位置付け。並び順の契約
+//! （id 昇順）は `TaskIndex::sorted_by_id` 側に集約する。
 //!
 //! # 構成
 //!
@@ -21,7 +22,7 @@ use std::sync::Arc;
 use tauri::State;
 use thiserror::Error;
 
-use super::task_index::Task;
+use super::task_index::{Task, TaskIndex};
 use crate::state::{AppState, AppStateError};
 
 /// `get_tasks` コマンドのエラー。
@@ -55,8 +56,9 @@ pub fn get_tasks(state: State<'_, Arc<AppState>>) -> Result<Vec<Task>, String> {
 
 /// 単体テスト境界の本体関数。
 ///
-/// `AppState::tasks_snapshot` で `Vec<Task>` を取得し、`id` 昇順 sort して返す。
-/// `tasks_cache` が空の場合は空 Vec をそのまま返す（未 open ケースを成功扱い）。
+/// `AppState::tasks_snapshot` で `Vec<Task>` を取得し、`TaskIndex` aggregate に
+/// 並び順の決定を委譲した結果を返す。`tasks_cache` が空の場合は空 Vec を返す
+/// （未 open ケースを成功扱い）。
 ///
 /// # Errors
 ///
@@ -64,15 +66,7 @@ pub fn get_tasks(state: State<'_, Arc<AppState>>) -> Result<Vec<Task>, String> {
 /// `GetTasksError::StateLockPoisoned` を返す。
 pub(crate) fn get_tasks_impl(state: &AppState) -> Result<Vec<Task>, GetTasksError> {
     let snapshot = state.tasks_snapshot()?;
-    Ok(get_tasks_usecase(snapshot))
-}
-
-/// 純粋部分: snapshot に `id` 昇順 sort を適用するだけのリネーム的関数。
-/// 旧 `get_tasks_impl` 内に直書きされていた sort ロジックを usecase 層として
-/// 切り出す。挙動変更なし。
-pub(crate) fn get_tasks_usecase(mut snapshot: Vec<Task>) -> Vec<Task> {
-    snapshot.sort_by(|a, b| a.id.cmp(&b.id));
-    snapshot
+    Ok(TaskIndex::from(snapshot).sorted_by_id())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -103,6 +103,18 @@ impl TaskIndex {
         &self.tasks
     }
 
+    /// aggregate が保持する `Task` を `id` 昇順に並べた `Vec<Task>` を返す。
+    ///
+    /// `get_tasks` 等の読み取り API が依存する「id 昇順」契約をこの aggregate に
+    /// 集約することで、application 層から並び順の知識を排除する。`Vec::sort_by`
+    /// は安定ソートのため、同一 `id` の `Task` が混入した場合は入力順を保持する。
+    /// aggregate を再利用しない読み取り用途のため `self` を消費する。
+    pub fn sorted_by_id(self) -> Vec<Task> {
+        let mut tasks = self.into_tasks();
+        tasks.sort_by(|a, b| a.id.cmp(&b.id));
+        tasks
+    }
+
     /// parent 参照の存在のみを検証し、見つからない場合は warning を追加する。
     pub fn validate_parent_existence(self) -> Self {
         Self {

--- a/src-tauri/src/task/task_index_tests.rs
+++ b/src-tauri/src/task/task_index_tests.rs
@@ -390,6 +390,61 @@ fn validate_parent_for_new_task_not_found_cases() {
 }
 
 #[test]
+fn sorted_by_id_returns_empty_for_empty_index() {
+    let result = TaskIndex::new(vec![]).sorted_by_id();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn sorted_by_id_returns_single_task_unchanged() {
+    let tasks = vec![task_without_parent("tasks/a.md")];
+    let result = TaskIndex::new(tasks).sorted_by_id();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].file_path, "tasks/a.md");
+}
+
+#[test]
+fn sorted_by_id_sorts_reverse_order_ascending() {
+    let tasks = vec![
+        task_without_parent("tasks/c.md"),
+        task_without_parent("tasks/b.md"),
+        task_without_parent("tasks/a.md"),
+    ];
+    let result = TaskIndex::new(tasks).sorted_by_id();
+    let ids: Vec<_> = result.iter().map(|t| t.file_path.as_str()).collect();
+    assert_eq!(ids, vec!["tasks/a.md", "tasks/b.md", "tasks/c.md"]);
+}
+
+#[test]
+fn sorted_by_id_sorts_random_order_ascending() {
+    let tasks = vec![
+        task_without_parent("tasks/b.md"),
+        task_without_parent("tasks/d.md"),
+        task_without_parent("tasks/a.md"),
+        task_without_parent("tasks/c.md"),
+    ];
+    let result = TaskIndex::new(tasks).sorted_by_id();
+    let ids: Vec<_> = result.iter().map(|t| t.file_path.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["tasks/a.md", "tasks/b.md", "tasks/c.md", "tasks/d.md"]
+    );
+}
+
+#[test]
+fn sorted_by_id_preserves_input_order_for_duplicate_ids() {
+    let mut first = task_without_parent("tasks/dup.md");
+    first.title = "first".into();
+    let mut second = task_without_parent("tasks/dup.md");
+    second.title = "second".into();
+    let tasks = vec![first, second];
+    let result = TaskIndex::new(tasks).sorted_by_id();
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].title, "first");
+    assert_eq!(result[1].title, "second");
+}
+
+#[test]
 fn validate_parent_for_new_task_cycle_or_too_deep_cases() {
     let chain_20 = parent_chain_with_edge_count(20);
     let cycle_pair = vec![


### PR DESCRIPTION
## 概要

application 層 (`task::get`) に残っていた `id` 昇順 sort の知識を `TaskIndex` aggregate の派生メソッド `sorted_by_id` に吸収する純粋な内部リファクタリング。PR #205 / #208 の Intent + aggregate 構成に揃え、application 層から並び順の知識を排除する。

**内部実装の整理。仕様変更なし。**

## 変更の種類

- ♻️ [Refactoring]: リファクタリング（外部仕様の変更なし）

## 追加した内容

- `TaskIndex::sorted_by_id(self) -> Vec<Task>`（aggregate に並び順の派生計算を集約。安定ソート保証 / `self` 消費形で `into_tasks` とセマンティクスを揃える）
- `task_index_tests.rs` に単体テスト 5 件（空 / 単一 / 逆順 / ランダム / 重複 id 安定性）

## 変更した内容

- `task::get::get_tasks_impl` を `TaskIndex::from(snapshot).sorted_by_id()` 呼び出しに置換
- `get.rs` のモジュール / `get_tasks_impl` doc コメントを「`TaskIndex` aggregate に並び順の決定を委譲」する表現へ更新

## 削除した内容

- `pub(crate) fn task::get::get_tasks_usecase(Vec<Task>) -> Vec<Task>`（aggregate 側に責務を移したため）

## 仕様ドキュメント更新

**不要**（純粋なリファクタリング / 内部実装の整理）。

`get_tasks` Tauri command の戻り値型 (`Result<Vec<Task>, String>`)・`GetTasksError::StateLockPoisoned` の Display 文字列 (`"内部状態のロックが破損しました"`)・FE から見た id 昇順契約はすべて不変。

## システム図

```mermaid
flowchart TB
    subgraph before[" before "]
        A1["#tauri::command get_tasks"]
        A2["get_tasks_impl"]
        A3["state.tasks_snapshot()"]
        A4["get_tasks_usecase(vec)<br/>sort_by id.cmp"]
        A1 --> A2 --> A3 --> A4 --> A5(["Vec&lt;Task&gt;<br/>id 昇順"])
    end

    subgraph after[" after "]
        B1["#tauri::command get_tasks"]
        B2["get_tasks_impl"]
        B3["state.tasks_snapshot()"]
        B4["TaskIndex::from(snapshot)<br/>.sorted_by_id()"]
        B1 --> B2 --> B3 --> B4 --> B5(["Vec&lt;Task&gt;<br/>id 昇順"])
        style B4 fill:#cfc,stroke:#393
    end
```

並び順契約 (`id` 昇順 / 安定ソート) の所在を application 層 → `TaskIndex` aggregate に移動。

## 関連Issue

Closes #207

## テスト

- `cd src-tauri && cargo test -p spec-board` → **430 件 pass / 0 failure**
- `cd src-tauri && cargo test -p spec-board task::task_index::` → 新規 5 件含む 57 件 pass
- `cd src-tauri && cargo test -p spec-board task::get::` → 既存 sort gate (`returns_tasks_sorted_by_id_after_open_project`) を含め全件 pass
- `cd src-tauri && cargo fmt --all --check` → 差分なし
- `cd src-tauri && cargo clippy --all-targets -- -D warnings` → 警告ゼロ
- `grep -rn "get_tasks_usecase" src-tauri/` → 0 件（残存参照なし）
- 手動検証（`pnpm tauri dev` での目視）は CI 環境制約により未実施。レビュアー側での確認を推奨

## レビューポイント

- `TaskIndex::sorted_by_id` の所有権セマンティクス（`self` 消費形）が `into_tasks` と揃っているか
- aggregate 側に並び順契約 (id 昇順 / 安定ソート) を doc コメントで集約できているか
- application 層 (`get.rs`) の doc コメントから「id 昇順 sort」の表現が排除されているか

## Follow-up candidate

本 PR スコープ外:

- `project/open.rs` の `build_payload` 内 `tasks.sort_by(|a, b| a.id.cmp(&b.id))` も `TaskIndex::sorted_by_id` に統合可能だが、open_project の Intent + WatcherFactory 層との合流を待ち別 PR で対応する

## チェックリスト

- [x] コードレビューの準備完了
- [x] テスト正常実行（`cargo test -p spec-board` 全件 pass）
- [x] ドキュメント更新（仕様変更なしのため `docs/spec-board/` は更新不要）
- [x] 適切なコミットメッセージ
- [x] IssueがPRにLinked（`Closes #207`）
- [x] セルフレビュー実施（Codex CLI レビュー: 問題なし）
- [x] 破壊的変更なし（公開 API・データ形式・FE 観測動作すべて不変）