### PR TITLE
🧪 [Tests]: #114 [FE] AddColumnButton 結線の invoke 失敗 + 末尾追加 order を結合層でカバー

### DIFF
--- a/src/__tests__/App.interaction.test.tsx
+++ b/src/__tests__/App.interaction.test.tsx
@@ -373,15 +373,47 @@ test("AddColumnButton で新カラム追加 → updateColumns invoke が呼ば�
   });
 
   expect(updateColumnsMock).toHaveBeenCalledTimes(1);
-  expect(updateColumnsMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      columns: expect.arrayContaining([
-        expect.objectContaining({ name: "Backlog" }),
-      ]),
-    }),
+  const columns = updateColumnsMock.mock.calls[0]?.[0].columns ?? [];
+  expect(columns).toHaveLength(3);
+  expect(columns[columns.length - 1]).toEqual(
+    expect.objectContaining({ name: "Backlog", order: 2 }),
   );
   expect(container?.textContent).toContain("Backlog");
   expect(container?.textContent).toContain("カラムを追加しました");
+});
+
+test("AddColumnButton で invoke 失敗時 → エラー toast + editor 維持", async () => {
+  mountApp();
+  await openSuccessfully();
+  updateColumnsMock.mockResolvedValueOnce(
+    Result.err(new TauriError("IO_ERROR", "io fail")),
+  );
+
+  await openAddColumnEditor();
+  const columnInput = querySelectorRequired<HTMLInputElement>(
+    '[data-testid="add-column-input"]',
+  );
+  setInputValue(columnInput, "Backlog");
+  await act(async () => {
+    pressEnter(columnInput);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  expect(updateColumnsMock).toHaveBeenCalledTimes(1);
+  expect(container?.textContent).toContain("カラムの追加に失敗しました");
+  expect(container?.textContent).toContain("io fail");
+
+  const stillInput = container?.querySelector<HTMLInputElement>(
+    '[data-testid="add-column-input"]',
+  );
+  expect(stillInput).not.toBeNull();
+  expect(
+    container?.querySelector('[data-testid="add-column-button"]'),
+  ).toBeNull();
+  expect(stillInput?.value).toBe("Backlog");
+  expect(stillInput?.disabled).toBe(false);
 });
 
 test("AddColumnButton で重複名を入力 → updateColumns invoke は呼ばれず重複エラーを表示", async () => {


### PR DESCRIPTION
## 概要

Issue #114 の探索で「AddColumnButton 結線の実装は完了済み」ことが確認されたため、残る結合層のカバレッジギャップ（IPC 失敗時の toast + editor 維持契約、末尾追加 order）を `src/__tests__/App.interaction.test.tsx` に characterization test として追加する。実装コードは無変更。

## 変更の種類

- 🧪 Tests

## 変更した内容

- **[ADD]** `App.interaction.test.tsx`: `"AddColumnButton で invoke 失敗時 → エラー toast + editor 維持"` テストを 1 件追加（成功テストと重複名テストの間に配置）
  - `updateColumnsMock` が 1 回呼ばれることで結線完了を保証
  - toast 文言を `カラムの追加に失敗しました` prefix + `io fail` 補間値の 2 substring で検証（文言全体が変わっても部分マッチで耐える）
  - editor 維持: `add-column-input` が DOM に残り、`add-column-button` が出ていないことを検証
  - 入力値 `"Backlog"` が保持され、`disabled === false` で再入力可能になっていることを検証
- **[MODIFY]** 既存成功テスト L358-385 の `updateColumnsMock` assertion を強化
  - `expect.arrayContaining` から `columns[columns.length - 1]` + `toHaveLength(3)` に置換し、**末尾要素であること** と `order: 2` (= `max(0,1) + 1`) を明示検証
  - テスト名は変更しない（成功フローの結線確認という意味は維持）

## 仕様ドキュメント更新

不要（テスト追加のみで実装コード・公開 API・データ形式・画面挙動は変更なし）。`board-view-spec.md` への末尾追加 / silent skip / editor 維持の詳細追記は別 Issue（spec doc 整備 Issue）で扱うのが整合的、と `implementation-plan.md` で整理済み。

## システム図

```mermaid
flowchart LR
  A[AddColumnButton<br/>onAdd Promise] --> B[Board.onAddColumn]
  B --> C[App.handleAddColumn]
  C --> D[useProject.updateColumns<br/>builder]
  D --> E[updateColumnsAction]
  E --> F[IPC update_columns]
  F -- Result.err --> G["throw new Error msg<br/>+ toast 'カラムの追加に失敗しました: io fail'"]
  G --> H["AddColumnButton catch<br/>editor 維持 / 入力値保持 / setIsBusy(false)"]
  F -- Result.ok --> I["末尾 push name:Backlog, order:2<br/>+ toast 'カラムを追加しました'"]

  style G stroke:#f66,stroke-width:2px
  style H stroke:#f66,stroke-width:2px
  style I stroke:#3a7,stroke-width:2px
```

赤線が新規テストでカバーする失敗→editor維持パス、緑線が assertion 強化対象の成功→末尾追加パス。

## 関連Issue

Refs #114

親 Issue: #113 （カラム CRUD を update_columns に接続）
BE 対応: #96

## テスト

- `pnpm test:run src/__tests__/App.interaction.test.tsx` — **19 passed**（新規 1 件 + 既存 18 件）
- `pnpm test:run` — **763 passed (89 files)** — 全件緑、リグレッションなし
- `pnpm build`（tsc + vite build）— 成功（型エラーなし）
- `git diff --stat` で `src/__tests__/App.interaction.test.tsx` のみが変更されていることを確認（実装コード無変更）
- AI レビュー（Codex CLI）— **問題なし**（計画整合性 / コード品質 / エッジケース / セキュリティ / パフォーマンス すべてクリア）

## レビューポイント

- **failure assertion を文言全体マッチではなく 2 substring に分けた判断**: prefix（`カラムの追加に失敗しました`）と補間値（`io fail`）どちらが将来変わっても片側で検出できる構造になっている
- **`columns[columns.length - 1]` を選んだ理由**: `Array.prototype.at(-1)` は ES2022 lib で本プロジェクトの `tsconfig.json (lib: ES2020)` だと型エラーになるため、ES2020 互換の末尾アクセスを採用
- **`applied:false`（builder 内 silent skip）の App 結合テストは追加しない判断**: hook 単体テストで既に直接カバー済みかつ App 層から再現するには `getColumnsMock` 経由 dispatch 順序の操作が必要で setup 複雑度が高い、と `hearing-notes.md` で整理済み
- **新規 helper の抽出を行わない判断**: AddColumnButton 操作 4 ステップ（`openAddColumnEditor` → `querySelectorRequired` → `setInputValue` → `pressEnter`）は 3 テストで反復するが、既存テストもこの粒度で書かれており、`columnInput.value` の差し替えを伴うため個別呼出のままが読みやすい

## チェックリスト

- [x] セルフレビューを実施した
- [x] pnpm test:run が通る
- [x] pnpm build が通る
- [x] Biome / oxlint の警告を解消した（環境的に CLI 未配備のため CI で再確認）
- [x] feature 間の依存は index.ts の公開 API 経由になっている（テストファイルは @/lib/tauri 経由のみ）
- [x] 関連 Issue を PR にリンクした（Refs #114）
- [x] 仕様変更なし → docs/spec-board/ 更新不要を本文に明記