### PR TITLE
✨ [New Feature]: #89 [BE] TaskIndex に plan_delete_abort aggregate method を追加

### DIFF
--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -1,5 +1,6 @@
 pub mod children;
 pub mod create;
+pub mod delete;
 pub mod frontmatter;
 pub mod get;
 pub mod io;

--- a/src-tauri/src/task/delete.rs
+++ b/src-tauri/src/task/delete.rs
@@ -1,0 +1,6 @@
+//! `delete_task` Tauri command のファサード。
+//!
+//! 現時点では aggregate validation のエラー型のみを公開する。IPC コマンド本体
+//! （`command.rs` / `args.rs`）は後続 Issue で追加する。
+
+pub mod error;

--- a/src-tauri/src/task/delete/error.rs
+++ b/src-tauri/src/task/delete/error.rs
@@ -1,0 +1,23 @@
+//! `delete_task` aggregate validation のエラー型。
+//!
+//! `TaskIndex::plan_delete_abort` が返す失敗値のみを保持する。effect 層
+//! （I/O / cache / watcher 連携）の失敗を表す型は後続 Issue で別途追加する。
+//!
+//! Display 文字列は FE 側 `TauriError.PATTERNS` で文字列マッチされるため、
+//! create_task / update_task と同じ自然文パターンを採用する。
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DeleteTaskError {
+    #[error(
+        "task has children: {path} (children: {})",
+        .children.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+    )]
+    HasChildren {
+        path: String,
+        children: Vec<PathBuf>,
+    },
+}

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::column_name::ColumnName;
 use crate::task::children::build_children;
 use crate::task::create::error::CreateTaskError;
+use crate::task::delete::error::DeleteTaskError;
 use crate::task::frontmatter::{self, Parsed, Priority};
 use crate::task::label::Label;
 use crate::task::parse::{task_from_parsed, TaskParseContext, TaskParseError};
@@ -456,13 +457,6 @@ impl TaskIndex {
     /// で吸収する。raw string 比較は意図的に避ける（plan_update の parent 比較と同じ理由）。
     ///
     /// 孫 task は含めない（直接の子のみ）。`deleted_path` が誰の親でもない場合は空 Vec。
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "delete_task IPC (Issue #90) で本 method を呼び出す予定。caller 追加時に expect を外す。"
-        )
-    )]
     pub(crate) fn children_paths_of(&self, deleted_path: &str) -> Vec<PathBuf> {
         let Some(deleted_norm) = normalize_parent_path_for_lookup(deleted_path) else {
             return Vec::new();
@@ -479,6 +473,32 @@ impl TaskIndex {
                 (parent_norm == deleted_norm).then(|| PathBuf::from(t.file_path.as_str()))
             })
             .collect()
+    }
+
+    /// 削除対象 task に直接の子 task が存在するかを検証する pure aggregate method。
+    ///
+    /// 子が 1 件でもあれば `DeleteTaskError::HasChildren` を返し、削除を中断させる。
+    /// 子の検出は `children_paths_of` に委譲するため、表記揺れ吸収・自己除外・
+    /// 直接の子のみ列挙といった契約はそちらに従う。
+    ///
+    /// `deleted_path` は呼び出し側（effect 層）で正規化済みのプロジェクトルート
+    /// 相対パスを渡す前提（不正パスのエラー化は effect 層の責務）。
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "delete_task IPC (Issue #90) で本 method を呼び出す予定。caller 追加時に expect を外す。"
+        )
+    )]
+    pub(crate) fn plan_delete_abort(&self, deleted_path: &str) -> Result<(), DeleteTaskError> {
+        let children = self.children_paths_of(deleted_path);
+        if children.is_empty() {
+            return Ok(());
+        }
+        Err(DeleteTaskError::HasChildren {
+            path: deleted_path.to_string(),
+            children,
+        })
     }
 
     /// 削除対象 task の全子 task について、parent キーを除去した new file_content と
@@ -911,3 +931,7 @@ mod task_index_plan_update_tests;
 #[cfg(test)]
 #[path = "task_index_clear_children_tests.rs"]
 mod task_index_clear_children_tests;
+
+#[cfg(test)]
+#[path = "task_index_plan_delete_abort_tests.rs"]
+mod task_index_plan_delete_abort_tests;

--- a/src-tauri/src/task/task_index_plan_delete_abort_tests.rs
+++ b/src-tauri/src/task/task_index_plan_delete_abort_tests.rs
@@ -1,0 +1,218 @@
+//! `TaskIndex::plan_delete_abort` の純粋関数ユニットテスト。AppState / TaskIo /
+//! fs::* に依存せず、すべて in-memory で完結する。
+
+use std::path::PathBuf;
+
+use super::{Task, TaskIndex};
+use crate::task::delete::error::DeleteTaskError;
+use crate::task::parse::{task_from_markdown, TaskParseContext};
+
+// ---------------------------------------------------------------------------
+// fixture helpers（task_index_clear_children_tests.rs を最小限で踏襲）
+// ---------------------------------------------------------------------------
+
+fn context(path: &str) -> TaskParseContext {
+    TaskParseContext {
+        file_path: PathBuf::from(path),
+        default_status: "Todo".into(),
+    }
+}
+
+fn task_from(input: &str, path: &str) -> Task {
+    task_from_markdown(input.as_bytes(), &context(path)).unwrap()
+}
+
+fn task_with_parent(path: &str, parent: &str) -> Task {
+    task_from(
+        &format!("---\ntitle: Task\nstatus: Todo\nparent: {parent}\n---\n"),
+        path,
+    )
+}
+
+fn task_without_parent(path: &str) -> Task {
+    task_from("---\ntitle: Task\nstatus: Todo\n---\n", path)
+}
+
+// ---------------------------------------------------------------------------
+// plan_delete_abort
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_delete_abort_returns_ok_when_no_children() {
+    let index = TaskIndex::new(vec![task_without_parent("tasks/p.md")]);
+
+    let result = index.plan_delete_abort("tasks/p.md");
+
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn plan_delete_abort_fails_with_direct_child_only_when_grandchildren_exist() {
+    // target -> c -> gc というチェーンで target を削除した際、
+    // HasChildren.children には c のみが含まれ gc は含まれない。
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+        task_with_parent("tasks/gc.md", "tasks/c.md"),
+    ]);
+
+    let result = index.plan_delete_abort("tasks/p.md");
+
+    assert_eq!(
+        result,
+        Err(DeleteTaskError::HasChildren {
+            path: "tasks/p.md".to_string(),
+            children: vec![PathBuf::from("tasks/c.md")],
+        })
+    );
+}
+
+#[test]
+fn plan_delete_abort_returns_ok_for_path_with_no_referrers() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/a.md"),
+        task_with_parent("tasks/b.md", "tasks/a.md"),
+    ]);
+
+    let result = index.plan_delete_abort("tasks/orphan.md");
+
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn plan_delete_abort_fails_with_single_direct_child() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let result = index.plan_delete_abort("tasks/p.md");
+
+    assert_eq!(
+        result,
+        Err(DeleteTaskError::HasChildren {
+            path: "tasks/p.md".to_string(),
+            children: vec![PathBuf::from("tasks/c.md")],
+        })
+    );
+}
+
+#[test]
+fn plan_delete_abort_fails_with_two_children_in_snapshot_order() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c1.md", "tasks/p.md"),
+        task_with_parent("tasks/c2.md", "tasks/p.md"),
+    ]);
+
+    let result = index.plan_delete_abort("tasks/p.md");
+
+    assert_eq!(
+        result,
+        Err(DeleteTaskError::HasChildren {
+            path: "tasks/p.md".to_string(),
+            children: vec![PathBuf::from("tasks/c1.md"), PathBuf::from("tasks/c2.md")],
+        })
+    );
+}
+
+#[test]
+fn plan_delete_abort_resolves_normalized_parent_with_dot_slash_prefix() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "./tasks/p.md"),
+    ]);
+
+    let result = index.plan_delete_abort("tasks/p.md");
+
+    assert_eq!(
+        result,
+        Err(DeleteTaskError::HasChildren {
+            path: "tasks/p.md".to_string(),
+            children: vec![PathBuf::from("tasks/c.md")],
+        })
+    );
+}
+
+#[test]
+fn plan_delete_abort_resolves_normalized_parent_with_backslash() {
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks\\p.md"),
+    ]);
+
+    let result = index.plan_delete_abort("tasks/p.md");
+
+    assert_eq!(
+        result,
+        Err(DeleteTaskError::HasChildren {
+            path: "tasks/p.md".to_string(),
+            children: vec![PathBuf::from("tasks/c.md")],
+        })
+    );
+}
+
+#[test]
+fn plan_delete_abort_does_not_treat_self_as_own_child() {
+    // 削除対象自身が自分自身を parent に持つ異常データでも自己除外される。
+    let mut self_referential = task_with_parent("tasks/p.md", "tasks/p.md");
+    // parent を表記揺れに変えて、正規化比較での自己除外も effective か確認。
+    self_referential.parent = Some(crate::task::task_file_path::TaskFilePath::from_lenient(
+        "./tasks/p.md",
+    ));
+
+    let index = TaskIndex::new(vec![self_referential]);
+
+    let result = index.plan_delete_abort("./tasks/p.md");
+
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn plan_delete_abort_error_path_field_matches_input() {
+    // エラーの `path` フィールドは引数 `deleted_path` をそのまま保持（正規化しない）。
+    let index = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c.md", "tasks/p.md"),
+    ]);
+
+    let result = index.plan_delete_abort("./tasks/p.md");
+
+    assert_eq!(
+        result,
+        Err(DeleteTaskError::HasChildren {
+            path: "./tasks/p.md".to_string(),
+            children: vec![PathBuf::from("tasks/c.md")],
+        })
+    );
+}
+
+#[test]
+fn plan_delete_abort_display_format_is_locked_down() {
+    // 子 1 件
+    let index_single = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c1.md", "tasks/p.md"),
+    ]);
+    let err_single = index_single
+        .plan_delete_abort("tasks/p.md")
+        .expect_err("should fail with HasChildren");
+    assert_eq!(
+        err_single.to_string(),
+        "task has children: tasks/p.md (children: tasks/c1.md)"
+    );
+
+    // 子 2 件
+    let index_double = TaskIndex::new(vec![
+        task_without_parent("tasks/p.md"),
+        task_with_parent("tasks/c1.md", "tasks/p.md"),
+        task_with_parent("tasks/c2.md", "tasks/p.md"),
+    ]);
+    let err_double = index_double
+        .plan_delete_abort("tasks/p.md")
+        .expect_err("should fail with HasChildren");
+    assert_eq!(
+        err_double.to_string(),
+        "task has children: tasks/p.md (children: tasks/c1.md, tasks/c2.md)"
+    );
+}


### PR DESCRIPTION
## 概要
- `TaskIndex` に **abort 戦略専用の純粋検証 aggregate method** `plan_delete_abort` を追加し、削除対象に直接の子があれば `DeleteTaskError::HasChildren` を返す pure validation を実装。
- 子検出は既存 `children_paths_of` に委譲することで「直接の子のみ列挙 / 表記揺れ吸収 / 自己除外」の契約をそのまま継承。
- `delete_task` IPC コマンド本体・ファイル削除・cache 更新・`lib.rs` `invoke_handler` 登録は **本 PR 範囲外（#90 で実装予定）**。

## 変更の種類
- ✨ 新機能

## 追加した内容
- `src-tauri/src/task/delete.rs`（ファサード、`pub mod error;` のみ）
- `src-tauri/src/task/delete/error.rs` — `DeleteTaskError::HasChildren { path, children }` を新規定義
  - `#[derive(Debug, thiserror::Error, PartialEq, Eq)]`
  - Display: `task has children: <path> (children: a, b, ...)`（FE 文字列マッチを意識した自然文）
- `src-tauri/src/task/task_index.rs`
  - `impl TaskIndex` に `plan_delete_abort(&self, deleted_path: &str) -> Result<(), DeleteTaskError>` を追加
  - `#[cfg_attr(not(test), expect(dead_code, ...))]` 付与（caller は #90 で追加）
- `src-tauri/src/task/task_index_plan_delete_abort_tests.rs` — ユニットテスト 10 件

## 変更した内容
- `src-tauri/src/task.rs` に `pub mod delete;` を追加
- `src-tauri/src/task/task_index.rs` の `children_paths_of` から `expect(dead_code)` を除去（`plan_delete_abort` が caller になり `unfulfilled_lint_expectations` が出るため）

## 仕様ドキュメント更新
- **不要**（`docs/spec-board/file-system-spec.md:198` で abort 戦略の振る舞いは既に記述済み。本 PR は spec 変更を伴わない aggregate method 追加のみ）

## システム図

```mermaid
flowchart TD
    A["plan_delete_abort(deleted_path)"] --> B["children_paths_of(deleted_path)<br/>= Vec&lt;PathBuf&gt;"]
    B --> C{children}
    C -- empty --> D["Ok(())"]
    C -- non-empty --> E["Err(DeleteTaskError::HasChildren {<br/>  path,<br/>  children,<br/>})"]
    style A fill:#fdf6b2,stroke:#b7791f
    style E fill:#fde2e2,stroke:#c53030
```

呼び出し関係（caller は #90 で追加予定）:

```mermaid
flowchart LR
    cmd["delete_task IPC<br/>(Issue #90 範囲外)"] -.-> abort["TaskIndex::plan_delete_abort<br/>[NEW]"]
    cmd -.-> clear["TaskIndex::plan_clear_children_of<br/>(#88 で実装済み)"]
    abort --> children["TaskIndex::children_paths_of"]
    clear --> children
    style abort fill:#fdf6b2,stroke:#b7791f
```

## 関連Issue
- Closes #89
- Refs #87（親 Epic）
- Relates to #90（`delete_task` IPC 本体の Issue）

## テスト
- `cargo test --manifest-path src-tauri/Cargo.toml --package spec-board task_index_plan_delete_abort` → **10/10 pass**（直接の子のみ列挙 / snapshot 順 / `./` prefix・`\` 表記揺れ / 自己除外 / `error.path` が入力をそのまま保持 / Display 文字列を完全一致で lock-down）
- `cargo test --manifest-path src-tauri/Cargo.toml`（全体回帰）→ **539/539 pass**
- `cargo fmt --manifest-path src-tauri/Cargo.toml` clean
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` clean
- `cargo check --manifest-path src-tauri/Cargo.toml` clean
- AI レビュー（Codex CLI）→ **問題なし**

## レビューポイント
- **DDD aggregate method として実装している点**: 子検出ロジックを `TaskIndex` の外に出さず、`plan_clear_children_of` と同じレイヤに揃えている（free function 3 段分離は採用しない）。
- **エラー型の階層分離**: 本 PR では aggregate validation 由来の `HasChildren` variant のみ定義し、`InvalidPath` / `FileNotFound` / `IoFailed` / `WriteIgnore` / `AppState` 等は #90 で `DeleteTaskCommandError` として別型に分離する方針（`create_task` / `update_task` の `*CommandError` パターンに揃える）。
- **Display 文字列の lock-down**: FE 側 `TauriError.PATTERNS` で文字列マッチされる前提で、子 1 件・子 2 件の両方を完全一致で固定（テスト `plan_delete_abort_display_format_is_locked_down`）。
- **`expect(dead_code)` の運用**: `plan_delete_abort` method のみに付与し、enum 本体 / variant には付けない（`unfulfilled_lint_expectations` 警告を避けるため）。`children_paths_of` は caller ができたので `expect` 除去済み。
- **`deleted_path` 入力の前提**: pure aggregate の責務として「正規化済みパスが渡される」前提で受ける（`children_paths_of` が `normalize_parent_path_for_lookup` で `None` を返すパスを空 Vec 化する挙動をそのまま継承）。不正パスのエラー化は #90 の effect 層で `DeleteTaskCommandError::InvalidPath` を追加する方針。

## チェックリスト
- [x] セルフレビュー実施
- [x] cargo test / cargo clippy / cargo fmt --check 全て通過
- [x] AI レビュー（Codex）通過
- [x] 関連 Issue (#89) を PR にリンク
- [x] 仕様変更なし（spec ドキュメント更新不要）
- [x] 破壊的変更なし