### PR TITLE
✨ [New Feature]: #110 [FE] HTML5 ネイティブ DnD でカード移動 / 並び替え

### DIFF
--- a/docs/impl/dnd-board.md
+++ b/docs/impl/dnd-board.md
@@ -46,7 +46,7 @@ toIndex 計算には次の罠がある:
 - 同一カラム内で「元 index < toIndex」のとき、元 task を除外せずに insert すると重複や位置ズレが起きる
 - toIndex が `tasks.length` を超える可能性がある（hover 計算の境界と挿入境界が別）
 
-これらを「target を一度除外 → clamp → 挿入」で一括処理する純粋関数として切り出した。Action 層 (`moveTaskAction`) と reducer / domain 層 (`applyCardOrderUpdated`) の双方から使え、テストもこの 1 関数に集約できる。
+これらを「同一カラムの hover index 補正 → target 除外 → clamp → 挿入」で一括処理する純粋関数として切り出した。Action 層 (`moveTaskAction`) からのみ呼ばれる feature レイヤの helper であり、`domains/project-data` の `applyCardOrderUpdated` はこの関数に依存しない（domain 側は IPC 確定後の filePaths を入力として受け取る）。テストもこの 1 関数に集約できる。
 
 ## `applyCardOrderUpdated` を ProjectData の companion に追加する
 

--- a/docs/impl/dnd-board.md
+++ b/docs/impl/dnd-board.md
@@ -37,7 +37,7 @@ drop 直後にローカルで先に並び替えてから IPC を投げる「楽�
 1. `update_task({ status: toColumn })`
 2. `update_card_order(toColumn, ...)`
 
-旧カラムの cardOrder は **BE 側 watcher が status 変更を検知して自動除去する**契約とした（BE 実装 issue 側で明文化）。3 連目をクライアント側で発行しないことで、レースコンディションが減り、reducer dispatch も 2 段で済む。
+旧カラムの cardOrder は **BE 側 watcher が status 変更を検知して自動除去する**契約とした（BE 実装 issue 側で明文化）。クライアント側で旧カラム向けの `update_card_order(fromColumn, ...)` を発行しないことで、レースコンディションが減り、reducer dispatch も 2 段で済む（残る IPC は `update_task` と `update_card_order(toColumn, ...)` の 2 つ）。
 
 ## `buildMovedFilePaths` を純粋関数として切り出す
 

--- a/docs/impl/dnd-board.md
+++ b/docs/impl/dnd-board.md
@@ -1,0 +1,73 @@
+# 実装メモ: Native DnD Board
+
+カンバンボードのカード Drag and Drop を、外部ライブラリを入れずに HTML5 ネイティブ DnD API のみで実現したときの設計判断を残す。`docs/spec-board/board-view-spec.md` が「何が起きるか」、ここでは「なぜそう書いたか」を扱う。
+
+## ライブラリを入れない理由
+
+`@dnd-kit/*` 等の DnD ライブラリは強力だが、本アプリの DnD 要件はシンプル（カード単位の並び替え + カラム間移動のみ）で、ネイティブ API で十分賄える。依存追加によるバンドルサイズ増 / バージョン追従コスト / ライブラリ独自の状態管理を学ぶコストを避け、Web 標準で完結させる方針とした。
+
+## DragState を Project state に持たない
+
+ドラッグ中の hover 位置や draggingTaskFilePath は **Board ローカルの useReducer** に置き、`useProject` の state には載せていない。
+
+理由:
+
+- ドラッグ中は per-pixel で更新が走るため、project state に置くと無関係なコンポーネントまで再 render される
+- DragState は IPC 確定前の一時的な UI 状態であり、永続化する必要が無い
+- 「project の真実」と「進行中の操作」を分離することで、reducer のテストが純粋に保てる
+
+## 楽観的 UI 更新を採用しない
+
+drop 直後にローカルで先に並び替えてから IPC を投げる「楽観 UI」は採用しなかった。
+
+- 既存の `createTask` / `updateTask` / `deleteTask` が IPC 完了後 dispatch のパターンで統一されており、それと整合させたい
+- 失敗時のロールバックロジックを書くと、ローカルでの並び替え状態と IPC 失敗時の真実状態の整合を取る複雑度が増える
+- IPC は数十 ms オーダーで完了するため、体感上の問題は無い
+
+## 3 連 IPC を避ける（旧カラム cardOrder の自動メンテ）
+
+カラム間移動の素朴な設計は次の 3 連だった:
+
+1. `update_task({ status: toColumn })`
+2. `update_card_order(fromColumn, ...)` — 旧カラムから外す
+3. `update_card_order(toColumn, ...)` — 新カラムに挿入
+
+これを **2 連 IPC** に削った:
+
+1. `update_task({ status: toColumn })`
+2. `update_card_order(toColumn, ...)`
+
+旧カラムの cardOrder は **BE 側 watcher が status 変更を検知して自動除去する**契約とした（BE 実装 issue 側で明文化）。3 連目をクライアント側で発行しないことで、レースコンディションが減り、reducer dispatch も 2 段で済む。
+
+## `buildMovedFilePaths` を純粋関数として切り出す
+
+toIndex 計算には次の罠がある:
+
+- 同一カラム内で「元 index < toIndex」のとき、元 task を除外せずに insert すると重複や位置ズレが起きる
+- toIndex が `tasks.length` を超える可能性がある（hover 計算の境界と挿入境界が別）
+
+これらを「target を一度除外 → clamp → 挿入」で一括処理する純粋関数として切り出した。Action 層 (`moveTaskAction`) と reducer / domain 層 (`applyCardOrderUpdated`) の双方から使え、テストもこの 1 関数に集約できる。
+
+## `applyCardOrderUpdated` を ProjectData の companion に追加する
+
+並び順反映ロジックは `domains/project-data` の companion API に inline で追加した（`Impl` ラッパは作らない）。理由:
+
+- `applyTaskCreated` / `applyTaskUpdated` / `applyTaskDeleted` と隣接配置することで、ドメインルールの一貫性が読みやすくなる
+- reducer から呼ぶ際の経路が短い（`ProjectSessionState.updateData(state, (data) => ProjectData.applyCardOrderUpdated(...))` の 1 行）
+- companion オブジェクトの責務（pure data transform）に完全に合致する
+
+## 「並び順変化なし」は IPC を呼ばない
+
+drop 後の filePaths を計算した結果、現状と完全一致なら `Result.ok(undefined)` で no-op return する。BE / ファイルシステムへの不要な書き込みと watcher 由来の余計な再 render を防ぐ。
+
+## DragLikeEvent をテストヘルパーに
+
+happy-dom 20 は `DragEvent` クラスを提供しない。`Event` のサブクラス `DragLikeEvent` を `src/test-fixtures/createDragEvent.ts` に置き、`dataTransfer` / `clientX` / `clientY` をインスタンスフィールドとして持たせた。
+
+旧来の `Object.defineProperty` で後付け注入する書き方は、繰り返しが多く `readonly` の意味も型レベルで表現できない。サブクラス化することで宣言的になり、`instanceof DragLikeEvent` でテスト内のマッチングも書きやすくなる。
+
+## drag 直後の synthetic click を抑止する
+
+`role="button"` の TaskCard はクリックで詳細パネルを開く。HTML5 ネイティブ DnD は `dragend` 直後に同位置の `click` イベントを synthetic に発火させるため、ドロップしただけで詳細パネルが意図せず開いてしまう。
+
+`dragGuardRef` を `true` に立て、`dragend` で `setTimeout(..., 0)` で 1 macrotask 後に解除することで、間に挟まる synthetic click だけを `onClick` から弾く。

--- a/docs/spec-board/board-view-spec.md
+++ b/docs/spec-board/board-view-spec.md
@@ -45,8 +45,8 @@
 | 操作 | トリガー | 振る舞い | 遷移先 |
 |:-----|:--------|:---------|:-------|
 | プロジェクトを開く | 「開く」ボタンクリック | OSのディレクトリ選択ダイアログを表示。選択後にmdファイルを読み込んでボードに表示 | ボードビュー |
-| タスクのステータス変更 | カードをドラッグして別カラムにドロップ | 対象タスクのmdファイルのフロントマター `status` を更新 | - |
-| カラム内のカード並び替え | カードをドラッグして同一カラム内でドロップ | カードの表示順序を更新し、`config.json` の `cardOrder` に永続化（[config-spec.md](./config-spec.md) 参照） | - |
+| タスクのステータス変更 | カードをドラッグして別カラムにドロップ | `update_task` IPC で対象タスクの frontmatter `status` を更新したのち、移動先カラムに対して `update_card_order` を 1 回呼び出す。旧カラムの `cardOrder` は BE 側 watcher が `status` 変更を検知して自動除去する契約 | - |
+| カラム内のカード並び替え | カードをドラッグして同一カラム内でドロップ | `update_card_order` IPC を 1 回呼び出してカード表示順を `.spec-board/config.json` の `cardOrder` に永続化（[config-spec.md](./config-spec.md) 参照）。並び順に変化が無い場合は IPC を呼ばない | - |
 | カラムの追加 | 「+ カラムを追加」ボタンクリック | カラム名入力フィールドを表示。入力確定で新カラムを追加 | - |
 | カラム名の編集 | カラムヘッダーのステータス名をクリック | インライン編集モードに切り替わり、ステータス名を変更可能。該当するタスクのmdファイルも一括更新 | - |
 | カラムの削除 | カラムヘッダーの右クリックメニュー | 確認ダイアログを表示。カラム内にタスクがある場合は移動先カラムをドロップダウンで選択させ、全タスクの `status` を一括更新してから削除。タスクがない場合はそのまま削除 | - |
@@ -108,6 +108,39 @@ stateDiagram-v2
 | キーボード操作 | Tab でカード間移動、Enter で詳細パネル展開、矢印キーでカラム間移動 |
 | スクリーンリーダー | カラムに `role="list"`、カードに `role="listitem"` を付与。ドラッグ操作時にライブリージョンでステータス変更を通知 |
 | フォーカス管理 | ドラッグ&ドロップ完了後、移動したカードにフォーカスを維持 |
+
+## ドラッグ&ドロップ仕様
+
+### 基本方針
+
+- HTML5 ネイティブ Drag and Drop API のみで実装する（外部 DnD ライブラリは導入しない）
+- カード要素に `draggable="true"` を付与し、独自 MIME `application/x-spec-board-task` で payload を運ぶ
+- 外部からの D&D（テキスト・ファイル等、独自 MIME を持たないもの）は `dragover` で `preventDefault` せず drop を受け付けない
+- BE 側コマンド `update_task` / `update_card_order` の実装は本仕様の依存先とする（別 issue で起票）
+
+### IPC シーケンス
+
+| 種類 | IPC 呼び出し |
+|:-----|:------------|
+| カラム間移動 | (1) `update_task({ filePath, status: toColumn })`、(2) 成功後 `update_card_order({ columnName: toColumn, filePaths })`。旧カラムの cardOrder は BE 側 watcher が status 変更を検知して自動除去する契約 |
+| 同一カラム内並び替え | `update_card_order({ columnName, filePaths })` を 1 回。並び順に変化が無い場合は IPC を呼ばない |
+
+楽観的 UI 更新は採用しない（IPC 完了後に reducer dispatch）。
+
+### UI 表現
+
+| 状態 | 表現 |
+|:-----|:----|
+| ドラッグ中のカード | `data-dragging="true"` 属性 + opacity 0.4 のクラスを付与 |
+| Drop ターゲットの hover 位置 | 対応する位置に `<li data-testid="drop-placeholder" aria-hidden="true">` のセパレータを表示 |
+| 中央境界判定 | マウス Y 座標がカード中央より厳密に上 (`clientY < middle`) なら上半分、それ以外（中央ピッタリ含む）は下半分扱い |
+
+### エッジケース
+
+- ESC キー押下: ブラウザが `dragend` を発火し、自動で IDLE 状態へ復帰
+- Drag 直後の synthetic click: `dragGuardRef` で次の macrotask まで `onClick` を抑止し、誤って詳細パネルが開かないようにする
+- IPC 失敗: 「タスクの移動に失敗しました」トーストを表示。dragState は finally で必ず null に戻す
+- stale state: queue 実行時に対象タスクが見つからない / `fromColumn` と `status` が乖離 / `toColumn` が消滅した場合は `invalid-state` で抜ける
 
 ## 制限事項
 

--- a/docs/spec-board/board-view-spec.md
+++ b/docs/spec-board/board-view-spec.md
@@ -46,7 +46,7 @@
 |:-----|:--------|:---------|:-------|
 | プロジェクトを開く | 「開く」ボタンクリック | OSのディレクトリ選択ダイアログを表示。選択後にmdファイルを読み込んでボードに表示 | ボードビュー |
 | タスクのステータス変更 | カードをドラッグして別カラムにドロップ | `update_task` IPC で対象タスクの frontmatter `status` を更新したのち、移動先カラムに対して `update_card_order` を 1 回呼び出す。旧カラムの `cardOrder` は BE 側 watcher が `status` 変更を検知して自動除去する契約 | - |
-| カラム内のカード並び替え | カードをドラッグして同一カラム内でドロップ | `update_card_order` IPC を 1 回呼び出してカード表示順を `.spec-board/config.json` の `cardOrder` に永続化（[config-spec.md](./config-spec.md) 参照）。並び順に変化が無い場合は IPC を呼ばない | - |
+| カラム内のカード並び替え | カードをドラッグして同一カラム内でドロップ | `update_card_order` IPC を 1 回呼び出してカード表示順を `.spec-board/config.json` の `cardOrder` に永続化（[config-spec.md](./config-spec.md) 参照）。並び順に変化が無い場合は IPC を呼ばない。**reopen 時の rehydration（`open_project` が `config.card_order` を読み込みカラム内の tasks を並び替える）は BE 側の対応が必要（別 issue 依存）** | - |
 | カラムの追加 | 「+ カラムを追加」ボタンクリック | カラム名入力フィールドを表示。入力確定で新カラムを追加 | - |
 | カラム名の編集 | カラムヘッダーのステータス名をクリック | インライン編集モードに切り替わり、ステータス名を変更可能。該当するタスクのmdファイルも一括更新 | - |
 | カラムの削除 | カラムヘッダーの右クリックメニュー | 確認ダイアログを表示。カラム内にタスクがある場合は移動先カラムをドロップダウンで選択させ、全タスクの `status` を一括更新してから削除。タスクがない場合はそのまま削除 | - |
@@ -116,7 +116,7 @@ stateDiagram-v2
 - HTML5 ネイティブ Drag and Drop API のみで実装する（外部 DnD ライブラリは導入しない）
 - カード要素に `draggable="true"` を付与し、独自 MIME `application/x-spec-board-task` で payload を運ぶ
 - 外部からの D&D（テキスト・ファイル等、独自 MIME を持たないもの）は `dragover` で `preventDefault` せず drop を受け付けない
-- BE 側コマンド `update_task` / `update_card_order` の実装は本仕様の依存先とする（別 issue で起票）
+- BE 側コマンド `update_task` / `update_card_order` の実装、および `open_project` が `config.card_order` を読み込んでカラム内 tasks を rehydrate する処理は本仕様の依存先とする（別 issue で起票）。現状の `open_project` は tasks を id 順で返すため、保存した cardOrder が reopen 後に反映されないことを許容する
 
 ### IPC シーケンス
 

--- a/docs/spec-board/board-view-spec.md
+++ b/docs/spec-board/board-view-spec.md
@@ -139,7 +139,8 @@ stateDiagram-v2
 
 - ESC キー押下: ブラウザが `dragend` を発火し、自動で IDLE 状態へ復帰
 - Drag 直後の synthetic click: `dragGuardRef` で次の macrotask まで `onClick` を抑止し、誤って詳細パネルが開かないようにする
-- IPC 失敗: 「タスクの移動に失敗しました」トーストを表示。dragState は finally で必ず null に戻す
+- IPC 失敗（generic）: `update_task` 失敗 / 同一カラム内の `update_card_order` 失敗時は「タスクの移動に失敗しました: &lt;原因&gt;」トーストを表示。dragState は finally で必ず null に戻す
+- IPC 部分失敗（partial-move）: カラム間移動で `update_task` 成功 + `update_card_order` 失敗のときは、カラム移動だけは完了しているため「カラムの移動は完了しましたが、並び順の保存に失敗しました。手動で並び替えてください。」と区別して表示する
 - stale state: queue 実行時に対象タスクが見つからない / `fromColumn` と `status` が乖離 / `toColumn` が消滅した場合は `invalid-state` で抜ける
 
 ## 制限事項

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Board,
   EmptyState,
   HeaderBar,
+  type MoveTaskParams,
   type ProjectError,
   type ProjectState,
   useProject,
@@ -84,6 +85,7 @@ export const App = () => {
     updateTask,
     deleteTask,
     updateColumns,
+    moveTask,
   } = useProject({
     onError: (err) => {
       showToast(projectErrorMessage(err), "error");
@@ -383,6 +385,17 @@ export const App = () => {
     [createTask, showToast],
   );
 
+  const handleTaskDrop = useCallback(
+    async (params: MoveTaskParams): Promise<void> => {
+      const result = await moveTask(params);
+      if (!result.ok) {
+        const message = projectErrorMessage(result.error);
+        showToast(`タスクの移動に失敗しました: ${message}`, "error");
+      }
+    },
+    [moveTask, showToast],
+  );
+
   const handleTaskDelete = useCallback(
     async (id: string): Promise<void> => {
       const filePath = tasks.find((t) => t.id === id)?.filePath;
@@ -433,6 +446,7 @@ export const App = () => {
           onRenameColumn={handleRenameColumn}
           onDeleteColumn={handleDeleteColumn}
           onTaskClick={handleTaskClick}
+          onTaskDrop={handleTaskDrop}
         />
         {tasks.length === 0 && (
           <div className="pointer-events-none absolute inset-x-0 top-12 flex justify-center">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,12 @@ import type { Task } from "./types/task";
  * @param err useProject から運ばれるエラー
  * @returns toast 等に出せる文字列
  */
-const projectErrorMessage = (err: ProjectError): string =>
-  err.kind === "tauri" ? err.error.message : err.message;
+const projectErrorMessage = (err: ProjectError): string => {
+  if (err.kind === "tauri") {
+    return err.error.message;
+  }
+  return err.message;
+};
 
 /** State の表示用 ProjectData を返すための内部型。 */
 type DisplayableData = {
@@ -389,6 +393,10 @@ export const App = () => {
     async (params: MoveTaskParams): Promise<void> => {
       const result = await moveTask(params);
       if (!result.ok) {
+        if (result.error.kind === "partial-move") {
+          showToast(result.error.message, "error");
+          return;
+        }
         const message = projectErrorMessage(result.error);
         showToast(`タスクの移動に失敗しました: ${message}`, "error");
       }

--- a/src/__tests__/App.interaction.test.tsx
+++ b/src/__tests__/App.interaction.test.tsx
@@ -10,6 +10,7 @@ import {
   vi,
 } from "vitest";
 import { App } from "@/App";
+import { DRAG_MIME_TYPE } from "@/features/board/components/Board/dragState";
 import {
   createTask as createTaskInvoke,
   deleteTask as deleteTaskInvoke,
@@ -18,9 +19,11 @@ import {
   openDirectoryDialog,
   openProject as openProjectInvoke,
   TauriError,
+  updateCardOrder as updateCardOrderInvoke,
   updateColumns as updateColumnsInvoke,
   updateTask as updateTaskInvoke,
 } from "@/lib/tauri";
+import { createDragEvent } from "@/test-fixtures/createDragEvent";
 import { Task } from "@/types/task";
 import { Result } from "@/utils/result";
 
@@ -36,6 +39,7 @@ vi.mock("@/lib/tauri", async () => {
     updateTask: vi.fn(),
     deleteTask: vi.fn(),
     updateColumns: vi.fn(),
+    updateCardOrder: vi.fn(),
   };
 });
 
@@ -50,6 +54,7 @@ const createTaskMock = vi.mocked(createTaskInvoke);
 const updateTaskMock = vi.mocked(updateTaskInvoke);
 const deleteTaskMock = vi.mocked(deleteTaskInvoke);
 const updateColumnsMock = vi.mocked(updateColumnsInvoke);
+const updateCardOrderMock = vi.mocked(updateCardOrderInvoke);
 
 const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -99,6 +104,7 @@ beforeEach(() => {
   updateTaskMock.mockReset();
   deleteTaskMock.mockReset();
   updateColumnsMock.mockReset();
+  updateCardOrderMock.mockReset();
 });
 
 afterEach(() => {
@@ -612,4 +618,67 @@ test("再 open の loading 中は旧 Board を非表示にして loading を表�
     await Promise.resolve();
   });
   expect(container?.textContent).toContain("A タスク");
+});
+
+/**
+ * Board の TaskCard を dragstart → Done カラム section へ drop して
+ * App.handleTaskDrop の onTaskDrop callback を発火させる。
+ */
+const dropFirstCardToDone = async () => {
+  const card = container?.querySelector<HTMLElement>(
+    "[data-testid='task-card']",
+  );
+  const doneSection = container?.querySelector<HTMLElement>(
+    "section[aria-label='Done']",
+  );
+  expect(card).not.toBeNull();
+  expect(doneSection).not.toBeNull();
+  await act(async () => {
+    card?.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const drop = createDragEvent("drop");
+  drop.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  await act(async () => {
+    doneSection?.dispatchEvent(drop);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+test("moveTask 失敗（generic）→ 「タスクの移動に失敗しました」 toast を表示", async () => {
+  mountApp();
+  await openSuccessfully();
+
+  updateTaskMock.mockResolvedValueOnce(
+    Result.err(new TauriError("IO_ERROR", "io fail")),
+  );
+
+  await dropFirstCardToDone();
+
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
+  expect(updateCardOrderMock).not.toHaveBeenCalled();
+  expect(container?.textContent).toContain("タスクの移動に失敗しました");
+  expect(container?.textContent).not.toContain("並び順の保存に失敗");
+});
+
+test("moveTask 部分失敗（partial-move）→ 並び順保存失敗の専用 toast を表示", async () => {
+  mountApp();
+  await openSuccessfully();
+
+  const movedA: Task = { ...taskA, status: "Done" };
+  updateTaskMock.mockResolvedValueOnce(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValueOnce(
+    Result.err(new TauriError("IO_ERROR", "order fail")),
+  );
+
+  await dropFirstCardToDone();
+
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
+  expect(updateCardOrderMock).toHaveBeenCalledTimes(1);
+  expect(container?.textContent).toContain("並び順の保存に失敗しました");
+  expect(container?.textContent).not.toContain("タスクの移動に失敗しました");
 });

--- a/src/domains/project-data/__tests__/applyCardOrderUpdated.behavior.test.ts
+++ b/src/domains/project-data/__tests__/applyCardOrderUpdated.behavior.test.ts
@@ -79,7 +79,7 @@ test("tasks.length は前後で変化しない", () => {
   expect(next.tasks.length).toBe(data.tasks.length);
 });
 
-test("filePaths にない既知でない path は無視される", () => {
+test("filePaths に含まれる未知の path は無視される", () => {
   const data = dataOf([
     ["tasks/a.md", "Todo"],
     ["tasks/b.md", "Todo"],

--- a/src/domains/project-data/__tests__/applyCardOrderUpdated.behavior.test.ts
+++ b/src/domains/project-data/__tests__/applyCardOrderUpdated.behavior.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "vitest";
+import { makeTask } from "@/domains/__tests__/taskFixtures";
+import type { Column } from "@/types/column";
+import { ProjectData, type ProjectData as ProjectDataT } from "..";
+
+const columns = (...names: string[]): Column[] =>
+  names.map((name, order) => ({ name, order }));
+
+const dataOf = (
+  pairs: ReadonlyArray<readonly [string, string]>,
+): ProjectDataT => ({
+  tasks: pairs.map(([filePath, status]) =>
+    makeTask({ id: filePath, filePath, status }),
+  ),
+  columns: columns("Todo", "Done"),
+});
+
+test("対象カラム内のタスクを filePaths 順に並べ替える", () => {
+  const data = dataOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/c.md", "Todo"],
+  ]);
+  const next = ProjectData.applyCardOrderUpdated(data, "Todo", [
+    "tasks/c.md",
+    "tasks/a.md",
+    "tasks/b.md",
+  ]);
+  expect(next.tasks.map((t) => t.filePath)).toEqual([
+    "tasks/c.md",
+    "tasks/a.md",
+    "tasks/b.md",
+  ]);
+});
+
+test("他カラムのタスク順序は維持される", () => {
+  const data = dataOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/x.md", "Done"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/y.md", "Done"],
+  ]);
+  const next = ProjectData.applyCardOrderUpdated(data, "Todo", [
+    "tasks/b.md",
+    "tasks/a.md",
+  ]);
+  expect(next.tasks.map((t) => t.filePath)).toEqual([
+    "tasks/b.md",
+    "tasks/x.md",
+    "tasks/a.md",
+    "tasks/y.md",
+  ]);
+});
+
+test("filePaths に含まれないタスクは末尾にフォールバック配置（元出現順を維持）", () => {
+  const data = dataOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/c.md", "Todo"],
+  ]);
+  const next = ProjectData.applyCardOrderUpdated(data, "Todo", ["tasks/c.md"]);
+  expect(next.tasks.map((t) => t.filePath)).toEqual([
+    "tasks/c.md",
+    "tasks/a.md",
+    "tasks/b.md",
+  ]);
+});
+
+test("tasks.length は前後で変化しない", () => {
+  const data = dataOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/x.md", "Done"],
+    ["tasks/b.md", "Todo"],
+  ]);
+  const next = ProjectData.applyCardOrderUpdated(data, "Todo", [
+    "tasks/b.md",
+    "tasks/a.md",
+  ]);
+  expect(next.tasks.length).toBe(data.tasks.length);
+});
+
+test("filePaths にない既知でない path は無視される", () => {
+  const data = dataOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+  ]);
+  const next = ProjectData.applyCardOrderUpdated(data, "Todo", [
+    "tasks/unknown.md",
+    "tasks/b.md",
+    "tasks/a.md",
+  ]);
+  expect(next.tasks.map((t) => t.filePath)).toEqual([
+    "tasks/b.md",
+    "tasks/a.md",
+  ]);
+});

--- a/src/domains/project-data/index.ts
+++ b/src/domains/project-data/index.ts
@@ -167,4 +167,52 @@ export const ProjectData = {
     ...data,
     doneColumn,
   }),
+
+  /**
+   * 指定カラム内のタスクを filePaths の順序で並べ替える。
+   *
+   * - 対象カラム外のタスク順序は維持
+   * - filePaths に含まれない対象カラム内タスクは末尾に元出現順で配置
+   * - tasks.length は変化しない
+   *
+   * @param data 元 ProjectData
+   * @param columnName 並べ替え対象のカラム名
+   * @param filePaths 期待する並び順（先頭が最上位）
+   * @returns 並び替え後の ProjectData
+   */
+  applyCardOrderUpdated: (
+    data: ProjectData,
+    columnName: string,
+    filePaths: readonly string[],
+  ): ProjectData => {
+    const inColumn = data.tasks.filter((t) => t.status === columnName);
+    if (inColumn.length === 0) {
+      return data;
+    }
+    const inColumnByFilePath = new Map(inColumn.map((t) => [t.filePath, t]));
+    const ordered: Task[] = [];
+    const used = new Set<string>();
+    for (const filePath of filePaths) {
+      const task = inColumnByFilePath.get(filePath);
+      if (task !== undefined && !used.has(filePath)) {
+        ordered.push(task);
+        used.add(filePath);
+      }
+    }
+    for (const task of inColumn) {
+      if (!used.has(task.filePath)) {
+        ordered.push(task);
+      }
+    }
+    let cursor = 0;
+    const tasks = data.tasks.map((task) => {
+      if (task.status !== columnName) {
+        return task;
+      }
+      const next = ordered[cursor];
+      cursor += 1;
+      return next ?? task;
+    });
+    return { ...data, tasks };
+  },
 } as const;

--- a/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
@@ -140,9 +140,12 @@ test("drop 完了後に dragState がリセットされる（プレースホル�
   act(() => {
     doneSection?.dispatchEvent(hover);
   });
-  expect(
-    container?.querySelector("[data-testid='drop-placeholder']"),
-  ).not.toBeNull();
+  // hover index 更新は rAF 越しに反映されるため waitFor で同期する
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelector("[data-testid='drop-placeholder']"),
+    ).not.toBeNull();
+  });
   const drop = createDragEvent("drop");
   drop.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
   act(() => {

--- a/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
@@ -47,17 +47,21 @@ const render = (props: Parameters<typeof Board>[0]) => {
   });
 };
 
-const queryCard = (filePath: string): HTMLElement => {
-  const cards = Array.from(
-    container?.querySelectorAll<HTMLElement>("[data-testid='task-card']") ?? [],
+/**
+ * カラム内の n 番目（0-origin）の TaskCard を取り出す。
+ * Mutating な dragstart 経由で識別するのを避け、DOM 構造のみで取得する。
+ */
+const queryCardInColumn = (columnName: string, index: number): HTMLElement => {
+  const section = container?.querySelector<HTMLElement>(
+    `section[aria-label='${columnName}']`,
   );
-  const matched = cards.find((c) => {
-    const drag = createDragEvent("dragstart");
-    c.dispatchEvent(drag);
-    return drag.dataTransfer.getData(DRAG_MIME_TYPE) === filePath;
-  });
-  expect(matched).toBeDefined();
-  return matched as HTMLElement;
+  expect(section).not.toBeNull();
+  const cards = section?.querySelectorAll<HTMLElement>(
+    "[data-testid='task-card']",
+  );
+  const card = cards?.[index];
+  expect(card).toBeDefined();
+  return card as HTMLElement;
 };
 
 const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
@@ -86,7 +90,7 @@ test("drop で onTaskDrop prop が期待引数で呼ばれる", async () => {
     onAddTask: vi.fn(),
     onTaskDrop,
   });
-  const cardA = queryCard("tasks/a.md");
+  const cardA = queryCardInColumn("Todo", 0);
   act(() => {
     cardA.dispatchEvent(createDragEvent("dragstart"));
   });
@@ -124,7 +128,7 @@ test("drop 完了後に dragState がリセットされる（プレースホル�
     onAddTask: vi.fn(),
     onTaskDrop,
   });
-  const cardA = queryCard("tasks/a.md");
+  const cardA = queryCardInColumn("Todo", 0);
   act(() => {
     cardA.dispatchEvent(createDragEvent("dragstart"));
   });
@@ -159,7 +163,7 @@ test("onTaskDrop が reject しても finally で dragState が null になる",
     onAddTask: vi.fn(),
     onTaskDrop,
   });
-  const cardA = queryCard("tasks/a.md");
+  const cardA = queryCardInColumn("Todo", 0);
   act(() => {
     cardA.dispatchEvent(createDragEvent("dragstart"));
   });
@@ -183,7 +187,7 @@ test("onTaskDrop が reject しても finally で dragState が null になる",
 
 test("dragend 単独（drop なし）で dragState が null になる", () => {
   render({ columns, tasks: [taskA, taskB], onAddTask: vi.fn() });
-  const cardA = queryCard("tasks/a.md");
+  const cardA = queryCardInColumn("Todo", 0);
   act(() => {
     cardA.dispatchEvent(createDragEvent("dragstart"));
   });

--- a/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
@@ -1,0 +1,195 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { createDragEvent } from "@/test-fixtures/createDragEvent";
+import type { Column as ColumnType } from "@/types/column";
+import { Task, type TaskPayload } from "@/types/task";
+import { Board } from "..";
+import { DRAG_MIME_TYPE } from "../dragState";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const makeTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+const columns: ColumnType[] = [
+  { name: "Todo", order: 0 },
+  { name: "Done", order: 1 },
+];
+
+const render = (props: Parameters<typeof Board>[0]) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(Board, props));
+  });
+};
+
+const queryCard = (filePath: string): HTMLElement => {
+  const cards = Array.from(
+    container?.querySelectorAll<HTMLElement>("[data-testid='task-card']") ?? [],
+  );
+  const matched = cards.find((c) => {
+    const drag = createDragEvent("dragstart");
+    c.dispatchEvent(drag);
+    return drag.dataTransfer.getData(DRAG_MIME_TYPE) === filePath;
+  });
+  expect(matched).toBeDefined();
+  return matched as HTMLElement;
+};
+
+const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
+const taskB = makeTask({ id: "b", filePath: "tasks/b.md", status: "Done" });
+
+test("dragstart 後、対象カードに data-dragging='true' が付く", () => {
+  render({ columns, tasks: [taskA, taskB], onAddTask: vi.fn() });
+  const cards =
+    container?.querySelectorAll<HTMLElement>("[data-testid='task-card']") ?? [];
+  const cardA = cards[0];
+  expect(cardA).toBeDefined();
+  act(() => {
+    cardA?.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const refreshed = container?.querySelector<HTMLElement>(
+    "[data-dragging='true']",
+  );
+  expect(refreshed).not.toBeNull();
+});
+
+test("drop で onTaskDrop prop が期待引数で呼ばれる", async () => {
+  const onTaskDrop = vi.fn().mockResolvedValue(undefined);
+  render({
+    columns,
+    tasks: [taskA, taskB],
+    onAddTask: vi.fn(),
+    onTaskDrop,
+  });
+  const cardA = queryCard("tasks/a.md");
+  act(() => {
+    cardA.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const doneSection = container?.querySelector<HTMLElement>(
+    "section[aria-label='Done']",
+  );
+  expect(doneSection).not.toBeNull();
+  // hover first
+  const hover = createDragEvent("dragover", { clientY: 0 });
+  hover.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    doneSection?.dispatchEvent(hover);
+  });
+  // then drop
+  const drop = createDragEvent("drop");
+  drop.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    doneSection?.dispatchEvent(drop);
+  });
+  await vi.waitFor(() => {
+    expect(onTaskDrop).toHaveBeenCalledWith({
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: expect.any(Number),
+    });
+  });
+});
+
+test("drop 完了後に dragState がリセットされる（プレースホルダ消失）", async () => {
+  const onTaskDrop = vi.fn().mockResolvedValue(undefined);
+  render({
+    columns,
+    tasks: [taskA, taskB],
+    onAddTask: vi.fn(),
+    onTaskDrop,
+  });
+  const cardA = queryCard("tasks/a.md");
+  act(() => {
+    cardA.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const doneSection = container?.querySelector<HTMLElement>(
+    "section[aria-label='Done']",
+  );
+  const hover = createDragEvent("dragover", { clientY: 0 });
+  hover.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    doneSection?.dispatchEvent(hover);
+  });
+  expect(
+    container?.querySelector("[data-testid='drop-placeholder']"),
+  ).not.toBeNull();
+  const drop = createDragEvent("drop");
+  drop.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    doneSection?.dispatchEvent(drop);
+  });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelector("[data-testid='drop-placeholder']"),
+    ).toBeNull();
+  });
+});
+
+test("onTaskDrop が reject しても finally で dragState が null になる", async () => {
+  const onTaskDrop = vi.fn().mockRejectedValue(new Error("boom"));
+  render({
+    columns,
+    tasks: [taskA, taskB],
+    onAddTask: vi.fn(),
+    onTaskDrop,
+  });
+  const cardA = queryCard("tasks/a.md");
+  act(() => {
+    cardA.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const doneSection = container?.querySelector<HTMLElement>(
+    "section[aria-label='Done']",
+  );
+  const hover = createDragEvent("dragover", { clientY: 0 });
+  hover.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    doneSection?.dispatchEvent(hover);
+  });
+  const drop = createDragEvent("drop");
+  drop.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    doneSection?.dispatchEvent(drop);
+  });
+  await vi.waitFor(() => {
+    expect(container?.querySelector("[data-dragging='true']")).toBeNull();
+  });
+});
+
+test("dragend 単独（drop なし）で dragState が null になる", () => {
+  render({ columns, tasks: [taskA, taskB], onAddTask: vi.fn() });
+  const cardA = queryCard("tasks/a.md");
+  act(() => {
+    cardA.dispatchEvent(createDragEvent("dragstart"));
+  });
+  expect(container?.querySelector("[data-dragging='true']")).not.toBeNull();
+  act(() => {
+    cardA.dispatchEvent(createDragEvent("dragend"));
+  });
+  expect(container?.querySelector("[data-dragging='true']")).toBeNull();
+});

--- a/src/features/board/components/Board/__tests__/dragState.behavior.test.ts
+++ b/src/features/board/components/Board/__tests__/dragState.behavior.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "vitest";
+import {
+  DRAG_MIME_TYPE,
+  DragAction,
+  type DragState,
+  dragReducer,
+} from "../dragState";
+
+const draggingState: DragState = {
+  draggingTaskFilePath: "tasks/a.md",
+  draggingFromColumn: "Todo",
+  hoverColumn: null,
+  hoverIndex: null,
+};
+
+test("DragAction.start は DragActionStart 型の object を返す", () => {
+  const action = DragAction.start("tasks/a.md", "Todo");
+  expect(action).toEqual({
+    type: "start",
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+  });
+});
+
+test("DragAction.hover は column / index を持つ DragActionHover を返す", () => {
+  const action = DragAction.hover("In Progress", 2);
+  expect(action).toEqual({ type: "hover", column: "In Progress", index: 2 });
+});
+
+test("DragAction.hover は null 引数も保持する", () => {
+  const action = DragAction.hover(null, null);
+  expect(action).toEqual({ type: "hover", column: null, index: null });
+});
+
+test("DragAction.end は DragActionEnd を返す", () => {
+  const action = DragAction.end();
+  expect(action).toEqual({ type: "end" });
+});
+
+test("初期 state は null", () => {
+  const state = dragReducer(null, DragAction.end());
+  expect(state).toBeNull();
+});
+
+test("start で DRAGGING 状態へ遷移し hoverColumn / hoverIndex は null", () => {
+  const next = dragReducer(null, DragAction.start("tasks/a.md", "Todo"));
+  expect(next).toEqual({
+    draggingTaskFilePath: "tasks/a.md",
+    draggingFromColumn: "Todo",
+    hoverColumn: null,
+    hoverIndex: null,
+  });
+});
+
+test("hover で hoverColumn と hoverIndex が設定される", () => {
+  const next = dragReducer(draggingState, DragAction.hover("Done", 1));
+  expect(next).toEqual({
+    ...draggingState,
+    hoverColumn: "Done",
+    hoverIndex: 1,
+  });
+});
+
+test("hover 同値時は同じ参照を返す（再 render 抑止）", () => {
+  const stateWithHover: DragState = {
+    ...draggingState,
+    hoverColumn: "Done",
+    hoverIndex: 1,
+  };
+  const next = dragReducer(stateWithHover, DragAction.hover("Done", 1));
+  expect(next).toBe(stateWithHover);
+});
+
+test("state が null の時 hover を呼んでも null のまま（参照同一）", () => {
+  const next = dragReducer(null, DragAction.hover("Todo", 0));
+  expect(next).toBeNull();
+});
+
+test("end で null に戻る", () => {
+  const next = dragReducer(draggingState, DragAction.end());
+  expect(next).toBeNull();
+});
+
+test("DRAG_MIME_TYPE は固定の application/x-spec-board-task", () => {
+  expect(DRAG_MIME_TYPE).toBe("application/x-spec-board-task");
+});

--- a/src/features/board/components/Board/dragState.ts
+++ b/src/features/board/components/Board/dragState.ts
@@ -1,0 +1,107 @@
+import type { Reducer } from "react";
+
+/** ドラッグ開始 action。 */
+export type DragActionStart = {
+  readonly type: "start";
+  readonly taskFilePath: string;
+  readonly fromColumn: string;
+};
+
+/** dragover による hover 位置更新 action。 */
+export type DragActionHover = {
+  readonly type: "hover";
+  readonly column: string | null;
+  readonly index: number | null;
+};
+
+/** ドラッグ終了 / drop 完了 action。 */
+export type DragActionEnd = {
+  readonly type: "end";
+};
+
+/** DragAction の discriminated union（reducer の入力型）。 */
+export type DragAction = DragActionStart | DragActionHover | DragActionEnd;
+
+/**
+ * ドラッグ中のローカル UI 状態。
+ * Project state には載せず、Board 内 useReducer で管理する。
+ */
+export type DragState = {
+  readonly draggingTaskFilePath: string;
+  readonly draggingFromColumn: string;
+  readonly hoverColumn: string | null;
+  readonly hoverIndex: number | null;
+} | null;
+
+/**
+ * DragAction の companion。各 variant のコンストラクタを集約する。
+ * 呼び出し側は `dispatch(DragAction.start(...))` のように使う。
+ */
+export const DragAction = {
+  /**
+   * 開始 action を構築する。
+   * @param taskFilePath ドラッグ対象 task の filePath
+   * @param fromColumn 元カラム名
+   * @returns DragActionStart
+   */
+  start: (taskFilePath: string, fromColumn: string): DragActionStart => ({
+    type: "start",
+    taskFilePath,
+    fromColumn,
+  }),
+  /**
+   * hover 位置更新 action を構築する。
+   * @param column hover 中のカラム名（外れた場合は null）
+   * @param index hover 中の挿入位置（外れた場合は null）
+   * @returns DragActionHover
+   */
+  hover: (column: string | null, index: number | null): DragActionHover => ({
+    type: "hover",
+    column,
+    index,
+  }),
+  /**
+   * 終了 action を構築する。
+   * @returns DragActionEnd
+   */
+  end: (): DragActionEnd => ({ type: "end" }),
+} as const;
+
+/**
+ * DragState reducer。
+ *
+ * @param state 現在の DragState
+ * @param action 適用する DragAction
+ * @returns 次の DragState
+ */
+export const dragReducer: Reducer<DragState, DragAction> = (state, action) => {
+  switch (action.type) {
+    case "start":
+      return {
+        draggingTaskFilePath: action.taskFilePath,
+        draggingFromColumn: action.fromColumn,
+        hoverColumn: null,
+        hoverIndex: null,
+      };
+    case "hover":
+      if (state === null) {
+        return state;
+      }
+      if (
+        state.hoverColumn === action.column &&
+        state.hoverIndex === action.index
+      ) {
+        return state;
+      }
+      return { ...state, hoverColumn: action.column, hoverIndex: action.index };
+    case "end":
+      return null;
+    default: {
+      action satisfies never;
+      return state;
+    }
+  }
+};
+
+/** DnD で使用する独自 MIME 型。外部 D&D を弾くための固定 string。 */
+export const DRAG_MIME_TYPE = "application/x-spec-board-task";

--- a/src/features/board/components/Board/dragState.ts
+++ b/src/features/board/components/Board/dragState.ts
@@ -83,7 +83,71 @@ export const DragAction = {
 } as const;
 
 /**
- * DragState reducer。
+ * DragState の companion。state factory / transformation / 判定を集約する。
+ * 命名は State の視点で行い、reducer / action 用語に引きずられない。
+ */
+export const DragState = {
+  /** idle（ドラッグしていない）の DragState 値。 */
+  idle: null as DragState,
+
+  /**
+   * dragging 状態の DragState を生成する。hover 情報は未設定で開始。
+   * @param taskFilePath ドラッグ対象 task の filePath
+   * @param fromColumn 元カラム名
+   * @returns dragging 状態の DragState
+   */
+  create: (taskFilePath: string, fromColumn: string): DragState => ({
+    draggingTaskFilePath: taskFilePath,
+    draggingFromColumn: fromColumn,
+    hoverColumn: null,
+    hoverIndex: null,
+  }),
+
+  /**
+   * hover 情報を差し替えた新しい DragState を返す。idle や同値時は元参照を返す。
+   * @param state 現在の DragState
+   * @param column hover 中のカラム名（外れた場合は null）
+   * @param index hover 中の挿入位置（外れた場合は null）
+   * @returns 更新後の DragState
+   */
+  withHover: (
+    state: DragState,
+    column: string | null,
+    index: number | null,
+  ): DragState => {
+    if (state === null) {
+      return state;
+    }
+    if (state.hoverColumn === column && state.hoverIndex === index) {
+      return state;
+    }
+    return { ...state, hoverColumn: column, hoverIndex: index };
+  },
+
+  /**
+   * 指定 task が現在ドラッグ中か判定する。
+   * @param state 現在の DragState
+   * @param taskFilePath 判定対象の task filePath
+   * @returns 判定結果
+   */
+  isDraggingTask: (state: DragState, taskFilePath: string): boolean =>
+    state !== null && state.draggingTaskFilePath === taskFilePath,
+
+  /**
+   * 指定カラムが hover ターゲットなら hoverIndex を返す。それ以外は null。
+   * placeholder 表示判定に使う。
+   * @param state 現在の DragState
+   * @param columnName 判定対象のカラム名
+   * @returns hoverIndex または null
+   */
+  hoverIndexFor: (state: DragState, columnName: string): number | null =>
+    state !== null && state.hoverColumn === columnName
+      ? state.hoverIndex
+      : null,
+} as const;
+
+/**
+ * DragState reducer。companion メソッドに委譲する。
  *
  * @param state 現在の DragState
  * @param action 適用する DragAction
@@ -92,25 +156,11 @@ export const DragAction = {
 export const dragReducer: Reducer<DragState, DragAction> = (state, action) => {
   switch (action.type) {
     case "start":
-      return {
-        draggingTaskFilePath: action.taskFilePath,
-        draggingFromColumn: action.fromColumn,
-        hoverColumn: null,
-        hoverIndex: null,
-      };
+      return DragState.create(action.taskFilePath, action.fromColumn);
     case "hover":
-      if (state === null) {
-        return state;
-      }
-      if (
-        state.hoverColumn === action.column &&
-        state.hoverIndex === action.index
-      ) {
-        return state;
-      }
-      return { ...state, hoverColumn: action.column, hoverIndex: action.index };
+      return DragState.withHover(state, action.column, action.index);
     case "end":
-      return null;
+      return DragState.idle;
     default: {
       action satisfies never;
       return state;

--- a/src/features/board/components/Board/dragState.ts
+++ b/src/features/board/components/Board/dragState.ts
@@ -33,38 +33,53 @@ export type DragState = {
   readonly hoverIndex: number | null;
 } | null;
 
-/**
- * DragAction の companion。各 variant のコンストラクタを集約する。
- * 呼び出し側は `dispatch(DragAction.start(...))` のように使う。
- */
-export const DragAction = {
+/** DragActionStart の companion。type alias と同名で declaration merging。 */
+export const DragActionStart = {
   /**
-   * 開始 action を構築する。
+   * DragActionStart を生成する。
    * @param taskFilePath ドラッグ対象 task の filePath
    * @param fromColumn 元カラム名
    * @returns DragActionStart
    */
-  start: (taskFilePath: string, fromColumn: string): DragActionStart => ({
+  create: (taskFilePath: string, fromColumn: string): DragActionStart => ({
     type: "start",
     taskFilePath,
     fromColumn,
   }),
+} as const;
+
+/** DragActionHover の companion。 */
+export const DragActionHover = {
   /**
-   * hover 位置更新 action を構築する。
+   * DragActionHover を生成する。
    * @param column hover 中のカラム名（外れた場合は null）
    * @param index hover 中の挿入位置（外れた場合は null）
    * @returns DragActionHover
    */
-  hover: (column: string | null, index: number | null): DragActionHover => ({
+  create: (column: string | null, index: number | null): DragActionHover => ({
     type: "hover",
     column,
     index,
   }),
+} as const;
+
+/** DragActionEnd の companion。 */
+export const DragActionEnd = {
   /**
-   * 終了 action を構築する。
+   * DragActionEnd を生成する。
    * @returns DragActionEnd
    */
-  end: (): DragActionEnd => ({ type: "end" }),
+  create: (): DragActionEnd => ({ type: "end" }),
+} as const;
+
+/**
+ * DragAction union 全体のファサード companion。
+ * 各 variant の `.create` を一段引いて呼べるショートカット。
+ */
+export const DragAction = {
+  start: DragActionStart.create,
+  hover: DragActionHover.create,
+  end: DragActionEnd.create,
 } as const;
 
 /**

--- a/src/features/board/components/Board/index.stories.tsx
+++ b/src/features/board/components/Board/index.stories.tsx
@@ -1,5 +1,6 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import { initialColumns, initialTasks } from "@/test-fixtures";
 import { Board } from ".";
 
@@ -17,6 +18,7 @@ const meta: Meta<typeof Board> = {
     onAddColumn: () => {},
     onRenameColumn: () => {},
     onDeleteColumn: () => {},
+    onTaskDrop: fn(),
   },
 };
 

--- a/src/features/board/components/Board/index.tsx
+++ b/src/features/board/components/Board/index.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useReducer } from "react";
 import type { Column as ColumnType } from "@/types/column";
 import type { Task } from "@/types/task";
 import { AddColumnButton } from "../AddColumnButton";
-import { Column } from "../Column";
+import { Column, type ColumnTaskDropParams } from "../Column";
+import { DragAction, dragReducer } from "./dragState";
 
 /** ボードの Props */
 type BoardProps = {
@@ -43,6 +44,11 @@ type BoardProps = {
    * @param destColumn - タスクの移動先カラム名。削除対象カラムにタスクが 0 件の場合は undefined
    */
   onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
+  /**
+   * Board が drop を受けたら呼ぶ。App.tsx で useProject.moveTask に配線する。
+   * @param params 移動パラメータ
+   */
+  onTaskDrop?: (params: ColumnTaskDropParams) => Promise<unknown> | undefined;
 };
 
 /**
@@ -59,6 +65,7 @@ export const Board = ({
   onAddColumn,
   onRenameColumn,
   onDeleteColumn,
+  onTaskDrop,
 }: BoardProps) => {
   const sorted = useMemo(
     () => [...columns].sort((a, b) => a.order - b.order),
@@ -77,6 +84,40 @@ export const Board = ({
   }, [tasks]);
 
   const columnNames = useMemo(() => columns.map((c) => c.name), [columns]);
+
+  const [dragState, dispatch] = useReducer(dragReducer, null);
+
+  const handleDragStart = useCallback(
+    (taskFilePath: string, fromColumn: string) => {
+      dispatch(DragAction.start(taskFilePath, fromColumn));
+    },
+    [],
+  );
+
+  const handleDragHover = useCallback(
+    (column: string | null, index: number | null) => {
+      dispatch(DragAction.hover(column, index));
+    },
+    [],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    dispatch(DragAction.end());
+  }, []);
+
+  const handleTaskDrop = useCallback(
+    async (params: ColumnTaskDropParams) => {
+      try {
+        await onTaskDrop?.(params);
+      } catch {
+        // unhandled rejection を防ぐため明示的に握る。
+        // エラー表示は App 側 onTaskDrop の責務。
+      } finally {
+        dispatch(DragAction.end());
+      }
+    },
+    [onTaskDrop],
+  );
 
   return (
     <div className="flex h-full gap-4 overflow-x-auto p-4">
@@ -101,6 +142,11 @@ export const Board = ({
               : undefined
           }
           canDelete={columns.length > 1}
+          dragState={dragState}
+          onDragHover={handleDragHover}
+          onTaskDrop={handleTaskDrop}
+          onTaskDragStart={handleDragStart}
+          onTaskDragEnd={handleDragEnd}
         />
       ))}
       {onAddColumn && (

--- a/src/features/board/components/Board/index.tsx
+++ b/src/features/board/components/Board/index.tsx
@@ -46,9 +46,11 @@ type BoardProps = {
   onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
   /**
    * Board が drop を受けたら呼ぶ。App.tsx で useProject.moveTask に配線する。
+   * 同期 / 非同期どちらのハンドラも受け付ける。
    * @param params 移動パラメータ
    */
-  onTaskDrop?: (params: ColumnTaskDropParams) => Promise<unknown> | undefined;
+  // biome-ignore lint/suspicious/noConfusingVoidType: void union allows synchronous handlers without forcing consumers to wrap them in Promises
+  onTaskDrop?: (params: ColumnTaskDropParams) => Promise<unknown> | void;
 };
 
 /**

--- a/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
@@ -76,7 +76,7 @@ test("他 MIME (text/plain) の dragover では preventDefault されない", ()
   expect(event.defaultPrevented).toBe(false);
 });
 
-test("dragover で onDragHover(name, index) が呼ばれる", () => {
+test("dragover で onDragHover(name, index) が呼ばれる", async () => {
   const onDragHover = vi.fn();
   render({
     name: "Todo",
@@ -91,7 +91,9 @@ test("dragover で onDragHover(name, index) が呼ばれる", () => {
   act(() => {
     section.dispatchEvent(event);
   });
-  expect(onDragHover).toHaveBeenCalledWith("Todo", 0);
+  await vi.waitFor(() => {
+    expect(onDragHover).toHaveBeenCalledWith("Todo", 0);
+  });
 });
 
 test("currentTarget 外への dragleave で onDragHover(null, null) が呼ばれる", () => {

--- a/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
@@ -1,0 +1,234 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { createDragEvent } from "@/test-fixtures/createDragEvent";
+import { Task, type TaskPayload } from "@/types/task";
+import { DRAG_MIME_TYPE, type DragState } from "../../Board/dragState";
+import { Column } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const makeTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+const render = (props: Parameters<typeof Column>[0]) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(Column, props));
+  });
+};
+
+const querySection = (): HTMLElement => {
+  const el = container?.querySelector<HTMLElement>("section");
+  expect(el).not.toBeNull();
+  return el as HTMLElement;
+};
+
+const draggingState = (filePath: string, fromColumn: string): DragState => ({
+  draggingTaskFilePath: filePath,
+  draggingFromColumn: fromColumn,
+  hoverColumn: null,
+  hoverIndex: null,
+});
+
+test("独自 MIME を持つ dragover で preventDefault される", () => {
+  render({ name: "Todo", tasks: [], onAddClick: vi.fn() });
+  const section = querySection();
+  const event = createDragEvent("dragover");
+  event.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(event.defaultPrevented).toBe(true);
+});
+
+test("他 MIME (text/plain) の dragover では preventDefault されない", () => {
+  render({ name: "Todo", tasks: [], onAddClick: vi.fn() });
+  const section = querySection();
+  const event = createDragEvent("dragover");
+  event.dataTransfer.setData("text/plain", "x");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(event.defaultPrevented).toBe(false);
+});
+
+test("dragover で onDragHover(name, index) が呼ばれる", () => {
+  const onDragHover = vi.fn();
+  render({
+    name: "Todo",
+    tasks: [],
+    onAddClick: vi.fn(),
+    onDragHover,
+    dragState: draggingState("tasks/a.md", "Done"),
+  });
+  const section = querySection();
+  const event = createDragEvent("dragover", { clientY: 0 });
+  event.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(onDragHover).toHaveBeenCalledWith("Todo", 0);
+});
+
+test("currentTarget 外への dragleave で onDragHover(null, null) が呼ばれる", () => {
+  const onDragHover = vi.fn();
+  render({
+    name: "Todo",
+    tasks: [],
+    onAddClick: vi.fn(),
+    onDragHover,
+    dragState: draggingState("tasks/a.md", "Done"),
+  });
+  const section = querySection();
+  const event = createDragEvent("dragleave");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(onDragHover).toHaveBeenCalledWith(null, null);
+});
+
+test("drop で onTaskDrop が期待引数で呼ばれる", () => {
+  const onTaskDrop = vi.fn();
+  render({
+    name: "Done",
+    tasks: [],
+    onAddClick: vi.fn(),
+    onTaskDrop,
+    dragState: {
+      draggingTaskFilePath: "tasks/a.md",
+      draggingFromColumn: "Todo",
+      hoverColumn: "Done",
+      hoverIndex: 0,
+    },
+  });
+  const section = querySection();
+  const event = createDragEvent("drop");
+  event.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(onTaskDrop).toHaveBeenCalledWith({
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+});
+
+test("dataTransfer 空の drop（外部 D&D）では onTaskDrop が呼ばれない", () => {
+  const onTaskDrop = vi.fn();
+  render({
+    name: "Done",
+    tasks: [],
+    onAddClick: vi.fn(),
+    onTaskDrop,
+    dragState: draggingState("tasks/a.md", "Todo"),
+  });
+  const section = querySection();
+  const event = createDragEvent("drop");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(onTaskDrop).not.toHaveBeenCalled();
+});
+
+test("dataTransfer の filePath が dragState と不一致なら onTaskDrop が呼ばれない", () => {
+  const onTaskDrop = vi.fn();
+  render({
+    name: "Done",
+    tasks: [],
+    onAddClick: vi.fn(),
+    onTaskDrop,
+    dragState: draggingState("tasks/a.md", "Todo"),
+  });
+  const section = querySection();
+  const event = createDragEvent("drop");
+  event.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/wrong.md");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(onTaskDrop).not.toHaveBeenCalled();
+});
+
+test("空カラムでの drop は toIndex=0 で呼ばれる", () => {
+  const onTaskDrop = vi.fn();
+  render({
+    name: "Done",
+    tasks: [],
+    onAddClick: vi.fn(),
+    onTaskDrop,
+    dragState: draggingState("tasks/a.md", "Todo"),
+  });
+  const section = querySection();
+  const event = createDragEvent("drop");
+  event.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(onTaskDrop).toHaveBeenCalledWith({
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+});
+
+test("dragState.hoverColumn === name の時のみ drop-placeholder が出る", () => {
+  const tasks = [makeTask({ id: "1", filePath: "tasks/1.md" })];
+  render({
+    name: "Todo",
+    tasks,
+    onAddClick: vi.fn(),
+    dragState: {
+      draggingTaskFilePath: "tasks/x.md",
+      draggingFromColumn: "Todo",
+      hoverColumn: "Todo",
+      hoverIndex: 0,
+    },
+  });
+  expect(
+    container?.querySelector("[data-testid='drop-placeholder']"),
+  ).not.toBeNull();
+});
+
+test("dragState.hoverColumn が他カラムの時は placeholder が出ない", () => {
+  const tasks = [makeTask({ id: "1", filePath: "tasks/1.md" })];
+  render({
+    name: "Todo",
+    tasks,
+    onAddClick: vi.fn(),
+    dragState: {
+      draggingTaskFilePath: "tasks/x.md",
+      draggingFromColumn: "Done",
+      hoverColumn: "Done",
+      hoverIndex: 0,
+    },
+  });
+  expect(
+    container?.querySelector("[data-testid='drop-placeholder']"),
+  ).toBeNull();
+});

--- a/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
@@ -199,6 +199,65 @@ test("空カラムでの drop は toIndex=0 で呼ばれる", () => {
   });
 });
 
+test("非空カラムでの drop は dragState.hoverIndex ではなく drop event の clientY から toIndex を同期計算する", () => {
+  const tasks = [
+    makeTask({ id: "1", filePath: "tasks/1.md", status: "Done" }),
+    makeTask({ id: "2", filePath: "tasks/2.md", status: "Done" }),
+    makeTask({ id: "3", filePath: "tasks/3.md", status: "Done" }),
+  ];
+  const onTaskDrop = vi.fn();
+  render({
+    name: "Done",
+    tasks,
+    onAddClick: vi.fn(),
+    onTaskDrop,
+    // dragState.hoverIndex は故意に 0（古い stale 値）に設定
+    dragState: {
+      draggingTaskFilePath: "tasks/a.md",
+      draggingFromColumn: "Todo",
+      hoverColumn: "Done",
+      hoverIndex: 0,
+    },
+  });
+  const liElements =
+    container?.querySelectorAll<HTMLLIElement>("li[data-task-card]") ?? [];
+  expect(liElements.length).toBe(3);
+  // 各カードに 40px 刻みの bounding rect を割り当てる
+  const rects = [
+    { top: 0, bottom: 40 },
+    { top: 40, bottom: 80 },
+    { top: 80, bottom: 120 },
+  ];
+  liElements.forEach((el, i) => {
+    const r = rects[i] as { top: number; bottom: number };
+    vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+      top: r.top,
+      bottom: r.bottom,
+      left: 0,
+      right: 100,
+      width: 100,
+      height: r.bottom - r.top,
+      x: 0,
+      y: r.top,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+  // clientY = 70（2 枚目の下半分 = 2 枚目と 3 枚目の間 → index 2）
+  const section = querySection();
+  const event = createDragEvent("drop", { clientY: 70 });
+  event.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  act(() => {
+    section.dispatchEvent(event);
+  });
+  expect(onTaskDrop).toHaveBeenCalledWith({
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 2,
+  });
+  // dragState.hoverIndex=0 ではなく 2 が使われていることが本テストの核心
+});
+
 test("dragState.hoverColumn === name の時のみ drop-placeholder が出る", () => {
   const tasks = [makeTask({ id: "1", filePath: "tasks/1.md" })];
   render({

--- a/src/features/board/components/Column/__tests__/dragHover.behavior.test.ts
+++ b/src/features/board/components/Column/__tests__/dragHover.behavior.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import { type CardRect, computeHoverIndex } from "../dragHover";
+
+const rect = (top: number, bottom: number): CardRect => ({ top, bottom });
+
+test("空配列なら 0 を返す", () => {
+  expect(computeHoverIndex([], 100)).toBe(0);
+});
+
+test("clientY が最初のカードの中央より上なら 0", () => {
+  const rects = [rect(0, 40), rect(40, 80)];
+  expect(computeHoverIndex(rects, 10)).toBe(0);
+});
+
+test("clientY が最後のカードの中央以上なら length", () => {
+  const rects = [rect(0, 40), rect(40, 80)];
+  expect(computeHoverIndex(rects, 100)).toBe(rects.length);
+});
+
+test("単一カードで中央ピッタリなら length（下半分扱い）", () => {
+  const rects = [rect(0, 40)];
+  expect(computeHoverIndex(rects, 20)).toBe(1);
+});
+
+test("3 件の中央カード上半分なら index=1", () => {
+  const rects = [rect(0, 40), rect(40, 80), rect(80, 120)];
+  expect(computeHoverIndex(rects, 50)).toBe(1);
+});
+
+test("3 件の中央カード下半分なら index=2", () => {
+  const rects = [rect(0, 40), rect(40, 80), rect(80, 120)];
+  expect(computeHoverIndex(rects, 70)).toBe(2);
+});
+
+test("3 件の中央カード中央ピッタリなら index=2（下半分扱い）", () => {
+  const rects = [rect(0, 40), rect(40, 80), rect(80, 120)];
+  expect(computeHoverIndex(rects, 60)).toBe(2);
+});

--- a/src/features/board/components/Column/__tests__/dragHover.behavior.test.ts
+++ b/src/features/board/components/Column/__tests__/dragHover.behavior.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "vitest";
-import { type CardRect, computeHoverIndex } from "../dragHover";
+import type { DragCardRect } from "@/types/dragCardRect";
+import { computeHoverIndex } from "../dragHover";
 
-const rect = (top: number, bottom: number): CardRect => ({ top, bottom });
+const rect = (top: number, bottom: number): DragCardRect => ({ top, bottom });
 
 test("空配列なら 0 を返す", () => {
   expect(computeHoverIndex([], 100)).toBe(0);

--- a/src/features/board/components/Column/dragHover.ts
+++ b/src/features/board/components/Column/dragHover.ts
@@ -1,5 +1,4 @@
-/** ドラッグ中の各カードの上下端 Y 座標を表す。 */
-export type CardRect = { readonly top: number; readonly bottom: number };
+import type { DragCardRect } from "@/types/dragCardRect";
 
 /**
  * dragover 時、マウス Y 座標と各カードの bounding rect の中央を比較して、
@@ -16,7 +15,7 @@ export type CardRect = { readonly top: number; readonly bottom: number };
  * @returns 挿入位置（0..rects.length）
  */
 export const computeHoverIndex = (
-  rects: readonly CardRect[],
+  rects: readonly DragCardRect[],
   clientY: number,
 ): number => {
   for (let i = 0; i < rects.length; i++) {

--- a/src/features/board/components/Column/dragHover.ts
+++ b/src/features/board/components/Column/dragHover.ts
@@ -1,0 +1,29 @@
+/** ドラッグ中の各カードの上下端 Y 座標を表す。 */
+export type CardRect = { readonly top: number; readonly bottom: number };
+
+/**
+ * dragover 時、マウス Y 座標と各カードの bounding rect の中央を比較して、
+ * 挿入インデックス (0..rects.length) を返す。
+ *
+ * - 空配列: 0
+ * - clientY が最初のカードの中央より厳密に上: 0
+ * - clientY が最後のカードの中央以上: rects.length
+ * - 判定式: `clientY < middle` なら index、`>= middle` は次の境界へ進む
+ *   （中央ピッタリは「下半分」扱い）
+ *
+ * @param rects 各カードの top/bottom 座標
+ * @param clientY マウス Y 座標
+ * @returns 挿入位置（0..rects.length）
+ */
+export const computeHoverIndex = (
+  rects: readonly CardRect[],
+  clientY: number,
+): number => {
+  for (let i = 0; i < rects.length; i++) {
+    const rect = rects[i];
+    if (clientY < (rect.top + rect.bottom) / 2) {
+      return i;
+    }
+  }
+  return rects.length;
+};

--- a/src/features/board/components/Column/index.stories.tsx
+++ b/src/features/board/components/Column/index.stories.tsx
@@ -1,5 +1,6 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import { initialTasks } from "@/test-fixtures";
 import { Task } from "@/types/task";
 import { Column } from ".";
@@ -22,6 +23,11 @@ const meta: Meta<typeof Column> = {
     onTaskClick: () => {},
     onRename: () => {},
     onDelete: () => {},
+    dragState: null,
+    onDragHover: fn(),
+    onTaskDrop: fn(),
+    onTaskDragStart: fn(),
+    onTaskDragEnd: fn(),
   },
 };
 
@@ -57,4 +63,35 @@ export const ManyTasks: Story = {
 
 export const WithoutMenu: Story = {
   args: { onDelete: undefined, onRename: undefined },
+};
+
+const draggingFromOther = {
+  draggingTaskFilePath: "tasks/external.md",
+  draggingFromColumn: "Done",
+};
+
+export const HoverTop: Story = {
+  args: {
+    dragState: { ...draggingFromOther, hoverColumn: "Todo", hoverIndex: 0 },
+  },
+};
+
+export const HoverMiddle: Story = {
+  args: {
+    dragState: {
+      ...draggingFromOther,
+      hoverColumn: "Todo",
+      hoverIndex: Math.max(1, Math.floor(todoTasks.length / 2)),
+    },
+  },
+};
+
+export const HoverBottom: Story = {
+  args: {
+    dragState: {
+      ...draggingFromOther,
+      hoverColumn: "Todo",
+      hoverIndex: todoTasks.length,
+    },
+  },
 };

--- a/src/features/board/components/Column/index.tsx
+++ b/src/features/board/components/Column/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import type { Task } from "@/types/task";
-import { DRAG_MIME_TYPE, type DragState } from "../Board/dragState";
+import { DRAG_MIME_TYPE, DragState } from "../Board/dragState";
 import { ColumnContextMenu } from "../ColumnContextMenu";
 import { ColumnHeader } from "../ColumnHeader";
 import { TaskCard } from "../TaskCard";
@@ -194,13 +194,7 @@ export const Column = ({
     });
   };
 
-  const showPlaceholder =
-    dragState !== undefined &&
-    dragState !== null &&
-    dragState.hoverColumn === name &&
-    dragState.hoverIndex !== null;
-  const placeholderIndex =
-    showPlaceholder && dragState ? dragState.hoverIndex : null;
+  const placeholderIndex = DragState.hoverIndexFor(dragState ?? null, name);
 
   const otherColumnNames = existingColumnNames ?? [];
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
@@ -309,7 +303,10 @@ export const Column = ({
                   childTasks={childTasks}
                   doneColumn={doneColumn}
                   fromColumn={name}
-                  isDragging={dragState?.draggingTaskFilePath === task.filePath}
+                  isDragging={DragState.isDraggingTask(
+                    dragState ?? null,
+                    task.filePath,
+                  )}
                   onClick={onTaskClick}
                   onDragStart={onTaskDragStart}
                   onDragEnd={onTaskDragEnd}

--- a/src/features/board/components/Column/index.tsx
+++ b/src/features/board/components/Column/index.tsx
@@ -174,7 +174,18 @@ export const Column = ({
     }
     e.preventDefault();
     cancelPendingHover();
-    const toIndex = dragState.hoverIndex ?? tasks.length;
+    // rAF throttle により dragState.hoverIndex は他カラムの drop で stale な
+    // 可能性がある。drop event の clientY から this カラムの DOM rect を使って
+    // toIndex を同期計算する。
+    const liElements = Array.from(
+      listRef.current?.querySelectorAll<HTMLLIElement>("li[data-task-card]") ??
+        [],
+    );
+    const rects = liElements.map((el) => {
+      const r = el.getBoundingClientRect();
+      return { top: r.top, bottom: r.bottom };
+    });
+    const toIndex = computeHoverIndex(rects, e.clientY);
     onTaskDrop?.({
       taskFilePath,
       fromColumn: dragState.draggingFromColumn,

--- a/src/features/board/components/Column/index.tsx
+++ b/src/features/board/components/Column/index.tsx
@@ -2,6 +2,7 @@ import {
   type DragEvent,
   Fragment,
   type MouseEvent,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -99,6 +100,11 @@ export const Column = ({
     [allTasks],
   );
   const listRef = useRef<HTMLUListElement>(null);
+  // dragover は高頻度発火するため、rAF 同フレーム内では rect 再計算を 1 回に
+  // 抑制する。pendingFrameRef が null でない間は新規 rAF を予約せず、最後の
+  // clientY を上書きするだけ。
+  const pendingFrameRef = useRef<number | null>(null);
+  const pendingClientYRef = useRef(0);
 
   const handleDragOver = (e: DragEvent<HTMLElement>) => {
     if (!e.dataTransfer.types.includes(DRAG_MIME_TYPE)) {
@@ -109,23 +115,49 @@ export const Column = ({
     if (!onDragHover) {
       return;
     }
-    const liElements = Array.from(
-      listRef.current?.querySelectorAll<HTMLLIElement>("li[data-task-card]") ??
-        [],
-    );
-    const rects = liElements.map((el) => {
-      const r = el.getBoundingClientRect();
-      return { top: r.top, bottom: r.bottom };
+    pendingClientYRef.current = e.clientY;
+    if (pendingFrameRef.current !== null) {
+      return;
+    }
+    pendingFrameRef.current = requestAnimationFrame(() => {
+      pendingFrameRef.current = null;
+      const liElements = Array.from(
+        listRef.current?.querySelectorAll<HTMLLIElement>(
+          "li[data-task-card]",
+        ) ?? [],
+      );
+      const rects = liElements.map((el) => {
+        const r = el.getBoundingClientRect();
+        return { top: r.top, bottom: r.bottom };
+      });
+      const index = computeHoverIndex(rects, pendingClientYRef.current);
+      onDragHover(name, index);
     });
-    const index = computeHoverIndex(rects, e.clientY);
-    onDragHover(name, index);
   };
+
+  const cancelPendingHover = () => {
+    if (pendingFrameRef.current !== null) {
+      cancelAnimationFrame(pendingFrameRef.current);
+      pendingFrameRef.current = null;
+    }
+  };
+
+  // unmount 時に pending rAF を解放（メモリリーク / mount 解除後の dispatch 防止）
+  useEffect(() => {
+    return () => {
+      if (pendingFrameRef.current !== null) {
+        cancelAnimationFrame(pendingFrameRef.current);
+        pendingFrameRef.current = null;
+      }
+    };
+  }, []);
 
   const handleDragLeave = (e: DragEvent<HTMLElement>) => {
     const related = e.relatedTarget as Node | null;
     if (related && e.currentTarget.contains(related)) {
       return;
     }
+    cancelPendingHover();
     onDragHover?.(null, null);
   };
 
@@ -141,6 +173,7 @@ export const Column = ({
       return;
     }
     e.preventDefault();
+    cancelPendingHover();
     const toIndex = dragState.hoverIndex ?? tasks.length;
     onTaskDrop?.({
       taskFilePath,

--- a/src/features/board/components/Column/index.tsx
+++ b/src/features/board/components/Column/index.tsx
@@ -1,10 +1,26 @@
-import type { MouseEvent } from "react";
-import { useMemo, useRef, useState } from "react";
+import {
+  type DragEvent,
+  Fragment,
+  type MouseEvent,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import type { Task } from "@/types/task";
+import { DRAG_MIME_TYPE, type DragState } from "../Board/dragState";
 import { ColumnContextMenu } from "../ColumnContextMenu";
 import { ColumnHeader } from "../ColumnHeader";
 import { TaskCard } from "../TaskCard";
+import { computeHoverIndex } from "./dragHover";
+
+/** Drop 確定時に呼ばれる引数。 */
+export type ColumnTaskDropParams = {
+  readonly taskFilePath: string;
+  readonly fromColumn: string;
+  readonly toColumn: string;
+  readonly toIndex: number;
+};
 
 /** 個別カラムの Props */
 type ColumnProps = {
@@ -40,6 +56,20 @@ type ColumnProps = {
   onDelete?: (destColumn: string | undefined) => void | Promise<void>;
   /** 削除操作を許可するか（false の場合は右クリックメニューの削除が無効化） */
   canDelete?: boolean;
+  /** Board から渡される DragState（自カラムが drop ターゲットか判断）。 */
+  dragState?: DragState;
+  /** dragover 時の hoverIndex 通知。 */
+  onDragHover?: (column: string | null, index: number | null) => void;
+  /** drop 確定時の通知。 */
+  onTaskDrop?: (params: ColumnTaskDropParams) => void;
+  /**
+   * 子 TaskCard の dragstart を Board に伝える。
+   * @param taskFilePath 対象 task の filePath
+   * @param fromColumn 元カラム名
+   */
+  onTaskDragStart?: (taskFilePath: string, fromColumn: string) => void;
+  /** 子 TaskCard の dragend を Board に伝える。 */
+  onTaskDragEnd?: () => void;
 };
 
 /**
@@ -58,11 +88,75 @@ export const Column = ({
   existingColumnNames,
   onDelete,
   canDelete = true,
+  dragState,
+  onDragHover,
+  onTaskDrop,
+  onTaskDragStart,
+  onTaskDragEnd,
 }: ColumnProps) => {
   const tasksByFilePath = useMemo(
     () => new Map(allTasks.map((t) => [t.filePath, t])),
     [allTasks],
   );
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const handleDragOver = (e: DragEvent<HTMLElement>) => {
+    if (!e.dataTransfer.types.includes(DRAG_MIME_TYPE)) {
+      return;
+    }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    if (!onDragHover) {
+      return;
+    }
+    const liElements = Array.from(
+      listRef.current?.querySelectorAll<HTMLLIElement>("li[data-task-card]") ??
+        [],
+    );
+    const rects = liElements.map((el) => {
+      const r = el.getBoundingClientRect();
+      return { top: r.top, bottom: r.bottom };
+    });
+    const index = computeHoverIndex(rects, e.clientY);
+    onDragHover(name, index);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLElement>) => {
+    const related = e.relatedTarget as Node | null;
+    if (related && e.currentTarget.contains(related)) {
+      return;
+    }
+    onDragHover?.(null, null);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLElement>) => {
+    if (!e.dataTransfer.types.includes(DRAG_MIME_TYPE)) {
+      return;
+    }
+    const taskFilePath = e.dataTransfer.getData(DRAG_MIME_TYPE);
+    if (!taskFilePath || !dragState) {
+      return;
+    }
+    if (taskFilePath !== dragState.draggingTaskFilePath) {
+      return;
+    }
+    e.preventDefault();
+    const toIndex = dragState.hoverIndex ?? tasks.length;
+    onTaskDrop?.({
+      taskFilePath,
+      fromColumn: dragState.draggingFromColumn,
+      toColumn: name,
+      toIndex,
+    });
+  };
+
+  const showPlaceholder =
+    dragState !== undefined &&
+    dragState !== null &&
+    dragState.hoverColumn === name &&
+    dragState.hoverIndex !== null;
+  const placeholderIndex =
+    showPlaceholder && dragState ? dragState.hoverIndex : null;
 
   const otherColumnNames = existingColumnNames ?? [];
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
@@ -138,6 +232,10 @@ export const Column = ({
     <section
       className="flex h-full w-72 min-w-72 flex-col rounded-lg bg-gray-50"
       aria-label={name}
+      data-testid={`column-${name}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
     >
       <ColumnHeader
         name={name}
@@ -147,22 +245,42 @@ export const Column = ({
         existingColumnNames={existingColumnNames}
         onContextMenu={handleContextMenu}
       />
-      <ul className="flex-1 overflow-y-auto px-2 pb-2">
-        {tasks.map((task) => {
+      <ul ref={listRef} className="flex-1 overflow-y-auto px-2 pb-2">
+        {tasks.map((task, i) => {
           const childTasks = task.hierarchy.childFilePaths
             .map((fp) => tasksByFilePath.get(fp))
             .filter((t): t is Task => t !== undefined);
           return (
-            <li key={task.id} className="mb-2">
-              <TaskCard
-                task={task}
-                childTasks={childTasks}
-                doneColumn={doneColumn}
-                onClick={onTaskClick}
-              />
-            </li>
+            <Fragment key={task.id}>
+              {placeholderIndex === i && (
+                <li
+                  data-testid="drop-placeholder"
+                  aria-hidden="true"
+                  className="mb-2 h-1 rounded bg-blue-300"
+                />
+              )}
+              <li data-task-card className="mb-2">
+                <TaskCard
+                  task={task}
+                  childTasks={childTasks}
+                  doneColumn={doneColumn}
+                  fromColumn={name}
+                  isDragging={dragState?.draggingTaskFilePath === task.filePath}
+                  onClick={onTaskClick}
+                  onDragStart={onTaskDragStart}
+                  onDragEnd={onTaskDragEnd}
+                />
+              </li>
+            </Fragment>
           );
         })}
+        {placeholderIndex === tasks.length && (
+          <li
+            data-testid="drop-placeholder"
+            aria-hidden="true"
+            className="mb-2 h-1 rounded bg-blue-300"
+          />
+        )}
       </ul>
       {menuPos && (
         <ColumnContextMenu

--- a/src/features/board/components/TaskCard/__tests__/TaskCard.dnd.test.tsx
+++ b/src/features/board/components/TaskCard/__tests__/TaskCard.dnd.test.tsx
@@ -1,0 +1,147 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { createDragEvent } from "@/test-fixtures/createDragEvent";
+import { Task, type TaskPayload } from "@/types/task";
+import { DRAG_MIME_TYPE } from "../../Board/dragState";
+import { TaskCard } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const makeTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const render = (props: Parameters<typeof TaskCard>[0]) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(TaskCard, props));
+  });
+};
+
+const queryCard = (): HTMLElement => {
+  const el = container?.querySelector<HTMLElement>("[data-testid='task-card']");
+  expect(el).not.toBeNull();
+  return el as HTMLElement;
+};
+
+test.each([
+  { name: "onClick あり", onClick: vi.fn() },
+  { name: "onClick なし", onClick: undefined },
+])("$name でも draggable=true 属性が出力される", ({ onClick }) => {
+  render({ task: makeTask(), fromColumn: "Todo", onClick });
+  const card = queryCard();
+  expect(card.getAttribute("draggable")).toBe("true");
+});
+
+test("dragstart で dataTransfer.setData(DRAG_MIME_TYPE, filePath) が呼ばれる", () => {
+  render({
+    task: makeTask({ filePath: "tasks/a.md" }),
+    fromColumn: "Todo",
+    onClick: vi.fn(),
+  });
+  const card = queryCard();
+  const event = createDragEvent("dragstart");
+  act(() => {
+    card.dispatchEvent(event);
+  });
+  expect(event.dataTransfer.getData(DRAG_MIME_TYPE)).toBe("tasks/a.md");
+});
+
+test("dragstart で onDragStart(filePath, fromColumn) が呼ばれる", () => {
+  const onDragStart = vi.fn();
+  render({
+    task: makeTask({ filePath: "tasks/a.md" }),
+    fromColumn: "Todo",
+    onDragStart,
+    onClick: vi.fn(),
+  });
+  const card = queryCard();
+  act(() => {
+    card.dispatchEvent(createDragEvent("dragstart"));
+  });
+  expect(onDragStart).toHaveBeenCalledWith("tasks/a.md", "Todo");
+});
+
+test("dragend で onDragEnd が呼ばれる", () => {
+  const onDragEnd = vi.fn();
+  render({
+    task: makeTask(),
+    fromColumn: "Todo",
+    onDragEnd,
+    onClick: vi.fn(),
+  });
+  const card = queryCard();
+  act(() => {
+    card.dispatchEvent(createDragEvent("dragend"));
+  });
+  expect(onDragEnd).toHaveBeenCalled();
+});
+
+test("isDragging=true で data-dragging='true' + opacity-40 class が付く", () => {
+  render({
+    task: makeTask(),
+    fromColumn: "Todo",
+    isDragging: true,
+    onClick: vi.fn(),
+  });
+  const card = queryCard();
+  expect(card.getAttribute("data-dragging")).toBe("true");
+  expect(card.className).toContain("opacity-40");
+});
+
+test("isDragging=false で data-dragging 属性が存在しない", () => {
+  render({
+    task: makeTask(),
+    fromColumn: "Todo",
+    isDragging: false,
+    onClick: vi.fn(),
+  });
+  const card = queryCard();
+  expect(card.hasAttribute("data-dragging")).toBe(false);
+});
+
+test("dragstart → click（synthetic）の順では onClick が呼ばれない", () => {
+  const onClick = vi.fn();
+  render({ task: makeTask(), fromColumn: "Todo", onClick });
+  const card = queryCard();
+  act(() => {
+    card.dispatchEvent(createDragEvent("dragstart"));
+  });
+  act(() => {
+    card.click();
+  });
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("通常 click（drag を介さない）は onClick が呼ばれる", () => {
+  const onClick = vi.fn();
+  render({ task: makeTask({ id: "x" }), fromColumn: "Todo", onClick });
+  const card = queryCard();
+  act(() => {
+    card.click();
+  });
+  expect(onClick).toHaveBeenCalledWith("x");
+});

--- a/src/features/board/components/TaskCard/__tests__/TaskCard.dnd.test.tsx
+++ b/src/features/board/components/TaskCard/__tests__/TaskCard.dnd.test.tsx
@@ -123,17 +123,52 @@ test("isDragging=false で data-dragging 属性が存在しない", () => {
   expect(card.hasAttribute("data-dragging")).toBe(false);
 });
 
-test("dragstart → click（synthetic）の順では onClick が呼ばれない", () => {
-  const onClick = vi.fn();
-  render({ task: makeTask(), fromColumn: "Todo", onClick });
-  const card = queryCard();
-  act(() => {
-    card.dispatchEvent(createDragEvent("dragstart"));
-  });
-  act(() => {
-    card.click();
-  });
-  expect(onClick).not.toHaveBeenCalled();
+test("dragstart → dragend → click（synthetic, macrotask 前）の順では onClick が呼ばれない", () => {
+  vi.useFakeTimers();
+  try {
+    const onClick = vi.fn();
+    render({ task: makeTask(), fromColumn: "Todo", onClick });
+    const card = queryCard();
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragstart"));
+    });
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragend"));
+    });
+    // dragend 内の setTimeout(0) はまだ走っていない。この間に発火する
+    // synthetic click は dragGuardRef により抑止される。
+    act(() => {
+      card.click();
+    });
+    expect(onClick).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("dragstart → dragend → macrotask 経過後の click は onClick が呼ばれる", () => {
+  vi.useFakeTimers();
+  try {
+    const onClick = vi.fn();
+    render({ task: makeTask({ id: "x" }), fromColumn: "Todo", onClick });
+    const card = queryCard();
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragstart"));
+    });
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragend"));
+    });
+    // dragend の setTimeout(0) を消化して guard を解除する
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    act(() => {
+      card.click();
+    });
+    expect(onClick).toHaveBeenCalledWith("x");
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("通常 click（drag を介さない）は onClick が呼ばれる", () => {

--- a/src/features/board/components/TaskCard/__tests__/TaskCard.rendering.test.tsx
+++ b/src/features/board/components/TaskCard/__tests__/TaskCard.rendering.test.tsx
@@ -31,12 +31,12 @@ function createTask(overrides: Partial<TaskPayload> = {}): Task {
   });
 }
 
-function render(props: Parameters<typeof TaskCard>[0]) {
+function render(props: Omit<Parameters<typeof TaskCard>[0], "fromColumn">) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root?.render(createElement(TaskCard, props));
+    root?.render(createElement(TaskCard, { fromColumn: "Todo", ...props }));
   });
 }
 

--- a/src/features/board/components/TaskCard/index.stories.tsx
+++ b/src/features/board/components/TaskCard/index.stories.tsx
@@ -1,5 +1,6 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import { initialTasks } from "@/test-fixtures";
 import type { Task } from "@/types/task";
 import { TaskCard } from ".";
@@ -12,6 +13,9 @@ const meta: Meta<typeof TaskCard> = {
     task: baseTask,
     childTasks: [],
     doneColumn: "Done",
+    fromColumn: "Todo",
+    onDragStart: fn(),
+    onDragEnd: fn(),
   },
 };
 
@@ -23,6 +27,17 @@ export const Default: Story = {};
 
 export const Clickable: Story = {
   args: { onClick: () => {} },
+};
+
+export const Dragging: Story = {
+  args: { isDragging: true },
+};
+
+export const Draggable: Story = {
+  args: {
+    onDragStart: fn(),
+    onDragEnd: fn(),
+  },
 };
 
 export const HighPriority: Story = {

--- a/src/features/board/components/TaskCard/index.tsx
+++ b/src/features/board/components/TaskCard/index.tsx
@@ -1,4 +1,7 @@
+import type { DragEvent } from "react";
+import { useRef } from "react";
 import type { Task } from "@/types/task";
+import { DRAG_MIME_TYPE } from "../Board/dragState";
 import { LabelTag } from "../LabelTag";
 import { PriorityBadge } from "../PriorityBadge";
 import { SubIssueProgress } from "../SubIssueProgress";
@@ -11,16 +14,29 @@ type TaskCardProps = {
   childTasks?: Task[];
   /** 完了カラム名 */
   doneColumn?: string;
+  /** 所属カラム名。onDragStart の引数に使う。 */
+  fromColumn: string;
+  /** ドラッグ中フラグ（Board の DragState から配布） */
+  isDragging?: boolean;
   /**
    * カードクリック時のコールバック
    * @param taskId - クリックされたタスクのID
    */
   onClick?: (taskId: string) => void;
+  /**
+   * ドラッグ開始時のコールバック。
+   * @param taskFilePath - 対象タスクの filePath
+   * @param fromColumn - 元カラム名
+   */
+  onDragStart?: (taskFilePath: string, fromColumn: string) => void;
+  /** ドラッグ終了時のコールバック。 */
+  onDragEnd?: () => void;
 };
 
 /**
- * @param props - {@link TaskCardProps}
- * @returns カード要素
+ * タスクカード本体の表示。
+ * @param props 表示用のタスク情報
+ * @returns カード内 markup
  */
 const CardContent = ({
   task,
@@ -52,7 +68,7 @@ const CardContent = ({
 };
 
 /**
- * タスクカードを表示する
+ * タスクカードを表示する。onClick の有無に関わらず draggable な div を返す。
  * @param props - {@link TaskCardProps}
  * @returns カード要素
  */
@@ -60,11 +76,43 @@ export const TaskCard = ({
   task,
   childTasks,
   doneColumn,
+  fromColumn,
+  isDragging = false,
   onClick,
+  onDragStart,
+  onDragEnd,
 }: TaskCardProps) => {
+  const dragGuardRef = useRef(false);
+
+  const handleDragStart = (e: DragEvent<HTMLDivElement>) => {
+    e.dataTransfer.setData(DRAG_MIME_TYPE, task.filePath);
+    e.dataTransfer.effectAllowed = "move";
+    dragGuardRef.current = true;
+    onDragStart?.(task.filePath, fromColumn);
+  };
+
+  const handleDragEnd = () => {
+    onDragEnd?.();
+    setTimeout(() => {
+      dragGuardRef.current = false;
+    }, 0);
+  };
+
+  const draggingClass = isDragging ? " opacity-40" : "";
+  const dataDragging = isDragging ? "true" : undefined;
+
   if (!onClick) {
     return (
-      <div className="w-full rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm">
+      // biome-ignore lint/a11y/noStaticElementInteractions: HTML5 native DnD requires draggable handlers on the card container; CardContent may include interactive descendants so a semantic element is unsuitable
+      <div
+        draggable
+        data-dragging={dataDragging}
+        data-testid="task-card"
+        aria-grabbed={isDragging}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        className={`w-full rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm${draggingClass}`}
+      >
         <CardContent
           task={task}
           childTasks={childTasks}
@@ -77,10 +125,21 @@ export const TaskCard = ({
   return (
     // biome-ignore lint/a11y/useSemanticElements: CardContent may include interactive descendants such as details/summary, so a semantic <button> cannot be used as the card container
     <div
+      draggable
+      data-dragging={dataDragging}
+      data-testid="task-card"
+      aria-grabbed={isDragging}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
       role="button"
       tabIndex={0}
-      className="w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md"
-      onClick={() => onClick(task.id)}
+      className={`w-full cursor-pointer rounded-lg border border-gray-200 bg-white p-3 text-left shadow-sm hover:border-blue-300 hover:shadow-md${draggingClass}`}
+      onClick={() => {
+        if (dragGuardRef.current) {
+          return;
+        }
+        onClick(task.id);
+      }}
       onKeyDown={(e) => {
         if (e.currentTarget !== e.target) {
           return;

--- a/src/features/board/hooks/useProject/__tests__/useProject.behavior.test.ts
+++ b/src/features/board/hooks/useProject/__tests__/useProject.behavior.test.ts
@@ -457,3 +457,57 @@ test("dataB を別途 loaded に持つ場合も open-fail 復元先が正しい"
   const next = reducer(start, { type: "open-fail", path: "/c", error: err });
   expect(next).toEqual({ kind: "loaded", path: "/b", data: dataB });
 });
+
+test("card-order-updated → 対象カラムの tasks が filePaths 順に並ぶ", () => {
+  const todoA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
+  const todoB = makeTask({ id: "b", filePath: "tasks/b.md", status: "Todo" });
+  const doneX = makeTask({ id: "x", filePath: "tasks/x.md", status: "Done" });
+  const loaded: ProjectState = {
+    kind: "loaded",
+    path: "/p",
+    data: { tasks: [todoA, doneX, todoB], columns: cols("Todo", "Done") },
+  };
+  const next = reducer(loaded, {
+    type: "card-order-updated",
+    columnName: "Todo",
+    filePaths: ["tasks/b.md", "tasks/a.md"],
+  });
+  const data = (next as { data: ProjectData }).data;
+  expect(data.tasks.map((t) => t.filePath)).toEqual([
+    "tasks/b.md",
+    "tasks/x.md",
+    "tasks/a.md",
+  ]);
+});
+
+test("card-order-updated → 他カラムの tasks 順序は不変", () => {
+  const todoA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
+  const doneX = makeTask({ id: "x", filePath: "tasks/x.md", status: "Done" });
+  const doneY = makeTask({ id: "y", filePath: "tasks/y.md", status: "Done" });
+  const loaded: ProjectState = {
+    kind: "loaded",
+    path: "/p",
+    data: { tasks: [todoA, doneX, doneY], columns: cols("Todo", "Done") },
+  };
+  const next = reducer(loaded, {
+    type: "card-order-updated",
+    columnName: "Todo",
+    filePaths: ["tasks/a.md"],
+  });
+  const data = (next as { data: ProjectData }).data;
+  expect(data.tasks.map((t) => t.filePath)).toEqual([
+    "tasks/a.md",
+    "tasks/x.md",
+    "tasks/y.md",
+  ]);
+});
+
+test("card-order-updated → idle state では no-op", () => {
+  const idle: ProjectState = { kind: "idle" };
+  const next = reducer(idle, {
+    type: "card-order-updated",
+    columnName: "Todo",
+    filePaths: ["tasks/a.md"],
+  });
+  expect(next).toBe(idle);
+});

--- a/src/features/board/hooks/useProject/actions/__tests__/buildMovedFilePaths.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/buildMovedFilePaths.behavior.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import { buildMovedFilePaths } from "../buildMovedFilePaths";
+
+const makeTask = (overrides: Partial<TaskPayload>): Task =>
+  Task.fromPayload({
+    id: overrides.filePath ?? "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+const tasksOf = (
+  pairs: ReadonlyArray<readonly [string, string]>,
+): ReadonlyArray<Task> =>
+  pairs.map(([filePath, status]) => makeTask({ filePath, status }));
+
+test("カラム間移動: 移動先カラムに target が含まれない状態から toIndex に挿入", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Done"],
+    ["tasks/c.md", "Done"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 1);
+  expect(result).toEqual(["tasks/b.md", "tasks/a.md", "tasks/c.md"]);
+});
+
+test("同一カラム下方向移動（元 0 → toIndex 2）で重複なし", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/c.md", "Todo"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", 2);
+  expect(result).toEqual(["tasks/b.md", "tasks/c.md", "tasks/a.md"]);
+});
+
+test("同一カラム上方向移動（元 2 → toIndex 0）で重複なし", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/c.md", "Todo"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/c.md", "Todo", 0);
+  expect(result).toEqual(["tasks/c.md", "tasks/a.md", "tasks/b.md"]);
+});
+
+test("末尾への移動（toIndex = length）で末尾配置", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Done"],
+    ["tasks/c.md", "Done"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 2);
+  expect(result).toEqual(["tasks/b.md", "tasks/c.md", "tasks/a.md"]);
+});
+
+test("toIndex 超過時の clamp（toIndex > length → 末尾）", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Done"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 999);
+  expect(result).toEqual(["tasks/b.md", "tasks/a.md"]);
+});
+
+test("空カラムへの移動（toIndex=0）で target 単独が返る", () => {
+  const tasks = tasksOf([["tasks/a.md", "Todo"]]);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 0);
+  expect(result).toEqual(["tasks/a.md"]);
+});
+
+test("同一カラムで結果が元配列と完全一致（no-op 判定用）", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/c.md", "Todo"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/b.md", "Todo", 1);
+  expect(result).toEqual(["tasks/a.md", "tasks/b.md", "tasks/c.md"]);
+});

--- a/src/features/board/hooks/useProject/actions/__tests__/buildMovedFilePaths.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/buildMovedFilePaths.behavior.test.ts
@@ -27,37 +27,47 @@ test("カラム間移動: 移動先カラムに target が含まれない状態�
     ["tasks/b.md", "Done"],
     ["tasks/c.md", "Done"],
   ]);
-  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 1);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", "Done", 1);
   expect(result).toEqual(["tasks/b.md", "tasks/a.md", "tasks/c.md"]);
 });
 
-test("同一カラム下方向移動（元 0 → toIndex 2）で重複なし", () => {
+test("同一カラム下方向移動: 元 0 → hover toIndex 2（B と C の間）で B,A,C", () => {
   const tasks = tasksOf([
     ["tasks/a.md", "Todo"],
     ["tasks/b.md", "Todo"],
     ["tasks/c.md", "Todo"],
   ]);
-  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", 2);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", "Todo", 2);
+  expect(result).toEqual(["tasks/b.md", "tasks/a.md", "tasks/c.md"]);
+});
+
+test("同一カラム下方向移動: 元 0 → hover toIndex 3（末尾）で B,C,A", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/c.md", "Todo"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", "Todo", 3);
   expect(result).toEqual(["tasks/b.md", "tasks/c.md", "tasks/a.md"]);
 });
 
-test("同一カラム上方向移動（元 2 → toIndex 0）で重複なし", () => {
+test("同一カラム上方向移動（元 2 → toIndex 0）で C,A,B", () => {
   const tasks = tasksOf([
     ["tasks/a.md", "Todo"],
     ["tasks/b.md", "Todo"],
     ["tasks/c.md", "Todo"],
   ]);
-  const result = buildMovedFilePaths(tasks, "tasks/c.md", "Todo", 0);
+  const result = buildMovedFilePaths(tasks, "tasks/c.md", "Todo", "Todo", 0);
   expect(result).toEqual(["tasks/c.md", "tasks/a.md", "tasks/b.md"]);
 });
 
-test("末尾への移動（toIndex = length）で末尾配置", () => {
+test("カラム間移動: 末尾（toIndex = toColumn 内 length）で末尾配置", () => {
   const tasks = tasksOf([
     ["tasks/a.md", "Todo"],
     ["tasks/b.md", "Done"],
     ["tasks/c.md", "Done"],
   ]);
-  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 2);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", "Done", 2);
   expect(result).toEqual(["tasks/b.md", "tasks/c.md", "tasks/a.md"]);
 });
 
@@ -66,22 +76,32 @@ test("toIndex 超過時の clamp（toIndex > length → 末尾）", () => {
     ["tasks/a.md", "Todo"],
     ["tasks/b.md", "Done"],
   ]);
-  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 999);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", "Done", 999);
   expect(result).toEqual(["tasks/b.md", "tasks/a.md"]);
 });
 
 test("空カラムへの移動（toIndex=0）で target 単独が返る", () => {
   const tasks = tasksOf([["tasks/a.md", "Todo"]]);
-  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Done", 0);
+  const result = buildMovedFilePaths(tasks, "tasks/a.md", "Todo", "Done", 0);
   expect(result).toEqual(["tasks/a.md"]);
 });
 
-test("同一カラムで結果が元配列と完全一致（no-op 判定用）", () => {
+test("同一カラムで元位置と同じ hover 位置（toIndex = 元 index + 1）なら結果が元配列と一致", () => {
   const tasks = tasksOf([
     ["tasks/a.md", "Todo"],
     ["tasks/b.md", "Todo"],
     ["tasks/c.md", "Todo"],
   ]);
-  const result = buildMovedFilePaths(tasks, "tasks/b.md", "Todo", 1);
+  const result = buildMovedFilePaths(tasks, "tasks/b.md", "Todo", "Todo", 2);
+  expect(result).toEqual(["tasks/a.md", "tasks/b.md", "tasks/c.md"]);
+});
+
+test("同一カラムで toIndex = 元 index なら結果が元配列と一致", () => {
+  const tasks = tasksOf([
+    ["tasks/a.md", "Todo"],
+    ["tasks/b.md", "Todo"],
+    ["tasks/c.md", "Todo"],
+  ]);
+  const result = buildMovedFilePaths(tasks, "tasks/b.md", "Todo", "Todo", 1);
   expect(result).toEqual(["tasks/a.md", "tasks/b.md", "tasks/c.md"]);
 });

--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -206,7 +206,7 @@ test("fromColumn === toColumn で並び順変化があれば updateCardOrder が
   expect(updateTaskMock).not.toHaveBeenCalled();
   expect(updateCardOrderMock).toHaveBeenCalledWith({
     columnName: "Todo",
-    filePaths: ["tasks/b.md", "tasks/c.md", "tasks/a.md"],
+    filePaths: ["tasks/b.md", "tasks/a.md", "tasks/c.md"],
   });
 });
 

--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -298,6 +298,7 @@ test("カラム間で updateTask 成功 / updateCardOrder 失敗 → task-update
   });
 
   expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("partial-move");
   expect(harness.actions.map((a) => a.type)).toEqual(["task-updated"]);
 });
 

--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -1,0 +1,398 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  TauriError,
+  updateCardOrder as updateCardOrderInvoke,
+  updateTask as updateTaskInvoke,
+} from "@/lib/tauri";
+import { Task, type TaskPayload } from "@/types/task";
+import { Result } from "@/utils/result";
+import {
+  createProjectVersion,
+  invalidateProject,
+  type ProjectCommandQueue,
+} from "../../concurrency";
+import type { ProjectError } from "../../errors";
+import type { ProjectAction, ProjectData, ProjectState } from "../../reducer";
+import { reducer } from "../../reducer";
+import { moveTaskAction } from "../moveTask";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    updateTask: vi.fn(),
+    updateCardOrder: vi.fn(),
+  };
+});
+
+const updateTaskMock = vi.mocked(updateTaskInvoke);
+const updateCardOrderMock = vi.mocked(updateCardOrderInvoke);
+
+const makeTask = (overrides: Partial<TaskPayload>): Task =>
+  Task.fromPayload({
+    id: overrides.filePath ?? "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+const makeData = (
+  pairs: ReadonlyArray<readonly [string, string]>,
+): ProjectData => ({
+  tasks: pairs.map(([filePath, status]) => makeTask({ filePath, status })),
+  columns: [
+    { name: "Todo", order: 0 },
+    { name: "Done", order: 1 },
+  ],
+});
+
+type Harness = {
+  state: { current: ProjectState };
+  actions: ProjectAction[];
+  deps: Parameters<typeof moveTaskAction>[0];
+};
+
+const setupLoaded = (data: ProjectData): Harness => {
+  const state = {
+    current: { kind: "loaded", path: "/p", data } as ProjectState,
+  };
+  const actions: ProjectAction[] = [];
+  const queue: ProjectCommandQueue = { current: Promise.resolve() };
+  const version = createProjectVersion();
+  return {
+    state,
+    actions,
+    deps: {
+      projectVersion: version,
+      projectCommandQueue: queue,
+      getState: () => state.current,
+      dispatchSync: (action) => {
+        actions.push(action);
+        state.current = reducer(state.current, action);
+      },
+    },
+  };
+};
+
+beforeEach(() => {
+  updateTaskMock.mockReset();
+  updateCardOrderMock.mockReset();
+});
+
+test("fromColumn !== toColumn で updateTask が呼ばれる", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  expect(updateTaskMock).toHaveBeenCalledWith({
+    filePath: "tasks/a.md",
+    status: "Done",
+  });
+});
+
+test("カラム間移動: updateTask 成功後 updateCardOrder が呼ばれる", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+      ["tasks/c.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 1,
+  });
+
+  expect(updateCardOrderMock).toHaveBeenCalledWith({
+    columnName: "Done",
+    filePaths: ["tasks/b.md", "tasks/a.md", "tasks/c.md"],
+  });
+});
+
+test("カラム間移動: task-updated → card-order-updated の順で dispatch される", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  expect(harness.actions.map((a) => a.type)).toEqual([
+    "task-updated",
+    "card-order-updated",
+  ]);
+});
+
+test("カラム間移動成功後、ProjectData.tasks に target が toIndex 位置で含まれる", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+      ["tasks/c.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 1,
+  });
+
+  const next = harness.state.current as { data: ProjectData };
+  const inDone = next.data.tasks
+    .filter((t) => t.status === "Done")
+    .map((t) => t.filePath);
+  expect(inDone).toEqual(["tasks/b.md", "tasks/a.md", "tasks/c.md"]);
+});
+
+test("fromColumn === toColumn で並び順変化があれば updateCardOrder が呼ばれる", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Todo"],
+      ["tasks/c.md", "Todo"],
+    ]),
+  );
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  const result = await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Todo",
+    toIndex: 2,
+  });
+
+  expect(result.ok).toBe(true);
+  expect(updateTaskMock).not.toHaveBeenCalled();
+  expect(updateCardOrderMock).toHaveBeenCalledWith({
+    columnName: "Todo",
+    filePaths: ["tasks/b.md", "tasks/c.md", "tasks/a.md"],
+  });
+});
+
+test("カラム内並び替え後の ProjectData.tasks 表示順が filePaths と一致", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Todo"],
+      ["tasks/c.md", "Todo"],
+    ]),
+  );
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/c.md",
+    fromColumn: "Todo",
+    toColumn: "Todo",
+    toIndex: 0,
+  });
+
+  const next = harness.state.current as { data: ProjectData };
+  expect(next.data.tasks.map((t) => t.filePath)).toEqual([
+    "tasks/c.md",
+    "tasks/a.md",
+    "tasks/b.md",
+  ]);
+});
+
+test("並び順変化なし → IPC を呼ばず Result.ok", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Todo"],
+    ]),
+  );
+
+  const result = await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Todo",
+    toIndex: 0,
+  });
+
+  expect(result.ok).toBe(true);
+  expect(updateTaskMock).toHaveBeenCalledTimes(0);
+  expect(updateCardOrderMock).toHaveBeenCalledTimes(0);
+});
+
+test("updateTask が Result.err なら ProjectError.tauri を返し updateCardOrder は呼ばれない", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const err = new TauriError("UNKNOWN", "x");
+  updateTaskMock.mockResolvedValue(Result.err(err));
+
+  const result = await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("tauri");
+  expect(updateCardOrderMock).not.toHaveBeenCalled();
+});
+
+test("カラム間で updateTask 成功 / updateCardOrder 失敗 → task-updated は dispatch、card-order-updated は dispatch されず Result.err", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(
+    Result.err(new TauriError("UNKNOWN", "x")),
+  );
+
+  const result = await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  expect(result.ok).toBe(false);
+  expect(harness.actions.map((a) => a.type)).toEqual(["task-updated"]);
+});
+
+test("session が loaded でない時 invalidState で抜ける", async () => {
+  const state = { current: { kind: "idle" } as ProjectState };
+  const queue: ProjectCommandQueue = { current: Promise.resolve() };
+  const version = createProjectVersion();
+  const result = await moveTaskAction(
+    {
+      projectVersion: version,
+      projectCommandQueue: queue,
+      getState: () => state.current,
+      dispatchSync: () => {},
+    },
+    {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: 0,
+    },
+  );
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("invalid-state");
+  expect(updateTaskMock).not.toHaveBeenCalled();
+});
+
+test("IPC 中に projectVersion が変わると invalidState で抜ける", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockImplementation(async () => {
+    invalidateProject(harness.deps.projectVersion);
+    return Result.ok(movedA);
+  });
+
+  const result = await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("invalid-state");
+  expect(updateCardOrderMock).not.toHaveBeenCalled();
+});
+
+test.each([
+  {
+    name: "target task が存在しない",
+    pairs: [
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ] as const,
+    params: {
+      taskFilePath: "tasks/missing.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: 0,
+    },
+  },
+  {
+    name: "target.status と fromColumn が異なる",
+    pairs: [
+      ["tasks/a.md", "Done"],
+      ["tasks/b.md", "Todo"],
+    ] as const,
+    params: {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: 0,
+    },
+  },
+  {
+    name: "toColumn が columns に存在しない",
+    pairs: [
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ] as const,
+    params: {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Unknown",
+      toIndex: 0,
+    },
+  },
+])("queue 実行時に $name → invalidState", async ({ pairs, params }) => {
+  const harness = setupLoaded(makeData(pairs));
+  const result = await moveTaskAction(harness.deps, params);
+  expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("invalid-state");
+});

--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -255,6 +255,32 @@ test("並び順変化なし → IPC を呼ばず Result.ok", async () => {
   expect(updateCardOrderMock).toHaveBeenCalledTimes(0);
 });
 
+test("同一カラムで updateCardOrder が Result.err → ProjectError.tauri、card-order-updated は dispatch されない", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Todo"],
+      ["tasks/c.md", "Todo"],
+    ]),
+  );
+  updateCardOrderMock.mockResolvedValue(
+    Result.err(new TauriError("IO_ERROR", "io fail")),
+  );
+
+  const result = await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Todo",
+    toIndex: 2,
+  });
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("tauri");
+  expect(updateTaskMock).not.toHaveBeenCalled();
+  expect(updateCardOrderMock).toHaveBeenCalledTimes(1);
+  expect(harness.actions.map((a) => a.type)).toEqual([]);
+});
+
 test("updateTask が Result.err なら ProjectError.tauri を返し updateCardOrder は呼ばれない", async () => {
   const harness = setupLoaded(
     makeData([

--- a/src/features/board/hooks/useProject/actions/buildMovedFilePaths.ts
+++ b/src/features/board/hooks/useProject/actions/buildMovedFilePaths.ts
@@ -1,0 +1,35 @@
+import type { Task } from "@/types/task";
+
+/**
+ * 移動先カラムの新しい filePaths を生成する純粋関数。
+ *
+ * 手順:
+ * 1. tasks から `toColumn` に属するタスクを抽出し、現状 filePaths を取得
+ * 2. 移動対象 (`taskFilePath`) が含まれていれば一度除外（同一カラム内移動の重複排除）
+ * 3. `toIndex` を `[0, withoutTarget.length]` に clamp
+ * 4. clamp 済み位置に `taskFilePath` を挿入
+ * 5. 結果を返す（移動後の toColumn 内 filePaths）
+ *
+ * @param tasks 現在の全 task
+ * @param taskFilePath 移動対象 task の filePath
+ * @param toColumn 移動先カラム名
+ * @param toIndex hover 計算で得られた挿入位置
+ * @returns 移動先カラムの新 filePaths（toColumn に属するタスクの並び順）
+ */
+export const buildMovedFilePaths = (
+  tasks: readonly Task[],
+  taskFilePath: string,
+  toColumn: string,
+  toIndex: number,
+): string[] => {
+  const filePathsInColumn = tasks
+    .filter((t) => t.status === toColumn)
+    .map((t) => t.filePath);
+  const withoutTarget = filePathsInColumn.filter((p) => p !== taskFilePath);
+  const clamped = Math.max(0, Math.min(toIndex, withoutTarget.length));
+  return [
+    ...withoutTarget.slice(0, clamped),
+    taskFilePath,
+    ...withoutTarget.slice(clamped),
+  ];
+};

--- a/src/features/board/hooks/useProject/actions/buildMovedFilePaths.ts
+++ b/src/features/board/hooks/useProject/actions/buildMovedFilePaths.ts
@@ -5,28 +5,38 @@ import type { Task } from "@/types/task";
  *
  * 手順:
  * 1. tasks から `toColumn` に属するタスクを抽出し、現状 filePaths を取得
- * 2. 移動対象 (`taskFilePath`) が含まれていれば一度除外（同一カラム内移動の重複排除）
- * 3. `toIndex` を `[0, withoutTarget.length]` に clamp
- * 4. clamp 済み位置に `taskFilePath` を挿入
- * 5. 結果を返す（移動後の toColumn 内 filePaths）
+ * 2. 同一カラム内（fromColumn === toColumn）かつ元 index &lt; toIndex のとき、
+ *    toIndex を 1 減らす。hover index は target を含む DOM から計算されるため、
+ *    target 除外後の配列に適用する際 1 ズレる。カラム間移動では target は
+ *    toColumn の DOM に含まれていなかったので補正しない。
+ * 3. 移動対象 (`taskFilePath`) が含まれていれば一度除外（同一カラム内移動の重複排除）
+ * 4. 補正済み toIndex を `[0, withoutTarget.length]` に clamp
+ * 5. clamp 済み位置に `taskFilePath` を挿入
+ * 6. 結果を返す（移動後の toColumn 内 filePaths）
  *
  * @param tasks 現在の全 task
  * @param taskFilePath 移動対象 task の filePath
+ * @param fromColumn 元カラム名（hover index 補正の判断に使用）
  * @param toColumn 移動先カラム名
- * @param toIndex hover 計算で得られた挿入位置
+ * @param toIndex hover 計算で得られた挿入位置（target を含む DOM 位置基準）
  * @returns 移動先カラムの新 filePaths（toColumn に属するタスクの並び順）
  */
 export const buildMovedFilePaths = (
   tasks: readonly Task[],
   taskFilePath: string,
+  fromColumn: string,
   toColumn: string,
   toIndex: number,
 ): string[] => {
   const filePathsInColumn = tasks
     .filter((t) => t.status === toColumn)
     .map((t) => t.filePath);
+  const originalIndex = filePathsInColumn.indexOf(taskFilePath);
+  const sameColumnDownward =
+    fromColumn === toColumn && originalIndex !== -1 && originalIndex < toIndex;
+  const adjustedIndex = sameColumnDownward ? toIndex - 1 : toIndex;
   const withoutTarget = filePathsInColumn.filter((p) => p !== taskFilePath);
-  const clamped = Math.max(0, Math.min(toIndex, withoutTarget.length));
+  const clamped = Math.max(0, Math.min(adjustedIndex, withoutTarget.length));
   return [
     ...withoutTarget.slice(0, clamped),
     taskFilePath,

--- a/src/features/board/hooks/useProject/actions/moveTask.ts
+++ b/src/features/board/hooks/useProject/actions/moveTask.ts
@@ -1,0 +1,158 @@
+import { updateCardOrder, updateTask } from "@/lib/tauri";
+import { Result, type Result as ResultT } from "@/utils/result";
+import { enqueueProjectCommand, isProjectCurrent } from "../concurrency";
+import { ProjectError } from "../errors";
+import { ProjectSessionState } from "../state/projectSessionState";
+import { buildMovedFilePaths } from "./buildMovedFilePaths";
+import type { TaskActionDeps } from "./tasks";
+
+/** moveTask が受け取るパラメータ。 */
+export type MoveTaskParams = {
+  readonly taskFilePath: string;
+  readonly fromColumn: string;
+  readonly toColumn: string;
+  readonly toIndex: number;
+};
+
+/**
+ * task command を受け付けられる data state か事前検証する。
+ *
+ * @param deps 最新 state を読むための依存
+ * @returns loaded / loading.previousLoaded なら ok、未 open なら invalid-state
+ */
+const ensureLoaded = (
+  deps: Pick<TaskActionDeps, "getState">,
+): ResultT<void, ProjectError> =>
+  ProjectSessionState.canAcceptDataCommand(deps.getState())
+    ? Result.ok(undefined)
+    : Result.err(ProjectError.invalidState());
+
+/**
+ * Drop 確定時に Board から呼ばれる単一 entry point。
+ * - fromColumn !== toColumn: updateTask + updateCardOrder(toColumn) の 2 連 IPC
+ * - fromColumn === toColumn: 並び替え後 filePaths と現状を比較し、変化なしなら no-op
+ *                            変化あれば updateCardOrder のみ
+ *
+ * @param deps queue / version / state / dispatch 依存
+ * @param params 移動パラメータ
+ * @returns 成功時 Result.ok(undefined) / 失敗時 Result.err(ProjectError)
+ */
+export const moveTaskAction = (
+  deps: TaskActionDeps,
+  params: MoveTaskParams,
+): Promise<ResultT<void, ProjectError>> => {
+  const preflight = ensureLoaded(deps);
+  if (!preflight.ok) {
+    return Promise.resolve(preflight);
+  }
+
+  const version = deps.projectVersion.current;
+
+  return enqueueProjectCommand(deps.projectCommandQueue, async () => {
+    if (
+      !ProjectSessionState.canAcceptDataCommand(deps.getState()) ||
+      !isProjectCurrent(deps.projectVersion, version)
+    ) {
+      return Result.err(
+        ProjectError.invalidState("プロジェクトが切り替わりました"),
+      );
+    }
+
+    const data = ProjectSessionState.visibleData(deps.getState());
+    if (data === null) {
+      return Result.err(ProjectError.invalidState("not loaded"));
+    }
+
+    const target = data.tasks.find((t) => t.filePath === params.taskFilePath);
+    if (!target) {
+      return Result.err(ProjectError.invalidState("task missing"));
+    }
+    if (target.status !== params.fromColumn) {
+      return Result.err(ProjectError.invalidState("fromColumn mismatch"));
+    }
+    if (!data.columns.some((c) => c.name === params.toColumn)) {
+      return Result.err(ProjectError.invalidState("toColumn missing"));
+    }
+
+    if (params.fromColumn !== params.toColumn) {
+      const updateResult = await updateTask({
+        filePath: params.taskFilePath,
+        status: params.toColumn,
+      });
+      if (!updateResult.ok) {
+        return Result.err(ProjectError.tauri(updateResult.error));
+      }
+      if (!isProjectCurrent(deps.projectVersion, version)) {
+        return Result.err(
+          ProjectError.invalidState("プロジェクトが切り替わりました"),
+        );
+      }
+      deps.dispatchSync({
+        type: "task-updated",
+        originalFilePath: params.taskFilePath,
+        task: updateResult.value,
+      });
+
+      const latestData = ProjectSessionState.visibleData(deps.getState());
+      const filePaths = buildMovedFilePaths(
+        latestData?.tasks ?? [],
+        params.taskFilePath,
+        params.toColumn,
+        params.toIndex,
+      );
+      const orderResult = await updateCardOrder({
+        columnName: params.toColumn,
+        filePaths,
+      });
+      if (!orderResult.ok) {
+        return Result.err(ProjectError.tauri(orderResult.error));
+      }
+      if (!isProjectCurrent(deps.projectVersion, version)) {
+        return Result.err(
+          ProjectError.invalidState("プロジェクトが切り替わりました"),
+        );
+      }
+      deps.dispatchSync({
+        type: "card-order-updated",
+        columnName: params.toColumn,
+        filePaths,
+      });
+      return Result.ok(undefined);
+    }
+
+    const currentFilePaths = data.tasks
+      .filter((t) => t.status === params.toColumn)
+      .map((t) => t.filePath);
+    const filePaths = buildMovedFilePaths(
+      data.tasks,
+      params.taskFilePath,
+      params.toColumn,
+      params.toIndex,
+    );
+    if (
+      filePaths.length === currentFilePaths.length &&
+      filePaths.every((p, i) => p === currentFilePaths[i])
+    ) {
+      return Result.ok(undefined);
+    }
+
+    const orderResult = await updateCardOrder({
+      columnName: params.toColumn,
+      filePaths,
+    });
+    if (!orderResult.ok) {
+      return Result.err(ProjectError.tauri(orderResult.error));
+    }
+    if (!isProjectCurrent(deps.projectVersion, version)) {
+      return Result.err(
+        ProjectError.invalidState("プロジェクトが切り替わりました"),
+      );
+    }
+    deps.dispatchSync({
+      type: "card-order-updated",
+      columnName: params.toColumn,
+      filePaths,
+    });
+    return Result.ok(undefined);
+  });
+};

--- a/src/features/board/hooks/useProject/actions/moveTask.ts
+++ b/src/features/board/hooks/useProject/actions/moveTask.ts
@@ -116,7 +116,7 @@ export const moveTaskAction = (
         filePaths,
       });
       if (!orderResult.ok) {
-        return Result.err(ProjectError.tauri(orderResult.error));
+        return Result.err(ProjectError.partialMove(orderResult.error));
       }
       if (!isProjectCurrent(deps.projectVersion, version)) {
         return Result.err(

--- a/src/features/board/hooks/useProject/actions/moveTask.ts
+++ b/src/features/board/hooks/useProject/actions/moveTask.ts
@@ -60,18 +60,28 @@ export const moveTaskAction = (
 
     const data = ProjectSessionState.visibleData(deps.getState());
     if (data === null) {
-      return Result.err(ProjectError.invalidState("not loaded"));
+      return Result.err(
+        ProjectError.invalidState("プロジェクトが開かれていません"),
+      );
     }
 
     const target = data.tasks.find((t) => t.filePath === params.taskFilePath);
     if (!target) {
-      return Result.err(ProjectError.invalidState("task missing"));
+      return Result.err(
+        ProjectError.invalidState("対象のタスクが見つかりません"),
+      );
     }
     if (target.status !== params.fromColumn) {
-      return Result.err(ProjectError.invalidState("fromColumn mismatch"));
+      return Result.err(
+        ProjectError.invalidState(
+          "タスクの状態が変わったためやり直してください",
+        ),
+      );
     }
     if (!data.columns.some((c) => c.name === params.toColumn)) {
-      return Result.err(ProjectError.invalidState("toColumn missing"));
+      return Result.err(
+        ProjectError.invalidState("移動先カラムが見つかりません"),
+      );
     }
 
     if (params.fromColumn !== params.toColumn) {

--- a/src/features/board/hooks/useProject/actions/moveTask.ts
+++ b/src/features/board/hooks/useProject/actions/moveTask.ts
@@ -97,6 +97,7 @@ export const moveTaskAction = (
       const filePaths = buildMovedFilePaths(
         latestData?.tasks ?? [],
         params.taskFilePath,
+        params.fromColumn,
         params.toColumn,
         params.toIndex,
       );
@@ -126,6 +127,7 @@ export const moveTaskAction = (
     const filePaths = buildMovedFilePaths(
       data.tasks,
       params.taskFilePath,
+      params.fromColumn,
       params.toColumn,
       params.toIndex,
     );

--- a/src/features/board/hooks/useProject/errors.ts
+++ b/src/features/board/hooks/useProject/errors.ts
@@ -4,10 +4,13 @@ import type { TauriError } from "@/lib/tauri";
  * useProject hook が呼び出し側に返すエラー型。discriminated union。
  * - `tauri`: BE / dialog 由来の TauriError をそのまま運ぶ
  * - `invalid-state`: hook 内部状態が不正（loaded 以外で task/column method を呼んだ等）
+ * - `partial-move`: カラム間移動で status 更新は成功したが card-order 保存に失敗した
+ *   ケース。「失敗」とだけ伝えると実際は移動済みなのに「失敗扱い」となるため区別する
  */
 export type ProjectError =
   | { kind: "tauri"; error: TauriError }
-  | { kind: "invalid-state"; message: string };
+  | { kind: "invalid-state"; message: string }
+  | { kind: "partial-move"; message: string; underlying: TauriError };
 
 export const ProjectError = {
   /**
@@ -30,5 +33,19 @@ export const ProjectError = {
   tauri: (error: TauriError): ProjectError => ({
     kind: "tauri",
     error,
+  }),
+
+  /**
+   * カラム間移動の途中失敗を表す error を作成する。status 更新は成功したが
+   * card-order 保存に失敗したケースで使う。
+   *
+   * @param underlying card-order IPC が返した TauriError
+   * @returns partial-move の ProjectError
+   */
+  partialMove: (underlying: TauriError): ProjectError => ({
+    kind: "partial-move",
+    message:
+      "カラムの移動は完了しましたが、並び順の保存に失敗しました。手動で並び替えてください。",
+    underlying,
   }),
 } as const;

--- a/src/features/board/hooks/useProject/index.ts
+++ b/src/features/board/hooks/useProject/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/lib/tauri";
 import { Task, type TaskPayload } from "@/types/task";
 import type { Result as ResultT } from "@/utils/result";
+import { type MoveTaskParams, moveTaskAction } from "./actions/moveTask";
 import { openProjectAction } from "./actions/openProject";
 import {
   createTaskAction,
@@ -40,6 +41,7 @@ export type { ProjectData, ProjectState } from "./reducer";
 export type {
   ColumnsCommand,
   ColumnsCommandBuilder,
+  MoveTaskParams,
   UpdateColumnsInput,
   UseProjectOptions,
   UseProjectResult,
@@ -250,6 +252,12 @@ export const useProject = (
     [actionDeps],
   );
 
+  const moveTask = useCallback(
+    (params: MoveTaskParams): Promise<ResultT<void, ProjectError>> =>
+      moveTaskAction(actionDeps(), params),
+    [actionDeps],
+  );
+
   const reset = useCallback((): void => {
     invalidateOpenRequests(projectVersionRef.current);
     invalidateProject(projectVersionRef.current);
@@ -263,6 +271,7 @@ export const useProject = (
     updateTask,
     deleteTask,
     updateColumns,
+    moveTask,
     reset,
   };
 };

--- a/src/features/board/hooks/useProject/reducer.ts
+++ b/src/features/board/hooks/useProject/reducer.ts
@@ -28,6 +28,7 @@ export type ProjectAction =
       doneColumn?: string;
     }
   | { type: "done-column-refreshed"; doneColumn: string }
+  | { type: "card-order-updated"; columnName: string; filePaths: string[] }
   | { type: "reset" };
 
 export const initialState: ProjectState = ProjectSessionState.initial;
@@ -77,6 +78,14 @@ export const reducer = (
     case "done-column-refreshed":
       return ProjectSessionState.updateData(state, (data) =>
         ProjectDataDomain.refreshDoneColumn(data, action.doneColumn),
+      );
+    case "card-order-updated":
+      return ProjectSessionState.updateData(state, (data) =>
+        ProjectDataDomain.applyCardOrderUpdated(
+          data,
+          action.columnName,
+          action.filePaths,
+        ),
       );
     case "reset":
       return ProjectSessionState.reset();

--- a/src/features/board/hooks/useProject/types.ts
+++ b/src/features/board/hooks/useProject/types.ts
@@ -9,6 +9,7 @@ import type {
   ColumnsCommand,
   ColumnsCommandBuilder,
 } from "./actions/columnsCommand";
+import type { MoveTaskParams } from "./actions/moveTask";
 import type { ProjectError } from "./errors";
 import type { ProjectSessionState } from "./state/projectSessionState";
 
@@ -16,6 +17,7 @@ export type {
   ColumnsCommand,
   ColumnsCommandBuilder,
 } from "./actions/columnsCommand";
+export type { MoveTaskParams } from "./actions/moveTask";
 
 export type UpdateColumnsInput = ColumnsCommand | ColumnsCommandBuilder;
 
@@ -59,6 +61,12 @@ export type UseProjectResult = {
   updateColumns: (
     command: UpdateColumnsInput,
   ) => Promise<ResultT<{ applied: boolean }, ProjectError>>;
+  /**
+   * task のカラム間移動 / カラム内並び替えを単一 entry point で受け付ける。
+   * @param params 移動パラメータ
+   * @returns 成否を表す Result または ProjectError
+   */
+  moveTask: (params: MoveTaskParams) => Promise<ResultT<void, ProjectError>>;
   /** project state を初期状態に戻す。 */
   reset: () => void;
 };

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -4,6 +4,7 @@ export { HeaderBar } from "./components/HeaderBar";
 export type {
   ColumnsCommand,
   ColumnsCommandBuilder,
+  MoveTaskParams,
   ProjectData,
   ProjectError,
   ProjectState,

--- a/src/test-fixtures/__tests__/createDragEvent.behavior.test.ts
+++ b/src/test-fixtures/__tests__/createDragEvent.behavior.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "vitest";
+import { createDragEvent } from "../createDragEvent";
+
+test("createDragEvent('dragstart') の type が 'dragstart'", () => {
+  const event = createDragEvent("dragstart");
+  expect(event.type).toBe("dragstart");
+});
+
+test("setData した値が getData で読める", () => {
+  const event = createDragEvent("dragstart");
+  event.dataTransfer.setData("application/x-spec-board-task", "tasks/a.md");
+  expect(event.dataTransfer.getData("application/x-spec-board-task")).toBe(
+    "tasks/a.md",
+  );
+});
+
+test("options を省略しても DataTransfer が注入される", () => {
+  const event = createDragEvent("dragover");
+  expect(event.dataTransfer).toBeInstanceOf(DataTransfer);
+  expect(event.clientX).toBe(0);
+  expect(event.clientY).toBe(0);
+});
+
+test("clientX / clientY を渡せる", () => {
+  const event = createDragEvent("dragover", { clientX: 12, clientY: 34 });
+  expect(event.clientX).toBe(12);
+  expect(event.clientY).toBe(34);
+});

--- a/src/test-fixtures/createDragEvent.ts
+++ b/src/test-fixtures/createDragEvent.ts
@@ -1,0 +1,61 @@
+/** createDragEvent が受け付ける DragEvent 種別。 */
+export type DragEventType =
+  | "dragstart"
+  | "dragover"
+  | "dragleave"
+  | "drop"
+  | "dragend";
+
+/** createDragEvent のオプション。 */
+export type CreateDragEventOptions = {
+  readonly dataTransfer?: DataTransfer;
+  readonly clientX?: number;
+  readonly clientY?: number;
+  readonly bubbles?: boolean;
+  readonly cancelable?: boolean;
+};
+
+/**
+ * happy-dom 20 には DragEvent class が無いため、Event のサブクラスで代替する。
+ * `dataTransfer` / `clientX` / `clientY` をインスタンスフィールドとして持たせる
+ * ことで、`Object.defineProperty` 等の後付け注入が不要になる。
+ */
+export class DragLikeEvent extends Event {
+  readonly dataTransfer: DataTransfer;
+  readonly clientX: number;
+  readonly clientY: number;
+
+  /**
+   * DragLikeEvent を構築する。
+   * @param type DragEvent 種別
+   * @param options 任意の dataTransfer / 座標 / propagation 設定
+   */
+  constructor(type: DragEventType, options: CreateDragEventOptions = {}) {
+    super(type, {
+      bubbles: options.bubbles ?? true,
+      cancelable: options.cancelable ?? true,
+    });
+    this.dataTransfer = options.dataTransfer ?? new DataTransfer();
+    this.clientX = options.clientX ?? 0;
+    this.clientY = options.clientY ?? 0;
+  }
+}
+
+/**
+ * テスト用の DragEvent 互換イベントを生成する thin factory。
+ *
+ * 使用例:
+ * ```ts
+ * const event = createDragEvent("dragstart");
+ * event.dataTransfer.setData("application/x-spec-board-task", "tasks/a.md");
+ * element.dispatchEvent(event);
+ * ```
+ *
+ * @param type DragEvent 種別
+ * @param options 任意の dataTransfer / 座標 / propagation 設定
+ * @returns DragLikeEvent インスタンス
+ */
+export const createDragEvent = (
+  type: DragEventType,
+  options: CreateDragEventOptions = {},
+): DragLikeEvent => new DragLikeEvent(type, options);

--- a/src/types/dragCardRect.ts
+++ b/src/types/dragCardRect.ts
@@ -1,0 +1,9 @@
+/**
+ * ドラッグ操作中の各カードの上下端 Y 座標を表す。
+ * `DOMRect` の top/bottom のみを抜き出した最小構造で、hover index 計算など
+ * 純粋関数のテストでもインスタンス生成しやすい。
+ */
+export type DragCardRect = {
+  readonly top: number;
+  readonly bottom: number;
+};


### PR DESCRIPTION
## 概要

- カンバンボードのカードを HTML5 ネイティブ Drag and Drop API のみで DnD 化（外部ライブラリ非導入）
- カラム間移動: `update_task` + `update_card_order` の 2 連 IPC、同一カラム並び替え: `update_card_order` 1 回
- BE 側 `update_task` / `update_card_order` 実装は別 issue 依存（本 PR は FE のみ）

## 変更の種類

- ✨ 新機能（FE）

## 追加した内容

- `src/features/board/components/Board/dragState.ts` — `DragState` reducer + `DragAction` companion + `DRAG_MIME_TYPE`
- `src/features/board/components/Column/dragHover.ts` — `computeHoverIndex` 純粋関数
- `src/features/board/hooks/useProject/actions/moveTask.ts` — `moveTaskAction` (2 連 IPC + version / stale state ガード)
- `src/features/board/hooks/useProject/actions/buildMovedFilePaths.ts` — toIndex clamp + 重複排除
- `src/test-fixtures/createDragEvent.ts` — happy-dom 用 `DragLikeEvent` factory
- 新規テスト 9 ファイル: `dragState` / `dragHover` / `createDragEvent` / `buildMovedFilePaths` / `applyCardOrderUpdated` / `TaskCard.dnd` / `Column.dnd` / `Board.dnd` / `moveTask.behavior`

## 変更した内容

- `TaskCard`: `draggable` 属性 + `data-dragging` / opacity 0.4、`fromColumn` prop を必須化
- `Column`: `dragover` / `dragleave` / `drop` ハンドラ + drop placeholder 描画
- `Board`: `useReducer(dragReducer)` で DragState 保持 → Column に配布、`onTaskDrop` を新設
- `useProject`: `moveTask` API 追加（reducer に `card-order-updated` 追加 / `ProjectData.applyCardOrderUpdated` 追加）
- `App.tsx`: `project.moveTask` を `<Board onTaskDrop>` に配線、失敗時はトースト
- Storybook: TaskCard `Dragging` / `Draggable`、Column `HoverTop` / `HoverMiddle` / `HoverBottom` を追加

## 削除した内容

なし

## 仕様ドキュメント更新

- `docs/spec-board/board-view-spec.md` — DnD 節を新設し、IPC シーケンス・UI 表現・エッジケースを明記
- `docs/impl/dnd-board.md` — 新規作成（設計判断メモ: ライブラリ非採用 / 楽観 UI 不採用 / 旧カラム cardOrder 自動メンテ契約 / `dragGuardRef` の synthetic click 抑止 等）

## システム図

```mermaid
flowchart TD
    A[ユーザー: カードをドラッグ] -->|TaskCard.onDragStart| B[Board: dispatch DragAction.start]
    B -->|dragState 配布| C[Column: dragover]
    C -->|computeHoverIndex| D[Board: dispatch DragAction.hover]
    D -->|placeholder 表示| E[Column: drop]
    E -->|onTaskDrop| F[App.handleTaskDrop]
    F --> G[useProject.moveTask]
    G --> H{fromColumn vs toColumn}
    H -->|異なる| I[updateTask IPC]
    I --> J[task-updated dispatch]
    J --> K[updateCardOrder IPC<br/>toColumn 側]
    K --> L[card-order-updated dispatch]
    H -->|同じ + 並び順変化| M[updateCardOrder IPC]
    M --> L
    H -->|同じ + 並び順不変| N[no-op Result.ok]
    L --> O[Board: handleTaskDrop finally で<br/>DragAction.end → dragState=null]
    N --> O

    style I fill:#e1f5ff
    style K fill:#e1f5ff
    style M fill:#e1f5ff
```

## 関連Issue

Refs #110

> BE 側 `update_task` / `update_card_order` の Tauri command 実装は別 issue で起票が必要（本 PR は FE のみで完結し、IPC は `vi.mock("@/lib/tauri", ...)` でモックテスト）。

## テスト

- `pnpm test:run`: **736 passed (87 files)**
- `pnpm typecheck`: エラーなし
- `pnpm lint`: 0 errors / 0 warnings

### テスト計画

- [ ] CI 全グリーン
- [ ] BE 実装後の手動検証（実機での DnD → BE 反映）

## レビューポイント

- `moveTaskAction` の version / stale state ガード（既存 `updateTaskAction` と同じパターン）
- `ProjectData.applyCardOrderUpdated` の他カラム順序維持と末尾フォールバックの挙動
- `dragGuardRef` による drag end 直後の synthetic click 抑止（詳細パネル誤発火防止）
- 並び順変化なしの no-op 判定（同一カラム drop で IPC を呼ばない）
- TaskCard の `fromColumn` 必須化に伴う既存 Storybook / テストの追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)