### PR TITLE
🧪 [Tests]: #111 [FE] ドロップ → updateTask 呼出契約を lock down

### DIFF
--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -104,6 +104,7 @@ test("fromColumn !== toColumn で updateTask が呼ばれる", async () => {
     toIndex: 0,
   });
 
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
   expect(updateTaskMock).toHaveBeenCalledWith({
     filePath: "tasks/a.md",
     status: "Done",
@@ -129,6 +130,8 @@ test("カラム間移動: updateTask 成功後 updateCardOrder が呼ばれる",
     toIndex: 1,
   });
 
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
+  expect(updateCardOrderMock).toHaveBeenCalledTimes(1);
   expect(updateCardOrderMock).toHaveBeenCalledWith({
     columnName: "Done",
     filePaths: ["tasks/b.md", "tasks/a.md", "tasks/c.md"],
@@ -204,6 +207,7 @@ test("fromColumn === toColumn で並び順変化があれば updateCardOrder が
 
   expect(result.ok).toBe(true);
   expect(updateTaskMock).not.toHaveBeenCalled();
+  expect(updateTaskMock).toHaveBeenCalledTimes(0);
   expect(updateCardOrderMock).toHaveBeenCalledWith({
     columnName: "Todo",
     filePaths: ["tasks/b.md", "tasks/a.md", "tasks/c.md"],
@@ -298,6 +302,11 @@ test("updateTask が Result.err なら ProjectError.tauri を返し updateCardOr
     toIndex: 0,
   });
 
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
+  expect(updateTaskMock).toHaveBeenCalledWith({
+    filePath: "tasks/a.md",
+    status: "Done",
+  });
   expect(result.ok).toBe(false);
   expect((result as { error: ProjectError }).error.kind).toBe("tauri");
   expect(updateCardOrderMock).not.toHaveBeenCalled();
@@ -323,6 +332,7 @@ test("カラム間で updateTask 成功 / updateCardOrder 失敗 → task-update
     toIndex: 0,
   });
 
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
   expect(result.ok).toBe(false);
   expect((result as { error: ProjectError }).error.kind).toBe("partial-move");
   expect(harness.actions.map((a) => a.type)).toEqual(["task-updated"]);


### PR DESCRIPTION
## 概要

`moveTask.behavior.test.ts` の既存 5 ケースに `toHaveBeenCalledTimes(...)` を追記し、ドロップ経路（`moveTaskAction` → `updateTask`）で **updateTask が「1 回だけ正しい引数で呼ばれる」契約** をテストで明示固定（lock down）する。production code は変更しない。

## 変更の種類

- 🧪 [Tests] テスト追加/修正

## 変更した内容

`src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts` の既存 5 ケースに以下の assert を追記（既存 assert は **削除せず** 補強のみ）。

- 「fromColumn !== toColumn で updateTask が呼ばれる」: `toHaveBeenCalledTimes(1)` を追記
- 「カラム間移動: updateTask 成功後 updateCardOrder が呼ばれる」: `updateTaskMock` / `updateCardOrderMock` の `toHaveBeenCalledTimes(1)` を追記
- 「fromColumn === toColumn で並び順変化があれば updateCardOrder が呼ばれる」: `not.toHaveBeenCalled()` を残しつつ `toHaveBeenCalledTimes(0)` を追記
- 「カラム間で updateTask 成功 / updateCardOrder 失敗」（partial-move）: `updateTaskMock.toHaveBeenCalledTimes(1)` を追記（retry / rollback の混入を検知）
- 「updateTask が Result.err なら ProjectError.tauri を返し updateCardOrder は呼ばれない」: `toHaveBeenCalledTimes(1)` と `toHaveBeenCalledWith({filePath, status})` を追記（失敗経路でも引数契約が崩れないことを担保）

差分は +10 行のみ、テストファイル 1 本に閉じている。

## 仕様ドキュメント更新

**不要**。`docs/spec-board/board-view-spec.md` の DnD 仕様は既に実装と完全一致しており、本 PR は既存実装の契約をテストで lock down するのみで仕様変更を伴わない（CLAUDE.md「仕様変更時のドキュメント更新」に該当しない）。

## システム図

ドロップ経路と本 PR の lock down 対象（updateTask 呼出契約）:

```mermaid
flowchart TD
    A["Column.handleDrop"] --> B["Board.handleTaskDrop"]
    B --> C["App.handleTaskDrop → useProject.moveTask"]
    C --> D["moveTaskAction queue"]
    D --> E{"fromColumn !== toColumn"}
    E -- "Yes" --> F["updateTask filePath, status:toColumn"]
    E -- "No" --> G["updateTask 呼ばない"]
    F -- "Ok" --> H["dispatch task-updated → updateCardOrder"]
    F -- "Err" --> I["ProjectError.tauri / updateCardOrder 呼ばない"]
    H -- "Err" --> J["partial-move"]
    style F fill:#ffd966,stroke:#b58900,stroke-width:2px
    style G fill:#cfe2f3,stroke:#0b5394
    style I fill:#f4cccc,stroke:#990000
    style J fill:#f4cccc,stroke:#990000
```

style ハイライト箇所がテストで lock down された呼出契約（`toHaveBeenCalledTimes(1)` / `toHaveBeenCalledTimes(0)` / 引数一致）の対象。

## 関連Issue

Refs #111

親 Issue #110（既に CLOSED, commit `0beea66` で実装済）の契約担保が目的。

## テスト

- `pnpm test:run moveTask.behavior` → **15/15 green**（テスト件数は増減せず、既存挙動を維持）
- `pnpm test:run` 全体 → **743/743 green**（リグレッションなし）
- `pnpm lint` (oxlint) → 0 warnings / 0 errors
- `pnpm typecheck` (tsc -b) → エラーなし
- `pnpm exec biome check src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts` → クリーン
- `git diff --stat` → テストファイル 1 本のみ（production code に差分なし）

UI 変更なし、production code 変更なしのため Tauri アプリでの実機確認はスキップ。

## レビューポイント

- 重複に見える assert（`toHaveBeenCalledWith` + `toHaveBeenCalledTimes(1)`、`not.toHaveBeenCalled()` + `toHaveBeenCalledTimes(0)`）は AC の「**1 回**呼ぶ」「**0 回**呼ばれない」を call count 軸で明示する目的のため、冗長指摘が来ても両方残す方針です。
- partial-move ケースの `toHaveBeenCalledTimes(1)` は将来 retry / rollback ロジックが誤って混入した際に即検知するための lock down です。