### PR TITLE
✨ [New Feature]: #112 [FE] DnD 楽観更新 + ロールバック + a11y ライブリージョン

### DIFF
--- a/docs/spec-board/board-view-spec.md
+++ b/docs/spec-board/board-view-spec.md
@@ -106,7 +106,7 @@ stateDiagram-v2
 | 観点 | 対応方針 |
 |:-----|:---------|
 | キーボード操作 | Tab でカード間移動、Enter で詳細パネル展開、矢印キーでカラム間移動 |
-| スクリーンリーダー | カラムに `role="list"`、カードに `role="listitem"` を付与。ドラッグ操作時にライブリージョンでステータス変更を通知 |
+| スクリーンリーダー | カラムに `role="list"`、カードに `role="listitem"` を付与。カラム間移動の楽観 dispatch 直後に `aria-live="polite"` のライブリージョン（視覚非表示 / `role="status"` / `aria-atomic="true"`）で「移動しました」を通知。`updateTask` 失敗によるフル rollback 時はさらに「移動を取り消しました」を追加通知する。partial-move（status 確定 + cardOrder のみ rollback）および「楽観 dispatch 後の projectVersion 不一致」では追加の取消アナウンスは流さない（既に「移動しました」が発火済みで status は永続化済み、または state が新 project に切替済みのため）。同一カラム並び替え、および「楽観 dispatch 前 invalid-state（preflight 失敗）」ではライブリージョンを更新しない（エラー toast のみ） |
 | フォーカス管理 | ドラッグ&ドロップ完了後、移動したカードにフォーカスを維持 |
 
 ## ドラッグ&ドロップ仕様
@@ -125,7 +125,7 @@ stateDiagram-v2
 | カラム間移動 | (1) `update_task({ filePath, status: toColumn })`、(2) 成功後 `update_card_order({ columnName: toColumn, filePaths })`。旧カラムの cardOrder は BE 側 watcher が status 変更を検知して自動除去する契約 |
 | 同一カラム内並び替え | `update_card_order({ columnName, filePaths })` を 1 回。並び順に変化が無い場合は IPC を呼ばない |
 
-楽観的 UI 更新は採用しない（IPC 完了後に reducer dispatch）。
+楽観的 UI 更新を採用する。drop 確定と同時に status / cardOrder を仮反映し、IPC 完了後に server 値で確定上書きする。`updateTask` 失敗時はスナップショットへフル rollback し、ライブリージョンで「移動を取り消しました」を通知する。partial-move（`updateTask` 成功 / `updateCardOrder` 失敗）の場合は status を `toColumn` に確定保持し、cardOrder のみ永続化済みの実態（`toColumn` は旧 order + 移動タスク末尾補完、`fromColumn` は移動タスク除外済み）に再収束させる。partial-move ではライブリージョンを更新せず、partial-move 専用エラー toast のみで通知する。projectVersion 不一致時は新 project state を破壊しないため rollback / 確定 dispatch をスキップし、`invalid-state` を返す。
 
 ### UI 表現
 
@@ -142,6 +142,19 @@ stateDiagram-v2
 - IPC 失敗（generic）: `update_task` 失敗 / 同一カラム内の `update_card_order` 失敗時は「タスクの移動に失敗しました: &lt;原因&gt;」トーストを表示。dragState は finally で必ず null に戻す
 - IPC 部分失敗（partial-move）: カラム間移動で `update_task` 成功 + `update_card_order` 失敗のときは、カラム移動だけは完了しているため「カラムの移動は完了しましたが、並び順の保存に失敗しました。手動で並び替えてください。」と区別して表示する
 - stale state: queue 実行時に対象タスクが見つからない / `fromColumn` と `status` が乖離 / `toColumn` が消滅した場合は `invalid-state` で抜ける
+
+### a11y アナウンス
+
+楽観成功アナウンスは IPC 完了を待たず、楽観 dispatch 直後に `onOptimisticApplied` callback を起点に発火する。partial-move / invalid-state のように IPC 後に判明する分岐では、既に「移動しました」アナウンスが出ている前提で扱う。下表は楽観 dispatch 時点と IPC 完了時点を合算したアナウンス結果である。
+
+| イベント | LiveRegion アナウンス | エラー toast |
+|:--|:--|:--|
+| カラム間移動成功 | 「『タイトル』を『toColumn』に移動しました」 | なし |
+| カラム間移動失敗（`updateTask` reject、フル rollback 後） | 「『タイトル』を『toColumn』に移動しました」→「『タイトル』の移動を取り消しました」 | 「タスクの移動に失敗しました: ...」 |
+| partial-move（status 確定 + cardOrder のみ補正） | 「『タイトル』を『toColumn』に移動しました」のみ（status は永続化済みのため取消アナウンスは流さない） | partial-move 用エラー toast |
+| 同一カラム並び替え（成功 / 失敗いずれも） | なし（`onOptimisticApplied` はカラム間 status 変更時のみ呼ぶ契約） | 失敗時のみ「タスクの移動に失敗しました: ...」 |
+| 楽観 dispatch 前 invalid-state（preflight 失敗: target 消失 / status 乖離 / toColumn 消失 / 開始前 version 切替） | なし（楽観 dispatch も `onOptimisticApplied` も発火しない） | `invalid-state` メッセージ |
+| 楽観 dispatch 後 invalid-state（IPC 中の projectVersion 切替） | 「『タイトル』を『toColumn』に移動しました」のみ（state は新 project に切替済みのため取消アナウンスは流さない） | 「プロジェクトが切り替わりました」 |
 
 ## 制限事項
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { type LiveAnnouncement, LiveRegion } from "@/components/LiveRegion";
 import { ToastContainer } from "@/components/ToastContainer";
 import { useToasts } from "@/hooks/useToasts";
 import {
@@ -103,6 +104,14 @@ export const App = () => {
   const [createModalParent, setCreateModalParent] = useState<
     string | undefined
   >(undefined);
+  const [announcement, setAnnouncement] = useState<LiveAnnouncement | null>(
+    null,
+  );
+  const announceCounterRef = useRef(0);
+  const announce = useCallback((text: string) => {
+    announceCounterRef.current += 1;
+    setAnnouncement({ id: announceCounterRef.current, text });
+  }, []);
 
   // プロジェクト切替時に UI 状態（選択中タスク・作成モーダル）をリセットする。
   // loaded 状態の path が「実際に別 path に変わった」ときだけ trigger する。
@@ -391,7 +400,34 @@ export const App = () => {
 
   const handleTaskDrop = useCallback(
     async (params: MoveTaskParams): Promise<void> => {
-      const result = await moveTask(params);
+      const targetTitle =
+        tasks.find((t) => t.filePath === params.taskFilePath)?.title ??
+        params.taskFilePath;
+      /**
+       * カラム間 status 変更の楽観 dispatch 直後に呼ばれる callback。
+       * 同一カラム並び替え（fromColumn === toColumn）では LiveRegion を更新しない。
+       *
+       * @param event optimistic 通知 payload
+       */
+      const onOptimisticApplied = (event: {
+        fromColumn: string;
+        toColumn: string;
+      }): void => {
+        if (event.fromColumn !== event.toColumn) {
+          announce(`「${targetTitle}」を「${event.toColumn}」に移動しました`);
+        }
+      };
+      /**
+       * カラム間 updateTask 失敗時の rollback 完了直後に呼ばれる callback。
+       * LiveRegion に「取り消しました」を流す。
+       */
+      const onRollback = (): void => {
+        announce(`「${targetTitle}」の移動を取り消しました`);
+      };
+      const result = await moveTask(params, {
+        onOptimisticApplied,
+        onRollback,
+      });
       if (!result.ok) {
         if (result.error.kind === "partial-move") {
           showToast(result.error.message, "error");
@@ -401,7 +437,7 @@ export const App = () => {
         showToast(`タスクの移動に失敗しました: ${message}`, "error");
       }
     },
-    [moveTask, showToast],
+    [tasks, moveTask, announce, showToast],
   );
 
   const handleTaskDelete = useCallback(
@@ -498,6 +534,7 @@ export const App = () => {
         />
       )}
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+      <LiveRegion announcement={announcement} />
     </div>
   );
 };

--- a/src/__tests__/App.live-region.test.tsx
+++ b/src/__tests__/App.live-region.test.tsx
@@ -1,0 +1,310 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { App } from "@/App";
+import { DRAG_MIME_TYPE } from "@/features/board/components/Board/dragState";
+import {
+  getColumns as getColumnsInvoke,
+  type OpenProjectPayload,
+  openDirectoryDialog,
+  openProject as openProjectInvoke,
+  TauriError,
+  updateCardOrder as updateCardOrderInvoke,
+  updateTask as updateTaskInvoke,
+} from "@/lib/tauri";
+import { createDragEvent } from "@/test-fixtures/createDragEvent";
+import { Task } from "@/types/task";
+import { Result } from "@/utils/result";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    openDirectoryDialog: vi.fn(),
+    openProject: vi.fn(),
+    getColumns: vi.fn(),
+    createTask: vi.fn(),
+    updateTask: vi.fn(),
+    deleteTask: vi.fn(),
+    updateColumns: vi.fn(),
+    updateCardOrder: vi.fn(),
+  };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+const openDirectoryDialogMock = vi.mocked(openDirectoryDialog);
+const openProjectMock = vi.mocked(openProjectInvoke);
+const getColumnsMock = vi.mocked(getColumnsInvoke);
+const updateTaskMock = vi.mocked(updateTaskInvoke);
+const updateCardOrderMock = vi.mocked(updateCardOrderInvoke);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+let hadIsReactActEnvironment = false;
+
+beforeAll(() => {
+  hadIsReactActEnvironment =
+    "IS_REACT_ACT_ENVIRONMENT" in reactActEnvironmentGlobal;
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+  const keysToDelete = hadIsReactActEnvironment
+    ? []
+    : (["IS_REACT_ACT_ENVIRONMENT"] as const);
+  for (const key of keysToDelete) {
+    Reflect.deleteProperty(reactActEnvironmentGlobal, key);
+  }
+});
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeEach(() => {
+  openDirectoryDialogMock.mockReset();
+  openProjectMock.mockReset();
+  getColumnsMock.mockReset();
+  getColumnsMock.mockResolvedValue({
+    ok: true,
+    value: {
+      columns: [
+        { name: "Todo", order: 0 },
+        { name: "Done", order: 1 },
+      ],
+      doneColumn: "Done",
+    },
+  });
+  updateTaskMock.mockReset();
+  updateCardOrderMock.mockReset();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+const taskA: Task = Task.fromPayload({
+  id: "a",
+  title: "A タスク",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/a.md",
+});
+
+const taskB: Task = Task.fromPayload({
+  id: "b",
+  title: "B タスク",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/b.md",
+});
+
+const payload: OpenProjectPayload = {
+  tasks: [taskA, taskB],
+  columns: ["Todo", "Done"],
+};
+
+/**
+ * テスト用の App マウントヘルパ。
+ */
+const mountApp = (): void => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<App />);
+  });
+};
+
+/**
+ * HeaderBar の「開く」ボタンを押下する。
+ */
+const clickHeaderOpenButton = (): void => {
+  const buttons = container?.querySelectorAll("header button") ?? [];
+  const openBtn = Array.from(buttons).find((b) => b.textContent === "開く") as
+    | HTMLButtonElement
+    | undefined;
+  openBtn?.click();
+};
+
+/**
+ * project を成功状態で読み込む。
+ */
+const openSuccessfully = async (): Promise<void> => {
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  openProjectMock.mockResolvedValueOnce(Result.ok(payload));
+  await act(async () => {
+    clickHeaderOpenButton();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+/**
+ * TaskCard を Done カラム section へ drop する。
+ */
+const dropFirstCardToDone = async (): Promise<void> => {
+  const card = container?.querySelector<HTMLElement>(
+    "[data-testid='task-card']",
+  );
+  const doneSection = container?.querySelector<HTMLElement>(
+    "section[aria-label='Done']",
+  );
+  await act(async () => {
+    card?.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const drop = createDragEvent("drop");
+  drop.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  await act(async () => {
+    doneSection?.dispatchEvent(drop);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+/**
+ * TaskCard を Todo カラム section へ drop（同一カラム並び替え相当）。
+ */
+const dropFirstCardWithinTodo = async (): Promise<void> => {
+  const card = container?.querySelector<HTMLElement>(
+    "[data-testid='task-card']",
+  );
+  const todoSection = container?.querySelector<HTMLElement>(
+    "section[aria-label='Todo']",
+  );
+  await act(async () => {
+    card?.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const drop = createDragEvent("drop");
+  drop.dataTransfer.setData(DRAG_MIME_TYPE, "tasks/a.md");
+  await act(async () => {
+    todoSection?.dispatchEvent(drop);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const liveRegion = (): HTMLElement | null =>
+  container?.querySelector<HTMLElement>('[data-testid="live-region"]') ?? null;
+
+test("drop 成功 → LiveRegion に「移動しました」が現れる", async () => {
+  mountApp();
+  await openSuccessfully();
+
+  const movedA: Task = { ...taskA, status: "Done" };
+  updateTaskMock.mockResolvedValueOnce(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValueOnce(Result.ok(undefined));
+
+  await dropFirstCardToDone();
+
+  expect(liveRegion()?.textContent).toBe(
+    "「A タスク」を「Done」に移動しました",
+  );
+});
+
+test("drop 楽観 announce は updateTask resolve 前に LiveRegion へ届いている", async () => {
+  mountApp();
+  await openSuccessfully();
+
+  type UpdateTaskResult = Awaited<ReturnType<typeof updateTaskMock>>;
+  let resolveUpdate: (value: UpdateTaskResult) => void = () => {};
+  updateTaskMock.mockReturnValueOnce(
+    new Promise<UpdateTaskResult>((resolve) => {
+      resolveUpdate = resolve;
+    }),
+  );
+  updateCardOrderMock.mockResolvedValueOnce(Result.ok(undefined));
+
+  await dropFirstCardToDone();
+  expect(liveRegion()?.textContent).toBe(
+    "「A タスク」を「Done」に移動しました",
+  );
+
+  await act(async () => {
+    resolveUpdate(Result.ok({ ...taskA, status: "Done" }));
+    await Promise.resolve();
+  });
+});
+
+test("drop 失敗 (updateTask reject) → LiveRegion が「取り消しました」になる", async () => {
+  mountApp();
+  await openSuccessfully();
+
+  updateTaskMock.mockResolvedValueOnce(
+    Result.err(new TauriError("IO_ERROR", "io fail")),
+  );
+
+  await dropFirstCardToDone();
+
+  expect(liveRegion()?.textContent).toBe("「A タスク」の移動を取り消しました");
+});
+
+test("同一カラム並び替え → LiveRegion textContent は空のまま", async () => {
+  mountApp();
+  await openSuccessfully();
+
+  updateCardOrderMock.mockResolvedValueOnce(Result.ok(undefined));
+
+  await dropFirstCardWithinTodo();
+
+  expect(liveRegion()?.textContent).toBe("");
+});
+
+test("同じ移動を連続実行 → 同じ text でも LiveRegion の div が key 変更で再 mount される", async () => {
+  mountApp();
+  await openSuccessfully();
+
+  const movedA: Task = { ...taskA, status: "Done" };
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await dropFirstCardToDone();
+  const first = liveRegion();
+  expect(first?.textContent).toBe("「A タスク」を「Done」に移動しました");
+
+  // 状態をリセットして同じ操作を実行する代わりに、別 announce を直接観測する。
+  // 楽観 dispatch は state を変えるので、最初の drop 後の状態で再度 dragstart →
+  // drop を行うと invalid-state が返るため、ここでは「同一文字列を 2 回 announce
+  // した場合に key が変わる」性質のみ LiveRegion の単体テストで担保し、
+  // App 結合では 1 回 drop 後の announce 結果が反映されることを確認する。
+  expect(first?.getAttribute("data-testid")).toBe("live-region");
+});

--- a/src/__tests__/App.live-region.test.tsx
+++ b/src/__tests__/App.live-region.test.tsx
@@ -226,6 +226,15 @@ const dropFirstCardWithinTodo = async (): Promise<void> => {
 const liveRegion = (): HTMLElement | null =>
   container?.querySelector<HTMLElement>('[data-testid="live-region"]') ?? null;
 
+/**
+ * LiveRegion の visible text を取得する。
+ * SR トリガ用に末尾へ付加される可能性のあるゼロ幅スペースを除去して比較する。
+ *
+ * @returns ゼロ幅スペースを除いた textContent
+ */
+const liveRegionText = (): string =>
+  (liveRegion()?.textContent ?? "").replace(/​/g, "");
+
 test("drop 成功 → LiveRegion に「移動しました」が現れる", async () => {
   mountApp();
   await openSuccessfully();
@@ -236,9 +245,7 @@ test("drop 成功 → LiveRegion に「移動しました」が現れる", async
 
   await dropFirstCardToDone();
 
-  expect(liveRegion()?.textContent).toBe(
-    "「A タスク」を「Done」に移動しました",
-  );
+  expect(liveRegionText()).toBe("「A タスク」を「Done」に移動しました");
 });
 
 test("drop 楽観 announce は updateTask resolve 前に LiveRegion へ届いている", async () => {
@@ -255,9 +262,7 @@ test("drop 楽観 announce は updateTask resolve 前に LiveRegion へ届いて
   updateCardOrderMock.mockResolvedValueOnce(Result.ok(undefined));
 
   await dropFirstCardToDone();
-  expect(liveRegion()?.textContent).toBe(
-    "「A タスク」を「Done」に移動しました",
-  );
+  expect(liveRegionText()).toBe("「A タスク」を「Done」に移動しました");
 
   await act(async () => {
     resolveUpdate(Result.ok({ ...taskA, status: "Done" }));
@@ -275,7 +280,7 @@ test("drop 失敗 (updateTask reject) → LiveRegion が「取り消しました
 
   await dropFirstCardToDone();
 
-  expect(liveRegion()?.textContent).toBe("「A タスク」の移動を取り消しました");
+  expect(liveRegionText()).toBe("「A タスク」の移動を取り消しました");
 });
 
 test("同一カラム並び替え → LiveRegion textContent は空のまま", async () => {
@@ -289,22 +294,17 @@ test("同一カラム並び替え → LiveRegion textContent は空のまま", a
   expect(liveRegion()?.textContent).toBe("");
 });
 
-test("同じ移動を連続実行 → 同じ text でも LiveRegion の div が key 変更で再 mount される", async () => {
+test("drop 後の LiveRegion は同一の安定 DOM ノードを維持しつつ visible text が更新される", async () => {
   mountApp();
   await openSuccessfully();
 
+  const before = liveRegion();
   const movedA: Task = { ...taskA, status: "Done" };
   updateTaskMock.mockResolvedValue(Result.ok(movedA));
   updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
 
   await dropFirstCardToDone();
-  const first = liveRegion();
-  expect(first?.textContent).toBe("「A タスク」を「Done」に移動しました");
-
-  // 状態をリセットして同じ操作を実行する代わりに、別 announce を直接観測する。
-  // 楽観 dispatch は state を変えるので、最初の drop 後の状態で再度 dragstart →
-  // drop を行うと invalid-state が返るため、ここでは「同一文字列を 2 回 announce
-  // した場合に key が変わる」性質のみ LiveRegion の単体テストで担保し、
-  // App 結合では 1 回 drop 後の announce 結果が反映されることを確認する。
-  expect(first?.getAttribute("data-testid")).toBe("live-region");
+  const after = liveRegion();
+  expect(after).toBe(before);
+  expect(liveRegionText()).toBe("「A タスク」を「Done」に移動しました");
 });

--- a/src/components/LiveRegion/__tests__/LiveRegion.rendering.test.tsx
+++ b/src/components/LiveRegion/__tests__/LiveRegion.rendering.test.tsx
@@ -1,0 +1,95 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, beforeEach, expect, test } from "vitest";
+import { LiveRegion } from "@/components/LiveRegion";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+beforeAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+const queryRegion = (): HTMLElement | null =>
+  container?.querySelector<HTMLElement>('[data-testid="live-region"]') ?? null;
+
+test("announcement に値があれば role=status / aria-live=polite / aria-atomic=true が付与される", () => {
+  act(() => {
+    root?.render(
+      createElement(LiveRegion, { announcement: { id: 1, text: "x" } }),
+    );
+  });
+  const el = queryRegion();
+  expect(el).not.toBeNull();
+  expect(el?.getAttribute("role")).toBe("status");
+  expect(el?.getAttribute("aria-live")).toBe("polite");
+  expect(el?.getAttribute("aria-atomic")).toBe("true");
+});
+
+test("announcement.text が textContent に反映される", () => {
+  act(() => {
+    root?.render(
+      createElement(LiveRegion, {
+        announcement: { id: 1, text: "「A」を「Done」に移動しました" },
+      }),
+    );
+  });
+  const el = queryRegion();
+  expect(el?.textContent).toBe("「A」を「Done」に移動しました");
+});
+
+test("視覚非表示クラス（sr-only）が付与される", () => {
+  act(() => {
+    root?.render(
+      createElement(LiveRegion, { announcement: { id: 1, text: "x" } }),
+    );
+  });
+  const el = queryRegion();
+  expect(el?.className).toContain("sr-only");
+});
+
+test("announcement=null でも要素自体は描画されるが空文字", () => {
+  act(() => {
+    root?.render(createElement(LiveRegion, { announcement: null }));
+  });
+  const el = queryRegion();
+  expect(el).not.toBeNull();
+  expect(el?.textContent).toBe("");
+});
+
+test("同じ text でも id が変わると div が再 mount される（連続同文言の announce が SR に届く）", () => {
+  act(() => {
+    root?.render(
+      createElement(LiveRegion, { announcement: { id: 1, text: "same" } }),
+    );
+  });
+  const before = queryRegion();
+  expect(before?.textContent).toBe("same");
+  act(() => {
+    root?.render(
+      createElement(LiveRegion, { announcement: { id: 2, text: "same" } }),
+    );
+  });
+  const after = queryRegion();
+  expect(after?.textContent).toBe("same");
+  expect(after).not.toBe(before);
+});

--- a/src/components/LiveRegion/__tests__/LiveRegion.rendering.test.tsx
+++ b/src/components/LiveRegion/__tests__/LiveRegion.rendering.test.tsx
@@ -45,11 +45,11 @@ test("announcement に値があれば role=status / aria-live=polite / aria-atom
   expect(el?.getAttribute("aria-atomic")).toBe("true");
 });
 
-test("announcement.text が textContent に反映される", () => {
+test("announcement.text が textContent に反映される（id 偶数で suffix なし）", () => {
   act(() => {
     root?.render(
       createElement(LiveRegion, {
-        announcement: { id: 1, text: "「A」を「Done」に移動しました" },
+        announcement: { id: 2, text: "「A」を「Done」に移動しました" },
       }),
     );
   });
@@ -76,20 +76,21 @@ test("announcement=null でも要素自体は描画されるが空文字", () =>
   expect(el?.textContent).toBe("");
 });
 
-test("同じ text でも id が変わると div が再 mount される（連続同文言の announce が SR に届く）", () => {
+test("div は安定 mount のまま textContent が id 連動で変化する（連続同文言の announce が SR に届く）", () => {
   act(() => {
     root?.render(
       createElement(LiveRegion, { announcement: { id: 1, text: "same" } }),
     );
   });
   const before = queryRegion();
-  expect(before?.textContent).toBe("same");
+  const beforeText = before?.textContent;
   act(() => {
     root?.render(
       createElement(LiveRegion, { announcement: { id: 2, text: "same" } }),
     );
   });
   const after = queryRegion();
-  expect(after?.textContent).toBe("same");
-  expect(after).not.toBe(before);
+  const afterText = after?.textContent;
+  expect(after).toBe(before);
+  expect(afterText).not.toBe(beforeText);
 });

--- a/src/components/LiveRegion/index.tsx
+++ b/src/components/LiveRegion/index.tsx
@@ -1,12 +1,13 @@
 /**
  * SR に通知する 1 件のアナウンスメッセージ。
  *
- * 同じ文字列を連続で setState しても React が再 render を省略して SR が
- * 読み上げないケースを避けるため、id を一意化して受け取り、key として
- * div を再 mount させる。
+ * 同じ文字列を連続で setState しても、live region の textContent が
+ * 同値なら DOM ミューテーションが起きず SR が再読しないケースがある。
+ * id を一意化して受け取り、id の偶奇でゼロ幅スペースを付け替えることで、
+ * 同一文言の連続通知でも textContent を必ず変化させて SR をトリガする。
  */
 export type LiveAnnouncement = {
-  /** 通知の連番（同じ text でも id が変われば div を再 mount し SR に届ける）。 */
+  /** 通知の連番（同じ text でも id が変われば textContent が変わり SR に届く）。 */
   readonly id: number;
   /** 読み上げる文字列。空文字なら SR トリガなし。 */
   readonly text: string;
@@ -17,12 +18,35 @@ type LiveRegionProps = {
   announcement: LiveAnnouncement | null;
 };
 
+/** ゼロ幅スペース。SR にトリガをかけるための不可視差分文字。 */
+const ZERO_WIDTH_SPACE = "​";
+
+/**
+ * announcement から render する textContent を組み立てる。
+ *
+ * live region は安定した DOM ノードに保ち、textContent のミューテーションで
+ * SR を駆動するのがアクセシビリティのベストプラクティス。一方で同一文言の
+ * 連続通知も SR に届ける必要があるため、id の偶奇で末尾にゼロ幅スペースを
+ * 付け替え、テキストが必ず変化するようにする。
+ *
+ * @param announcement 現在のアナウンス
+ * @returns div の textContent として描画する文字列
+ */
+const renderText = (announcement: LiveAnnouncement | null): string => {
+  if (announcement === null) {
+    return "";
+  }
+  const suffix = announcement.id % 2 === 0 ? "" : ZERO_WIDTH_SPACE;
+  return `${announcement.text}${suffix}`;
+};
+
 /**
  * 視覚非表示の aria-live="polite" 領域。
  *
  * status 変更などの非緊急アナウンスを SR に通知する目的で使用する。
- * 同一テキストの連続通知でも `announcement.id` を更新することで div の key が
- * 変わり再 mount されるため、SR が再度読み上げる。
+ * div 自体はマウント以後一度も unmount されず、textContent のみが更新される。
+ * 同一文言の連続通知は {@link renderText} がゼロ幅スペースを付け替えることで
+ * SR に再読をトリガする。
  *
  * @param props LiveRegion の props
  * @returns aria-live polite な div 要素
@@ -30,14 +54,13 @@ type LiveRegionProps = {
 export const LiveRegion = ({ announcement }: LiveRegionProps) => {
   return (
     <div
-      key={announcement?.id ?? 0}
       role="status"
       aria-live="polite"
       aria-atomic="true"
       data-testid="live-region"
       className="sr-only absolute -m-px h-px w-px overflow-hidden border-0 p-0 [clip:rect(0,0,0,0)]"
     >
-      {announcement?.text ?? ""}
+      {renderText(announcement)}
     </div>
   );
 };

--- a/src/components/LiveRegion/index.tsx
+++ b/src/components/LiveRegion/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * SR に通知する 1 件のアナウンスメッセージ。
+ *
+ * 同じ文字列を連続で setState しても React が再 render を省略して SR が
+ * 読み上げないケースを避けるため、id を一意化して受け取り、key として
+ * div を再 mount させる。
+ */
+export type LiveAnnouncement = {
+  /** 通知の連番（同じ text でも id が変われば div を再 mount し SR に届ける）。 */
+  readonly id: number;
+  /** 読み上げる文字列。空文字なら SR トリガなし。 */
+  readonly text: string;
+};
+
+type LiveRegionProps = {
+  /** null のとき何も読み上げない（初期状態）。 */
+  announcement: LiveAnnouncement | null;
+};
+
+/**
+ * 視覚非表示の aria-live="polite" 領域。
+ *
+ * status 変更などの非緊急アナウンスを SR に通知する目的で使用する。
+ * 同一テキストの連続通知でも `announcement.id` を更新することで div の key が
+ * 変わり再 mount されるため、SR が再度読み上げる。
+ *
+ * @param props LiveRegion の props
+ * @returns aria-live polite な div 要素
+ */
+export const LiveRegion = ({ announcement }: LiveRegionProps) => {
+  return (
+    <div
+      key={announcement?.id ?? 0}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="live-region"
+      className="sr-only absolute -m-px h-px w-px overflow-hidden border-0 p-0 [clip:rect(0,0,0,0)]"
+    >
+      {announcement?.text ?? ""}
+    </div>
+  );
+};

--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -405,6 +405,53 @@ test("カラム間移動: updateTask 失敗時の rollback dispatch 順序が固
   ]);
 });
 
+test("rollback 中に外部 listener が task-updated を dispatch していたら、snapshot で上書きせず外部更新を保護する", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  // IPC 待機中に外部 listener が task-updated を発火させた状況を再現する。
+  // tasks/a.md は楽観 dispatch によって status=Done に切り替わった後、
+  // 外部の file watcher 由来 listener が title を書き換えつつ status を
+  // "InProgress" に更新したと仮定する。
+  updateTaskMock.mockImplementation(async () => {
+    harness.deps.dispatchSync({
+      type: "task-updated",
+      originalFilePath: "tasks/a.md",
+      task: makeTask({
+        filePath: "tasks/a.md",
+        status: "InProgress",
+        title: "外部更新後タイトル",
+      }),
+    });
+    return Result.err(new TauriError("UNKNOWN", "x"));
+  });
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  // 楽観 dispatch x2 + 外部 listener の task-updated x1 = 3 件が先行する。
+  // rollback では snapshot による task 上書きが省略され、cardOrder の
+  // rollback 2 件のみ流れる（全体で 5 件）。
+  expect(harness.actions.map((a) => a.type)).toEqual([
+    "task-updated",
+    "card-order-updated",
+    "task-updated",
+    "card-order-updated",
+    "card-order-updated",
+  ]);
+  const next = harness.state.current as { data: ProjectData };
+  const target = next.data.tasks.find((t) => t.filePath === "tasks/a.md");
+  expect(target?.title).toBe("外部更新後タイトル");
+  expect(target?.status).toBe("InProgress");
+});
+
 test("カラム間移動: updateTask 失敗時に onRollback callback が呼ばれ、onOptimisticApplied は事前に 1 度呼ばれている", async () => {
   const harness = setupLoaded(
     makeData([

--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -29,6 +29,11 @@ vi.mock("@/lib/tauri", async () => {
 const updateTaskMock = vi.mocked(updateTaskInvoke);
 const updateCardOrderMock = vi.mocked(updateCardOrderInvoke);
 
+/**
+ * Task payload を最小限の overrides で生成するテストヘルパ。
+ * @param overrides 上書きする TaskPayload フィールド
+ * @returns ProjectData に格納可能な Task
+ */
 const makeTask = (overrides: Partial<TaskPayload>): Task =>
   Task.fromPayload({
     id: overrides.filePath ?? "id",
@@ -43,6 +48,11 @@ const makeTask = (overrides: Partial<TaskPayload>): Task =>
     ...overrides,
   });
 
+/**
+ * filePath / status の組から ProjectData を生成するテストヘルパ。
+ * @param pairs [filePath, status] のタプル配列
+ * @returns Todo / Done カラムを持つ ProjectData
+ */
 const makeData = (
   pairs: ReadonlyArray<readonly [string, string]>,
 ): ProjectData => ({
@@ -59,6 +69,11 @@ type Harness = {
   deps: Parameters<typeof moveTaskAction>[0];
 };
 
+/**
+ * loaded 状態の moveTaskAction 実行に必要な harness を組み立てる。
+ * @param data 初期 ProjectData
+ * @returns moveTaskAction 呼び出しに必要な harness
+ */
 const setupLoaded = (data: ProjectData): Harness => {
   const state = {
     current: { kind: "loaded", path: "/p", data } as ProjectState,
@@ -138,7 +153,7 @@ test("カラム間移動: updateTask 成功後 updateCardOrder が呼ばれる",
   });
 });
 
-test("カラム間移動: task-updated → card-order-updated の順で dispatch される", async () => {
+test("カラム間移動: 楽観 → 確定の順で task-updated x2 + card-order-updated x2 が dispatch される", async () => {
   const harness = setupLoaded(
     makeData([
       ["tasks/a.md", "Todo"],
@@ -159,7 +174,40 @@ test("カラム間移動: task-updated → card-order-updated の順で dispatch
   expect(harness.actions.map((a) => a.type)).toEqual([
     "task-updated",
     "card-order-updated",
+    "task-updated",
+    "card-order-updated",
   ]);
+});
+
+test("カラム間移動: 楽観 dispatch が IPC 完了前に getState() に反映される", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+
+  let snapshotDuringIpc: ProjectData | null = null;
+  updateTaskMock.mockImplementation(async () => {
+    snapshotDuringIpc =
+      (harness.state.current as { data?: ProjectData }).data ?? null;
+    return Result.ok(movedA);
+  });
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  expect(snapshotDuringIpc).not.toBeNull();
+  const inDone = (snapshotDuringIpc as unknown as ProjectData).tasks
+    .filter((t) => t.status === "Done")
+    .map((t) => t.filePath);
+  expect(inDone).toEqual(["tasks/a.md", "tasks/b.md"]);
 });
 
 test("カラム間移動成功後、ProjectData.tasks に target が toIndex 位置で含まれる", async () => {
@@ -188,7 +236,7 @@ test("カラム間移動成功後、ProjectData.tasks に target が toIndex 位
   expect(inDone).toEqual(["tasks/b.md", "tasks/a.md", "tasks/c.md"]);
 });
 
-test("fromColumn === toColumn で並び順変化があれば updateCardOrder が呼ばれる", async () => {
+test("同一カラム並び替え: 楽観 → 確定で card-order-updated が 2 回 dispatch される", async () => {
   const harness = setupLoaded(
     makeData([
       ["tasks/a.md", "Todo"],
@@ -207,11 +255,14 @@ test("fromColumn === toColumn で並び順変化があれば updateCardOrder が
 
   expect(result.ok).toBe(true);
   expect(updateTaskMock).not.toHaveBeenCalled();
-  expect(updateTaskMock).toHaveBeenCalledTimes(0);
   expect(updateCardOrderMock).toHaveBeenCalledWith({
     columnName: "Todo",
     filePaths: ["tasks/b.md", "tasks/a.md", "tasks/c.md"],
   });
+  expect(harness.actions.map((a) => a.type)).toEqual([
+    "card-order-updated",
+    "card-order-updated",
+  ]);
 });
 
 test("カラム内並び替え後の ProjectData.tasks 表示順が filePaths と一致", async () => {
@@ -239,7 +290,7 @@ test("カラム内並び替え後の ProjectData.tasks 表示順が filePaths �
   ]);
 });
 
-test("並び順変化なし → IPC を呼ばず Result.ok", async () => {
+test("並び順変化なし → IPC を呼ばず Result.ok / 楽観 dispatch も走らない", async () => {
   const harness = setupLoaded(
     makeData([
       ["tasks/a.md", "Todo"],
@@ -257,9 +308,10 @@ test("並び順変化なし → IPC を呼ばず Result.ok", async () => {
   expect(result.ok).toBe(true);
   expect(updateTaskMock).toHaveBeenCalledTimes(0);
   expect(updateCardOrderMock).toHaveBeenCalledTimes(0);
+  expect(harness.actions).toEqual([]);
 });
 
-test("同一カラムで updateCardOrder が Result.err → ProjectError.tauri、card-order-updated は dispatch されない", async () => {
+test("同一カラム並び替え: updateCardOrder 失敗 → 楽観 dispatch が rollback され state 原状", async () => {
   const harness = setupLoaded(
     makeData([
       ["tasks/a.md", "Todo"],
@@ -282,10 +334,17 @@ test("同一カラムで updateCardOrder が Result.err → ProjectError.tauri�
   expect((result as { error: ProjectError }).error.kind).toBe("tauri");
   expect(updateTaskMock).not.toHaveBeenCalled();
   expect(updateCardOrderMock).toHaveBeenCalledTimes(1);
-  expect(harness.actions.map((a) => a.type)).toEqual([]);
+  expect(harness.actions.map((a) => a.type)).toEqual([
+    "card-order-updated",
+    "card-order-updated",
+  ]);
+  const next = harness.state.current as { data: ProjectData };
+  expect(
+    next.data.tasks.filter((t) => t.status === "Todo").map((t) => t.filePath),
+  ).toEqual(["tasks/a.md", "tasks/b.md", "tasks/c.md"]);
 });
 
-test("updateTask が Result.err なら ProjectError.tauri を返し updateCardOrder は呼ばれない", async () => {
+test("updateTask が Result.err なら ProjectError.tauri を返し updateCardOrder は呼ばれない / カラムは原状", async () => {
   const harness = setupLoaded(
     makeData([
       ["tasks/a.md", "Todo"],
@@ -310,9 +369,79 @@ test("updateTask が Result.err なら ProjectError.tauri を返し updateCardOr
   expect(result.ok).toBe(false);
   expect((result as { error: ProjectError }).error.kind).toBe("tauri");
   expect(updateCardOrderMock).not.toHaveBeenCalled();
+  const next = harness.state.current as { data: ProjectData };
+  const todoPaths = next.data.tasks
+    .filter((t) => t.status === "Todo")
+    .map((t) => t.filePath);
+  const donePaths = next.data.tasks
+    .filter((t) => t.status === "Done")
+    .map((t) => t.filePath);
+  expect(todoPaths).toEqual(["tasks/a.md"]);
+  expect(donePaths).toEqual(["tasks/b.md"]);
 });
 
-test("カラム間で updateTask 成功 / updateCardOrder 失敗 → task-updated は dispatch、card-order-updated は dispatch されず Result.err", async () => {
+test("カラム間移動: updateTask 失敗時の rollback dispatch 順序が固定される", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  updateTaskMock.mockResolvedValue(Result.err(new TauriError("UNKNOWN", "x")));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  expect(harness.actions.map((a) => a.type)).toEqual([
+    "task-updated",
+    "card-order-updated",
+    "card-order-updated",
+    "task-updated",
+    "card-order-updated",
+  ]);
+});
+
+test("カラム間移動: updateTask 失敗時に onRollback callback が呼ばれ、onOptimisticApplied は事前に 1 度呼ばれている", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  updateTaskMock.mockResolvedValue(Result.err(new TauriError("UNKNOWN", "x")));
+
+  const optimistic = vi.fn();
+  const rollback = vi.fn();
+  await moveTaskAction(
+    harness.deps,
+    {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: 0,
+    },
+    { onOptimisticApplied: optimistic, onRollback: rollback },
+  );
+
+  expect(optimistic).toHaveBeenCalledTimes(1);
+  expect(optimistic).toHaveBeenCalledWith({
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+  });
+  expect(rollback).toHaveBeenCalledTimes(1);
+  expect(rollback).toHaveBeenCalledWith({
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+  });
+});
+
+test("カラム間で updateTask 成功 / updateCardOrder 失敗 → partial-move: status 確定保持 / cardOrder 補正 / onRollback は呼ばれない", async () => {
   const harness = setupLoaded(
     makeData([
       ["tasks/a.md", "Todo"],
@@ -325,6 +454,47 @@ test("カラム間で updateTask 成功 / updateCardOrder 失敗 → task-update
     Result.err(new TauriError("UNKNOWN", "x")),
   );
 
+  const rollback = vi.fn();
+  const result = await moveTaskAction(
+    harness.deps,
+    {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: 0,
+    },
+    { onRollback: rollback },
+  );
+
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
+  expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("partial-move");
+  expect(rollback).not.toHaveBeenCalled();
+
+  const next = harness.state.current as { data: ProjectData };
+  const target = next.data.tasks.find((t) => t.filePath === "tasks/a.md");
+  expect(target?.status).toBe("Done");
+  const donePaths = next.data.tasks
+    .filter((t) => t.status === "Done")
+    .map((t) => t.filePath);
+  expect(donePaths).toEqual(["tasks/b.md", "tasks/a.md"]);
+  const todoPaths = next.data.tasks
+    .filter((t) => t.status === "Todo")
+    .map((t) => t.filePath);
+  expect(todoPaths).toEqual([]);
+});
+
+test("callbacks 未指定でも例外なく動作する（カラム間成功）", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
   const result = await moveTaskAction(harness.deps, {
     taskFilePath: "tasks/a.md",
     fromColumn: "Todo",
@@ -332,10 +502,66 @@ test("カラム間で updateTask 成功 / updateCardOrder 失敗 → task-update
     toIndex: 0,
   });
 
+  expect(result.ok).toBe(true);
+});
+
+test("onOptimisticApplied が throw しても queue 進行は止まらず IPC が呼ばれる", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  const result = await moveTaskAction(
+    harness.deps,
+    {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: 0,
+    },
+    {
+      onOptimisticApplied: () => {
+        throw new Error("boom");
+      },
+    },
+  );
+
+  expect(result.ok).toBe(true);
   expect(updateTaskMock).toHaveBeenCalledTimes(1);
-  expect(result.ok).toBe(false);
-  expect((result as { error: ProjectError }).error.kind).toBe("partial-move");
-  expect(harness.actions.map((a) => a.type)).toEqual(["task-updated"]);
+});
+
+test("同一カラム並び替えでは onOptimisticApplied / onRollback は呼ばれない", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Todo"],
+      ["tasks/c.md", "Todo"],
+    ]),
+  );
+  updateCardOrderMock.mockResolvedValue(
+    Result.err(new TauriError("IO_ERROR", "io fail")),
+  );
+
+  const optimistic = vi.fn();
+  const rollback = vi.fn();
+  await moveTaskAction(
+    harness.deps,
+    {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Todo",
+      toIndex: 2,
+    },
+    { onOptimisticApplied: optimistic, onRollback: rollback },
+  );
+
+  expect(optimistic).not.toHaveBeenCalled();
+  expect(rollback).not.toHaveBeenCalled();
 });
 
 test("session が loaded でない時 invalidState で抜ける", async () => {
@@ -362,7 +588,7 @@ test("session が loaded でない時 invalidState で抜ける", async () => {
   expect(updateTaskMock).not.toHaveBeenCalled();
 });
 
-test("IPC 中に projectVersion が変わると invalidState で抜ける", async () => {
+test("IPC 中に projectVersion が変わると invalidState で抜け、rollback dispatch も走らない", async () => {
   const harness = setupLoaded(
     makeData([
       ["tasks/a.md", "Todo"],
@@ -375,16 +601,62 @@ test("IPC 中に projectVersion が変わると invalidState で抜ける", asyn
     return Result.ok(movedA);
   });
 
-  const result = await moveTaskAction(harness.deps, {
+  const rollback = vi.fn();
+  const result = await moveTaskAction(
+    harness.deps,
+    {
+      taskFilePath: "tasks/a.md",
+      fromColumn: "Todo",
+      toColumn: "Done",
+      toIndex: 0,
+    },
+    { onRollback: rollback },
+  );
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: ProjectError }).error.kind).toBe("invalid-state");
+  expect(updateCardOrderMock).not.toHaveBeenCalled();
+  expect(rollback).not.toHaveBeenCalled();
+  expect(harness.actions.map((a) => a.type)).toEqual([
+    "task-updated",
+    "card-order-updated",
+  ]);
+});
+
+test("楽観 dispatch + 外部 listen の二重 dispatch でも最終 state が同じ（idempotent）", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  const movedA = makeTask({ filePath: "tasks/a.md", status: "Done" });
+  updateTaskMock.mockResolvedValue(Result.ok(movedA));
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
     taskFilePath: "tasks/a.md",
     fromColumn: "Todo",
     toColumn: "Done",
     toIndex: 0,
   });
+  const beforeReplay = harness.state.current;
 
-  expect(result.ok).toBe(false);
-  expect((result as { error: ProjectError }).error.kind).toBe("invalid-state");
-  expect(updateCardOrderMock).not.toHaveBeenCalled();
+  harness.deps.dispatchSync({
+    type: "task-updated",
+    originalFilePath: "tasks/a.md",
+    task: movedA,
+  });
+  harness.deps.dispatchSync({
+    type: "card-order-updated",
+    columnName: "Done",
+    filePaths: ["tasks/a.md", "tasks/b.md"],
+  });
+  const afterReplay = harness.state.current;
+
+  expect((afterReplay as { data: ProjectData }).data).toEqual(
+    (beforeReplay as { data: ProjectData }).data,
+  );
 });
 
 test.each([
@@ -432,4 +704,5 @@ test.each([
   const result = await moveTaskAction(harness.deps, params);
   expect(result.ok).toBe(false);
   expect((result as { error: ProjectError }).error.kind).toBe("invalid-state");
+  expect(harness.actions).toEqual([]);
 });

--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -452,6 +452,42 @@ test("rollback 中に外部 listener が task-updated を dispatch していた�
   expect(target?.status).toBe("InProgress");
 });
 
+test("rollback: status=toColumn のまま title 等が concurrent 更新された場合、rollback task は current のタイトルを保持し status のみ fromColumn に戻る", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Done"],
+    ]),
+  );
+  // 楽観 dispatch 後、IPC 待機中に外部 listener が title だけを書き換える
+  // （status は optimistic と同じ Done のまま）。
+  updateTaskMock.mockImplementation(async () => {
+    harness.deps.dispatchSync({
+      type: "task-updated",
+      originalFilePath: "tasks/a.md",
+      task: makeTask({
+        filePath: "tasks/a.md",
+        status: "Done",
+        title: "外部更新後タイトル",
+      }),
+    });
+    return Result.err(new TauriError("UNKNOWN", "x"));
+  });
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Done",
+    toIndex: 0,
+  });
+
+  const next = harness.state.current as { data: ProjectData };
+  const target = next.data.tasks.find((t) => t.filePath === "tasks/a.md");
+  // status は fromColumn=Todo に戻る一方、title は外部更新の値を保持する。
+  expect(target?.status).toBe("Todo");
+  expect(target?.title).toBe("外部更新後タイトル");
+});
+
 test("カラム間移動: updateTask 失敗時に onRollback callback が呼ばれ、onOptimisticApplied は事前に 1 度呼ばれている", async () => {
   const harness = setupLoaded(
     makeData([

--- a/src/features/board/hooks/useProject/actions/moveTask.ts
+++ b/src/features/board/hooks/useProject/actions/moveTask.ts
@@ -160,12 +160,17 @@ export const MoveSnapshot = {
    * 同一 task を concurrent に更新している可能性があるため、`currentTask`
    * を見て分岐する:
    *
-   * - `currentTask` が optimistic 状態（status === toColumn）と一致する場合
-   *   は通常の 3 段 rollback（cardOrder(to 旧) → task(原) → cardOrder(from 旧)）。
+   * - `currentTask` が optimistic 状態（status === toColumn）に留まっている
+   *   場合は、move 関連のフィールド（status）のみを fromColumn に戻し、
+   *   その他のフィールド（title / body / labels / 等）は currentTask の値を
+   *   そのまま採用する task-updated を発火する。これにより status は同じだが
+   *   title 等が外部更新されたケースでも concurrent な更新を保護する。
+   *   通常の 3 段（cardOrder(to 旧) → task(rollback) → cardOrder(from 旧)）。
    *   ②で task が fromColumn 末尾に補完される現象を③で打ち消す前提。
-   * - `currentTask` が optimistic と乖離している場合は外部 listener による
-   *   concurrent 更新が入ったとみなし、task-updated rollback を省略して
-   *   cardOrder のみ復元する。外部更新を snapshot で上書きしない保護策。
+   * - `currentTask` が optimistic と乖離している（status が toColumn 以外 /
+   *   task が消失した）場合は、外部 listener による status / 存在の concurrent
+   *   更新が入ったとみなし、task-updated rollback を省略して cardOrder のみ
+   *   復元する。snapshot で上書きしないことで外部更新を保護する。
    *
    * @param snapshot drop 直前 snapshot
    * @param params 移動パラメータ
@@ -177,8 +182,6 @@ export const MoveSnapshot = {
     params: MoveTaskParams,
     currentTask: Task | undefined,
   ): readonly ProjectAction[] => {
-    const taskMatchesOptimistic =
-      currentTask !== undefined && currentTask.status === params.toColumn;
     const head: ProjectAction = {
       type: "card-order-updated",
       columnName: params.toColumn,
@@ -189,13 +192,13 @@ export const MoveSnapshot = {
       columnName: params.fromColumn,
       filePaths: [...snapshot.fromColumnOrderBefore],
     };
-    if (!taskMatchesOptimistic) {
+    if (currentTask === undefined || currentTask.status !== params.toColumn) {
       return [head, tail];
     }
     const middle: ProjectAction = {
       type: "task-updated",
       originalFilePath: params.taskFilePath,
-      task: snapshot.originalTask,
+      task: { ...currentTask, status: params.fromColumn },
     };
     return [head, middle, tail];
   },

--- a/src/features/board/hooks/useProject/actions/moveTask.ts
+++ b/src/features/board/hooks/useProject/actions/moveTask.ts
@@ -1,7 +1,9 @@
 import { updateCardOrder, updateTask } from "@/lib/tauri";
+import type { Task } from "@/types/task";
 import { Result, type Result as ResultT } from "@/utils/result";
 import { enqueueProjectCommand, isProjectCurrent } from "../concurrency";
 import { ProjectError } from "../errors";
+import type { ProjectAction, ProjectData } from "../reducer";
 import { ProjectSessionState } from "../state/projectSessionState";
 import { buildMovedFilePaths } from "./buildMovedFilePaths";
 import type { TaskActionDeps } from "./tasks";
@@ -12,6 +14,35 @@ export type MoveTaskParams = {
   readonly fromColumn: string;
   readonly toColumn: string;
   readonly toIndex: number;
+};
+
+/**
+ * moveTask の楽観 dispatch / rollback 発生を呼び出し側に通知する callback。
+ * 通知は IPC 結果を待たず、reducer 反映直後に呼ばれる。callback 例外は
+ * 内部で握り潰し queue 進行に影響させない。
+ */
+export type MoveTaskCallbacks = {
+  /**
+   * カラム間 status 変更（fromColumn !== toColumn）の楽観 dispatch が
+   * reducer に反映された直後に 1 度だけ呼ばれる。同一カラム並び替え
+   * （fromColumn === toColumn）では呼ばれない。preflight 失敗（target 消失 /
+   * status 乖離 / toColumn 不存在 / 開始前 version 切替）でも呼ばれない。
+   */
+  readonly onOptimisticApplied?: (params: {
+    taskFilePath: string;
+    fromColumn: string;
+    toColumn: string;
+  }) => void;
+  /**
+   * カラム間 status 変更の updateTask 失敗による rollback が完了した直後に
+   * 1 度だけ呼ばれる。同一カラム rollback / partial-move（status 確定保持）
+   * / projectVersion 不一致による invalid-state では呼ばれない。
+   */
+  readonly onRollback?: (params: {
+    taskFilePath: string;
+    fromColumn: string;
+    toColumn: string;
+  }) => void;
 };
 
 /**
@@ -28,137 +59,325 @@ const ensureLoaded = (
     : Result.err(ProjectError.invalidState());
 
 /**
- * Drop 確定時に Board から呼ばれる単一 entry point。
- * - fromColumn !== toColumn: updateTask + updateCardOrder(toColumn) の 2 連 IPC
- * - fromColumn === toColumn: 並び替え後 filePaths と現状を比較し、変化なしなら no-op
- *                            変化あれば updateCardOrder のみ
- *
- * @param deps queue / version / state / dispatch 依存
- * @param params 移動パラメータ
- * @returns 成功時 Result.ok(undefined) / 失敗時 Result.err(ProjectError)
+ * drop 直前の Board 状態を保持する VO。companion object に振る舞いを集約し、
+ * 楽観 dispatch 列 / rollback dispatch 列 / partial-move 補正列の組み立ては
+ * ここに閉じる。effect 側からは pure メソッドとして呼び出す。
  */
-export const moveTaskAction = (
+export type MoveSnapshot = {
+  readonly originalTask: Task;
+  readonly fromColumnOrderBefore: readonly string[];
+  readonly toColumnOrderBefore: readonly string[];
+};
+
+/**
+ * 指定カラムに属するタスクの filePath 列を抽出する pure helper。
+ *
+ * @param data 現在の ProjectData
+ * @param columnName 抽出対象カラム名
+ * @returns 該当カラムに属するタスクの filePath 配列（既存並び順を維持）
+ */
+const filePathsInColumn = (
+  data: ProjectData,
+  columnName: string,
+): readonly string[] =>
+  data.tasks.filter((t) => t.status === columnName).map((t) => t.filePath);
+
+export const MoveSnapshot = {
+  /**
+   * ProjectData と target Task から snapshot を採取する（pure）。
+   *
+   * @param data drop 直前の ProjectData
+   * @param originalTask 移動対象 task の immutable 参照
+   * @param params 移動パラメータ
+   * @returns 採取した MoveSnapshot
+   */
+  from: (
+    data: ProjectData,
+    originalTask: Task,
+    params: MoveTaskParams,
+  ): MoveSnapshot => ({
+    originalTask,
+    fromColumnOrderBefore: filePathsInColumn(data, params.fromColumn),
+    toColumnOrderBefore: filePathsInColumn(data, params.toColumn),
+  }),
+
+  /**
+   * snapshot.originalTask を楽観 status (toColumn) で書き換えた新 Task を返す（pure）。
+   *
+   * @param snapshot drop 直前 snapshot
+   * @param toColumn 移動先カラム名（楽観反映する新 status）
+   * @returns status を toColumn に差し替えた新 Task
+   */
+  toOptimisticTask: (snapshot: MoveSnapshot, toColumn: string): Task => ({
+    ...snapshot.originalTask,
+    status: toColumn,
+  }),
+
+  /**
+   * 同一カラム並び替えで「変化なし」かを判定する（pure）。
+   *
+   * @param snapshot drop 直前 snapshot
+   * @param filePaths 並び替え後の filePath 列（提案順）
+   * @returns 提案順が toColumnOrderBefore と一致するなら true
+   */
+  isSameOrder: (
+    snapshot: MoveSnapshot,
+    filePaths: readonly string[],
+  ): boolean =>
+    filePaths.length === snapshot.toColumnOrderBefore.length &&
+    filePaths.every((p, i) => p === snapshot.toColumnOrderBefore[i]),
+
+  /**
+   * カラム間 楽観 dispatch 列（pure）。
+   * 順序: ① task-updated(楽観) → ② card-order-updated(楽観 toOrder)。
+   *
+   * @param snapshot drop 直前 snapshot
+   * @param params 移動パラメータ
+   * @param optimisticToOrder 楽観反映後の toColumn filePath 列
+   * @returns dispatch 順に並んだ ProjectAction の配列
+   */
+  optimisticCrossDispatches: (
+    snapshot: MoveSnapshot,
+    params: MoveTaskParams,
+    optimisticToOrder: readonly string[],
+  ): readonly ProjectAction[] => [
+    {
+      type: "task-updated",
+      originalFilePath: params.taskFilePath,
+      task: MoveSnapshot.toOptimisticTask(snapshot, params.toColumn),
+    },
+    {
+      type: "card-order-updated",
+      columnName: params.toColumn,
+      filePaths: [...optimisticToOrder],
+    },
+  ],
+
+  /**
+   * カラム間 updateTask 失敗時の rollback 3 段（逆順）（pure）。
+   * ②で task が fromColumn 末尾に補完される現象を③で打ち消し、drop 前位置を復元する。
+   *
+   * @param snapshot drop 直前 snapshot
+   * @param params 移動パラメータ
+   * @returns 逆順 rollback 用 ProjectAction 配列（3 段）
+   */
+  rollbackCrossDispatches: (
+    snapshot: MoveSnapshot,
+    params: MoveTaskParams,
+  ): readonly ProjectAction[] => [
+    {
+      type: "card-order-updated",
+      columnName: params.toColumn,
+      filePaths: [...snapshot.toColumnOrderBefore],
+    },
+    {
+      type: "task-updated",
+      originalFilePath: params.taskFilePath,
+      task: snapshot.originalTask,
+    },
+    {
+      type: "card-order-updated",
+      columnName: params.fromColumn,
+      filePaths: [...snapshot.fromColumnOrderBefore],
+    },
+  ],
+
+  /** partial-move（status 確定保持 / cardOrder のみ補正）の dispatch 列（pure）。 */
+  partialRollbackDispatches: (
+    snapshot: MoveSnapshot,
+    params: MoveTaskParams,
+  ): readonly ProjectAction[] => [
+    {
+      type: "card-order-updated",
+      columnName: params.toColumn,
+      filePaths: [...snapshot.toColumnOrderBefore],
+    },
+    {
+      type: "card-order-updated",
+      columnName: params.fromColumn,
+      filePaths: [...snapshot.fromColumnOrderBefore],
+    },
+  ],
+
+  /** 同一カラム rollback の dispatch（toColumnOrderBefore 1 段のみ）（pure）。 */
+  rollbackSameDispatches: (
+    snapshot: MoveSnapshot,
+    params: MoveTaskParams,
+  ): readonly ProjectAction[] => [
+    {
+      type: "card-order-updated",
+      columnName: params.toColumn,
+      filePaths: [...snapshot.toColumnOrderBefore],
+    },
+  ],
+} as const;
+
+/** version 一致確認の共通ガード。不一致なら Result.err(invalid-state) を返す。 */
+const versionGuard = (
+  deps: TaskActionDeps,
+  version: number,
+): ResultT<void, ProjectError> | null =>
+  isProjectCurrent(deps.projectVersion, version)
+    ? null
+    : Result.err(ProjectError.invalidState("プロジェクトが切り替わりました"));
+
+/** 単一引数を受け取り副作用のみ起こす callback の型エイリアス。 */
+type SafeCallbackFn<T> = (arg: T) => void;
+
+/**
+ * callback 例外を握り潰す共通ヘルパ。queue 進行を絶対に止めない。
+ *
+ * @param fn 呼び出し対象の callback（undefined のとき no-op）
+ * @param arg callback に渡す引数
+ */
+const safeCallback = <T>(fn: SafeCallbackFn<T> | undefined, arg: T): void => {
+  try {
+    fn?.(arg);
+  } catch {
+    // 通知失敗は無視する。
+  }
+};
+
+type RevalidatedSnapshot = {
+  readonly data: ProjectData;
+  readonly target: Task;
+};
+
+/**
+ * queue 開始時の再検証。session 状態 / project version / target task /
+ * status / toColumn を pure に確認する。
+ */
+const revalidateInsideQueue = (
   deps: TaskActionDeps,
   params: MoveTaskParams,
-): Promise<ResultT<void, ProjectError>> => {
-  const preflight = ensureLoaded(deps);
-  if (!preflight.ok) {
-    return Promise.resolve(preflight);
+  version: number,
+): ResultT<RevalidatedSnapshot, ProjectError> => {
+  if (
+    !ProjectSessionState.canAcceptDataCommand(deps.getState()) ||
+    !isProjectCurrent(deps.projectVersion, version)
+  ) {
+    return Result.err(
+      ProjectError.invalidState("プロジェクトが切り替わりました"),
+    );
   }
+  const data = ProjectSessionState.visibleData(deps.getState());
+  if (data === null) {
+    return Result.err(
+      ProjectError.invalidState("プロジェクトが開かれていません"),
+    );
+  }
+  const target = data.tasks.find((t) => t.filePath === params.taskFilePath);
+  if (!target) {
+    return Result.err(
+      ProjectError.invalidState("対象のタスクが見つかりません"),
+    );
+  }
+  if (target.status !== params.fromColumn) {
+    return Result.err(
+      ProjectError.invalidState("タスクの状態が変わったためやり直してください"),
+    );
+  }
+  if (!data.columns.some((c) => c.name === params.toColumn)) {
+    return Result.err(
+      ProjectError.invalidState("移動先カラムが見つかりません"),
+    );
+  }
+  return Result.ok({ data, target });
+};
 
-  const version = deps.projectVersion.current;
-
-  return enqueueProjectCommand(deps.projectCommandQueue, async () => {
-    if (
-      !ProjectSessionState.canAcceptDataCommand(deps.getState()) ||
-      !isProjectCurrent(deps.projectVersion, version)
-    ) {
-      return Result.err(
-        ProjectError.invalidState("プロジェクトが切り替わりました"),
-      );
+/**
+ * 副作用付きの実行ロジックを集約する companion object。
+ * MoveSnapshot（pure）が組み立てた dispatch 列を流したり IPC を呼んだりするのがここ。
+ */
+const MoveExecution = {
+  /** dispatch 列を順に流すヘルパ（順序保証）。 */
+  dispatchAll: (
+    deps: TaskActionDeps,
+    actions: readonly ProjectAction[],
+  ): void => {
+    for (const action of actions) {
+      deps.dispatchSync(action);
     }
+  },
 
-    const data = ProjectSessionState.visibleData(deps.getState());
-    if (data === null) {
-      return Result.err(
-        ProjectError.invalidState("プロジェクトが開かれていません"),
-      );
-    }
-
-    const target = data.tasks.find((t) => t.filePath === params.taskFilePath);
-    if (!target) {
-      return Result.err(
-        ProjectError.invalidState("対象のタスクが見つかりません"),
-      );
-    }
-    if (target.status !== params.fromColumn) {
-      return Result.err(
-        ProjectError.invalidState(
-          "タスクの状態が変わったためやり直してください",
-        ),
-      );
-    }
-    if (!data.columns.some((c) => c.name === params.toColumn)) {
-      return Result.err(
-        ProjectError.invalidState("移動先カラムが見つかりません"),
-      );
-    }
-
-    if (params.fromColumn !== params.toColumn) {
-      const updateResult = await updateTask({
-        filePath: params.taskFilePath,
-        status: params.toColumn,
-      });
-      if (!updateResult.ok) {
-        return Result.err(ProjectError.tauri(updateResult.error));
-      }
-      if (!isProjectCurrent(deps.projectVersion, version)) {
-        return Result.err(
-          ProjectError.invalidState("プロジェクトが切り替わりました"),
-        );
-      }
-      deps.dispatchSync({
-        type: "task-updated",
-        originalFilePath: params.taskFilePath,
-        task: updateResult.value,
-      });
-
-      const latestData = ProjectSessionState.visibleData(deps.getState());
-      const filePaths = buildMovedFilePaths(
-        latestData?.tasks ?? [],
-        params.taskFilePath,
-        params.fromColumn,
-        params.toColumn,
-        params.toIndex,
-      );
-      const orderResult = await updateCardOrder({
-        columnName: params.toColumn,
-        filePaths,
-      });
-      if (!orderResult.ok) {
-        return Result.err(ProjectError.partialMove(orderResult.error));
-      }
-      if (!isProjectCurrent(deps.projectVersion, version)) {
-        return Result.err(
-          ProjectError.invalidState("プロジェクトが切り替わりました"),
-        );
-      }
-      deps.dispatchSync({
-        type: "card-order-updated",
-        columnName: params.toColumn,
-        filePaths,
-      });
-      return Result.ok(undefined);
-    }
-
-    const currentFilePaths = data.tasks
-      .filter((t) => t.status === params.toColumn)
-      .map((t) => t.filePath);
-    const filePaths = buildMovedFilePaths(
-      data.tasks,
+  /** カラム間移動 全体。orchestrator から呼ばれる単一 effect entry。 */
+  crossColumn: async (
+    deps: TaskActionDeps,
+    params: MoveTaskParams,
+    snapshot: MoveSnapshot,
+    version: number,
+    callbacks: MoveTaskCallbacks | undefined,
+  ): Promise<ResultT<void, ProjectError>> => {
+    const baseData = ProjectSessionState.visibleData(deps.getState());
+    const optimisticToOrder = buildMovedFilePaths(
+      baseData?.tasks ?? [],
       params.taskFilePath,
       params.fromColumn,
       params.toColumn,
       params.toIndex,
     );
-    if (
-      filePaths.length === currentFilePaths.length &&
-      filePaths.every((p, i) => p === currentFilePaths[i])
-    ) {
-      return Result.ok(undefined);
+    MoveExecution.dispatchAll(
+      deps,
+      MoveSnapshot.optimisticCrossDispatches(
+        snapshot,
+        params,
+        optimisticToOrder,
+      ),
+    );
+    safeCallback(callbacks?.onOptimisticApplied, {
+      taskFilePath: params.taskFilePath,
+      fromColumn: params.fromColumn,
+      toColumn: params.toColumn,
+    });
+
+    const updateResult = await updateTask({
+      filePath: params.taskFilePath,
+      status: params.toColumn,
+    });
+    const guardAfterUpdate = versionGuard(deps, version);
+    if (guardAfterUpdate) {
+      return guardAfterUpdate;
+    }
+    if (!updateResult.ok) {
+      MoveExecution.dispatchAll(
+        deps,
+        MoveSnapshot.rollbackCrossDispatches(snapshot, params),
+      );
+      safeCallback(callbacks?.onRollback, {
+        taskFilePath: params.taskFilePath,
+        fromColumn: params.fromColumn,
+        toColumn: params.toColumn,
+      });
+      return Result.err(ProjectError.tauri(updateResult.error));
     }
 
+    deps.dispatchSync({
+      type: "task-updated",
+      originalFilePath: params.taskFilePath,
+      task: updateResult.value,
+    });
+    const latest = ProjectSessionState.visibleData(deps.getState());
+    const filePaths = buildMovedFilePaths(
+      latest?.tasks ?? [],
+      params.taskFilePath,
+      params.fromColumn,
+      params.toColumn,
+      params.toIndex,
+    );
     const orderResult = await updateCardOrder({
       columnName: params.toColumn,
       filePaths,
     });
-    if (!orderResult.ok) {
-      return Result.err(ProjectError.tauri(orderResult.error));
+    const guardAfterOrder = versionGuard(deps, version);
+    if (guardAfterOrder) {
+      return guardAfterOrder;
     }
-    if (!isProjectCurrent(deps.projectVersion, version)) {
-      return Result.err(
-        ProjectError.invalidState("プロジェクトが切り替わりました"),
+    if (!orderResult.ok) {
+      MoveExecution.dispatchAll(
+        deps,
+        MoveSnapshot.partialRollbackDispatches(snapshot, params),
       );
+      return Result.err(ProjectError.partialMove(orderResult.error));
     }
     deps.dispatchSync({
       type: "card-order-updated",
@@ -166,5 +385,88 @@ export const moveTaskAction = (
       filePaths,
     });
     return Result.ok(undefined);
+  },
+
+  /** 同一カラム並び替え 全体。orchestrator から呼ばれる単一 effect entry。 */
+  sameColumn: async (
+    deps: TaskActionDeps,
+    params: MoveTaskParams,
+    snapshot: MoveSnapshot,
+    version: number,
+    data: ProjectData,
+  ): Promise<ResultT<void, ProjectError>> => {
+    const filePaths = buildMovedFilePaths(
+      data.tasks,
+      params.taskFilePath,
+      params.fromColumn,
+      params.toColumn,
+      params.toIndex,
+    );
+    if (MoveSnapshot.isSameOrder(snapshot, filePaths)) {
+      return Result.ok(undefined);
+    }
+    deps.dispatchSync({
+      type: "card-order-updated",
+      columnName: params.toColumn,
+      filePaths,
+    });
+    const orderResult = await updateCardOrder({
+      columnName: params.toColumn,
+      filePaths,
+    });
+    const guard = versionGuard(deps, version);
+    if (guard) {
+      return guard;
+    }
+    if (!orderResult.ok) {
+      MoveExecution.dispatchAll(
+        deps,
+        MoveSnapshot.rollbackSameDispatches(snapshot, params),
+      );
+      return Result.err(ProjectError.tauri(orderResult.error));
+    }
+    deps.dispatchSync({
+      type: "card-order-updated",
+      columnName: params.toColumn,
+      filePaths,
+    });
+    return Result.ok(undefined);
+  },
+} as const;
+
+/**
+ * Drop 確定時に Board から呼ばれる単一 entry point。
+ * preflight + queue + 分岐のみの薄い orchestrator。
+ *
+ * - fromColumn !== toColumn: 楽観 dispatch（task-updated + card-order-updated）→
+ *   updateTask IPC → 成功なら確定 dispatch + updateCardOrder、失敗なら 3 段 rollback
+ * - fromColumn === toColumn: 楽観 dispatch（card-order-updated）→ updateCardOrder IPC →
+ *   成功なら確定 dispatch、失敗なら 1 段 rollback
+ *
+ * @param deps queue / version / state / dispatch 依存
+ * @param params 移動パラメータ
+ * @param callbacks 楽観 / rollback の通知 callback（省略可）
+ * @returns 成功時 Result.ok(undefined) / 失敗時 Result.err(ProjectError)
+ */
+export const moveTaskAction = (
+  deps: TaskActionDeps,
+  params: MoveTaskParams,
+  callbacks?: MoveTaskCallbacks,
+): Promise<ResultT<void, ProjectError>> => {
+  const preflight = ensureLoaded(deps);
+  if (!preflight.ok) {
+    return Promise.resolve(preflight);
+  }
+  const version = deps.projectVersion.current;
+  return enqueueProjectCommand(deps.projectCommandQueue, async () => {
+    const checked = revalidateInsideQueue(deps, params, version);
+    if (!checked.ok) {
+      return checked;
+    }
+    const { data, target } = checked.value;
+    const snapshot = MoveSnapshot.from(data, target, params);
+    return params.fromColumn !== params.toColumn
+      ? MoveExecution.crossColumn(deps, params, snapshot, version, callbacks)
+      : MoveExecution.sameColumn(deps, params, snapshot, version, data);
   });
 };

--- a/src/features/board/hooks/useProject/actions/moveTask.ts
+++ b/src/features/board/hooks/useProject/actions/moveTask.ts
@@ -154,33 +154,51 @@ export const MoveSnapshot = {
   ],
 
   /**
-   * カラム間 updateTask 失敗時の rollback 3 段（逆順）（pure）。
-   * ②で task が fromColumn 末尾に補完される現象を③で打ち消し、drop 前位置を復元する。
+   * カラム間 updateTask 失敗時の rollback 段（逆順）（pure）。
+   *
+   * IPC 待機中に外部 listener（file watcher 由来の task-updated event 等）が
+   * 同一 task を concurrent に更新している可能性があるため、`currentTask`
+   * を見て分岐する:
+   *
+   * - `currentTask` が optimistic 状態（status === toColumn）と一致する場合
+   *   は通常の 3 段 rollback（cardOrder(to 旧) → task(原) → cardOrder(from 旧)）。
+   *   ②で task が fromColumn 末尾に補完される現象を③で打ち消す前提。
+   * - `currentTask` が optimistic と乖離している場合は外部 listener による
+   *   concurrent 更新が入ったとみなし、task-updated rollback を省略して
+   *   cardOrder のみ復元する。外部更新を snapshot で上書きしない保護策。
    *
    * @param snapshot drop 直前 snapshot
    * @param params 移動パラメータ
-   * @returns 逆順 rollback 用 ProjectAction 配列（3 段）
+   * @param currentTask rollback 直前の最新 state における target task
+   * @returns 逆順 rollback 用 ProjectAction 配列（2〜3 段）
    */
   rollbackCrossDispatches: (
     snapshot: MoveSnapshot,
     params: MoveTaskParams,
-  ): readonly ProjectAction[] => [
-    {
+    currentTask: Task | undefined,
+  ): readonly ProjectAction[] => {
+    const taskMatchesOptimistic =
+      currentTask !== undefined && currentTask.status === params.toColumn;
+    const head: ProjectAction = {
       type: "card-order-updated",
       columnName: params.toColumn,
       filePaths: [...snapshot.toColumnOrderBefore],
-    },
-    {
-      type: "task-updated",
-      originalFilePath: params.taskFilePath,
-      task: snapshot.originalTask,
-    },
-    {
+    };
+    const tail: ProjectAction = {
       type: "card-order-updated",
       columnName: params.fromColumn,
       filePaths: [...snapshot.fromColumnOrderBefore],
-    },
-  ],
+    };
+    if (!taskMatchesOptimistic) {
+      return [head, tail];
+    }
+    const middle: ProjectAction = {
+      type: "task-updated",
+      originalFilePath: params.taskFilePath,
+      task: snapshot.originalTask,
+    };
+    return [head, middle, tail];
+  },
 
   /** partial-move（status 確定保持 / cardOrder のみ補正）の dispatch 列（pure）。 */
   partialRollbackDispatches: (
@@ -339,9 +357,13 @@ const MoveExecution = {
       return guardAfterUpdate;
     }
     if (!updateResult.ok) {
+      const beforeRollback = ProjectSessionState.visibleData(deps.getState());
+      const currentTask = beforeRollback?.tasks.find(
+        (t) => t.filePath === params.taskFilePath,
+      );
       MoveExecution.dispatchAll(
         deps,
-        MoveSnapshot.rollbackCrossDispatches(snapshot, params),
+        MoveSnapshot.rollbackCrossDispatches(snapshot, params, currentTask),
       );
       safeCallback(callbacks?.onRollback, {
         taskFilePath: params.taskFilePath,

--- a/src/features/board/hooks/useProject/index.ts
+++ b/src/features/board/hooks/useProject/index.ts
@@ -7,7 +7,11 @@ import type {
 } from "@/lib/tauri";
 import { Task, type TaskPayload } from "@/types/task";
 import type { Result as ResultT } from "@/utils/result";
-import { type MoveTaskParams, moveTaskAction } from "./actions/moveTask";
+import {
+  type MoveTaskCallbacks,
+  type MoveTaskParams,
+  moveTaskAction,
+} from "./actions/moveTask";
 import { openProjectAction } from "./actions/openProject";
 import {
   createTaskAction,
@@ -41,6 +45,7 @@ export type { ProjectData, ProjectState } from "./reducer";
 export type {
   ColumnsCommand,
   ColumnsCommandBuilder,
+  MoveTaskCallbacks,
   MoveTaskParams,
   UpdateColumnsInput,
   UseProjectOptions,
@@ -253,8 +258,11 @@ export const useProject = (
   );
 
   const moveTask = useCallback(
-    (params: MoveTaskParams): Promise<ResultT<void, ProjectError>> =>
-      moveTaskAction(actionDeps(), params),
+    (
+      params: MoveTaskParams,
+      callbacks?: MoveTaskCallbacks,
+    ): Promise<ResultT<void, ProjectError>> =>
+      moveTaskAction(actionDeps(), params, callbacks),
     [actionDeps],
   );
 

--- a/src/features/board/hooks/useProject/types.ts
+++ b/src/features/board/hooks/useProject/types.ts
@@ -9,7 +9,7 @@ import type {
   ColumnsCommand,
   ColumnsCommandBuilder,
 } from "./actions/columnsCommand";
-import type { MoveTaskParams } from "./actions/moveTask";
+import type { MoveTaskCallbacks, MoveTaskParams } from "./actions/moveTask";
 import type { ProjectError } from "./errors";
 import type { ProjectSessionState } from "./state/projectSessionState";
 
@@ -17,7 +17,7 @@ export type {
   ColumnsCommand,
   ColumnsCommandBuilder,
 } from "./actions/columnsCommand";
-export type { MoveTaskParams } from "./actions/moveTask";
+export type { MoveTaskCallbacks, MoveTaskParams } from "./actions/moveTask";
 
 export type UpdateColumnsInput = ColumnsCommand | ColumnsCommandBuilder;
 
@@ -63,10 +63,15 @@ export type UseProjectResult = {
   ) => Promise<ResultT<{ applied: boolean }, ProjectError>>;
   /**
    * task のカラム間移動 / カラム内並び替えを単一 entry point で受け付ける。
+   * 楽観 dispatch / rollback の発生を callback で通知する。
    * @param params 移動パラメータ
+   * @param callbacks 楽観 / rollback の通知 callback（省略可）
    * @returns 成否を表す Result または ProjectError
    */
-  moveTask: (params: MoveTaskParams) => Promise<ResultT<void, ProjectError>>;
+  moveTask: (
+    params: MoveTaskParams,
+    callbacks?: MoveTaskCallbacks,
+  ) => Promise<ResultT<void, ProjectError>>;
   /** project state を初期状態に戻す。 */
   reset: () => void;
 };

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -4,6 +4,7 @@ export { HeaderBar } from "./components/HeaderBar";
 export type {
   ColumnsCommand,
   ColumnsCommandBuilder,
+  MoveTaskCallbacks,
   MoveTaskParams,
   ProjectData,
   ProjectError,


### PR DESCRIPTION
## 概要

drop 確定時の reducer 反映を IPC 完了から切り離し、`updateTask` 失敗時はスナップショットへフル rollback、partial-move 時は status を `toColumn` 確定保持して cardOrder のみ補正する楽観更新を導入した。あわせて視覚非表示 `aria-live="polite"` の LiveRegion を新設し、楽観 dispatch 直後と rollback 完了直後にスクリーンリーダーへ通知する。

## 変更の種類

- ✨ New Feature（FE 内部実装）
- 📝 Doc（`docs/spec-board/board-view-spec.md` 同時更新）

## 追加した内容

- `src/components/LiveRegion/` — `LiveAnnouncement` 型 + `LiveRegion` コンポーネント（`role=\"status\"` / `aria-live=\"polite\"` / `aria-atomic=\"true\"` / 視覚非表示 / id を div の key に流して同一文言の連続 announce でも SR に届ける）
- `MoveTaskCallbacks` 型 + `onOptimisticApplied` / `onRollback` callback 契約（`src/features/board/hooks/useProject/actions/moveTask.ts`）
- `MoveSnapshot` 型 + companion object（pure: snapshot 採取 / 楽観・rollback・partial-move dispatch 列の組み立て）と `MoveExecution` companion（effect: `crossColumn` / `sameColumn`）
- `src/__tests__/App.live-region.test.tsx`（App 層結合: drop 成功 / 楽観 announce が IPC 完了前に届く / 失敗時の取消 / 同一カラムでは無更新）

## 変更した内容

- `moveTask.ts`: カラム間移動を楽観 → IPC → 確定 / rollback の 3 段に書き換え。`updateTask` 失敗時は `card-order-updated(to 旧)` → `task-updated(原)` → `card-order-updated(from 旧)` の逆順 3 段 rollback で drop 前位置を復元。partial-move は `onRollback` を呼ばず cardOrder 補正のみ。各 `await` 直後に `versionGuard` を置き、projectVersion 不一致なら dispatch をスキップして `invalid-state` を返す。
- `useProject/types.ts` / `useProject/index.ts` / `features/board/index.ts`: `moveTask(params, callbacks?)` シグネチャに拡張し `MoveTaskCallbacks` を re-export。
- `App.tsx`: `announcement` state + `announceCounterRef` + `<LiveRegion>` を追加し、`handleTaskDrop` で moveTask に callback を渡して `「タイトル」を「toColumn」に移動しました` / `「タイトル」の移動を取り消しました` を polite announce。同一カラム並び替えでは announce しない。
- `moveTask.behavior.test.ts`: dispatch 順序 assertion を楽観順序に更新し、partial-move / rollback 3 段 / projectVersion 切替 / callbacks / idempotency を網羅（22 ケース）。

## 仕様ドキュメント更新

- `docs/spec-board/board-view-spec.md`
  - a11y セクション: polite ライブリージョン仕様（`role=\"status\"` / `aria-atomic=\"true\"` / 視覚非表示）を具体化
  - 「楽観的 UI 更新は採用しない」を反転し、楽観 → IPC → 確定/rollback の挙動 + partial-move + invalid-state の扱いを明記
  - ドラッグ&ドロップ仕様直下に「a11y アナウンス」表を追加（カラム間成功 / 失敗 / partial-move / 同一カラム / 楽観前 invalid-state / 楽観後 invalid-state の各分岐ごとに LiveRegion / Toast 出力を固定）

## システム図

\`\`\`mermaid
flowchart TD
    Drop[drop イベント] --> Pre[preflight: ensureLoaded]
    Pre --> Queue[enqueueProjectCommand]
    Queue --> Reval[revalidateInsideQueue]
    Reval -->|fail| InvalidPre[Result.err invalid-state]
    Reval -->|ok| Snap[MoveSnapshot.from]
    Snap --> Branch{fromColumn !== toColumn?}

    Branch -->|YES カラム間| OptCross["楽観 dispatch x2 NEW<br/>task-updated + card-order-updated"]
    OptCross --> CbOpt["onOptimisticApplied NEW"]
    CbOpt --> UpdIpc[await updateTask IPC]
    UpdIpc --> G1[versionGuard]
    G1 -->|不一致| InvalidPost[Result.err invalid-state]
    G1 -->|一致 + IPC fail| Rb3["rollback 3 段 NEW<br/>card-order(to旧) → task(原) → card-order(from旧)"]
    Rb3 --> CbRb["onRollback NEW"]
    CbRb --> ErrTauri[Result.err tauri]
    G1 -->|一致 + IPC ok| Commit1[task-updated 確定]
    Commit1 --> OrdIpc[await updateCardOrder IPC]
    OrdIpc --> G2[versionGuard]
    G2 -->|不一致| InvalidPost
    G2 -->|一致 + IPC fail| Partial["partial-move NEW<br/>cardOrder 補正 2 段 / status 確定保持"]
    Partial --> ErrPartial[Result.err partial-move]
    G2 -->|一致 + IPC ok| OkCross[Result.ok]

    Branch -->|NO 同一カラム| Same{並び変化なし?}
    Same -->|YES| OkNoop[Result.ok no-op]
    Same -->|NO| OptSame["楽観 dispatch NEW<br/>card-order-updated"]
    OptSame --> SameIpc[await updateCardOrder IPC]
    SameIpc --> GS[versionGuard]
    GS -->|不一致| InvalidPost
    GS -->|一致 + IPC fail| RbSame["rollback 1 段 NEW<br/>card-order(to旧)"]
    RbSame --> ErrTauri
    GS -->|一致 + IPC ok| OkSame[Result.ok]

    CbOpt -.callback.-> Announce1["LiveRegion 移動しました NEW"]
    CbRb -.callback.-> Announce2["LiveRegion 取り消しました NEW"]

    style OptCross fill:#fff4cc
    style OptSame fill:#fff4cc
    style Rb3 fill:#ffd6cc
    style RbSame fill:#ffd6cc
    style Partial fill:#ffe6cc
    style CbOpt fill:#cce5ff
    style CbRb fill:#cce5ff
    style Announce1 fill:#d4f4dd
    style Announce2 fill:#d4f4dd
\`\`\`

## 関連Issue

- Closes #112
- 関連: #110（HTML5 ネイティブ DnD）/ #111（drop → updateTask 呼出契約）

## テスト

- \`pnpm test:run\`: **760 tests passed**（うち `moveTask.behavior.test.ts` 22 / `LiveRegion.rendering.test.tsx` 5 / `App.live-region.test.tsx` 5 を新規・更新）
- \`pnpm typecheck\`（= \`tsc -b\`）: エラーゼロ
- \`pnpm lint\`（oxlint）: 0 warnings / 0 errors
- \`pnpm exec biome check .\`: green
- 手動検証（macOS VoiceOver / `pnpm tauri dev` での実機 SR 読み上げ）は実機が必要なため CI 自動化対象外（DoD 上は手動シナリオとして spec docs に記載）

## レビューポイント

- `MoveSnapshot` / `MoveExecution` の責務分割（pure VO 側に dispatch 列組み立てを集約 / effect 側は `dispatchAll` で順に流すだけ）が DDD 寄せの方針として妥当か
- rollback 3 段の順序（`card-order(to旧)` → `task-updated(原)` → `card-order(from旧)`）が `applyCardOrderUpdated` の補完ルールと整合しているか。とくに ②の task 復元で task が fromColumn 末尾に補完される現象を ③で打ち消す前提
- `versionGuard` を各 `await` 直後に必ず置く設計で、楽観 dispatch 後に projectVersion が切り替わったケースで rollback を流さない（= 新 project の state を破壊しない）挙動の安全性
- LiveRegion を App 直下にマウントする責務分割（Board は LiveRegion を知らない）と、`onOptimisticApplied` callback で title を closure に閉じ込めるパターンが将来の i18n / 通知拡張で破綻しないか