### PR TITLE
✨ [New Feature]: #88 [BE] TaskIndex に clear_children aggregate method を追加

### DIFF
--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -448,6 +448,106 @@ impl TaskIndex {
             needs_full_rebuild: parent_changed,
         })
     }
+
+    /// 削除対象 path を parent に持つ直接の子 task の **プロジェクトルート相対** path を
+    /// snapshot 順で列挙する pure aggregate query。
+    ///
+    /// 表記揺れ（`./tasks/x.md` / `tasks\x.md` 等）は `normalize_parent_path_for_lookup`
+    /// で吸収する。raw string 比較は意図的に避ける（plan_update の parent 比較と同じ理由）。
+    ///
+    /// 孫 task は含めない（直接の子のみ）。`deleted_path` が誰の親でもない場合は空 Vec。
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "delete_task IPC (Issue #90) で本 method を呼び出す予定。caller 追加時に expect を外す。"
+        )
+    )]
+    pub(crate) fn children_paths_of(&self, deleted_path: &str) -> Vec<PathBuf> {
+        let Some(deleted_norm) = normalize_parent_path_for_lookup(deleted_path) else {
+            return Vec::new();
+        };
+        self.tasks
+            .iter()
+            // 自己除外は raw 文字列ではなく lookup-normalized 同士で比較する。
+            // 表記揺れ（`./tasks/p.md` vs `tasks/p.md` 等）で自分自身を
+            // 子としてすり抜けさせないため。
+            .filter(|t| normalize_task_path_for_lookup(t.file_path.as_str()) != deleted_norm)
+            .filter_map(|t| {
+                let parent = t.parent.as_ref()?;
+                let parent_norm = normalize_parent_path_for_lookup(parent.as_str())?;
+                (parent_norm == deleted_norm).then(|| PathBuf::from(t.file_path.as_str()))
+            })
+            .collect()
+    }
+
+    /// 削除対象 task の全子 task について、parent キーを除去した new file_content と
+    /// 更新後 Task を計算する pure aggregate method。I/O / 時計 / 乱数に依存しない。
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "delete_task IPC (Issue #90) で本 method を呼び出す予定。caller 追加時に expect を外す。"
+        )
+    )]
+    pub(crate) fn plan_clear_children_of(
+        &self,
+        _deleted_path: &str,
+        loaded: Vec<ClearChildrenInput>,
+    ) -> Result<ClearChildrenOutcome, ClearChildrenError> {
+        let mut entries = Vec::with_capacity(loaded.len());
+
+        for ClearChildrenInput { path, parsed } in loaded {
+            let Parsed {
+                mut frontmatter,
+                body,
+            } = parsed;
+
+            // parent キー除去（typed フィールドではなく extras 上に保持されているため
+            // plan_update と同じ `extras.remove` API を使う）。
+            frontmatter
+                .extras
+                .remove(serde_yaml_ng::Value::String("parent".into()));
+
+            let serialized = frontmatter::serialize(&Parsed {
+                frontmatter: frontmatter.clone(),
+                body: body.clone(),
+            });
+
+            TaskContent::try_new(serialized.clone()).map_err(|err| {
+                ClearChildrenError::ContentRejected {
+                    path: path.clone(),
+                    reason: err.to_string(),
+                }
+            })?;
+
+            let default_status = self
+                .find_task_by_path(&path)
+                .map(|t| t.status.clone())
+                .unwrap_or_else(|| ColumnName::from_lenient(""));
+            let context = TaskParseContext {
+                file_path: path.clone(),
+                default_status,
+            };
+            let updated_task = task_from_parsed(Parsed { frontmatter, body }, &context);
+
+            entries.push(ClearedChildEntry {
+                path,
+                updated_task,
+                file_content: serialized,
+            });
+        }
+
+        Ok(ClearChildrenOutcome { entries })
+    }
+
+    /// 内部 helper: snapshot 上で `path` と一致する task を返す（正規化済み比較）。
+    fn find_task_by_path(&self, path: &Path) -> Option<&Task> {
+        let target = normalize_task_path_for_lookup(&path.to_string_lossy());
+        self.tasks
+            .iter()
+            .find(|t| normalize_task_path_for_lookup(t.file_path.as_str()) == target)
+    }
 }
 
 impl From<Vec<Task>> for TaskIndex {
@@ -504,6 +604,58 @@ pub struct CreateTaskOutcome {
     pub content: TaskContent,
     /// effect 層が cache commit 時の `default_status` として使う。
     pub status: ColumnName,
+}
+
+/// `TaskIndex::plan_clear_children_of` への入力。
+///
+/// effect 層（`delete_task` IPC コマンド）が `io.read` + `frontmatter::parse_bytes`
+/// で事前に取得した子 task 1 件分の (path, Parsed) ペア。
+pub(crate) struct ClearChildrenInput {
+    /// プロジェクトルート相対 path（`children_paths_of` の出力をそのまま使う想定）。
+    pub path: PathBuf,
+    /// `frontmatter::parse_bytes` で得た Parsed。
+    /// frontmatter が無い md は effect 層側で別エラーに変換し、本関数には到達させない。
+    pub parsed: Parsed,
+}
+
+/// `TaskIndex::plan_clear_children_of` の計算結果。effect 層が消費する。
+#[derive(Debug)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "delete_task IPC (Issue #90) が本型を消費する予定。caller 追加時に expect を外す。"
+    )
+)]
+pub(crate) struct ClearChildrenOutcome {
+    pub entries: Vec<ClearedChildEntry>,
+}
+
+/// clear 対象 1 件分の計算結果。
+#[derive(Debug)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "delete_task IPC (Issue #90) が本型を消費する予定。caller 追加時に expect を外す。"
+    )
+)]
+pub(crate) struct ClearedChildEntry {
+    /// 入力 `ClearChildrenInput::path` をそのまま保持。
+    pub path: PathBuf,
+    /// `task_from_parsed` で再構築済みの新 Task（effect 層が cache に書き戻す）。
+    pub updated_task: Task,
+    /// `frontmatter::serialize` 出力（effect 層が `io.write_existing` で書き戻す）。
+    pub file_content: String,
+}
+
+/// `TaskIndex::plan_clear_children_of` のエラー。
+///
+/// pure 関数のため I/O 系 variant は持たない。それらは effect 層が独自エラー型に詰め直す。
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ClearChildrenError {
+    #[error("content rejected for {}: {reason}", .path.display())]
+    ContentRejected { path: PathBuf, reason: String },
 }
 
 /// 親 task の dirname を返す。親未指定なら `tasks/`。
@@ -755,3 +907,7 @@ mod task_index_plan_create_tests;
 #[cfg(test)]
 #[path = "task_index_plan_update_tests.rs"]
 mod task_index_plan_update_tests;
+
+#[cfg(test)]
+#[path = "task_index_clear_children_tests.rs"]
+mod task_index_clear_children_tests;

--- a/src-tauri/src/task/task_index_clear_children_tests.rs
+++ b/src-tauri/src/task/task_index_clear_children_tests.rs
@@ -1,0 +1,385 @@
+//! `TaskIndex::children_paths_of` / `TaskIndex::plan_clear_children_of` の
+//! 純粋関数ユニットテスト。AppState / TaskIo / fs::* に依存せず、
+//! すべて in-memory で完結する。
+
+use std::path::PathBuf;
+
+use super::{ClearChildrenError, ClearChildrenInput, Task, TaskIndex};
+use crate::task::frontmatter::{parse as parse_frontmatter, Parsed};
+use crate::task::parse::{task_from_markdown, TaskParseContext};
+
+// ---------------------------------------------------------------------------
+// fixture helpers（`children_tests.rs:9-29` を踏襲）
+// ---------------------------------------------------------------------------
+
+fn context(path: &str) -> TaskParseContext {
+    TaskParseContext {
+        file_path: PathBuf::from(path),
+        default_status: "Todo".into(),
+    }
+}
+
+fn task_from(input: &str, path: &str) -> Task {
+    task_from_markdown(input.as_bytes(), &context(path)).unwrap()
+}
+
+fn task_with_parent(path: &str, parent: &str) -> Task {
+    task_from(
+        &format!("---\ntitle: Task\nstatus: Todo\nparent: {parent}\n---\n"),
+        path,
+    )
+}
+
+fn task_without_parent(path: &str) -> Task {
+    task_from("---\ntitle: Task\nstatus: Todo\n---\n", path)
+}
+
+fn parsed_from_md(md: &str) -> Parsed {
+    parse_frontmatter(md).expect("parse ok").expect("some")
+}
+
+// ---------------------------------------------------------------------------
+// children_paths_of（7 ケース）
+// ---------------------------------------------------------------------------
+
+#[test]
+fn children_paths_of_returns_single_direct_child() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let result = index.children_paths_of("tasks/p.md");
+
+    assert_eq!(result, vec![PathBuf::from("tasks/c.md")]);
+}
+
+#[test]
+fn children_paths_of_returns_two_children_in_snapshot_order() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c1.md", "tasks/p.md"),
+        task_with_parent("tasks/c2.md", "tasks/p.md"),
+    ]);
+
+    let result = index.children_paths_of("tasks/p.md");
+
+    assert_eq!(
+        result,
+        vec![PathBuf::from("tasks/c1.md"), PathBuf::from("tasks/c2.md")]
+    );
+}
+
+#[test]
+fn children_paths_of_returns_empty_when_target_has_no_children() {
+    let index = TaskIndex::new(vec![task_without_parent("tasks/p.md")]);
+
+    let result = index.children_paths_of("tasks/p.md");
+
+    assert!(result.is_empty());
+}
+
+#[test]
+fn children_paths_of_returns_empty_when_target_is_no_ones_parent() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/a.md"),
+        task_with_parent("tasks/b.md", "tasks/a.md"),
+    ]);
+
+    let result = index.children_paths_of("tasks/orphan.md");
+
+    assert!(result.is_empty());
+}
+
+#[test]
+fn children_paths_of_excludes_grandchildren() {
+    // p -> c -> g という 3 世代構造で、p の直接の子は c のみ。
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+        task_with_parent("tasks/g.md", "tasks/c.md"),
+    ]);
+
+    let result = index.children_paths_of("tasks/p.md");
+
+    assert_eq!(result, vec![PathBuf::from("tasks/c.md")]);
+}
+
+#[test]
+fn children_paths_of_distinguishes_same_title_by_path() {
+    // 同一 title だが path が異なる 2 task。parent が p.md を指すのは c-real.md のみ。
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c-real.md", "tasks/p.md"),
+        task_with_parent("tasks/c-fake.md", "tasks/other.md"),
+        task_without_parent("tasks/other.md"),
+    ]);
+
+    let result = index.children_paths_of("tasks/p.md");
+
+    assert_eq!(result, vec![PathBuf::from("tasks/c-real.md")]);
+}
+
+#[test]
+fn children_paths_of_normalizes_path_notation() {
+    // 子の parent 値が `./tasks/p.md` で記載されていても、
+    // 引数 `tasks/p.md` と同一視して一致と判定する。
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "./tasks/p.md"),
+    ]);
+
+    let result = index.children_paths_of("tasks/p.md");
+
+    assert_eq!(result, vec![PathBuf::from("tasks/c.md")]);
+}
+
+#[test]
+fn children_paths_of_excludes_self_under_path_notation_variance() {
+    // 異常データ: 削除対象自身が自分自身を parent として持つ。
+    // raw 文字列比較だと `t.file_path = "tasks/p.md"` と `deleted_path = "./tasks/p.md"`
+    // で自己除外をすり抜けて自分が子に出てしまうため、正規化比較で防ぐ。
+    let mut self_referential = task_with_parent("tasks/p.md", "tasks/p.md");
+    // parent をあえて表記揺れに変えて、正規化比較で同一視されることを確認する。
+    self_referential.parent = Some(crate::task::task_file_path::TaskFilePath::from_lenient(
+        "./tasks/p.md",
+    ));
+
+    let index = TaskIndex::new(vec![self_referential]);
+
+    let result = index.children_paths_of("./tasks/p.md");
+
+    assert!(result.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// plan_clear_children_of（8 ケース）
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_clear_children_of_returns_empty_outcome_for_empty_loaded() {
+    let index = TaskIndex::new(Vec::new());
+
+    let outcome = index
+        .plan_clear_children_of("tasks/p.md", Vec::new())
+        .expect("ok");
+
+    assert!(outcome.entries.is_empty());
+}
+
+#[test]
+fn plan_clear_children_of_removes_parent_key_only() {
+    let child_md = "---\n\
+                    title: Child\n\
+                    status: Doing\n\
+                    priority: High\n\
+                    labels:\n  - bug\n  - api\n\
+                    parent: tasks/p.md\n\
+                    links:\n  - tasks/other.md\n\
+                    ---\nbody\n";
+    let parsed = parsed_from_md(child_md);
+    let child_task = task_with_parent("tasks/c.md", "tasks/p.md");
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        child_task,
+        task_without_parent("tasks/other.md"),
+    ]);
+
+    let loaded = vec![ClearChildrenInput {
+        path: PathBuf::from("tasks/c.md"),
+        parsed,
+    }];
+    let outcome = index
+        .plan_clear_children_of("tasks/p.md", loaded)
+        .expect("ok");
+
+    assert_eq!(outcome.entries.len(), 1);
+    let entry = &outcome.entries[0];
+    assert_eq!(entry.path, PathBuf::from("tasks/c.md"));
+    assert!(!entry.file_content.contains("parent:"));
+    assert!(entry.file_content.contains("title: Child"));
+    assert!(entry.file_content.contains("status: Doing"));
+    assert!(entry.file_content.contains("priority: High"));
+    assert!(entry.file_content.contains("- bug"));
+    assert!(entry.file_content.contains("- api"));
+    assert!(entry.file_content.contains("- tasks/other.md"));
+    assert!(entry.updated_task.parent.is_none());
+    assert_eq!(entry.updated_task.title.as_str(), "Child");
+    assert_eq!(entry.updated_task.status.as_str(), "Doing");
+}
+
+#[test]
+fn plan_clear_children_of_preserves_loaded_order_with_two_inputs() {
+    let parsed_a = parsed_from_md("---\ntitle: A\nstatus: Todo\nparent: tasks/p.md\n---\n");
+    let parsed_b = parsed_from_md("---\ntitle: B\nstatus: Todo\nparent: tasks/p.md\n---\n");
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/a.md", "tasks/p.md"),
+        task_with_parent("tasks/b.md", "tasks/p.md"),
+    ]);
+
+    let loaded = vec![
+        ClearChildrenInput {
+            path: PathBuf::from("tasks/a.md"),
+            parsed: parsed_a,
+        },
+        ClearChildrenInput {
+            path: PathBuf::from("tasks/b.md"),
+            parsed: parsed_b,
+        },
+    ];
+    let outcome = index
+        .plan_clear_children_of("tasks/p.md", loaded)
+        .expect("ok");
+
+    assert_eq!(outcome.entries.len(), 2);
+    assert_eq!(outcome.entries[0].path, PathBuf::from("tasks/a.md"));
+    assert_eq!(outcome.entries[1].path, PathBuf::from("tasks/b.md"));
+    assert!(outcome.entries[0].updated_task.parent.is_none());
+    assert!(outcome.entries[1].updated_task.parent.is_none());
+    assert_eq!(outcome.entries[0].updated_task.title.as_str(), "A");
+    assert_eq!(outcome.entries[1].updated_task.title.as_str(), "B");
+}
+
+#[test]
+fn plan_clear_children_of_preserves_typed_field_order() {
+    // frontmatter::serialize 規約: title → status → priority → labels → links → extras 出現順
+    let parsed = parsed_from_md(
+        "---\n\
+         title: T\n\
+         status: Todo\n\
+         priority: Medium\n\
+         labels:\n  - x\n\
+         parent: tasks/p.md\n\
+         links:\n  - tasks/o.md\n\
+         due: 2026-05-17\n\
+         ---\n",
+    );
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let loaded = vec![ClearChildrenInput {
+        path: PathBuf::from("tasks/c.md"),
+        parsed,
+    }];
+    let outcome = index
+        .plan_clear_children_of("tasks/p.md", loaded)
+        .expect("ok");
+
+    let content = &outcome.entries[0].file_content;
+    let title_pos = content.find("title:").expect("title present");
+    let status_pos = content.find("status:").expect("status present");
+    let priority_pos = content.find("priority:").expect("priority present");
+    let labels_pos = content.find("labels:").expect("labels present");
+    let links_pos = content.find("links:").expect("links present");
+    let due_pos = content.find("due:").expect("due present");
+
+    assert!(title_pos < status_pos);
+    assert!(status_pos < priority_pos);
+    assert!(priority_pos < labels_pos);
+    assert!(labels_pos < links_pos);
+    assert!(links_pos < due_pos);
+    assert!(!content.contains("parent:"));
+}
+
+#[test]
+fn plan_clear_children_of_normalizes_crlf_to_lf_in_body() {
+    // 入力 md は CRLF 込みで構築するが、parse_frontmatter 段階で LF 正規化されるため、
+    // serialize 出力にも CRLF は混入しない。
+    let parsed = parsed_from_md(
+        "---\r\ntitle: T\r\nstatus: Todo\r\nparent: tasks/p.md\r\n---\r\nbody line\r\nnext\r\n",
+    );
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let loaded = vec![ClearChildrenInput {
+        path: PathBuf::from("tasks/c.md"),
+        parsed,
+    }];
+    let outcome = index
+        .plan_clear_children_of("tasks/p.md", loaded)
+        .expect("ok");
+
+    let content = &outcome.entries[0].file_content;
+    assert!(!content.contains('\r'));
+    assert!(content.contains("body line\nnext"));
+}
+
+#[test]
+fn plan_clear_children_of_appends_trailing_newline_to_body() {
+    // 入力 body 末尾に改行がなくても、serialize 規約により出力末尾には `\n` が付く。
+    let parsed =
+        parsed_from_md("---\ntitle: T\nstatus: Todo\nparent: tasks/p.md\n---\nno-trailing-newline");
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let loaded = vec![ClearChildrenInput {
+        path: PathBuf::from("tasks/c.md"),
+        parsed,
+    }];
+    let outcome = index
+        .plan_clear_children_of("tasks/p.md", loaded)
+        .expect("ok");
+
+    let content = &outcome.entries[0].file_content;
+    assert!(content.ends_with('\n'));
+}
+
+#[test]
+fn plan_clear_children_of_rejects_oversized_content() {
+    // body を 1 MiB 超に膨らませる。serialize 後の出力が 1 MiB を超えるため
+    // TaskContent::try_new で TooLarge エラーになる。
+    let big_body: String = "a".repeat(1024 * 1024 + 16);
+    let md = format!("---\ntitle: T\nstatus: Todo\nparent: tasks/p.md\n---\n{big_body}\n");
+    let parsed = parsed_from_md(&md);
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let loaded = vec![ClearChildrenInput {
+        path: PathBuf::from("tasks/c.md"),
+        parsed,
+    }];
+    let err = index
+        .plan_clear_children_of("tasks/p.md", loaded)
+        .expect_err("should reject oversized content");
+
+    match err {
+        ClearChildrenError::ContentRejected { path, .. } => {
+            assert_eq!(path, PathBuf::from("tasks/c.md"));
+        }
+    }
+}
+
+#[test]
+fn plan_clear_children_of_rejects_nul_byte_content() {
+    // body に NUL byte を含めると TaskContent::try_new が BinaryDetected を返す。
+    let parsed = parsed_from_md(
+        "---\ntitle: T\nstatus: Todo\nparent: tasks/p.md\n---\nbefore\u{0000}after\n",
+    );
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let loaded = vec![ClearChildrenInput {
+        path: PathBuf::from("tasks/c.md"),
+        parsed,
+    }];
+    let err = index
+        .plan_clear_children_of("tasks/p.md", loaded)
+        .expect_err("should reject NUL byte content");
+
+    match err {
+        ClearChildrenError::ContentRejected { path, .. } => {
+            assert_eq!(path, PathBuf::from("tasks/c.md"));
+        }
+    }
+}


### PR DESCRIPTION
## 概要

`delete_task` の orphanStrategy: `clear` で必要となる純粋計算を `TaskIndex` aggregate に集約。effect 層 (#90) が事前に取得した子 `Parsed` を入力に、`parent` キー除去 → serialize → scanner eligibility 検証 → `updated_task` 再構築 までを pure aggregate method として提供する。本 PR では IPC コマンド本体 (`delete_task`) は実装せず、aggregate method 2 本 + 補助型 4 本の追加に閉じる。

## 変更の種類

- ✨ New Feature（BE / `src-tauri`）

## 追加した内容

- `TaskIndex::children_paths_of(&str) -> Vec<PathBuf>`
  - 削除対象 path を parent に持つ直接子の **プロジェクトルート相対** path を snapshot 順で列挙する pure aggregate query
  - 自己除外は `normalize_task_path_for_lookup` ベースで正規化比較し、表記揺れによる自己包含を防ぐ
- `TaskIndex::plan_clear_children_of(&str, Vec<ClearChildrenInput>) -> Result<ClearChildrenOutcome, ClearChildrenError>`
  - effect 層が事前に読み込んだ子 `Parsed` から `frontmatter.extras.remove("parent")` → `frontmatter::serialize` → `TaskContent::try_new` → `task_from_parsed` の流れで `ClearedChildEntry` 列を組み立てる pure aggregate method
  - I/O / 時計 / 乱数に依存しない
- 補助型 4 本（すべて `pub(crate)`）
  - `ClearChildrenInput { path, parsed }`
  - `ClearChildrenOutcome { entries }`
  - `ClearedChildEntry { path, updated_task, file_content }`
  - `ClearChildrenError::ContentRejected { path, reason }` — 1MiB 超 / NUL byte のみ。I/O 系 variant は持たない（#90 effect 層の責務）
- private helper `TaskIndex::find_task_by_path` — `default_status` フォールバック用
- ユニットテスト **16 ケース**（`src-tauri/src/task/task_index_clear_children_tests.rs` 新規、兄弟配置 `#[path]` 経由）
  - `children_paths_of`: 8 ケース（計画 7 + レビュー指摘の表記揺れ自己除外回帰 1）
  - `plan_clear_children_of`: 8 ケース

## 変更した内容

- `src-tauri/src/task/task_index.rs`
  - `impl TaskIndex` に上記 2 method + private helper を追加
  - 末尾の `mod` 宣言群に `task_index_clear_children_tests` を追加（兄弟配置のため `#[path]` 必須）
  - 末尾の型定義群に補助型 4 本を追加
- 既存 method / 型に retro 影響なし

## 削除した内容

なし。

## 仕様ドキュメント更新

**不要（純粋な内部 aggregate method 追加）**。公開 API / IPC コマンド / 画面挙動 / 設定項目に変更なし。`docs/spec-board/file-system-spec.md` の `delete_task` セクションは IPC コマンド本体を実装する #90 完了時に更新する。

## システム図

`plan_clear_children_of` の pure 計算遷移（1 件分のループ内）:

```mermaid
flowchart TD
    A[loaded 次入力?] -->|None| Z[Ok ClearChildrenOutcome]
    A -->|Some ClearChildrenInput| B["extras.remove parent"]
    B --> C["frontmatter serialize"]
    C --> D["TaskContent try_new"]
    D -->|Err| E["Err ContentRejected path reason"]
    D -->|Ok| F["task_from_parsed updated_task"]
    F --> G["entries.push ClearedChildEntry"]
    G --> A

    style B fill:#fffbcc
    style C fill:#fffbcc
    style D fill:#fffbcc
    style F fill:#fffbcc
    style G fill:#fffbcc
```

`children_paths_of` の pure aggregate query:

```mermaid
flowchart TD
    A["deleted_path"] --> B["normalize_parent_path_for_lookup"]
    B -->|None 表記異常| Z1["Vec::new"]
    B -->|Some deleted_norm| C["snapshot.tasks 走査"]
    C --> D["自己除外 normalize_task_path_for_lookup != deleted_norm"]
    D --> E["parent 正規化と一致?"]
    E -->|Yes| F["push PathBuf"]
    E -->|No| C
    F --> C
    C -->|完了| Z2["Vec<PathBuf>"]

    style D fill:#fffbcc
    style E fill:#fffbcc
```

## 関連Issue

Refs #88

## テスト

- `cargo fmt --all` 適用済
- `cargo clippy --all-targets -- -D warnings` warning ゼロ
- `cargo test -p spec-board` **529 passed**（既存 `task_index_plan_create_tests` / `task_index_plan_update_tests` 等に retro 影響なし）
- `cargo test -p spec-board-fs` **116 passed**
- `cargo test task_index_clear_children` **16 passed**（新規）
- AI レビュー: Codex CLI で 2 周実施。1 回目の Should Fix（自己除外の raw 比較 / `pub` 昇格）を反映後、2 回目で「問題なし」

## レビューポイント

1. **DDD aggregate 集約方針**
   - 既存 `plan_create` / `plan_update` と完全同形式の 2 method 構成を採用。free function での 3 段分離は parent 不変条件の責務が散らばるため避け、`TaskIndex` aggregate に閉じ込めている
2. **自己除外の正規化比較**（`task_index.rs::children_paths_of`）
   - 削除対象自身が自分自身を parent に持つ異常データに対し、raw 比較だと `tasks/p.md` vs `./tasks/p.md` のような表記揺れですり抜ける。`normalize_task_path_for_lookup` 経由で揺れを吸収済（回帰テスト `children_paths_of_excludes_self_under_path_notation_variance` で固定化）
3. **`#[cfg_attr(not(test), expect(dead_code, reason = ...))]` の使用**
   - 本 PR では caller (`delete_task_impl`) は実装されないため、production 側で aggregate method / `ClearChildrenOutcome` / `ClearedChildEntry` が dead になる。`#[expect]` を使うことで #90 で caller が追加された際に「期待された lint が消えた」エラーで強制的に annotation を外させる設計
4. **pure 関数契約**
   - `plan_clear_children_of` は I/O / 時計 / 乱数すべて非依存。失敗時の atomicity は呼び出し元 (#90) の責務。`ContentRejected` 以外のエラー variant は持たない

## チェックリスト

- [x] セルフレビュー実施
- [x] `cargo test / clippy / fmt` 通過（src-tauri 変更のみ）
- [x] AI レビュー（Codex）2 周で「問題なし」
- [x] 仕様ドキュメント更新の要否を本文で明記（不要）
- [x] 関連 Issue (#88) を本文にリンク
- [x] feature 間依存ルールは該当なし（BE 内 aggregate 変更）
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)