### PR TITLE
✨ [New Feature]: #84 [BE] update_task IPC コマンドの部分マージ更新を実装

### DIFF
--- a/docs/impl/update_task.md
+++ b/docs/impl/update_task.md
@@ -1,0 +1,92 @@
+# update_task 実装メモ
+
+`update_task` Tauri command（既存タスクの部分マージ更新）の設計判断を記録する。
+仕様は [task-format-spec.md](../spec-board/task-format-spec.md) を参照。
+
+## 全体方針
+
+副作用は effect 層（`task::update::command::update_task_impl`）に集約し、純粋計算は
+aggregate（`task::task_index::TaskIndex::plan_update`）に閉じ込める。effect 層は
+`TaskIo` port 経由でのみファイルにアクセスし、`std::fs::*` の直接呼び出しは行わない。
+
+### なぜ Parsed を渡すのか
+
+`Task` 構造体は raw frontmatter を保持しない（typed フィールドの抽出と warning
+生成だけで成立する）。一方で update_task では「ファイル書き戻し時に未知 key /
+`links` / YAML 値型 / 出現順を保持する」必要があるため、effect 層は
+`io.read` → `frontmatter::parse_bytes` で `Parsed { frontmatter, body }` を取り、
+それをそのまま `plan_update` に渡す。`plan_update` は `Parsed` の mut copy に対して
+patch を当て、`frontmatter::serialize(&Parsed)` で書き戻すので raw 情報が損なわれない。
+
+### なぜ `UpdateTaskError::Serialize` を持たないのか
+
+`frontmatter::serialize(&Parsed) -> String` は YAML 構文として常に成功する純粋関数
+（内部で `serde_yaml_ng::to_string` が失敗するケースは `Parsed` を `parse_bytes` 由来
+で構築している限り発生しない）。このため effect 層と error 型に Serialize variant を
+持たせる必要がない。
+
+### parent 変更時の cache 再構築フロー
+
+`needs_full_rebuild=true` の場合のみ、effect 層は以下を行う:
+
+1. cache の values をすべて `Vec<Task>` に集める
+2. 対象 task を `outcome.updated_task` に置換
+3. `TaskIndex::new(values).validate_parent_hierarchy().build_children().build_reverse_links()`
+4. cache を clear して再構築結果で再挿入
+5. 再構築後の対象 Task を取り直して返す
+
+scalar / labels / body / title / status / priority の単独更新では再構築しない。
+これらの変更は他タスクの `children` / `reverse_links` に影響しないため。
+
+### `validate_with_new_task` ではなく `validate_parent_hierarchy` を使う理由
+
+`validate_with_new_task` は新規追加用 API。既存 task を `push` する前提なので、
+update では対象 task が 2 件混ざってしまう（自分と「新規追加版」）。代わりに
+「対象 task を `preliminary_task` に置換した `Vec<Task>` を作って
+`TaskIndex::new(values).validate_parent_hierarchy()`」を呼ぶ。
+
+### parent 存在チェックを別途行う理由
+
+`validate_parent_hierarchy` は parent が cache に無いとき warning を追加するだけで
+エラーにしない。これは scan 時 / 編集時の "parent が後から追加される" ユースケースを
+壊さないため。一方 update_task は「指定された parent が見つからないなら明示エラー」が
+spec 上望ましい。そこで plan_update 内で `resolve_parent_for_new_task` を使い、
+`./` プレフィックスや `\` 含み path も create と同じ基準で正規化して一致検索を行う。
+見つからなければ `ParentNotFound { path }` を返す。
+
+### `TaskContent::try_new(String)` を使う理由
+
+`TaskContent::try_new` は `String` を受け取る（`&[u8]` ではない）。serialize の
+結果 `String` をそのまま渡せるため、追加のアロケーションも as_bytes 変換も不要。
+
+### `From<TaskParseError>` / `From<TaskContentError>` を入れた理由
+
+`validate_parent_hierarchy` の戻り値は `Result<TaskIndex, TaskParseError>` であり、
+`TaskContent::try_new` の戻り値は `Result<_, TaskContentError>`。それぞれ
+`UpdateTaskError` への変換を `From` で書いておくことで、`plan_update` 内の
+`?` 演算子と `.map_err(UpdateTaskError::from)` だけでエラー経路を畳み込める。
+
+### filePath を canonicalize しない理由
+
+canonicalize は symlink 解決 / OS 依存の正規化など副作用が大きく、project_root 外
+の検出と引き換えにテストの安定性が著しく下がる。spec-board は POSIX 主体で
+symlink を含むレイアウトはまれであり、lexical 正規化（`..` 検出 / `strip_prefix(root)`）
+だけで十分実用的。trade-off として、symlink を悪用した root 外書き込みは検出できない。
+
+### 空 title を許可する理由
+
+frontmatter parser は `extras.title` が空文字のとき
+`invalidTitleUsedFileName` warning を吐き、ファイル名を fallback title として使う。
+update_task で空 title を弾くと「既存ファイルに空 title が書かれていた場合」と
+仕様が乖離する。本コマンドは空 title 自体を許可し、`task_from_parsed` を再走させて
+warning を再生成する。warning の source of truth は parser 側に集約する。
+
+### `task_from_parsed` 再走の意図
+
+`build_patched_task` で得た中間 Task は parent 変更時の hierarchy 検証用に使うのみ。
+最終的に返却する `updated_task` は `Parsed { frontmatter, body }` を
+`task_from_parsed` に通し直して構築する。これにより:
+
+- 空 title → `invalidTitleUsedFileName` warning が再生成される
+- typed フィールド（priority / labels / links 等）が parser の最新ロジックで再抽出される
+- 既存 Task の warnings は破棄され、新しい warnings 群に置き換わる

--- a/docs/spec-board/task-format-spec.md
+++ b/docs/spec-board/task-format-spec.md
@@ -253,6 +253,44 @@ parent: tasks/search-ui.md
 検索バーのオートコンプリート機能。
 ```
 
+## update_task（部分マージ更新）
+
+既存タスクの frontmatter / body を部分的に上書きする IPC コマンド。
+
+入力: `{ filePath, title?, status?, priority?, labels?, parent?, body? }`
+
+### マージ規則
+
+- `Some` で渡されたフィールドだけが反映され、未指定フィールドは保持される
+- raw frontmatter の未知 key・`links`・YAML 値型・出現順は **そのまま保持** される
+  （内部実装は `Parsed { frontmatter, body }` の mut copy に patch を当て、`frontmatter::serialize` で書き戻す）
+- `parent: ""` で親解除（frontmatter から `parent` キーを除去）
+- `labels: []` で全ラベル削除
+- `priority: None` は不変。**priority 自体を「なし」にする操作は本コマンドではサポートしない**
+- **title 変更時もファイル名は不変**（rename はしない）
+- 空 title 指定は許可される。書き戻し後の Task 再 parse で `invalidTitleUsedFileName` warning が乗る
+- `children` は派生計算のため update_task では更新できない
+
+### ファイル位置
+
+update_task は `filePath` で識別し、**ファイル移動は一切行わない**。
+`parent` を変更しても物理配置は元のディレクトリのまま。
+
+### エラー（Display 文字列パターン）
+
+- `file not found: <abs path>` — 対象ファイルが存在しない / cache に無い
+- `invalid path: <input>` — `..` を含む、`.md` 以外、project_root 外、空、ディレクトリ指定
+- `parse failed: <reason>` — 既存ファイルの frontmatter が壊れている / delimiter 不在
+- `parent not found: <path>` — 指定 parent が cache に無い
+- `parent validation: <file_path> (<reason>)` — 親チェーン循環 / 深度超過
+- `content not scanner eligible: <reason>` — 更新後 body が 1 MiB 超 / NUL 含む
+
+### parent 変更時の cache 再構築
+
+`parent` フィールドが変化した場合のみ TaskIndex 全体を再構築し、
+`validate_parent_hierarchy` + `build_children` + `build_reverse_links` を実行する。
+title / status / priority / labels / body 単独の更新では再構築しない。
+
 ## 制限事項
 
 - ファイルエンコーディングは **UTF-8（BOMなし）** のみサポート。BOM付きUTF-8はBOMを除去して読み込む。その他のエンコーディング（Shift-JIS等）はパースエラー

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,7 +33,8 @@ pub fn run() {
             greet,
             project::open::open_project,
             task::get::get_tasks,
-            task::create::create_task
+            task::create::create_task,
+            task::update::update_task
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -13,4 +13,5 @@ pub mod task_file_name;
 pub mod task_file_path;
 pub mod task_index;
 pub mod task_title;
+pub mod update;
 pub mod warning;

--- a/src-tauri/src/task/io.rs
+++ b/src-tauri/src/task/io.rs
@@ -47,11 +47,12 @@ pub trait TaskIo: Send + Sync {
     /// 既存ファイル前提の上書き書き込み。
     ///
     /// 契約:
-    /// - `path` が存在しない場合の挙動は実装依存（`FsTaskIo` は `std::fs::write`
-    ///   のセマンティクスに従い新規作成し得る）。effect 層は呼び出し前に必ず
-    ///   `read()` で存在を確認する。
-    /// - 部分書き込み失敗時のロールバックは実装に委ねる。事前 `read` で復元
-    ///   できるため、呼び出し側で独自に rollback ロジックを持つ必要はない。
+    /// - `path` が存在しない場合の挙動は実装依存（`FsTaskIo` は新規作成し得る）。
+    ///   effect 層は呼び出し前に必ず `read()` で存在を確認する。
+    /// - 書き込みは **アトミック** であること。`Err` を返した場合、`path` の内容は
+    ///   呼び出し前と同一であることを保証する（部分書き込みで破壊しない）。
+    ///   `FsTaskIo` は同一ディレクトリの一時ファイルに書いてから `rename` する
+    ///   POSIX atomic 契約で実現する。
     /// - `path` がディレクトリを指す場合は `Err` を返す。
     fn write_existing(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError>;
 
@@ -103,7 +104,19 @@ impl TaskIo for FsTaskIo {
     }
 
     fn write_existing(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError> {
-        std::fs::write(path, bytes).map_err(TaskIoError::from)
+        // アトミック上書き: 同一ディレクトリの一時ファイルに書き込んだ後 rename する。
+        // disk-full 等で書き込みが途中失敗しても元ファイルは無傷で残る
+        // （rename は同一ファイルシステム上で atomic、POSIX 契約）。
+        let tmp_path = atomic_tmp_path_for(path);
+        if let Err(err) = std::fs::write(&tmp_path, bytes) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(TaskIoError::from(err));
+        }
+        if let Err(err) = std::fs::rename(&tmp_path, path) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(TaskIoError::from(err));
+        }
+        Ok(())
     }
 
     fn remove(&self, path: &Path) -> Result<(), TaskIoError> {
@@ -113,6 +126,26 @@ impl TaskIo for FsTaskIo {
     fn read(&self, path: &Path) -> Result<Vec<u8>, TaskIoError> {
         std::fs::read(path).map_err(TaskIoError::from)
     }
+}
+
+/// `write_existing` のアトミック書き込み用 tmp パスを組み立てる。
+///
+/// dotfile + `.tmp` 拡張子で命名し、scanner / watcher の `.md` フィルタを通過しない
+/// ようにする。process id + 高精度時刻で同時実行衝突を最小化する（厳密な一意性は
+/// 必要としない: rename は atomic で、衝突しても最後に rename した内容で確定する）。
+fn atomic_tmp_path_for(path: &Path) -> std::path::PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("update");
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    parent.join(format!(".{filename}.{pid}.{nanos}.update.tmp"))
 }
 
 /// テスト用 in-memory 実装。`PathBuf` キーの `HashMap` で状態を保持する。

--- a/src-tauri/src/task/io.rs
+++ b/src-tauri/src/task/io.rs
@@ -44,6 +44,17 @@ pub trait TaskIo: Send + Sync {
     ///   行わない（二重削除防止）。
     fn write_new(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError>;
 
+    /// 既存ファイル前提の上書き書き込み。
+    ///
+    /// 契約:
+    /// - `path` が存在しない場合の挙動は実装依存（`FsTaskIo` は `std::fs::write`
+    ///   のセマンティクスに従い新規作成し得る）。effect 層は呼び出し前に必ず
+    ///   `read()` で存在を確認する。
+    /// - 部分書き込み失敗時のロールバックは実装に委ねる。事前 `read` で復元
+    ///   できるため、呼び出し側で独自に rollback ロジックを持つ必要はない。
+    /// - `path` がディレクトリを指す場合は `Err` を返す。
+    fn write_existing(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError>;
+
     /// `path` を削除する。`NotFound` も `Err` として返し、呼び出し側で
     /// `io::Error::kind()` 判定する。
     fn remove(&self, path: &Path) -> Result<(), TaskIoError>;
@@ -89,6 +100,10 @@ impl TaskIo for FsTaskIo {
             return Err(TaskIoError::Io(err));
         }
         Ok(())
+    }
+
+    fn write_existing(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError> {
+        std::fs::write(path, bytes).map_err(TaskIoError::from)
     }
 
     fn remove(&self, path: &Path) -> Result<(), TaskIoError> {
@@ -199,6 +214,18 @@ impl TaskIo for InMemoryTaskIo {
                 }
             }
             _ => {}
+        }
+        g.files.insert(path.to_path_buf(), bytes.to_vec());
+        Ok(())
+    }
+
+    fn write_existing(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError> {
+        let mut g = self.inner.lock().expect("InMemoryTaskIo lock");
+        if g.dirs.contains(path) {
+            return Err(TaskIoError::Io(io::Error::new(
+                io::ErrorKind::IsADirectory,
+                "path is a directory",
+            )));
         }
         g.files.insert(path.to_path_buf(), bytes.to_vec());
         Ok(())

--- a/src-tauri/src/task/io_tests.rs
+++ b/src-tauri/src/task/io_tests.rs
@@ -244,6 +244,38 @@ fn write_existing_creates_when_path_missing_following_std_fs_write_semantics() {
 }
 
 #[test]
+fn write_existing_preserves_original_content_when_rename_target_is_dir() {
+    // FsTaskIo の atomic rename 経路を検証: target が directory のとき rename は
+    // 失敗するが、tmp file は cleanup され、元の directory も unchanged のまま。
+    let tmp = TempDir::new().expect("create tempdir");
+    let dir_target = tmp.path().join("blocking-dir");
+    std::fs::create_dir(&dir_target).expect("seed dir");
+    let inside = dir_target.join("inside.md");
+    std::fs::write(&inside, b"keep-me").expect("seed sentinel");
+
+    let err = FsTaskIo
+        .write_existing(&dir_target, b"overwrite-attempt")
+        .expect_err("rename onto directory should fail");
+    let _ = err;
+
+    // ディレクトリ配下の sentinel が残っていることで元 directory が無傷である
+    // ことを担保（cleanup されていれば inside.md は読める）。
+    let read = std::fs::read(&inside).expect("sentinel still readable");
+    assert_eq!(b"keep-me".to_vec(), read);
+
+    // 同 dir 内に *.update.tmp が残っていないことを確認。
+    let leftover: Vec<_> = std::fs::read_dir(tmp.path())
+        .expect("read_dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with(".update.tmp"))
+        .collect();
+    assert!(
+        leftover.is_empty(),
+        "tmp file must be cleaned up after failure: {leftover:?}"
+    );
+}
+
+#[test]
 fn write_existing_rejects_when_target_is_dir() {
     with_both(|io, base| {
         let dir = base.join("dir-as-target");

--- a/src-tauri/src/task/io_tests.rs
+++ b/src-tauri/src/task/io_tests.rs
@@ -222,6 +222,40 @@ fn write_new_partial_write_cleanup_not_observable_on_normal_path() {
 }
 
 #[test]
+fn write_existing_overwrites_existing_file_with_new_bytes() {
+    with_both(|io, base| {
+        let path = base.join("update-target.md");
+        io.write_new(&path, b"original").expect("seed");
+        io.write_existing(&path, b"updated").expect("overwrite ok");
+        let read = io.read(&path).expect("read ok");
+        assert_eq!(b"updated".to_vec(), read);
+    });
+}
+
+#[test]
+fn write_existing_creates_when_path_missing_following_std_fs_write_semantics() {
+    with_both(|io, base| {
+        let path = base.join("brand-new.md");
+        io.write_existing(&path, b"fresh")
+            .expect("write_existing ok");
+        let read = io.read(&path).expect("read ok");
+        assert_eq!(b"fresh".to_vec(), read);
+    });
+}
+
+#[test]
+fn write_existing_rejects_when_target_is_dir() {
+    with_both(|io, base| {
+        let dir = base.join("dir-as-target");
+        io.ensure_dir(&dir).expect("seed dir");
+        let err = io
+            .write_existing(&dir, b"x")
+            .expect_err("target-is-dir should fail");
+        let _ = err;
+    });
+}
+
+#[test]
 fn task_io_error_display_matches_inner_io_error_display() {
     // `From<TaskIoError> for CreateTaskCommandError` で Display を素通しさせる
     // ための前提条件として、`TaskIoError::Io(_)` の Display が inner と完全

--- a/src-tauri/src/task/path_lookup.rs
+++ b/src-tauri/src/task/path_lookup.rs
@@ -35,6 +35,27 @@ pub(super) fn normalize_link_path_for_lookup(link: &str) -> Option<String> {
     normalize_parent_path_for_lookup(link)
 }
 
+/// command 層（IPC args）から渡されるユーザ入力 path を、parent lookup と同じ
+/// 基準で軽量正規化する。
+///
+/// 既存 `normalize_parent_path_for_lookup` と異なり drive prefix (`C:`) も除去し、
+/// 入力の空 / `/` / `\` 始まり / drive prefix は `None` にする。
+pub(crate) fn normalize_relative_path_for_input(raw: &str) -> Option<String> {
+    if raw.is_empty() || raw.starts_with('/') || raw.starts_with('\\') {
+        return None;
+    }
+    if has_windows_drive_prefix(raw) {
+        return None;
+    }
+    let path_text = raw.replace('\\', "/");
+    let normalized = normalize_path_parts(&path_text, true);
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
 pub(super) fn task_path_index(tasks: &[Task]) -> HashSet<String> {
     tasks
         .iter()

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -393,7 +393,15 @@ impl TaskIndex {
             }
         };
         if let Some(b) = &intent.body {
-            body = format!("\n{b}");
+            // create_task と同じ正規化: 空文字は空 body / 既に `\n` で始まる入力は
+            // そのまま採用 / それ以外は `---` 直後の慣例的な空行として `\n` を 1 個だけ前置。
+            body = if b.is_empty() {
+                String::new()
+            } else if b.starts_with('\n') {
+                b.clone()
+            } else {
+                format!("\n{b}")
+            };
         }
 
         if let Some(parent_str) = intent.parent.as_deref().filter(|s| !s.is_empty()) {

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -381,11 +381,15 @@ impl TaskIndex {
                     serde_yaml_ng::Value::String("parent".into()),
                     serde_yaml_ng::Value::String(s.clone()),
                 );
-                existing
+                // 正規化済み lookup key で比較する。raw string equality だと
+                // `./tasks/p.md` / `tasks\p.md` 等の表記揺れで同一 task を指していても
+                // changed と誤判定し、不要な full rebuild と非正規形での書き戻しを招く。
+                let new_normalized = normalize_parent_path_for_lookup(s);
+                let existing_normalized = existing
                     .parent
                     .as_ref()
-                    .map(|p| p.as_str() != s.as_str())
-                    .unwrap_or(true)
+                    .and_then(|p| normalize_parent_path_for_lookup(p.as_str()));
+                new_normalized != existing_normalized
             }
         };
         if let Some(b) = &intent.body {

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -14,9 +14,9 @@ use serde::{Deserialize, Serialize};
 use crate::config::column_name::ColumnName;
 use crate::task::children::build_children;
 use crate::task::create::error::CreateTaskError;
-use crate::task::frontmatter::Priority;
+use crate::task::frontmatter::{self, Parsed, Priority};
 use crate::task::label::Label;
-use crate::task::parse::TaskParseError;
+use crate::task::parse::{task_from_parsed, TaskParseContext, TaskParseError};
 use crate::task::path_lookup::{
     normalize_link_path_for_lookup, normalize_parent_path_for_lookup,
     normalize_task_path_for_lookup, parent_lookup_index, task_path_index,
@@ -26,6 +26,7 @@ use crate::task::task_content::TaskContent;
 use crate::task::task_file_name::{TaskFileName, TaskFileNameError};
 use crate::task::task_file_path::TaskFilePath;
 use crate::task::task_title::TaskTitle;
+use crate::task::update::error::UpdateTaskError;
 use crate::task::warning::{TaskWarning, TaskWarningCode};
 
 const MAX_PARENT_DEPTH: usize = 20;
@@ -319,6 +320,122 @@ impl TaskIndex {
             status: intent.status.clone(),
         })
     }
+
+    /// 既存 Task と raw `Parsed`（frontmatter + body）から、書き込むべき file_content
+    /// と更新後 Task を計算する純粋関数。I/O / 時計 / 乱数に依存しない。
+    ///
+    /// 呼び出し側（effect 層）は事前に以下を済ませてから本関数を呼ぶ:
+    ///
+    /// - `io.read` で existing bytes 取得
+    /// - `frontmatter::parse_bytes` で `Parsed` を取得（`None` ならエラーに変換）
+    /// - cache から既存 Task を取得
+    ///
+    /// 検証順序:
+    ///
+    /// 1. parent 存在チェック（cache key 探索）→ なければ `ParentNotFound`
+    /// 2. parent 置換後の `Vec<Task>` に対して `validate_parent_hierarchy`
+    /// 3. patch 適用 + `frontmatter::serialize` で `String` を構築
+    /// 4. `TaskContent::try_new(String)` で eligibility 検証
+    /// 5. `task_from_parsed` を呼び直して updated_task を再構築し warning を再生成
+    pub(crate) fn plan_update(
+        &self,
+        _project_root: &Path,
+        intent: UpdateTaskIntent,
+        existing: &Task,
+        existing_parsed: Parsed,
+    ) -> Result<UpdateTaskOutcome, UpdateTaskError> {
+        let Parsed {
+            mut frontmatter,
+            mut body,
+        } = existing_parsed;
+
+        if let Some(title) = &intent.title {
+            frontmatter.extras.insert(
+                serde_yaml_ng::Value::String("title".into()),
+                serde_yaml_ng::Value::String(title.clone()),
+            );
+        }
+        if let Some(status) = &intent.status {
+            frontmatter.extras.insert(
+                serde_yaml_ng::Value::String("status".into()),
+                serde_yaml_ng::Value::String(status.clone()),
+            );
+        }
+        if let Some(priority) = intent.priority {
+            frontmatter.priority = Some(priority);
+        }
+        if let Some(labels) = &intent.labels {
+            frontmatter.labels = labels.clone();
+        }
+        let parent_changed = match &intent.parent {
+            None => false,
+            Some(s) if s.is_empty() => {
+                let removed = frontmatter
+                    .extras
+                    .remove(serde_yaml_ng::Value::String("parent".into()))
+                    .is_some();
+                removed || existing.parent.is_some()
+            }
+            Some(s) => {
+                frontmatter.extras.insert(
+                    serde_yaml_ng::Value::String("parent".into()),
+                    serde_yaml_ng::Value::String(s.clone()),
+                );
+                existing
+                    .parent
+                    .as_ref()
+                    .map(|p| p.as_str() != s.as_str())
+                    .unwrap_or(true)
+            }
+        };
+        if let Some(b) = &intent.body {
+            body = format!("\n{b}");
+        }
+
+        if let Some(parent_str) = intent.parent.as_deref().filter(|s| !s.is_empty()) {
+            if resolve_parent_for_new_task(parent_str, self.as_slice()).is_none() {
+                return Err(UpdateTaskError::ParentNotFound {
+                    path: parent_str.to_string(),
+                });
+            }
+        }
+
+        if parent_changed {
+            let preliminary_task = build_patched_task(existing, &intent);
+            let mut values: Vec<Task> = self.as_slice().to_vec();
+            let target_key = intent.file_path.to_string_lossy();
+            if let Some(slot) = values
+                .iter_mut()
+                .find(|t| t.file_path.as_str() == target_key.as_ref())
+            {
+                *slot = preliminary_task;
+            } else {
+                values.push(preliminary_task);
+            }
+            TaskIndex::new(values)
+                .validate_parent_hierarchy()
+                .map_err(UpdateTaskError::from)?;
+        }
+
+        let serialized = frontmatter::serialize(&Parsed {
+            frontmatter: frontmatter.clone(),
+            body: body.clone(),
+        });
+
+        TaskContent::try_new(serialized.clone()).map_err(UpdateTaskError::from)?;
+
+        let context = TaskParseContext {
+            file_path: existing.file_path.as_path_buf(),
+            default_status: existing.status.clone(),
+        };
+        let updated_task = task_from_parsed(Parsed { frontmatter, body }, &context);
+
+        Ok(UpdateTaskOutcome {
+            updated_task,
+            file_content: serialized,
+            needs_full_rebuild: parent_changed,
+        })
+    }
 }
 
 impl From<Vec<Task>> for TaskIndex {
@@ -339,6 +456,31 @@ pub struct CreateTaskIntent {
     pub labels: Vec<Label>,
     pub parent: Option<TaskFilePath>,
     pub body: Option<String>,
+}
+
+/// `update_task` IPC 境界から domain に渡される更新意図。
+///
+/// `Some` のフィールドだけが適用される。`parent: Some("")` は親解除。
+/// `priority` は `None` = 不変。
+#[derive(Debug, Clone)]
+pub struct UpdateTaskIntent {
+    /// 対象タスクのプロジェクトルート相対パス（正規化済み）。
+    pub file_path: PathBuf,
+    pub title: Option<String>,
+    pub status: Option<String>,
+    pub priority: Option<Priority>,
+    pub labels: Option<Vec<String>>,
+    pub parent: Option<String>,
+    pub body: Option<String>,
+}
+
+/// `TaskIndex::plan_update` の計算結果。effect 層が消費する。
+#[derive(Debug)]
+pub struct UpdateTaskOutcome {
+    pub updated_task: Task,
+    pub file_content: String,
+    /// parent が変化した場合のみ true。effect 層は TaskIndex を再構築する。
+    pub needs_full_rebuild: bool,
 }
 
 /// `TaskIndex::plan_create` の計算結果。effect 層が消費する。
@@ -387,6 +529,40 @@ fn join_rel_path(target_dir: &Path, filename: &TaskFileName) -> PathBuf {
     } else {
         target_dir.join(filename.as_str())
     }
+}
+
+/// `plan_update` で parent 変更を検証する際の置換用 Task を作る。
+///
+/// 最終的に返却される Task は `task_from_parsed` 再走の結果に置き換わるため、
+/// ここでは循環/深さ検証に必要なフィールド（特に `parent`）だけ正しく埋まっていればよい。
+fn build_patched_task(existing: &Task, intent: &UpdateTaskIntent) -> Task {
+    let mut task = existing.clone();
+    if let Some(title) = &intent.title {
+        task.title = TaskTitle::from_lenient(title.clone());
+    }
+    if let Some(priority) = intent.priority {
+        task.priority = Some(priority);
+    }
+    if let Some(labels) = &intent.labels {
+        task.labels = labels
+            .iter()
+            .map(|s| Label::from_lenient(s.clone()))
+            .collect();
+    }
+    if let Some(parent) = &intent.parent {
+        if parent.is_empty() {
+            task.parent = None;
+        } else {
+            task.parent = Some(TaskFilePath::from_lenient(parent.clone()));
+        }
+    }
+    if let Some(body) = &intent.body {
+        task.body = format!("\n{body}");
+    }
+    if let Some(status) = &intent.status {
+        task.status = ColumnName::from_lenient(status.clone());
+    }
+    task
 }
 
 /// augmented hierarchy 検証用に最低限のフィールドだけ埋めた Task を作る。
@@ -563,3 +739,7 @@ mod task_index_parent_chain_tests;
 #[cfg(test)]
 #[path = "task_index_plan_create_tests.rs"]
 mod task_index_plan_create_tests;
+
+#[cfg(test)]
+#[path = "task_index_plan_update_tests.rs"]
+mod task_index_plan_update_tests;

--- a/src-tauri/src/task/task_index_plan_update_tests.rs
+++ b/src-tauri/src/task/task_index_plan_update_tests.rs
@@ -256,6 +256,44 @@ fn plan_update_with_no_parent_change_returns_no_rebuild_flag() {
 }
 
 #[test]
+fn plan_update_same_parent_with_dot_prefix_is_not_treated_as_change() {
+    // 既存 parent="tasks/p.md" の task に、./tasks/p.md（同一 task を指す表記揺れ）
+    // を渡しても needs_full_rebuild=false を返すこと。
+    let task = make_task("tasks/a.md", Some("tasks/p.md"));
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/p.md\n---\n");
+    let index = TaskIndex::new(vec![task.clone(), make_task("tasks/p.md", None)]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("./tasks/p.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+    assert!(
+        !outcome.needs_full_rebuild,
+        "lexically equivalent parent should not trigger rebuild"
+    );
+}
+
+#[test]
+fn plan_update_same_parent_with_backslash_separator_is_not_treated_as_change() {
+    let task = make_task("tasks/a.md", Some("tasks/p.md"));
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/p.md\n---\n");
+    let index = TaskIndex::new(vec![task.clone(), make_task("tasks/p.md", None)]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks\\p.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+    assert!(
+        !outcome.needs_full_rebuild,
+        "backslash separator pointing to same task should not trigger rebuild"
+    );
+}
+
+#[test]
 fn plan_update_parent_added_returns_needs_full_rebuild() {
     let task = make_task("tasks/a.md", None);
     let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");

--- a/src-tauri/src/task/task_index_plan_update_tests.rs
+++ b/src-tauri/src/task/task_index_plan_update_tests.rs
@@ -126,6 +126,51 @@ fn plan_update_body_only_replaces_body() {
 }
 
 #[test]
+fn plan_update_body_with_leading_newline_is_not_double_prefixed() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\nold\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.body = Some("\nhello".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+    // ---\n の直後に 1 行だけ空行が入り、その後 hello。\n\n が二重化しないこと。
+    assert!(
+        outcome.file_content.contains("---\n\nhello\n"),
+        "leading newline must not be double-prefixed: {:?}",
+        outcome.file_content
+    );
+    assert!(
+        !outcome.file_content.contains("---\n\n\nhello"),
+        "no triple-newline allowed"
+    );
+}
+
+#[test]
+fn plan_update_body_empty_string_clears_body_without_extra_newline() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\nold body\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.body = Some(String::new());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+    // Empty body は frontmatter 直下 `---\n` で終わる（余分な空行を残さない）。
+    assert!(
+        outcome.file_content.ends_with("---\n"),
+        "empty body must not leave a trailing blank line: {:?}",
+        outcome.file_content
+    );
+    assert!(!outcome.file_content.contains("old body"));
+}
+
+#[test]
 fn plan_update_title_changes_frontmatter_title_only_file_path_unchanged() {
     let task = make_task("tasks/a.md", None);
     let parsed = parsed_from_md("---\ntitle: Old\nstatus: Todo\n---\n");

--- a/src-tauri/src/task/task_index_plan_update_tests.rs
+++ b/src-tauri/src/task/task_index_plan_update_tests.rs
@@ -1,0 +1,554 @@
+//! `TaskIndex::plan_update` の純粋関数ユニットテスト。
+//!
+//! AppState / TaskIo / fs::* に依存せず、すべて in-memory で完結する。
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::{ParentHierarchyErrorReason, Task, TaskIndex, UpdateTaskIntent};
+use crate::config::column_name::ColumnName;
+use crate::task::create::error::ContentRejectReason;
+use crate::task::frontmatter::{parse as parse_frontmatter, Parsed, Priority};
+use crate::task::parse::TaskParseError;
+use crate::task::task_content::TaskContentError;
+use crate::task::task_file_path::TaskFilePath;
+use crate::task::task_index::ParentValidationFailure;
+use crate::task::update::error::UpdateTaskError;
+use crate::task::warning::TaskWarningCode;
+
+fn make_task(file_path: &str, parent: Option<&str>) -> Task {
+    let fp = TaskFilePath::from_lenient(file_path);
+    Task {
+        id: fp.clone(),
+        file_path: fp,
+        title: "T".into(),
+        status: ColumnName::from_lenient("Todo"),
+        priority: None,
+        labels: Vec::new(),
+        parent: parent.map(TaskFilePath::from_lenient),
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: BTreeMap::new(),
+        warnings: Vec::new(),
+    }
+}
+
+fn parsed_from_md(md: &str) -> Parsed {
+    parse_frontmatter(md).expect("parse ok").expect("some")
+}
+
+fn empty_intent(rel: &str) -> UpdateTaskIntent {
+    UpdateTaskIntent {
+        file_path: PathBuf::from(rel),
+        title: None,
+        status: None,
+        priority: None,
+        labels: None,
+        parent: None,
+        body: None,
+    }
+}
+
+fn project_root() -> &'static Path {
+    Path::new("/project")
+}
+
+#[test]
+fn plan_update_status_only_changes_status_line_only() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\nbody\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.status = Some("Doing".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.file_content.contains("status: Doing"));
+    assert!(outcome.file_content.contains("title: A"));
+    assert!(!outcome.needs_full_rebuild);
+    assert_eq!(outcome.updated_task.status.as_str(), "Doing");
+}
+
+#[test]
+fn plan_update_priority_only_replaces_typed_priority() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\npriority: High\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.priority = Some(Priority::Medium);
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.file_content.contains("priority: Medium"));
+    assert!(!outcome.file_content.contains("priority: High"));
+}
+
+#[test]
+fn plan_update_labels_empty_list_clears_labels() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nlabels:\n  - bug\n  - api\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.labels = Some(Vec::new());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(!outcome.file_content.contains("- bug"));
+    assert!(!outcome.file_content.contains("labels:"));
+}
+
+#[test]
+fn plan_update_body_only_replaces_body() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\nold body\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.body = Some("new body".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.file_content.contains("new body"));
+    assert!(!outcome.file_content.contains("old body"));
+}
+
+#[test]
+fn plan_update_title_changes_frontmatter_title_only_file_path_unchanged() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: Old\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.title = Some("New Title".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.file_content.contains("title: New Title"));
+    assert_eq!(outcome.updated_task.file_path, "tasks/a.md");
+    assert!(!outcome.needs_full_rebuild);
+}
+
+#[test]
+fn plan_update_empty_title_re_runs_parser_and_emits_invalid_title_warning() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: Old\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.title = Some(String::new());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    let has_warning = outcome
+        .updated_task
+        .warnings
+        .iter()
+        .any(|w| w.code == TaskWarningCode::InvalidTitleUsedFileName);
+    assert!(
+        has_warning,
+        "expected invalidTitleUsedFileName warning, got {:?}",
+        outcome.updated_task.warnings
+    );
+}
+
+#[test]
+fn plan_update_preserves_unknown_keys_in_extras() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nassignee: alice\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.title = Some("Updated".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(
+        outcome.file_content.contains("assignee: alice"),
+        "unknown key should be preserved: {}",
+        outcome.file_content
+    );
+}
+
+#[test]
+fn plan_update_preserves_links_array() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md(
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n  - tasks/c.md\n---\n",
+    );
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.title = Some("Updated".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.file_content.contains("tasks/b.md"));
+    assert!(outcome.file_content.contains("tasks/c.md"));
+}
+
+#[test]
+fn plan_update_preserves_numeric_unknown_key() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\npriority_score: 42\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.title = Some("Updated".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.file_content.contains("priority_score: 42"));
+}
+
+#[test]
+fn plan_update_preserves_boolean_unknown_key() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\narchived: true\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.title = Some("Updated".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.file_content.contains("archived: true"));
+}
+
+#[test]
+fn plan_update_with_no_parent_change_returns_no_rebuild_flag() {
+    let task = make_task("tasks/a.md", Some("tasks/p.md"));
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/p.md\n---\n");
+    let index = TaskIndex::new(vec![task.clone(), make_task("tasks/p.md", None)]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/p.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(!outcome.needs_full_rebuild);
+}
+
+#[test]
+fn plan_update_parent_added_returns_needs_full_rebuild() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone(), make_task("tasks/p.md", None)]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/p.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.needs_full_rebuild);
+    assert!(outcome.file_content.contains("parent: tasks/p.md"));
+}
+
+#[test]
+fn plan_update_parent_cleared_with_empty_string_returns_needs_full_rebuild() {
+    let task = make_task("tasks/a.md", Some("tasks/p.md"));
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/p.md\n---\n");
+    let index = TaskIndex::new(vec![task.clone(), make_task("tasks/p.md", None)]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some(String::new());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert!(outcome.needs_full_rebuild);
+    assert!(!outcome.file_content.contains("parent:"));
+}
+
+#[test]
+fn plan_update_returns_parent_not_found_for_missing_parent() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/missing.md".to_string());
+
+    let err = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect_err("fail");
+
+    match err {
+        UpdateTaskError::ParentNotFound { path } => {
+            assert_eq!("tasks/missing.md", path);
+        }
+        other => panic!("expected ParentNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_update_resolves_parent_with_dot_prefix_via_normalization() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone(), make_task("tasks/p.md", None)]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("./tasks/p.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+    assert!(outcome.needs_full_rebuild);
+}
+
+#[test]
+fn plan_update_resolves_parent_with_backslash_separator_via_normalization() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone(), make_task("tasks/p.md", None)]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks\\p.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+    assert!(outcome.needs_full_rebuild);
+}
+
+#[test]
+fn plan_update_self_reference_returns_parent_cycle() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/a.md".to_string());
+
+    let err = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect_err("fail");
+    match err {
+        UpdateTaskError::ParentCycleOrTooDeep { reason, .. } => {
+            assert_eq!(ParentHierarchyErrorReason::Cycle, reason);
+        }
+        other => panic!("expected ParentCycleOrTooDeep, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_update_descendant_parent_returns_parent_cycle() {
+    let task_a = make_task("tasks/a.md", None);
+    let task_b = make_task("tasks/b.md", Some("tasks/a.md"));
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task_a.clone(), task_b]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/b.md".to_string());
+
+    let err = index
+        .plan_update(project_root(), intent, &task_a, parsed)
+        .expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::ParentCycleOrTooDeep { .. }));
+}
+
+#[test]
+fn plan_update_chain_too_deep_returns_parent_too_deep() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+
+    // a (no parent) + B0..B20 chain (B0.parent=B1, ..., B19.parent=B20, B20=None)
+    // After setting a.parent = B0, chain becomes a → B0 → ... → B20 (22 nodes / 21 edges)
+    // depth reaches 21 which exceeds MAX_PARENT_DEPTH (20) → TooDeep.
+    let mut tasks = vec![task.clone()];
+    for i in 0..20 {
+        tasks.push(make_task(
+            &format!("tasks/B{i}.md"),
+            Some(&format!("tasks/B{}.md", i + 1)),
+        ));
+    }
+    tasks.push(make_task("tasks/B20.md", None));
+    let index = TaskIndex::new(tasks);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/B0.md".to_string());
+
+    let err = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect_err("fail");
+    match err {
+        UpdateTaskError::ParentCycleOrTooDeep { reason, .. } => {
+            assert_eq!(ParentHierarchyErrorReason::TooDeep, reason);
+        }
+        other => panic!("expected ParentCycleOrTooDeep(TooDeep), got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_update_body_over_1mib_returns_content_too_large() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.body = Some("a".repeat(1024 * 1024 + 1));
+
+    let err = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect_err("fail");
+    match err {
+        UpdateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::TooLarge { .. },
+        } => {}
+        other => panic!("expected ContentNotScannerEligible(TooLarge), got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_update_body_with_nul_byte_returns_binary_detected() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    let mut body = String::from("hello");
+    body.push('\u{0000}');
+    body.push_str("world");
+    intent.body = Some(body);
+
+    let err = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect_err("fail");
+    match err {
+        UpdateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::BinaryDetected,
+        } => {}
+        other => panic!("expected ContentNotScannerEligible(BinaryDetected), got {other:?}"),
+    }
+}
+
+#[test]
+fn from_task_parse_error_cycle_maps_to_parent_cycle() {
+    let err = TaskParseError::CycleOrTooDeep {
+        file_path: "tasks/a.md".to_string(),
+        reason: ParentHierarchyErrorReason::Cycle,
+    };
+    let mapped: UpdateTaskError = err.into();
+    match mapped {
+        UpdateTaskError::ParentCycleOrTooDeep { file_path, reason } => {
+            assert_eq!("tasks/a.md", file_path);
+            assert_eq!(ParentHierarchyErrorReason::Cycle, reason);
+        }
+        other => panic!("expected ParentCycleOrTooDeep, got {other:?}"),
+    }
+}
+
+#[test]
+fn from_task_parse_error_not_task_maps_to_parse_failed() {
+    let mapped: UpdateTaskError = TaskParseError::NotTask.into();
+    match mapped {
+        UpdateTaskError::ParseFailed(msg) => {
+            assert!(msg.contains("no frontmatter"), "msg={msg}");
+        }
+        other => panic!("expected ParseFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn from_task_content_error_too_large_maps_to_content_not_scanner_eligible() {
+    let err = TaskContentError::TooLarge {
+        size: 9999,
+        limit: 1024,
+    };
+    let mapped: UpdateTaskError = err.into();
+    match mapped {
+        UpdateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::TooLarge { size },
+        } => {
+            assert_eq!(9999, size);
+        }
+        other => panic!("expected ContentNotScannerEligible(TooLarge), got {other:?}"),
+    }
+}
+
+#[test]
+fn from_task_content_error_binary_detected_maps_to_content_not_scanner_eligible() {
+    let err = TaskContentError::BinaryDetected { probe: 8192 };
+    let mapped: UpdateTaskError = err.into();
+    match mapped {
+        UpdateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::BinaryDetected,
+        } => {}
+        other => panic!("expected ContentNotScannerEligible(BinaryDetected), got {other:?}"),
+    }
+}
+
+#[test]
+fn from_parent_validation_failure_not_found_maps_to_parent_not_found() {
+    let err = ParentValidationFailure::NotFound {
+        parent: "tasks/missing.md".to_string(),
+    };
+    let mapped: UpdateTaskError = err.into();
+    match mapped {
+        UpdateTaskError::ParentNotFound { path } => {
+            assert_eq!("tasks/missing.md", path);
+        }
+        other => panic!("expected ParentNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn from_parent_validation_failure_chain_invalid_maps_to_parent_cycle() {
+    let err = ParentValidationFailure::ChainInvalid {
+        parent: "tasks/a.md".to_string(),
+        reason: ParentHierarchyErrorReason::Cycle,
+    };
+    let mapped: UpdateTaskError = err.into();
+    match mapped {
+        UpdateTaskError::ParentCycleOrTooDeep { file_path, reason } => {
+            assert_eq!("tasks/a.md", file_path);
+            assert_eq!(ParentHierarchyErrorReason::Cycle, reason);
+        }
+        other => panic!("expected ParentCycleOrTooDeep, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_update_returns_root_relative_file_path_in_updated_task() {
+    let task = make_task("tasks/a.md", None);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task.clone()]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.title = Some("New".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ok");
+
+    assert_eq!(outcome.updated_task.file_path, "tasks/a.md");
+}

--- a/src-tauri/src/task/update.rs
+++ b/src-tauri/src/task/update.rs
@@ -1,0 +1,3 @@
+//! `update_task` Tauri command のファサード。
+
+pub mod error;

--- a/src-tauri/src/task/update.rs
+++ b/src-tauri/src/task/update.rs
@@ -1,3 +1,11 @@
 //! `update_task` Tauri command のファサード。
 
+pub mod args;
+pub mod command;
 pub mod error;
+
+#[allow(unused_imports)]
+pub use command::{__cmd__update_task, update_task};
+
+#[allow(unused_imports)]
+pub(crate) use command::update_task_impl;

--- a/src-tauri/src/task/update/args.rs
+++ b/src-tauri/src/task/update/args.rs
@@ -1,0 +1,87 @@
+//! `update_task` Tauri command の引数 DTO。
+//!
+//! filePath は既存の path-normalization helper を再利用して
+//! `UpdateTaskIntent` に詰め直す。canonicalize は使わない。
+
+use std::path::{Component, Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::task::frontmatter::Priority;
+use crate::task::path_lookup::normalize_relative_path_for_input;
+use crate::task::task_index::UpdateTaskIntent;
+use crate::task::update::error::UpdateTaskError;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateTaskArgs {
+    /// 対象タスクのファイルパス。絶対パスまたは project_root 相対。
+    pub file_path: String,
+    pub title: Option<String>,
+    pub status: Option<String>,
+    /// `"High" | "Medium" | "Low"` 想定。不正値は `None` に倒す lenient 変換。
+    /// `None` = 未指定（不変）。priority クリアは本 Issue ではサポートしない。
+    pub priority: Option<String>,
+    pub labels: Option<Vec<String>>,
+    /// 空文字で親解除、`None` で不変、`Some(path)` で上書き。
+    pub parent: Option<String>,
+    pub body: Option<String>,
+}
+
+impl UpdateTaskArgs {
+    /// project_root を起点に filePath を lexical 正規化し、`UpdateTaskIntent` に詰め直す。
+    pub fn into_intent(self, project_root: &Path) -> Result<UpdateTaskIntent, UpdateTaskError> {
+        let rel_path = normalize_input_file_path(&self.file_path, project_root)?;
+
+        let priority = self.priority.as_deref().and_then(Priority::from_ascii_ci);
+
+        Ok(UpdateTaskIntent {
+            file_path: rel_path,
+            title: self.title,
+            status: self.status,
+            priority,
+            labels: self.labels,
+            parent: self.parent,
+            body: self.body,
+        })
+    }
+}
+
+fn normalize_input_file_path(raw: &str, project_root: &Path) -> Result<PathBuf, UpdateTaskError> {
+    if raw.trim().is_empty() {
+        return Err(UpdateTaskError::InvalidPath("empty".into()));
+    }
+
+    let candidate_text = if Path::new(raw).is_absolute() {
+        Path::new(raw)
+            .strip_prefix(project_root)
+            .map_err(|_| UpdateTaskError::InvalidPath(raw.into()))?
+            .to_string_lossy()
+            .into_owned()
+    } else {
+        raw.to_string()
+    };
+
+    let normalized = normalize_relative_path_for_input(&candidate_text)
+        .ok_or_else(|| UpdateTaskError::InvalidPath(raw.into()))?;
+
+    let rel = Path::new(&normalized);
+
+    if rel.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(UpdateTaskError::InvalidPath(raw.into()));
+    }
+
+    if rel.extension().and_then(|e| e.to_str()) != Some("md") {
+        return Err(UpdateTaskError::InvalidPath(raw.into()));
+    }
+
+    if rel.as_os_str().is_empty() {
+        return Err(UpdateTaskError::InvalidPath(raw.into()));
+    }
+
+    Ok(rel.to_path_buf())
+}
+
+#[cfg(test)]
+#[path = "args_tests.rs"]
+mod args_tests;

--- a/src-tauri/src/task/update/args_tests.rs
+++ b/src-tauri/src/task/update/args_tests.rs
@@ -1,0 +1,145 @@
+use std::path::Path;
+
+use super::UpdateTaskArgs;
+use crate::task::update::error::UpdateTaskError;
+
+fn raw_args(file_path: &str) -> UpdateTaskArgs {
+    UpdateTaskArgs {
+        file_path: file_path.to_string(),
+        title: None,
+        status: None,
+        priority: None,
+        labels: None,
+        parent: None,
+        body: None,
+    }
+}
+
+#[test]
+fn absolute_inside_root_succeeds_and_relative_path_is_stripped() {
+    let root = Path::new("/project");
+    let args = raw_args("/project/tasks/foo.md");
+    let intent = args.into_intent(root).expect("ok");
+    assert_eq!(Path::new("tasks/foo.md"), intent.file_path.as_path());
+}
+
+#[test]
+fn absolute_outside_root_returns_invalid_path() {
+    let root = Path::new("/project");
+    let args = raw_args("/elsewhere/foo.md");
+    let err = args.into_intent(root).expect_err("should fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn plain_relative_md_path_succeeds() {
+    let root = Path::new("/project");
+    let intent = raw_args("tasks/foo.md").into_intent(root).expect("ok");
+    assert_eq!(Path::new("tasks/foo.md"), intent.file_path.as_path());
+}
+
+#[test]
+fn dot_prefix_is_normalized() {
+    let root = Path::new("/project");
+    let intent = raw_args("./tasks/foo.md").into_intent(root).expect("ok");
+    assert_eq!(Path::new("tasks/foo.md"), intent.file_path.as_path());
+}
+
+#[test]
+fn parent_dir_segment_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("../etc/passwd")
+        .into_intent(root)
+        .expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn non_md_extension_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("tasks/foo.txt")
+        .into_intent(root)
+        .expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn double_extension_md_bak_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("tasks/foo.md.bak")
+        .into_intent(root)
+        .expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn no_extension_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("tasks/foo").into_intent(root).expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn directory_path_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("tasks/").into_intent(root).expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn backslash_separator_is_normalized_to_forward_slash() {
+    let root = Path::new("/project");
+    let intent = raw_args("tasks\\foo.md").into_intent(root).expect("ok");
+    assert_eq!(Path::new("tasks/foo.md"), intent.file_path.as_path());
+}
+
+#[test]
+fn windows_drive_prefix_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("C:\\Users\\foo.md")
+        .into_intent(root)
+        .expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn posix_absolute_outside_root_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("/abs/outside.md")
+        .into_intent(root)
+        .expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn empty_input_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("").into_intent(root).expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn whitespace_only_input_is_rejected() {
+    let root = Path::new("/project");
+    let err = raw_args("   ").into_intent(root).expect_err("fail");
+    assert!(matches!(err, UpdateTaskError::InvalidPath(_)));
+}
+
+#[test]
+fn priority_string_is_normalized_to_enum() {
+    use crate::task::frontmatter::Priority;
+    let root = Path::new("/project");
+    let mut args = raw_args("tasks/foo.md");
+    args.priority = Some("high".into());
+    let intent = args.into_intent(root).expect("ok");
+    assert_eq!(Some(Priority::High), intent.priority);
+}
+
+#[test]
+fn invalid_priority_string_becomes_none() {
+    let root = Path::new("/project");
+    let mut args = raw_args("tasks/foo.md");
+    args.priority = Some("urgent".into());
+    let intent = args.into_intent(root).expect("ok");
+    assert_eq!(None, intent.priority);
+}

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -1,0 +1,128 @@
+//! `update_task` Tauri command と effect 層実装。
+
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tauri::State;
+
+use crate::state::AppState;
+use crate::task::frontmatter;
+use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
+use crate::task::task_index::{Task, TaskIndex, UpdateTaskOutcome};
+use crate::task::update::args::UpdateTaskArgs;
+use crate::task::update::error::{UpdateTaskCommandError, UpdateTaskError};
+
+/// `update_task` Tauri command 薄層。
+#[tauri::command]
+pub fn update_task(state: State<'_, Arc<AppState>>, args: UpdateTaskArgs) -> Result<Task, String> {
+    update_task_impl(state.inner().as_ref(), &FsTaskIo, args).map_err(|e| e.to_string())
+}
+
+/// effect 層本体（テスト境界）。
+pub(crate) fn update_task_impl(
+    state: &AppState,
+    io: &dyn TaskIo,
+    args: UpdateTaskArgs,
+) -> Result<Task, UpdateTaskCommandError> {
+    state.check_tasks_cache_lock()?;
+    let _ = state.write_ignore().is_empty()?;
+
+    let project_root = state
+        .project_path()?
+        .ok_or(UpdateTaskCommandError::NoProjectOpen)?;
+
+    let intent = args
+        .into_intent(project_root.as_path())
+        .map_err(UpdateTaskCommandError::Validation)?;
+    let rel_path = intent.file_path.clone();
+    let abs = project_root.join(&rel_path);
+
+    let snapshot = state.tasks_snapshot()?;
+    let existing_task = snapshot
+        .iter()
+        .find(|t| Path::new(t.file_path.as_str()) == rel_path.as_path())
+        .cloned()
+        .ok_or_else(|| UpdateTaskError::FileNotFound(abs.clone()))?;
+
+    let bytes = match io.read(&abs) {
+        Ok(b) => b,
+        Err(TaskIoError::Io(source)) if source.kind() == ErrorKind::NotFound => {
+            return Err(UpdateTaskError::FileNotFound(abs.clone()).into());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let parsed = frontmatter::parse_bytes(&bytes)
+        .map_err(UpdateTaskError::Frontmatter)?
+        .ok_or_else(|| {
+            UpdateTaskError::ParseFailed("no frontmatter delimiter found".to_string())
+        })?;
+
+    let index = TaskIndex::new(snapshot);
+    let outcome: UpdateTaskOutcome = index
+        .plan_update(project_root.as_path(), intent, &existing_task, parsed)
+        .map_err(UpdateTaskCommandError::Validation)?;
+
+    let watcher_active = state.is_watcher_installed()?;
+
+    if watcher_active {
+        state.write_ignore().register(&abs)?;
+    }
+
+    if let Err(err) = io.write_existing(&abs, outcome.file_content.as_bytes()) {
+        if watcher_active {
+            let _ = state.write_ignore().unregister(&abs);
+        }
+        return Err(err.into());
+    }
+
+    let returned = commit_cache(state, &rel_path, &outcome)?;
+    Ok(returned)
+}
+
+/// cache を更新し、返却すべき最終的な Task を返す。
+fn commit_cache(
+    state: &AppState,
+    rel_path: &Path,
+    outcome: &UpdateTaskOutcome,
+) -> Result<Task, UpdateTaskCommandError> {
+    let cache_key: PathBuf = rel_path.to_path_buf();
+    let returned = state.with_tasks_cache_mut(|cache: &mut HashMap<PathBuf, Task>| {
+        if outcome.needs_full_rebuild {
+            let mut values: Vec<Task> = cache.values().cloned().collect();
+            let target_str = rel_path.to_string_lossy();
+            if let Some(slot) = values
+                .iter_mut()
+                .find(|t| t.file_path.as_str() == target_str.as_ref())
+            {
+                *slot = outcome.updated_task.clone();
+            } else {
+                values.push(outcome.updated_task.clone());
+            }
+            let index = TaskIndex::new(values)
+                .validate_parent_hierarchy()
+                .expect("validated in plan_update")
+                .build_children()
+                .expect("validated in plan_update")
+                .build_reverse_links();
+            cache.clear();
+            for task in index.into_tasks() {
+                cache.insert(PathBuf::from(task.file_path.as_str()), task);
+            }
+            cache.get(&cache_key).cloned()
+        } else {
+            cache.insert(cache_key.clone(), outcome.updated_task.clone());
+            Some(outcome.updated_task.clone())
+        }
+    })?;
+
+    returned.ok_or(UpdateTaskCommandError::Validation(
+        UpdateTaskError::FileNotFound(cache_key),
+    ))
+}
+
+#[cfg(test)]
+#[path = "command_tests.rs"]
+mod command_tests;

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -83,42 +83,48 @@ pub(crate) fn update_task_impl(
 }
 
 /// cache を更新し、返却すべき最終的な Task を返す。
+///
+/// `plan_update` の snapshot 取得と本関数の lock 再取得の間に他コマンドが cache を
+/// 変更すると、再構築用 `Vec<Task>` の hierarchy が `plan_update` 時点と乖離する
+/// 可能性がある。validation を `?` で propagate して panic を避け、レース由来の
+/// 不整合は `UpdateTaskCommandError::Validation` として呼び出し側に返す。
 fn commit_cache(
     state: &AppState,
     rel_path: &Path,
     outcome: &UpdateTaskOutcome,
 ) -> Result<Task, UpdateTaskCommandError> {
     let cache_key: PathBuf = rel_path.to_path_buf();
-    let returned = state.with_tasks_cache_mut(|cache: &mut HashMap<PathBuf, Task>| {
-        if outcome.needs_full_rebuild {
-            let mut values: Vec<Task> = cache.values().cloned().collect();
-            let target_str = rel_path.to_string_lossy();
-            if let Some(slot) = values
-                .iter_mut()
-                .find(|t| t.file_path.as_str() == target_str.as_ref())
-            {
-                *slot = outcome.updated_task.clone();
+    let returned: Result<Option<Task>, UpdateTaskError> =
+        state.with_tasks_cache_mut(|cache: &mut HashMap<PathBuf, Task>| {
+            if outcome.needs_full_rebuild {
+                let mut values: Vec<Task> = cache.values().cloned().collect();
+                let target_str = rel_path.to_string_lossy();
+                if let Some(slot) = values
+                    .iter_mut()
+                    .find(|t| t.file_path.as_str() == target_str.as_ref())
+                {
+                    *slot = outcome.updated_task.clone();
+                } else {
+                    values.push(outcome.updated_task.clone());
+                }
+                let index = TaskIndex::new(values)
+                    .validate_parent_hierarchy()
+                    .map_err(UpdateTaskError::from)?
+                    .build_children()
+                    .map_err(UpdateTaskError::from)?
+                    .build_reverse_links();
+                cache.clear();
+                for task in index.into_tasks() {
+                    cache.insert(PathBuf::from(task.file_path.as_str()), task);
+                }
+                Ok(cache.get(&cache_key).cloned())
             } else {
-                values.push(outcome.updated_task.clone());
+                cache.insert(cache_key.clone(), outcome.updated_task.clone());
+                Ok(Some(outcome.updated_task.clone()))
             }
-            let index = TaskIndex::new(values)
-                .validate_parent_hierarchy()
-                .expect("validated in plan_update")
-                .build_children()
-                .expect("validated in plan_update")
-                .build_reverse_links();
-            cache.clear();
-            for task in index.into_tasks() {
-                cache.insert(PathBuf::from(task.file_path.as_str()), task);
-            }
-            cache.get(&cache_key).cloned()
-        } else {
-            cache.insert(cache_key.clone(), outcome.updated_task.clone());
-            Some(outcome.updated_task.clone())
-        }
-    })?;
+        })?;
 
-    returned.ok_or(UpdateTaskCommandError::Validation(
+    returned?.ok_or(UpdateTaskCommandError::Validation(
         UpdateTaskError::FileNotFound(cache_key),
     ))
 }

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -55,7 +55,7 @@ pub(crate) fn update_task_impl(
     };
 
     let parsed = frontmatter::parse_bytes(&bytes)
-        .map_err(UpdateTaskError::Frontmatter)?
+        .map_err(|e| UpdateTaskError::ParseFailed(e.to_string()))?
         .ok_or_else(|| {
             UpdateTaskError::ParseFailed("no frontmatter delimiter found".to_string())
         })?;

--- a/src-tauri/src/task/update/command_tests.rs
+++ b/src-tauri/src/task/update/command_tests.rs
@@ -1,0 +1,467 @@
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use super::super::args::UpdateTaskArgs;
+use super::super::error::{UpdateTaskCommandError, UpdateTaskError};
+use super::update_task_impl;
+use crate::project::open::open_project_impl;
+use crate::project::watcher_factory::NoopWatcherFactory;
+use crate::project::OpenProjectIntent;
+use crate::state::AppState;
+use crate::task::create::error::ContentRejectReason;
+use crate::task::io::FsTaskIo;
+use crate::task::warning::TaskWarningCode;
+
+fn tempdir() -> TempDir {
+    tempfile::tempdir().expect("create temp dir")
+}
+
+fn open_with_noop(state: Arc<AppState>, path: &Path) {
+    let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
+        .expect("non-empty path");
+    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+}
+
+fn seed_md(root: &Path, rel: &str, content: &str) {
+    let abs = root.join(rel);
+    fs::create_dir_all(abs.parent().unwrap()).unwrap();
+    fs::write(&abs, content).unwrap();
+}
+
+fn args_for(rel: &str) -> UpdateTaskArgs {
+    UpdateTaskArgs {
+        file_path: rel.to_string(),
+        title: None,
+        status: None,
+        priority: None,
+        labels: None,
+        parent: None,
+        body: None,
+    }
+}
+
+#[test]
+fn update_status_only_writes_file_and_updates_cache() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.status = Some("Doing".into());
+
+    let task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    assert_eq!(task.status.as_str(), "Doing");
+
+    let content = fs::read_to_string(dir.path().join("tasks/a.md")).expect("read");
+    assert!(content.contains("status: Doing"));
+}
+
+#[test]
+fn update_title_keeps_file_path_unchanged() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: Old\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.title = Some("New Title".into());
+
+    let task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    assert_eq!(task.file_path, "tasks/a.md");
+    assert!(dir.path().join("tasks/a.md").exists());
+    let content = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert!(content.contains("title: New Title"));
+}
+
+#[test]
+fn update_empty_title_is_accepted_and_warns_invalid_title() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: Old\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.title = Some(String::new());
+
+    let task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    assert_eq!(task.file_path, "tasks/a.md");
+    assert!(
+        task.warnings
+            .iter()
+            .any(|w| w.code == TaskWarningCode::InvalidTitleUsedFileName),
+        "expected invalidTitleUsedFileName warning, got {:?}",
+        task.warnings
+    );
+}
+
+#[test]
+fn update_labels_replaces_existing_labels() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlabels:\n  - old\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.labels = Some(vec!["bug".into(), "api".into()]);
+
+    let _task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    let content = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert!(content.contains("- bug"));
+    assert!(content.contains("- api"));
+    assert!(!content.contains("- old"));
+}
+
+#[test]
+fn update_body_only_replaces_body_in_file() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nold body\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.body = Some("brand new body".into());
+
+    let _task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    let content = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert!(content.contains("brand new body"));
+    assert!(!content.contains("old body"));
+}
+
+#[test]
+fn update_priority_only_writes_typed_priority() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.priority = Some("high".into());
+
+    let _task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    let content = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert!(content.contains("priority: High"));
+}
+
+#[test]
+fn update_preserves_unknown_keys_on_disk() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nassignee: alice\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.title = Some("Updated".into());
+
+    let _task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    let content = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert!(content.contains("assignee: alice"));
+}
+
+#[test]
+fn update_preserves_links_array_on_disk() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.title = Some("Updated".into());
+
+    let _task = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    let content = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert!(content.contains("tasks/b.md"));
+}
+
+#[test]
+fn update_parent_rebuilds_children_in_cache() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/p.md",
+        "---\ntitle: P\nstatus: Todo\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.parent = Some("tasks/p.md".into());
+
+    let returned = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+    assert_eq!(returned.file_path, "tasks/a.md");
+
+    let snap = state.tasks_snapshot().unwrap();
+    let parent = snap
+        .iter()
+        .find(|t| t.file_path == "tasks/p.md")
+        .expect("parent in cache");
+    assert!(parent.children.iter().any(|c| c.as_str() == "tasks/a.md"));
+}
+
+#[test]
+fn update_parent_change_removes_from_old_parent_and_adds_to_new() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/p1.md",
+        "---\ntitle: P1\nstatus: Todo\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/p2.md",
+        "---\ntitle: P2\nstatus: Todo\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nparent: tasks/p1.md\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.parent = Some("tasks/p2.md".into());
+
+    let _ = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+
+    let snap = state.tasks_snapshot().unwrap();
+    let p1 = snap.iter().find(|t| t.file_path == "tasks/p1.md").unwrap();
+    let p2 = snap.iter().find(|t| t.file_path == "tasks/p2.md").unwrap();
+    assert!(!p1.children.iter().any(|c| c.as_str() == "tasks/a.md"));
+    assert!(p2.children.iter().any(|c| c.as_str() == "tasks/a.md"));
+}
+
+#[test]
+fn update_parent_clear_removes_from_parent_children() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/p.md",
+        "---\ntitle: P\nstatus: Todo\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nparent: tasks/p.md\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let mut args = args_for("tasks/a.md");
+    args.parent = Some(String::new());
+
+    let _ = update_task_impl(&state, &FsTaskIo, args).expect("ok");
+
+    let snap = state.tasks_snapshot().unwrap();
+    let p = snap.iter().find(|t| t.file_path == "tasks/p.md").unwrap();
+    assert!(p.children.is_empty());
+}
+
+#[test]
+fn update_parent_not_found_leaves_state_untouched() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let original = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+
+    let mut args = args_for("tasks/a.md");
+    args.parent = Some("tasks/missing.md".into());
+
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    match err {
+        UpdateTaskCommandError::Validation(UpdateTaskError::ParentNotFound { path }) => {
+            assert_eq!("tasks/missing.md", path);
+        }
+        other => panic!("expected ParentNotFound, got {other:?}"),
+    }
+
+    let after = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert_eq!(original, after);
+    assert!(state.write_ignore().is_empty().unwrap());
+}
+
+#[test]
+fn update_file_not_found_when_cache_miss() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let args = args_for("tasks/ghost.md");
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(
+        err,
+        UpdateTaskCommandError::Validation(UpdateTaskError::FileNotFound(_))
+    ));
+}
+
+#[test]
+fn update_invalid_path_with_traversal_returns_invalid_path() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let args = args_for("../etc/passwd");
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(
+        err,
+        UpdateTaskCommandError::Validation(UpdateTaskError::InvalidPath(_))
+    ));
+}
+
+#[test]
+fn update_invalid_path_non_md_extension_returns_invalid_path() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let args = args_for("tasks/foo.txt");
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(
+        err,
+        UpdateTaskCommandError::Validation(UpdateTaskError::InvalidPath(_))
+    ));
+}
+
+#[test]
+fn update_invalid_path_directory_returns_invalid_path() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let args = args_for("tasks/");
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(
+        err,
+        UpdateTaskCommandError::Validation(UpdateTaskError::InvalidPath(_))
+    ));
+}
+
+#[test]
+fn update_parse_failed_when_existing_file_has_no_frontmatter() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // Now corrupt the on-disk file to have no frontmatter; cache still has the task.
+    fs::write(dir.path().join("tasks/a.md"), "no frontmatter here\n").unwrap();
+
+    let mut args = args_for("tasks/a.md");
+    args.status = Some("Doing".into());
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(
+        err,
+        UpdateTaskCommandError::Validation(UpdateTaskError::ParseFailed(_))
+    ));
+}
+
+#[test]
+fn update_returns_no_project_open_when_project_not_opened() {
+    let state = AppState::new();
+    let args = args_for("tasks/a.md");
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(err, UpdateTaskCommandError::NoProjectOpen));
+}
+
+#[test]
+fn update_body_too_large_does_not_modify_file_or_cache() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let original = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+
+    let mut args = args_for("tasks/a.md");
+    args.body = Some("a".repeat(1024 * 1024 + 1));
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    match err {
+        UpdateTaskCommandError::Validation(UpdateTaskError::ContentNotScannerEligible {
+            reason: ContentRejectReason::TooLarge { .. },
+        }) => {}
+        other => panic!("expected ContentNotScannerEligible(TooLarge), got {other:?}"),
+    }
+
+    let after = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert_eq!(original, after);
+    assert!(state.write_ignore().is_empty().unwrap());
+}
+
+#[test]
+fn update_self_cycle_is_rejected_without_filesystem_change() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let original = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+
+    let mut args = args_for("tasks/a.md");
+    args.parent = Some("tasks/a.md".into());
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(
+        err,
+        UpdateTaskCommandError::Validation(UpdateTaskError::ParentCycleOrTooDeep { .. })
+    ));
+
+    let after = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert_eq!(original, after);
+}

--- a/src-tauri/src/task/update/command_tests.rs
+++ b/src-tauri/src/task/update/command_tests.rs
@@ -383,6 +383,33 @@ fn update_invalid_path_directory_returns_invalid_path() {
 }
 
 #[test]
+fn update_parse_failed_when_existing_file_has_broken_yaml() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // Replace on-disk content with broken YAML (unclosed bracket).
+    fs::write(
+        dir.path().join("tasks/a.md"),
+        "---\ntitle: [unclosed\n---\n",
+    )
+    .unwrap();
+
+    let mut args = args_for("tasks/a.md");
+    args.status = Some("Doing".into());
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    match err {
+        UpdateTaskCommandError::Validation(UpdateTaskError::ParseFailed(_)) => {}
+        other => panic!("expected ParseFailed for broken YAML, got {other:?}"),
+    }
+}
+
+#[test]
 fn update_parse_failed_when_existing_file_has_no_frontmatter() {
     let dir = tempdir();
     seed_md(

--- a/src-tauri/src/task/update/error.rs
+++ b/src-tauri/src/task/update/error.rs
@@ -9,7 +9,6 @@ use thiserror::Error;
 
 use crate::state::AppStateError;
 use crate::task::create::error::ContentRejectReason;
-use crate::task::frontmatter::FrontmatterError;
 use crate::task::io::TaskIoError;
 use crate::task::parse::TaskParseError;
 use crate::task::task_content::TaskContentError;
@@ -39,8 +38,6 @@ pub enum UpdateTaskError {
     },
     #[error("content not scanner eligible: {reason}")]
     ContentNotScannerEligible { reason: ContentRejectReason },
-    #[error(transparent)]
-    Frontmatter(#[from] FrontmatterError),
 }
 
 #[derive(Debug, Error)]

--- a/src-tauri/src/task/update/error.rs
+++ b/src-tauri/src/task/update/error.rs
@@ -1,0 +1,108 @@
+//! `update_task` のエラー型。
+//!
+//! FE 側 `TauriError.PATTERNS` で文字列マッチされるため、Display 文字列は
+//! create_task と同じ自然文パターン (`"file not found: ..."` 等) を採用する。
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use crate::state::AppStateError;
+use crate::task::create::error::ContentRejectReason;
+use crate::task::frontmatter::FrontmatterError;
+use crate::task::io::TaskIoError;
+use crate::task::parse::TaskParseError;
+use crate::task::task_content::TaskContentError;
+use crate::task::task_index::{ParentHierarchyErrorReason, ParentValidationFailure};
+use spec_board_fs::watcher::write_ignore::WriteIgnoreError;
+
+#[derive(Debug, Error)]
+pub enum UpdateTaskError {
+    #[error("invalid path: {0}")]
+    InvalidPath(String),
+    #[error("file not found: {}", .0.display())]
+    FileNotFound(PathBuf),
+    /// 既存ファイル parse 失敗（frontmatter 不在 / 構文エラー）。
+    /// `frontmatter::parse_bytes` が `Ok(None)` を返した場合もこれにマップする。
+    #[error("parse failed: {0}")]
+    ParseFailed(String),
+    /// 指定された parent が cache に見つからない。
+    /// validate_parent_hierarchy は不在を warning にするだけのため、
+    /// plan_update 内で明示的に検出してこの variant を返す。
+    #[error("parent not found: {path}")]
+    ParentNotFound { path: String },
+    /// parent チェーンが循環している、あるいは深さ上限を超えている。
+    #[error("parent validation: {file_path} ({reason})")]
+    ParentCycleOrTooDeep {
+        file_path: String,
+        reason: ParentHierarchyErrorReason,
+    },
+    #[error("content not scanner eligible: {reason}")]
+    ContentNotScannerEligible { reason: ContentRejectReason },
+    #[error(transparent)]
+    Frontmatter(#[from] FrontmatterError),
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateTaskCommandError {
+    #[error(transparent)]
+    Validation(#[from] UpdateTaskError),
+    #[error("project is not opened")]
+    NoProjectOpen,
+    #[error("internal state lock poisoned")]
+    AppState(#[from] AppStateError),
+    #[error(transparent)]
+    WriteIgnore(#[from] WriteIgnoreError),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<ParentValidationFailure> for UpdateTaskError {
+    fn from(f: ParentValidationFailure) -> Self {
+        match f {
+            ParentValidationFailure::NotFound { parent } => Self::ParentNotFound { path: parent },
+            ParentValidationFailure::ChainInvalid { parent, reason } => {
+                Self::ParentCycleOrTooDeep {
+                    file_path: parent,
+                    reason,
+                }
+            }
+        }
+    }
+}
+
+impl From<ParentValidationFailure> for UpdateTaskCommandError {
+    fn from(f: ParentValidationFailure) -> Self {
+        Self::Validation(UpdateTaskError::from(f))
+    }
+}
+
+impl From<TaskIoError> for UpdateTaskCommandError {
+    fn from(err: TaskIoError) -> Self {
+        match err {
+            TaskIoError::Io(source) => UpdateTaskCommandError::Io(source),
+        }
+    }
+}
+
+impl From<TaskContentError> for UpdateTaskError {
+    fn from(err: TaskContentError) -> Self {
+        let reason = match err {
+            TaskContentError::TooLarge { size, .. } => ContentRejectReason::TooLarge { size },
+            TaskContentError::BinaryDetected { .. } => ContentRejectReason::BinaryDetected,
+        };
+        Self::ContentNotScannerEligible { reason }
+    }
+}
+
+impl From<TaskParseError> for UpdateTaskError {
+    fn from(err: TaskParseError) -> Self {
+        match err {
+            TaskParseError::CycleOrTooDeep { file_path, reason } => {
+                Self::ParentCycleOrTooDeep { file_path, reason }
+            }
+            TaskParseError::NotTask => Self::ParseFailed("no frontmatter found".to_string()),
+            TaskParseError::Frontmatter(e) => Self::ParseFailed(e.to_string()),
+        }
+    }
+}


### PR DESCRIPTION
## 概要

既存タスク (Markdown ファイル) を部分マージで更新する Tauri command `update_task` を実装する。`Some` で指定されたフィールドだけを既存 `Parsed { frontmatter, body }` にマージし、未知 key / `links` / YAML 値型 / 出現順をそのまま保持して書き戻す。title 変更時もファイル名は不変、parent 変更時のみ TaskIndex を再構築して `children` / `reverse_links` を再生成する。

## 変更の種類

- ✨ New Feature（バックエンド）
- 📝 Doc（仕様 / 実装ガイド）

## 追加した内容

- `task::update::command::update_task` Tauri command と effect 層 `update_task_impl`
- `task::update::args::UpdateTaskArgs` DTO と `into_intent` 正規化（`./` / `\` / drive prefix を既存 `path_lookup` と同基準で扱う lexical 正規化）
- `task::update::error::{UpdateTaskError, UpdateTaskCommandError}`（`From<TaskContentError>` / `From<TaskParseError>` / `From<ParentValidationFailure>` を実装）
- `task::task_index::{UpdateTaskIntent, UpdateTaskOutcome, plan_update}` 純粋関数
- `task::io::TaskIo::write_existing`（`FsTaskIo` / `InMemoryTaskIo` 両実装）
- `task::path_lookup::normalize_relative_path_for_input`（command 層引数と parent lookup で同じ正規化基準を共有）
- `docs/impl/update_task.md`（設計判断メモ）
- 単体テスト計 58 件（io: 3 件 / plan_update: 25 件 / args: 14 件 / command E2E: 16 件）

## 変更した内容

- `task::io::TaskIo` trait に `write_existing` メソッドを追加（既存実装は契約遵守）
- `lib.rs` の `generate_handler!` に `task::update::update_task` を登録
- `task.rs` に `pub mod update;` を追加
- `docs/spec-board/task-format-spec.md` に update_task セクションを追記

## 削除した内容

なし。

## 仕様ドキュメント更新

- `docs/spec-board/task-format-spec.md` に「update_task（部分マージ更新）」セクションを追加（マージ規則 / ファイル位置 / エラー文字列パターン / parent 変更時の cache 再構築フローを明文化）
- `docs/impl/update_task.md` を新規追加（Parsed ベース設計の根拠、validate_with_new_task ではなく validate_parent_hierarchy を使う理由、parent 存在 check / TaskContent::try_new(String) / From 実装の意図、lexical 正規化の trade-off、空 title 許可と task_from_parsed 再走の関係を記録）

## システム図

```mermaid
flowchart TD
    A[FE: invoke update_task args] --> B[update_task_impl]
    B --> C[check_tasks_cache_lock]
    C --> D[project_path / tasks_snapshot]
    D --> E[args.into_intent\n lexical 正規化]
    E --> F{cache に target?}
    F -- no --> Z1[FileNotFound]
    F -- yes --> G[io.read abs]
    G --> H[frontmatter::parse_bytes]
    H -->|Ok None / Err| Z2[ParseFailed / Frontmatter]
    H -->|Ok Some Parsed| I[TaskIndex::plan_update]
    I --> I1{parent 存在 check\n resolve_parent_for_new_task}
    I1 -- 不在 --> Z3[ParentNotFound]
    I1 -- 解決 --> I2{parent 変更?}
    I2 -- yes --> I3[Vec Task 置換 +\n validate_parent_hierarchy]
    I3 -->|Cycle / TooDeep| Z4[ParentCycleOrTooDeep]
    I3 --> I4
    I2 -- no --> I4
    I4[frontmatter::serialize] --> I5[TaskContent::try_new String]
    I5 -->|TooLarge / Binary| Z5[ContentNotScannerEligible]
    I5 --> I6[task_from_parsed 再走\n warning 再生成]
    I6 --> J{watcher 起動?}
    J -- yes --> J1[write_ignore.register]
    J -- no --> K
    J1 --> K[io.write_existing]
    K -->|Err| K1[write_ignore.unregister\n ロールバック]
    K --> L{needs_full_rebuild?}
    L -- yes --> L1[TaskIndex 再構築\n validate + build_children + build_reverse_links]
    L -- no --> L2[cache.insert single]
    L1 --> M[return Task with children/reverse_links 反映済]
    L2 --> M
    style I fill:#dfd,stroke:#363
    style I1 fill:#ffd,stroke:#960
    style I6 fill:#ffd,stroke:#960
    style L1 fill:#ddf,stroke:#369
```

## 関連Issue

Closes #84

## テスト

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets --workspace -- -D warnings`
- ✅ `cargo test --workspace`（613 件 pass: spec-board 497 / spec-board-fs 116）
- ✅ `pnpm test:run`（661 件 pass）
- ⏳ `pnpm tauri dev` での手動 round-trip（UI → BE → file system）は本セッションでは未確認。レビュアーまたは後続ジョブで実機確認をお願いします。

## レビューポイント

- **Parsed を `plan_update` に渡す設計**: `Task` 構造体は raw frontmatter を保持しないため、未知 key / `links` / YAML 値型 / 順序を維持するには effect 層で `frontmatter::parse_bytes` の結果をそのまま domain に渡す必要がある。`plan_update` は受け取った `Parsed` の mut copy に patch を当て、`frontmatter::serialize(&Parsed)` で書き戻す（`docs/impl/update_task.md` 参照）。
- **parent 存在 check を `resolve_parent_for_new_task` 経由で行う理由**: raw string equality だと `./` プレフィックスや `\` 区切りで create_task と挙動が乖離するため、create と同じ normalize_parent_path_for_lookup を使う正規化一致検索に統一している。
- **空 title 許可と warning 再生成**: 空 title を弾くと既存ファイルに空 title が書かれていた場合に挙動が乖離するため許可。最終的な Task は `task_from_parsed` を再走させて `invalidTitleUsedFileName` warning を再生成する（source of truth は parser 側）。
- **lexical 正規化のみで canonicalize しない trade-off**: symlink を悪用した root 外書き込みは検出できないが、`..` 検出 / `strip_prefix(root)` で実用上は十分。`docs/impl/update_task.md` に記載。
- **cache 再構築の条件**: `needs_full_rebuild=true`（parent 変更時）のみ TaskIndex 全体再構築。scalar / labels / body / title / status / priority 単独更新は他タスクに影響しないため再構築しない。

## チェックリスト

- [x] セルフレビューを実施した
- [x] `pnpm test:run` が通る
- [x] `cargo test` / `cargo clippy` / `cargo fmt --check` が通る
- [x] 仕様変更があるため `docs/spec-board/task-format-spec.md` を更新
- [x] feature 間の依存は公開 API 経由（task::update::update_task が唯一の公開点）
- [x] 関連 Issue #84 を PR にリンク
- [ ] UI 変更は無いが、`pnpm tauri dev` 経由の round-trip 確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)