### PR TITLE
🧪 [Tests]: #86 [BE] update_task の watcher 結合テスト + spec doc 追従

### DIFF
--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -170,12 +170,13 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 4. フロントマター + 本文を再構成して書き出し
 5. **`title` を変更してもファイル名はリネームしない**（`parent` や `links` での参照が壊れるため）
 
-> Implementation notes (2026-05-11): parent 循環検証は
+> Implementation notes (2026-05-16): parent 循環検証は
 > `task_index::validate_parent_hierarchy` / `validate_chain_from_parent` で行う。
-> `create_task` command は本ドキュメントの振る舞いを実装済み。dangling parent
-> 解決による cycle / too-deep は `validate_parent_hierarchy` を augmented snapshot
-> に対して呼ぶことで検出する。`update_task` command は未実装で、接続時に
-> 同様の augmented 検証を行う前提。
+> `create_task` / `update_task` command は本ドキュメントの振る舞いを実装済み。
+> dangling parent 解決による cycle / too-deep は `validate_parent_hierarchy` を
+> augmented snapshot に対して呼ぶことで検出する。`update_task` は部分マージ更新
+> （未指定フィールドは変更しない）で、`parent` が変更される場合のみ augmented
+> 検証を実行する。
 
 ---
 

--- a/src-tauri/src/task/update/command_tests.rs
+++ b/src-tauri/src/task/update/command_tests.rs
@@ -492,3 +492,67 @@ fn update_self_cycle_is_rejected_without_filesystem_change() {
     let after = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
     assert_eq!(original, after);
 }
+
+#[test]
+fn update_task_registers_write_ignore_and_consumes_on_modified_and_renamed_events() {
+    use crate::watcher_event::handler::handle_event;
+    use crate::watcher_event::AdapterContext;
+    use crate::watcher_event::EmitFn;
+    use spec_board_fs::watcher::core::FsEvent;
+    use std::sync::Mutex;
+
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+    let abs = dir.path().join("tasks/a.md");
+
+    let log: Arc<Mutex<Vec<(String, serde_json::Value)>>> = Arc::new(Mutex::new(Vec::new()));
+    let log_for_emit = Arc::clone(&log);
+    let emit: EmitFn = Box::new(move |ev, payload| {
+        log_for_emit.lock().unwrap().push((ev.to_string(), payload));
+    });
+    let ctx = AdapterContext {
+        root: dir.path().to_path_buf(),
+        default_status: "Todo".into(),
+        state: Arc::clone(&state),
+        emit,
+        io: Arc::new(FsTaskIo) as Arc<dyn crate::task::io::TaskIo>,
+    };
+
+    let mut args1 = args_for("tasks/a.md");
+    args1.status = Some("Doing".into());
+    let _t1 = update_task_impl(&state, &FsTaskIo, args1).expect("update#1 ok");
+    assert_eq!(1, state.write_ignore().len().expect("len"));
+
+    handle_event(&FsEvent::Modified(abs.clone()), &ctx).expect("handle Modified ok");
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "self-write should not emit IPC on Modified"
+    );
+    assert!(state.write_ignore().is_empty().unwrap());
+
+    let mut args2 = args_for("tasks/a.md");
+    args2.priority = Some("high".into());
+    let _t2 = update_task_impl(&state, &FsTaskIo, args2).expect("update#2 ok");
+    assert_eq!(1, state.write_ignore().len().expect("len"));
+
+    let tmp = abs.with_extension("md.tmp.0");
+    handle_event(
+        &FsEvent::Renamed {
+            from: tmp,
+            to: abs.clone(),
+        },
+        &ctx,
+    )
+    .expect("handle Renamed ok");
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "self-write should not emit IPC on Renamed(tmp -> abs)"
+    );
+    assert!(state.write_ignore().is_empty().unwrap());
+}

--- a/src-tauri/src/task/update/command_tests.rs
+++ b/src-tauri/src/task/update/command_tests.rs
@@ -600,6 +600,11 @@ fn update_chain_too_deep_is_rejected_without_filesystem_change() {
     assert_eq!(before_c_task.parent, after_c_task.parent);
 }
 
+// watcher install 下で update_task_impl が write_ignore に自前 write のパスを登録し、
+// 続く handle_event(FsEvent::Modified / Renamed) でその token が consume されて
+// IPC emit が抑止される self-write 抑止経路を handler-level integration で検証する。
+// FsTaskIo::write_existing が tmp → rename のアトミック書き込みを行うため、
+// 実 watcher は Modified / Renamed どちらも発火し得る前提で両ケースを確認する。
 #[test]
 fn update_task_registers_write_ignore_and_consumes_on_modified_and_renamed_events() {
     use crate::watcher_event::handler::handle_event;
@@ -615,9 +620,13 @@ fn update_task_registers_write_ignore_and_consumes_on_modified_and_renamed_event
         "---\ntitle: A\nstatus: Todo\n---\nbody\n",
     );
     let state = Arc::new(AppState::new());
+    // NoopWatcherFactory を install することで is_watcher_installed() == true になり、
+    // update_task_impl が write_ignore へ register する経路に入る。
     open_with_noop(Arc::clone(&state), dir.path());
     let abs = dir.path().join("tasks/a.md");
 
+    // emit closure は呼ばれた event 名 + payload を log に蓄積する。
+    // self-write 抑止が効いていれば log は最後まで空のまま。
     let log: Arc<Mutex<Vec<(String, serde_json::Value)>>> = Arc::new(Mutex::new(Vec::new()));
     let log_for_emit = Arc::clone(&log);
     let emit: EmitFn = Box::new(move |ev, payload| {
@@ -631,11 +640,14 @@ fn update_task_registers_write_ignore_and_consumes_on_modified_and_renamed_event
         io: Arc::new(FsTaskIo) as Arc<dyn crate::task::io::TaskIo>,
     };
 
+    // 1 回目: status だけを更新 → write_ignore に abs が register される。
     let mut args1 = args_for("tasks/a.md");
     args1.status = Some("Doing".into());
     let _t1 = update_task_impl(&state, &FsTaskIo, args1).expect("update#1 ok");
     assert_eq!(1, state.write_ignore().len().expect("len"));
 
+    // FsEvent::Modified(abs) が handler に届くと token が consume され、
+    // IPC emit は抑止される（self-write は FE に通知しない）。
     handle_event(&FsEvent::Modified(abs.clone()), &ctx).expect("handle Modified ok");
     assert!(
         log.lock().unwrap().is_empty(),
@@ -643,11 +655,17 @@ fn update_task_registers_write_ignore_and_consumes_on_modified_and_renamed_event
     );
     assert!(state.write_ignore().is_empty().unwrap());
 
+    // 2 回目: priority を更新して再度 write_ignore に abs を register する。
     let mut args2 = args_for("tasks/a.md");
     args2.priority = Some("high".into());
     let _t2 = update_task_impl(&state, &FsTaskIo, args2).expect("update#2 ok");
     assert_eq!(1, state.write_ignore().len().expect("len"));
 
+    // FsEvent::Renamed { from: tmp, to: abs } 経路でも、handler は from を delete として
+    // 処理した後 to を upsert として処理する。abs 側が write_ignore に登録されているため
+    // upsert 段階で consume されて IPC emit は抑止される。
+    // tmp の実 path は試験対象でないため、実装と同じ命名規則に合わせる必要はない
+    // （from 側は rel 解決失敗で早期 return される）。
     let tmp = abs.with_extension("md.tmp.0");
     handle_event(
         &FsEvent::Renamed {


### PR DESCRIPTION
## 概要

親 Issue #83 / 最後の Sub-issue #86 をクローズ可能にするための 2 つの最小変更:

- **変更 A**: `update_task` の watcher 経路（self-write 抑止）を handler-level integration test として 1 件追加
- **変更 B**: `docs/spec-board/file-system-spec.md` の Implementation notes を現状（部分マージ + augmented 検証 実装済み）に追従

実装本体（部分マージ・parent 循環検証・write_ignore 登録・lib.rs 登録）は `b7dff4c` までで完了済みのため、本 PR では `task::update::command.rs` 等のロジックには触れていない。

## 変更の種類

- 🧪 [Tests]: watcher 結合テスト追加
- 📝 [Doc]: file-system-spec.md 追従

## 追加した内容

- `src-tauri/src/task/update/command_tests.rs`
  - `update_task_registers_write_ignore_and_consumes_on_modified_and_renamed_events` を追記
    - `NoopWatcherHandle` install 下で `update_task_impl` 後に `handle_event(FsEvent::Modified(abs))` で IPC emit 抑止 + write_ignore 消費を確認
    - 再 `update_task_impl` 後に `handle_event(FsEvent::Renamed { from: tmp, to: abs })` でも emit 抑止 + write_ignore 消費を確認

## 変更した内容

- `docs/spec-board/file-system-spec.md` line 173-179
  - 日付を `2026-05-11` → `2026-05-16` に更新
  - `update_task` を `create_task` と並列に「実装済み」として記述
  - 部分マージ更新（未指定フィールドは変更しない）+ `parent` 変更時のみ augmented 検証を行う旨を補足

## 仕様ドキュメント更新

- ✅ `docs/spec-board/file-system-spec.md` を更新
- ✅ `docs/spec-board/task-format-spec.md` §update_task は既に最新化済みのため変更なし
- ✅ `docs/spec-board/index.md` は `update_task` への参照なし（不整合なし）

## システム図

watcher self-write 抑止フロー（変更 A の検証対象）:

```mermaid
flowchart LR
    A[update_task_impl] -->|register abs| WI[write_ignore]
    A -->|FsTaskIo::write_existing<br/>tmp -> rename| FS[(fs)]
    FS -.notify.-> CV[convert_event]
    CV -->|Modify Data| M[FsEvent::Modified abs]
    CV -->|Modify Name, paths>=2| R[FsEvent::Renamed tmp -> abs]
    M --> H[handle_event]
    R --> H
    H -->|consume abs| WI
    H -->|emit 抑止| FE([FE IPC])
    style M fill:#e1f5e1
    style R fill:#e1f5e1
    style WI fill:#fff4e1
```

## 関連Issue

- Closes #86
- Refs #83

## テスト

- `(cd src-tauri && cargo test)` → **504 passed / 0 failed**（task::update 38 件 pass、追加テスト含む）
- `(cd src-tauri && cargo fmt --check)` → 差分なし
- `(cd src-tauri && cargo clippy --all-targets -- -D warnings)` → exit 0
- `pnpm test:run` → **661 passed / 78 files**
- AI コードレビュー (Codex CLI) → **問題なし**

## レビューポイント

- handler-level integration の境界選択（実 `notify` watcher を使わず `handle_event` 直叩き）は precedent `create/command_tests.rs:222-258` と同じ方針
- `Renamed { from: tmp, to: abs }` の `tmp` path は試験対象でないため `abs.with_extension("md.tmp.0")` で十分（`handle_delete(tmp)` は rel 解決失敗で早期 return される）
- `FsEvent::Created(abs)` / `FsEvent::Removed(abs)` 単独ケースは `convert_event` の動作上想定外（atomic rename は `Modify(Name)`/`Modify(Data)` を発火する）のため本 PR の保証対象外（実装計画 §1.2.2 に明記）