### PR TITLE
🧪 [Tests]: #85 [BE] update_task の parent 変更時 循環検証テストを網羅

### DIFF
--- a/docs/spec-board/task-format-spec.md
+++ b/docs/spec-board/task-format-spec.md
@@ -291,6 +291,17 @@ update_task は `filePath` で識別し、**ファイル移動は一切行わな
 `validate_parent_hierarchy` + `build_children` + `build_reverse_links` を実行する。
 title / status / priority / labels / body 単独の更新では再構築しない。
 
+`parent` フィールドの「変化」は `intent.parent` の値に応じて以下のように判定する:
+
+- `None`: parent は変更されない（`parent_changed=false`）。hierarchy 検証はスキップする（全タスク走査の O(N) コストを回避）。
+- `Some("")`: parent を解除する。既存 parent が存在する、または frontmatter から `parent` キーが除去された場合に `parent_changed=true` となり hierarchy 検証を実行する（親解除なので構造的に循環は発生しないが、不正データの早期検出のため検証は走る）。
+- `Some(path)`（非空）: 検証は以下の順序で実行する:
+  1. **parent 存在チェック** — `parent_changed` の真偽に関わらず、最初に cache から該当 task を引き当てる。存在しなければ `parent not found: <path>` を返す。
+  2. **正規化等価判定** — 正規化済みパス（`./tasks/p.md` / `tasks\p.md` などの表記揺れを吸収する lookup key）が既存 parent と等価なら `parent_changed=false` として hierarchy 検証はスキップする。
+  3. **hierarchy 検証** — 正規化等価でない場合のみ `parent_changed=true` となり、対象 task を patch した暫定状態で全タスクの parent チェーンを `validate_parent_hierarchy` により再検証する。
+
+検証に失敗した場合は `parent validation: <file_path> (<reason>)` を返し、ファイル書き込みおよび cache 更新は行わない。`reason` は循環検出 (`Cycle`) または 20 段超過 (`TooDeep`) のいずれか。
+
 ## 制限事項
 
 - ファイルエンコーディングは **UTF-8（BOMなし）** のみサポート。BOM付きUTF-8はBOMを除去して読み込む。その他のエンコーディング（Shift-JIS等）はパースエラー

--- a/src-tauri/src/task/task_index_plan_update_tests.rs
+++ b/src-tauri/src/task/task_index_plan_update_tests.rs
@@ -635,3 +635,213 @@ fn plan_update_returns_root_relative_file_path_in_updated_task() {
 
     assert_eq!(outcome.updated_task.file_path, "tasks/a.md");
 }
+
+// `intent.parent = None` のとき、cache 側に独立循環があっても
+// hierarchy 検証はスキップされ、`needs_full_rebuild=false` で返ること。
+// `TaskIndex::new` は validation を走らせない契約を利用して
+// 不正状態の cache を直接構築できる。
+#[test]
+fn plan_update_with_no_parent_change_skips_hierarchy_validation() {
+    let tasks = vec![
+        make_task("tasks/x.md", Some("tasks/y.md")),
+        make_task("tasks/y.md", Some("tasks/x.md")),
+        make_task("tasks/a.md", None),
+    ];
+    let task = tasks
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .unwrap()
+        .clone();
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(tasks);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.status = Some("Doing".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("validation should be skipped when parent is unchanged");
+    assert!(
+        !outcome.needs_full_rebuild,
+        "parent unchanged → no full rebuild"
+    );
+}
+
+// 既存 parent と正規化等価な値を渡しても `parent_changed=false` でスキップされ、
+// cache 中の独立循環は検出されないこと（`plan_update_same_parent_with_dot_prefix_is_not_treated_as_change`
+// との差分: 独立循環を含む cache でも結果が変わらないことの観測）。
+#[test]
+fn plan_update_normalized_equal_parent_skips_hierarchy_validation() {
+    let tasks = vec![
+        make_task("tasks/x.md", Some("tasks/y.md")),
+        make_task("tasks/y.md", Some("tasks/x.md")),
+        make_task("tasks/p.md", None),
+        make_task("tasks/a.md", Some("tasks/p.md")),
+    ];
+    let task = tasks
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .unwrap()
+        .clone();
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/p.md\n---\n");
+    let index = TaskIndex::new(tasks);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("./tasks/p.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("normalized-equal parent must skip hierarchy validation");
+    assert!(
+        !outcome.needs_full_rebuild,
+        "normalized-equal parent → no rebuild, independent cycle stays hidden"
+    );
+}
+
+// 非祖先・非子孫 subtree への parent 接続が許可されること
+// （chain A: c → b → a, chain B: y → x の root x を c に付け替え → 非循環）。
+#[test]
+fn plan_update_sibling_parent_change_is_allowed() {
+    let tasks = vec![
+        make_task("tasks/a.md", None),
+        make_task("tasks/b.md", Some("tasks/a.md")),
+        make_task("tasks/c.md", Some("tasks/b.md")),
+        make_task("tasks/x.md", None),
+        make_task("tasks/y.md", Some("tasks/x.md")),
+    ];
+    let task = tasks
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/x.md")
+        .unwrap()
+        .clone();
+    let parsed = parsed_from_md("---\ntitle: X\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(tasks);
+
+    let mut intent = empty_intent("tasks/x.md");
+    intent.parent = Some("tasks/c.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("cross-subtree reparent must be allowed");
+    assert!(outcome.needs_full_rebuild);
+    assert!(outcome.file_content.contains("parent: tasks/c.md"));
+}
+
+// 親 b を一段飛ばして祖先 c に付け替えるケースが許可されること。
+// patch 後: a.parent=c, b.parent=c, c.parent=None → 循環なし。
+#[test]
+fn plan_update_reparent_to_ancestor_is_allowed() {
+    let tasks = vec![
+        make_task("tasks/a.md", Some("tasks/b.md")),
+        make_task("tasks/b.md", Some("tasks/c.md")),
+        make_task("tasks/c.md", None),
+    ];
+    let task = tasks
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .unwrap()
+        .clone();
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\n");
+    let index = TaskIndex::new(tasks);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/c.md".to_string());
+
+    let outcome = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect("ancestor reparent (grandparent) must not be treated as cycle");
+    assert!(outcome.needs_full_rebuild);
+    assert!(outcome.file_content.contains("parent: tasks/c.md"));
+}
+
+// 親解除 (`Some("")`) でも `parent_changed=true` のとき hierarchy 検証が全タスクを走り、
+// 独立循環が検出されることを Err 期待で観測する
+// （既存 `plan_update_parent_cleared_with_empty_string_returns_needs_full_rebuild` は
+// 循環なし cache で `needs_full_rebuild=true` を確認するのみ）。
+#[test]
+fn plan_update_parent_removal_to_empty_string_triggers_hierarchy_validation() {
+    let tasks = vec![
+        make_task("tasks/x.md", Some("tasks/y.md")),
+        make_task("tasks/y.md", Some("tasks/x.md")),
+        make_task("tasks/a.md", Some("tasks/b.md")),
+        make_task("tasks/b.md", None),
+    ];
+    let task = tasks
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .unwrap()
+        .clone();
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\n");
+    let index = TaskIndex::new(tasks);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some(String::new());
+
+    let err = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect_err("parent removal must trigger validation that surfaces existing cycle");
+    match err {
+        UpdateTaskError::ParentCycleOrTooDeep { reason, .. } => {
+            assert_eq!(ParentHierarchyErrorReason::Cycle, reason);
+        }
+        other => panic!("expected ParentCycleOrTooDeep(Cycle), got {other:?}"),
+    }
+}
+
+// parent 変更がトリガーで全タスク再検証が走り、関係ない独立循環も検出されること
+// （副次的検出の挙動を固定化）。
+#[test]
+fn plan_update_detects_independent_cycle_in_cache_when_parent_changes() {
+    let tasks = vec![
+        make_task("tasks/x.md", Some("tasks/y.md")),
+        make_task("tasks/y.md", Some("tasks/x.md")),
+        make_task("tasks/a.md", None),
+        make_task("tasks/b.md", None),
+    ];
+    let task = tasks
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .unwrap()
+        .clone();
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(tasks);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/b.md".to_string());
+
+    let err = index
+        .plan_update(project_root(), intent, &task, parsed)
+        .expect_err("independent cycle should be surfaced when parent changes");
+    match err {
+        UpdateTaskError::ParentCycleOrTooDeep { reason, .. } => {
+            assert_eq!(ParentHierarchyErrorReason::Cycle, reason);
+        }
+        other => panic!("expected ParentCycleOrTooDeep(Cycle), got {other:?}"),
+    }
+}
+
+// 中継ノード 1 段を挟む 3 段循環が検出されること
+// （既存 `plan_update_descendant_parent_returns_parent_cycle` は 2 段循環）。
+// 既存: a.parent=None, b.parent=a, c.parent=b
+// intent: a.parent = c.md → a → c → b → a の 3 段循環
+#[test]
+fn plan_update_three_node_descendant_cycle_returns_parent_cycle() {
+    let task_a = make_task("tasks/a.md", None);
+    let task_b = make_task("tasks/b.md", Some("tasks/a.md"));
+    let task_c = make_task("tasks/c.md", Some("tasks/b.md"));
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+    let index = TaskIndex::new(vec![task_a.clone(), task_b, task_c]);
+
+    let mut intent = empty_intent("tasks/a.md");
+    intent.parent = Some("tasks/c.md".to_string());
+
+    let err = index
+        .plan_update(project_root(), intent, &task_a, parsed)
+        .expect_err("3-node descendant cycle must be detected");
+    match err {
+        UpdateTaskError::ParentCycleOrTooDeep { reason, .. } => {
+            assert_eq!(ParentHierarchyErrorReason::Cycle, reason);
+        }
+        other => panic!("expected ParentCycleOrTooDeep(Cycle), got {other:?}"),
+    }
+}

--- a/src-tauri/src/task/update/command_tests.rs
+++ b/src-tauri/src/task/update/command_tests.rs
@@ -13,6 +13,7 @@ use crate::project::OpenProjectIntent;
 use crate::state::AppState;
 use crate::task::create::error::ContentRejectReason;
 use crate::task::io::FsTaskIo;
+use crate::task::task_index::ParentHierarchyErrorReason;
 use crate::task::warning::TaskWarningCode;
 
 fn tempdir() -> TempDir {
@@ -491,4 +492,110 @@ fn update_self_cycle_is_rejected_without_filesystem_change() {
 
     let after = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
     assert_eq!(original, after);
+}
+
+// 2 段 descendant cycle (a → b → a) を E2E で拒否し、
+// ファイル内容 + cache snapshot の対象 task の parent/children が不変であることを確認する。
+#[test]
+fn update_descendant_cycle_is_rejected_without_filesystem_change() {
+    let dir = tempdir();
+    let root = dir.path();
+    seed_md(root, "tasks/a.md", "---\ntitle: A\nstatus: Todo\n---\n");
+    seed_md(
+        root,
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), root);
+
+    let before_a = fs::read_to_string(root.join("tasks/a.md")).unwrap();
+    let before_b = fs::read_to_string(root.join("tasks/b.md")).unwrap();
+    let before_snapshot = state.tasks_snapshot().unwrap();
+
+    let mut args = args_for("tasks/a.md");
+    args.parent = Some("tasks/b.md".into());
+
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    assert!(matches!(
+        err,
+        UpdateTaskCommandError::Validation(UpdateTaskError::ParentCycleOrTooDeep { .. })
+    ));
+
+    assert_eq!(
+        fs::read_to_string(root.join("tasks/a.md")).unwrap(),
+        before_a
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("tasks/b.md")).unwrap(),
+        before_b
+    );
+
+    let after_snapshot = state.tasks_snapshot().unwrap();
+    let before_a_task = before_snapshot
+        .iter()
+        .find(|t| t.file_path == "tasks/a.md")
+        .expect("before a");
+    let after_a_task = after_snapshot
+        .iter()
+        .find(|t| t.file_path == "tasks/a.md")
+        .expect("after a");
+    assert_eq!(before_a_task.parent, after_a_task.parent);
+    assert_eq!(before_a_task.children, after_a_task.children);
+}
+
+// 21 edge chain (C → B0 → ... → B20) を E2E で `TooDeep` として拒否し、
+// 更新対象 C.md のファイル + cache の parent が不変であることを確認する。
+#[test]
+fn update_chain_too_deep_is_rejected_without_filesystem_change() {
+    let dir = tempdir();
+    let root = dir.path();
+    // 20 edge chain: B0.parent=B1, ..., B19.parent=B20, B20.parent=None
+    for i in 0..20 {
+        seed_md(
+            root,
+            &format!("tasks/B{i}.md"),
+            &format!(
+                "---\ntitle: B{i}\nstatus: Todo\nparent: tasks/B{}.md\n---\n",
+                i + 1
+            ),
+        );
+    }
+    seed_md(root, "tasks/B20.md", "---\ntitle: B20\nstatus: Todo\n---\n");
+    seed_md(root, "tasks/C.md", "---\ntitle: C\nstatus: Todo\n---\n");
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), root);
+
+    let before_c = fs::read_to_string(root.join("tasks/C.md")).unwrap();
+    let before_snapshot = state.tasks_snapshot().unwrap();
+
+    // C.parent = B0 → C → B0 → ... → B20 で 21 edge → TooDeep
+    let mut args = args_for("tasks/C.md");
+    args.parent = Some("tasks/B0.md".into());
+
+    let err = update_task_impl(&state, &FsTaskIo, args).expect_err("fail");
+    match err {
+        UpdateTaskCommandError::Validation(UpdateTaskError::ParentCycleOrTooDeep {
+            reason: ParentHierarchyErrorReason::TooDeep,
+            ..
+        }) => {}
+        other => panic!("expected ParentCycleOrTooDeep(TooDeep), got {other:?}"),
+    }
+
+    assert_eq!(
+        fs::read_to_string(root.join("tasks/C.md")).unwrap(),
+        before_c
+    );
+
+    let after_snapshot = state.tasks_snapshot().unwrap();
+    let before_c_task = before_snapshot
+        .iter()
+        .find(|t| t.file_path == "tasks/C.md")
+        .expect("before C");
+    let after_c_task = after_snapshot
+        .iter()
+        .find(|t| t.file_path == "tasks/C.md")
+        .expect("after C");
+    assert_eq!(before_c_task.parent, after_c_task.parent);
 }


### PR DESCRIPTION
## 概要

`update_task` IPC コマンドで **parent が変更されるケース** において、循環参照（self / 子孫 / 中継ノード経由）と深さ上限 (`MAX_PARENT_DEPTH = 20`) 超過が validation 層で確実に弾かれることを、テストで網羅する。

検証ロジックは PR #210 で既に実装済みのため、本 PR では **既存実装の網羅性確認 + 未カバーシナリオのテスト追加**（9 件）と spec ドキュメント加筆が中心。実装コードへの変更は無し。

## 変更の種類

- 🧪 Tests
- 📝 Doc

## 追加した内容

### plan_update 単体テスト（7 件）

`src-tauri/src/task/task_index_plan_update_tests.rs`:

- **T1** `plan_update_with_no_parent_change_skips_hierarchy_validation` — `intent.parent = None` のとき、cache 側に独立循環があっても hierarchy 検証はスキップされる
- **T2** `plan_update_normalized_equal_parent_skips_hierarchy_validation` — 正規化等価 (`./tasks/p.md` ↔ `tasks/p.md`) の場合に `parent_changed=false` でスキップされる
- **T3** `plan_update_sibling_parent_change_is_allowed` — cross-subtree への parent 接続が許可される
- **T4** `plan_update_reparent_to_ancestor_is_allowed` — 親を一段飛ばして祖先に付け替えるケースが許可される
- **T5** `plan_update_parent_removal_to_empty_string_triggers_hierarchy_validation` — 親解除 (`Some("")`) でも `parent_changed=true` のとき hierarchy 検証が走り、独立循環が検出される
- **T6** `plan_update_detects_independent_cycle_in_cache_when_parent_changes` — 関係ない task の parent 変更がトリガーで、cache 中の独立循環が副次的に検出される
- **T7** `plan_update_three_node_descendant_cycle_returns_parent_cycle` — 中継ノード 1 段を挟む 3 段子孫循環が `Cycle` として検出される

### command 層 E2E テスト（2 件）

`src-tauri/src/task/update/command_tests.rs`:

- **T8** `update_descendant_cycle_is_rejected_without_filesystem_change` — 2 段 descendant cycle が `UpdateTaskCommandError::Validation(ParentCycleOrTooDeep)` で拒否され、ファイル + cache snapshot の対象 task の `parent` / `children` が不変
- **T9** `update_chain_too_deep_is_rejected_without_filesystem_change` — 21 edge chain (`C → B0 → ... → B20`) が `TooDeep` として厳密 match で拒否され、対象 task の `parent` が不変

## 変更した内容

- 実装コード（`task_index.rs` / `update/command.rs` / `update/error.rs`）への変更は **なし**

## 仕様ドキュメント更新

`docs/spec-board/task-format-spec.md` の `### parent 変更時の cache 再構築` セクションを拡張:

- `intent.parent` の値（`None` / `Some("")` / `Some(path)`）ごとの `parent_changed` 判定
- 非空 `Some(path)` 時の検証順序: (1) parent 存在チェック → (2) 正規化等価判定 → (3) hierarchy 検証
- 失敗時のエラー文字列パターンと `reason` の取りうる値（`Cycle` / `TooDeep`）

## システム図

`intent.parent` 分岐と validation 実行の状態マシン（追加テストが網羅する分岐をハイライト）:

```mermaid
flowchart TD
    A[UpdateTaskIntent.parent] --> B{値}
    B -->|None| C[parent_changed=false<br/>validation skip]
    B -->|Some empty| D{既存 parent あり<br/>or extras 除去}
    B -->|Some path| E[parent 存在チェック]
    E -->|不在| F[ParentNotFound]
    E -->|存在| G{正規化等価?}
    G -->|YES| C
    G -->|NO| H[parent_changed=true]
    D -->|YES| H
    D -->|NO| C
    H --> I[build_patched_task + validate_parent_hierarchy]
    I -->|Ok| J[UpdateTaskOutcome<br/>needs_full_rebuild=true]
    I -->|Cycle/TooDeep| K[ParentCycleOrTooDeep]
    C --> L[UpdateTaskOutcome<br/>needs_full_rebuild=false]
    style C fill:#e6f3ff
    style H fill:#fff4e6
    style I fill:#fff4e6
    style K fill:#ffe6e6
```

## 関連Issue

Closes #85

## テスト

- `cargo test --workspace`: **628 passed; 0 failed**（spec-board lib 512 + spec-board-fs 116）
- `cargo clippy --all-targets -- -D warnings`: pass（warning 0）
- `cargo fmt`: 適用済み
- Codex CLI レビュー: **問題なし**

UI 変更なし（テスト追加 + ドキュメント加筆のみ）。

## レビューポイント

- T6（独立循環の副次的検出）の「parent 変更がトリガーで全タスク再検証 → 既存不正データを暴く」挙動を意図的に固定化している点
- T9 の 21 edge 構築（`B0..B20` ループ + 独立 `C.md`）が `MAX_PARENT_DEPTH=20` を 1 段超えで決定的に発火することの妥当性