### PR TITLE
✨ [New Feature]: #93 [BE] remove_link Tauri command を実装

### DIFF
--- a/docs/impl/remove_link.md
+++ b/docs/impl/remove_link.md
@@ -1,0 +1,137 @@
+# remove_link 実装メモ
+
+`remove_link({ sourceFilePath, targetFilePath })` は、source タスクの frontmatter
+`links` 配列から target タスクへのエントリを取り除く Tauri command。`add_link` と
+対称な BE 機能で、仕様は `docs/spec-board/task-format-spec.md` の links 章を
+参照する。ここではコードを書くうえで判断に迷いやすかった点を散文で残す。Rust の
+所有権や `Option` に不慣れな読み手を想定して、文脈を厚めに書く。
+
+## なぜ `TaskIndex::plan_remove_link` という aggregate method に閉じ込めたか
+
+`add_link.md` と同じ理由で、表記揺れを吸収する `normalize_link_path_for_lookup`
+は `pub(super)` 可視性で task ドメインに閉じている。effect 層から重複検出を
+やりたくなると path_lookup の可視性を緩めることになり、設計意図が壊れる。
+だから target を `retain` で除去する判定は aggregate method 内に集約してある。
+
+`plan_create` / `plan_update` / `plan_add_link` で既に踏襲されているスタイルで、
+user feedback memory `spec-board-aggregate-method` でも矯正されている方針なので、
+合わせる形で書いた。free function 3 段分離（pure select / read effect /
+write effect）の設計は取っていない。
+
+## なぜ Outcome を `Write` / `NoOp` の 2 値にしたか（含まれていなければ NoOp の逆転）
+
+`add_link` では「同じ target がすでに含まれていれば NoOp」だったが、`remove_link`
+では逆に「target が含まれていなければ NoOp」となる。意味は逆転しているが、
+effect 層から見れば「ファイル書き込みと cache mutate をやるかどうかの 2 値」と
+いう構造は同じ。だから `RemoveLinkOutcome` も `Write` / `NoOp` の 2 値に切って
+いる。
+
+`NoOp` には `existing_task: Task` を載せている。aggregate に渡した
+`source_existing` を clone して詰めただけだが、effect 層が「noop なので
+IPC 戻り値に何を返せばよいか」を考えなくて済むようにする目的。`add_link` と同じ。
+
+## なぜ重複登録を `retain` で全削除する設計にしたか
+
+`add_link` 側は「すでに含まれていれば NoOp」なので、本来は同じ target が複数
+登録される状況は起こらないはずだが、外部の手書き編集や過去仕様時代のファイル
+など、現実には重複が混入している可能性がある。`remove_link` は
+
+- `frontmatter.links.retain(|l| normalize(...) != Some(target_norm))`
+
+で完全一致するエントリを **すべて** 除去する。Set 化してから 1 件除く設計に
+すると、表記揺れの正規化形は集約されても元の表記が失われるため、テキストとして
+読みやすい状態を保ちたい場合に表記情報を残せない。`retain` ベースなら、削除
+対象以外の要素は原文表記のまま保持される。重複登録の掃除も同時に行えるので、
+副次的なメンテナンス効果も得られる。
+
+## なぜ target 側 frontmatter には書き戻さないか
+
+`add_link.md` と同じ。spec で「リンクは双方向として扱うが、リンク先のフロント
+マターには書き込まない。表示時に逆引きする」と明示されている。`plan_remove_link`
+の入力に target の Parsed は渡さず、target の存在も照会しない（次節）。
+
+target 側を書き換える設計にすると watcher event の自己書き込み抑止
+(`write_ignore`) を source / target の 2 ファイル分手配する必要が出てきて、
+失敗時の unregister 含めた race 設計がぐっと複雑になる。spec が「逆引きで
+済ませる」と決めているので、無理に双方向 write する理由はない。
+
+## なぜ target が cache に居なくても fail にしないか（dangling link 掃除ユースケース）
+
+`add_link` では target の存在を aggregate と cache の両方で検証し、存在しなければ
+`TargetNotFound` / `TargetVanished` で fail させていた。`remove_link` ではこれを
+**意図的に外している**。
+
+理由は dangling link の掃除を許容したいから。target ファイルがすでに削除されて
+いる、あるいは scan のタイミングで cache に乗っていない、といった状況でも、
+「source の links から target エントリを消す」操作自体は実行できないと困る。
+逆に「target が存在しないと remove できない」設計にすると、削除済み task への
+orphan link を消す手段が IPC 経由で失われてしまう。
+
+aggregate `plan_remove_link` は target が aggregate に存在するかを照会しない。
+effect 層の `commit_cache` でも target が cache にあれば `reverse_links` から
+source を除去するが、target が見つからない場合は `if let Some(...)` の else 経路で
+何もせず skip する（fail にしない）。
+
+## lock 取得順 + write_ignore register → write → unregister の理由
+
+`add_link.md` と同じ。`AppState` のロック順 `project_path → config →
+tasks_cache → watcher_handle → write_ignore` に従い、`remove_link_impl` も
+同じ順番で各 accessor を呼ぶ。
+
+watcher install 済みの場合は書き込み前に `write_ignore.register` で source path
+を予約し、write 成功後はそのまま entry を残す（watcher event の handler 側で
+consume される）。`io.write_existing` が失敗した場合は即 `unregister` で entry を
+回収する。`commit_cache` が `SourceVanished` で失敗した場合も同様に
+`unregister` してから返す（disk への write は完了しているため、watcher event を
+通常経路で処理して cache を disk に追従させる必要がある）。`add_link_impl` /
+`update_task_impl` と同型のパターン。
+
+## cache commit の "検証 → mutate" 構成
+
+`add_link` の `commit_cache` は source と target の **両方** の存在を先に確認
+してから mutate していたが、`remove_link` では target を検証不要にしたため
+**source の存在確認だけ** を冒頭で行う。
+
+```rust
+if !cache.contains_key(&source_key) {
+    return Err(RemoveLinkError::SourceVanished { ... });
+}
+```
+
+source を確認してから `cache.get_mut(&source_key)` で取り直して上書きする。
+`task_from_parsed` 由来の updated_task は `children` / `reverse_links` /
+`warnings` が空（または再生成）になっているので、cache 既存値を `std::mem::take`
+で抜き取って struct update syntax で詰め直す。`add_link` と同じ手順。
+
+target 側は `find_task_mut_by_normalized` で取り直して `reverse_links.retain(|p|
+p != &updated.file_path)` で source への逆引きを除去する。`add_link` 側が
+`push` だったのに対し、こちらは `retain`。cache に target が居なければ何もしない。
+
+## NoOp 経路の特徴
+
+`RemoveLinkOutcome::NoOp` の場合、effect 層は
+
+- `is_watcher_installed` も呼ばない
+- `write_ignore.register` もしない
+- `io.write_existing` もしない
+- `commit_cache` もしない
+
+ので、cache / disk / watcher の状態は完全に不変。テスト
+`noop_when_link_not_present` で「write_ignore に slot が増えていない」ことを
+明示的に検証している。
+
+## aggregate と effect 層を別 enum にしている理由（AddLinkError と共有しない）
+
+`RemoveLinkError` は `AddLinkError` と縮小集合だが別 enum にしている。具体的には
+
+- `TargetNotFound` を持たない（cache での target 存在検証をしないため）
+- `SelfLink` を持たない（self-link でも links に登録されていれば普通に除去されるだけ）
+- `TargetVanished` を持たない（commit 時に target 不在でも fail しない）
+- 代わりに `InvalidTargetPath` を持つ（args 段階の target 不正は意味的に
+  `SourceNotFound` でも `ParseFailed` でもないため、専用バリアントを追加）
+
+無理に enum を共有すると、`remove_link` で本来到達しないバリアントを持ち続ける
+ことになり、`match` の網羅性で「ありえないパス」を扱う羽目になる。意味の混同を
+避けるため別型にした。`RemoveLinkIntent` を `AddLinkIntent` の type alias にせず
+別 struct にしているのも同じ理由（aggregate method の引数型から `add_link` への
+依存を切る目的）。

--- a/docs/spec-board/task-format-spec.md
+++ b/docs/spec-board/task-format-spec.md
@@ -88,6 +88,7 @@ links:
 - リンクは**双方向**として扱う。片方のタスクに `links` を設定すると、リンク先タスクからも関連タスクとして表示される（リンク先のフロントマターには書き込まない。表示時に逆引きする）
 - 指定されたファイルが存在しない場合、リンク切れとして警告アイコンを表示
 - Tauri command `add_link({ sourceFilePath, targetFilePath })` で `links` への追加が可能。同じ target がすでに含まれる場合は noop（書き込みもキャッシュ更新も行わない）。リンク先（target）のフロントマターは書き換えない（双方向リンクは表示時の逆引きで実現する）
+- Tauri command `remove_link({ sourceFilePath, targetFilePath })` で `links` から target の完全一致エントリを **すべて** 取り除く（パス表記揺れは正規化して吸収）。最後の 1 件を消した場合は `links:` キーごと消える。target がすでに含まれていない場合は冪等な no-op として成功を返す（書き込みもキャッシュ更新も行わない）。target タスクが削除済みで存在しなくても source の `links` からの除去は実行する（dangling link 掃除の用途を兼ねる）。リンク先（target）のフロントマターは書き換えない（双方向リンクは表示時の逆引きで実現する点は `add_link` と同じ）
 
 ### 本文
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,7 +35,8 @@ pub fn run() {
             task::get::get_tasks,
             task::create::create_task,
             task::update::update_task,
-            task::add_link::add_link
+            task::add_link::add_link,
+            task::remove_link::remove_link
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -9,6 +9,7 @@ pub mod label;
 pub mod parse;
 pub mod path_lookup;
 pub(crate) mod path_normalization;
+pub mod remove_link;
 pub mod reverse_links;
 pub mod task_content;
 pub mod task_file_name;

--- a/src-tauri/src/task/remove_link.rs
+++ b/src-tauri/src/task/remove_link.rs
@@ -1,0 +1,11 @@
+//! `remove_link` Tauri command のファサード。
+
+pub mod args;
+pub mod command;
+pub mod error;
+
+#[allow(unused_imports)]
+pub use command::{__cmd__remove_link, remove_link};
+
+#[allow(unused_imports)]
+pub(crate) use command::remove_link_impl;

--- a/src-tauri/src/task/remove_link/args.rs
+++ b/src-tauri/src/task/remove_link/args.rs
@@ -1,0 +1,81 @@
+//! `remove_link` Tauri command の引数 DTO。
+//!
+//! sourceFilePath / targetFilePath は絶対パスまたは project_root 相対のいずれも
+//! 受け、共通の path normalization helper で project_root 相対の正規形に倒す。
+
+use std::path::{Component, Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::task::path_lookup::normalize_relative_path_for_input;
+use crate::task::remove_link::error::RemoveLinkError;
+use crate::task::task_index::RemoveLinkIntent;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveLinkArgs {
+    pub source_file_path: String,
+    pub target_file_path: String,
+}
+
+impl RemoveLinkArgs {
+    /// project_root を起点に sourceFilePath / targetFilePath を lexical 正規化し、
+    /// `RemoveLinkIntent` に詰め直す。
+    ///
+    /// source の検証失敗は `SourceNotFound`、target の検証失敗は
+    /// `InvalidTargetPath` を返す（add_link と異なり target は aggregate での
+    /// 存在検証を行わないため、不正 path はここで一元的に弾く）。
+    pub fn into_intent(self, project_root: &Path) -> Result<RemoveLinkIntent, RemoveLinkError> {
+        let source = normalize_input_path(&self.source_file_path, project_root, true)?;
+        let target = normalize_input_path(&self.target_file_path, project_root, false)?;
+        Ok(RemoveLinkIntent { source, target })
+    }
+}
+
+fn normalize_input_path(
+    raw: &str,
+    project_root: &Path,
+    is_source: bool,
+) -> Result<PathBuf, RemoveLinkError> {
+    let make_err = |raw: &str| -> RemoveLinkError {
+        if is_source {
+            RemoveLinkError::SourceNotFound {
+                path: raw.to_string(),
+            }
+        } else {
+            RemoveLinkError::InvalidTargetPath {
+                path: raw.to_string(),
+            }
+        }
+    };
+
+    if raw.trim().is_empty() {
+        return Err(make_err(raw));
+    }
+
+    let candidate_text = if Path::new(raw).is_absolute() {
+        Path::new(raw)
+            .strip_prefix(project_root)
+            .map_err(|_| make_err(raw))?
+            .to_string_lossy()
+            .into_owned()
+    } else {
+        raw.to_string()
+    };
+
+    let normalized =
+        normalize_relative_path_for_input(&candidate_text).ok_or_else(|| make_err(raw))?;
+    let rel = Path::new(&normalized);
+    if rel.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(make_err(raw));
+    }
+    if rel.as_os_str().is_empty() {
+        return Err(make_err(raw));
+    }
+
+    Ok(rel.to_path_buf())
+}
+
+#[cfg(test)]
+#[path = "args_tests.rs"]
+mod args_tests;

--- a/src-tauri/src/task/remove_link/args_tests.rs
+++ b/src-tauri/src/task/remove_link/args_tests.rs
@@ -1,0 +1,63 @@
+//! `RemoveLinkArgs::into_intent` の lenient 変換テスト。
+
+use std::path::{Path, PathBuf};
+
+use super::RemoveLinkArgs;
+use crate::task::remove_link::error::RemoveLinkError;
+
+fn args(source: &str, target: &str) -> RemoveLinkArgs {
+    RemoveLinkArgs {
+        source_file_path: source.to_string(),
+        target_file_path: target.to_string(),
+    }
+}
+
+#[test]
+fn accepts_relative_paths() {
+    let intent = args("tasks/a.md", "tasks/b.md")
+        .into_intent(Path::new("/project"))
+        .expect("ok");
+    assert_eq!(intent.source, PathBuf::from("tasks/a.md"));
+    assert_eq!(intent.target, PathBuf::from("tasks/b.md"));
+}
+
+#[test]
+fn strips_project_root_for_absolute_paths() {
+    let intent = args("/project/tasks/a.md", "/project/tasks/b.md")
+        .into_intent(Path::new("/project"))
+        .expect("ok");
+    assert_eq!(intent.source, PathBuf::from("tasks/a.md"));
+    assert_eq!(intent.target, PathBuf::from("tasks/b.md"));
+}
+
+#[test]
+fn rejects_traversal_in_source() {
+    let err = args("../foo.md", "tasks/b.md")
+        .into_intent(Path::new("/project"))
+        .expect_err("traversal in source");
+    assert!(matches!(err, RemoveLinkError::SourceNotFound { .. }));
+}
+
+#[test]
+fn rejects_traversal_in_target() {
+    let err = args("tasks/a.md", "../foo.md")
+        .into_intent(Path::new("/project"))
+        .expect_err("traversal in target");
+    assert!(matches!(err, RemoveLinkError::InvalidTargetPath { .. }));
+}
+
+#[test]
+fn rejects_empty_source_and_target() {
+    let err_source = args("", "tasks/b.md")
+        .into_intent(Path::new("/project"))
+        .expect_err("empty source");
+    assert!(matches!(err_source, RemoveLinkError::SourceNotFound { .. }));
+
+    let err_target = args("tasks/a.md", "  ")
+        .into_intent(Path::new("/project"))
+        .expect_err("whitespace target");
+    assert!(matches!(
+        err_target,
+        RemoveLinkError::InvalidTargetPath { .. }
+    ));
+}

--- a/src-tauri/src/task/remove_link/command.rs
+++ b/src-tauri/src/task/remove_link/command.rs
@@ -1,0 +1,177 @@
+//! `remove_link` Tauri command と effect 層実装。
+
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::sync::Arc;
+
+use tauri::State;
+
+use crate::state::AppState;
+use crate::task::frontmatter;
+use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
+use crate::task::remove_link::args::RemoveLinkArgs;
+use crate::task::remove_link::error::{RemoveLinkCommandError, RemoveLinkError};
+use crate::task::task_index::{find_task_mut_by_normalized, RemoveLinkOutcome, Task, TaskIndex};
+
+/// `remove_link` Tauri command 薄層。
+#[tauri::command]
+pub fn remove_link(state: State<'_, Arc<AppState>>, args: RemoveLinkArgs) -> Result<Task, String> {
+    remove_link_impl(state.inner().as_ref(), &FsTaskIo, args).map_err(|e| e.to_string())
+}
+
+/// effect 層本体（テスト境界）。
+pub(crate) fn remove_link_impl(
+    state: &AppState,
+    io: &dyn TaskIo,
+    args: RemoveLinkArgs,
+) -> Result<Task, RemoveLinkCommandError> {
+    state.check_tasks_cache_lock()?;
+    let _ = state.write_ignore().is_empty()?;
+
+    let project_root = state
+        .project_path()?
+        .ok_or(RemoveLinkCommandError::NoProjectOpen)?;
+
+    let intent = args
+        .into_intent(project_root.as_path())
+        .map_err(RemoveLinkCommandError::Validation)?;
+    let source_rel = intent.source.clone();
+    let source_abs = project_root.join(&source_rel);
+
+    let snapshot = state.tasks_snapshot()?;
+    let existing_source = snapshot
+        .iter()
+        .find(|t| Path::new(t.file_path.as_str()) == source_rel.as_path())
+        .cloned()
+        .ok_or_else(|| RemoveLinkError::SourceNotFound {
+            path: source_rel.to_string_lossy().into_owned(),
+        })?;
+
+    let bytes = match io.read(&source_abs) {
+        Ok(b) => b,
+        Err(TaskIoError::Io(source)) if source.kind() == ErrorKind::NotFound => {
+            return Err(RemoveLinkError::SourceNotFound {
+                path: source_rel.to_string_lossy().into_owned(),
+            }
+            .into());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let parsed = frontmatter::parse_bytes(&bytes)
+        .map_err(|e| RemoveLinkError::ParseFailed(e.to_string()))?
+        .ok_or_else(|| {
+            RemoveLinkError::ParseFailed("no frontmatter delimiter found".to_string())
+        })?;
+
+    let index = TaskIndex::new(snapshot);
+    let outcome = index
+        .plan_remove_link(
+            project_root.as_path(),
+            intent.clone(),
+            &existing_source,
+            parsed,
+        )
+        .map_err(RemoveLinkCommandError::Validation)?;
+
+    match outcome {
+        RemoveLinkOutcome::NoOp { existing_task } => Ok(existing_task),
+        RemoveLinkOutcome::Write {
+            updated_task,
+            file_content,
+            target_normalized,
+        } => {
+            let watcher_active = state.is_watcher_installed()?;
+            if watcher_active {
+                state.write_ignore().register(&source_abs)?;
+            }
+            if let Err(err) = io.write_existing(&source_abs, file_content.as_bytes()) {
+                if watcher_active {
+                    let _ = state.write_ignore().unregister(&source_abs);
+                }
+                return Err(err.into());
+            }
+
+            // commit_cache が SourceVanished で失敗した場合、disk への write は
+            // 完了済みのため watcher event を通常経路で処理して cache を disk に
+            // 追従させる必要がある。write_ignore に entry が残ったままだと event が
+            // consume されて cache が永続的に disk と乖離するので、commit 失敗時は
+            // unregister して watcher 側で再走させる（add_link_impl と同型）。
+            match commit_cache(state, &source_rel, &target_normalized, &updated_task) {
+                Ok(returned) => Ok(returned),
+                Err(err) => {
+                    if watcher_active {
+                        let _ = state.write_ignore().unregister(&source_abs);
+                    }
+                    Err(err)
+                }
+            }
+        }
+    }
+}
+
+/// snapshot 取得から本関数呼出までの間に他コマンドが cache を変更すると、source
+/// が cache から消えていることがある。先に source の存在確認をしてから mutate に
+/// 入る。target は cache に存在しなくても fail にしない（dangling link 掃除を
+/// 許容するため、add_link と異なる）。
+fn commit_cache(
+    state: &AppState,
+    source_rel: &Path,
+    target_normalized: &str,
+    updated_task: &Task,
+) -> Result<Task, RemoveLinkCommandError> {
+    let source_key = source_rel.to_path_buf();
+    let target_norm = target_normalized.to_string();
+    let updated = updated_task.clone();
+
+    let returned: Result<Task, RemoveLinkError> =
+        state.with_tasks_cache_mut(|cache: &mut HashMap<_, Task>| {
+            if !cache.contains_key(&source_key) {
+                return Err(RemoveLinkError::SourceVanished {
+                    path: source_key.to_string_lossy().into_owned(),
+                });
+            }
+
+            // 派生フィールド (children / reverse_links / warnings) を保持しつつ
+            // parse 由来フィールドのみ上書きする。remove_link は parent / title /
+            // status / labels / extras を一切変更せず links を縮めるだけのため、
+            // warnings は既存値の保持で正しい状態が維持される。
+            let source_entry = cache
+                .get_mut(&source_key)
+                .expect("source presence verified above");
+            let preserved_children = std::mem::take(&mut source_entry.children);
+            let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
+            let preserved_warnings = std::mem::take(&mut source_entry.warnings);
+            *source_entry = Task {
+                children: preserved_children,
+                reverse_links: preserved_reverse,
+                warnings: preserved_warnings,
+                ..updated.clone()
+            };
+
+            // target の reverse_links から source を除去。cache に target が存在
+            // しない場合は orphan link 掃除のユースケースを許容するため fail にせず
+            // skip する。self-link（source == target）のケースでは source 自身の
+            // reverse_links が retain されるため、戻り値は target update 後に
+            // cache から再取得する必要がある。
+            if let Some(target_task) = find_task_mut_by_normalized(cache, &target_norm) {
+                target_task
+                    .reverse_links
+                    .retain(|p| p != &updated.file_path);
+            }
+
+            let returned_task = cache
+                .get(&source_key)
+                .expect("source presence verified above")
+                .clone();
+
+            Ok(returned_task)
+        })?;
+
+    Ok(returned?)
+}
+
+#[cfg(test)]
+#[path = "command_tests.rs"]
+mod command_tests;

--- a/src-tauri/src/task/remove_link/command_tests.rs
+++ b/src-tauri/src/task/remove_link/command_tests.rs
@@ -1,0 +1,335 @@
+//! `remove_link_impl` の結合テスト。
+//!
+//! tempfile + `NoopWatcherFactory` + `FsTaskIo` で実 FS 上の動作を検証する。
+
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use super::super::args::RemoveLinkArgs;
+use super::super::error::{RemoveLinkCommandError, RemoveLinkError};
+use super::remove_link_impl;
+use crate::project::open::open_project_impl;
+use crate::project::watcher_factory::NoopWatcherFactory;
+use crate::project::OpenProjectIntent;
+use crate::state::AppState;
+use crate::task::io::FsTaskIo;
+
+fn tempdir() -> TempDir {
+    tempfile::tempdir().expect("create temp dir")
+}
+
+fn open_with_noop(state: Arc<AppState>, path: &Path) {
+    let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
+        .expect("non-empty path");
+    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+}
+
+fn seed_md(root: &Path, rel: &str, content: &str) {
+    let abs = root.join(rel);
+    fs::create_dir_all(abs.parent().unwrap()).unwrap();
+    fs::write(&abs, content).unwrap();
+}
+
+fn args_for(source: &str, target: &str) -> RemoveLinkArgs {
+    RemoveLinkArgs {
+        source_file_path: source.to_string(),
+        target_file_path: target.to_string(),
+    }
+}
+
+#[test]
+fn removes_link_from_disk_and_cache() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n---\nbody\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let task =
+        remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/b.md")).expect("ok");
+    assert_eq!(task.file_path, "tasks/a.md");
+    assert!(
+        task.links.is_empty(),
+        "links should be empty, got {:?}",
+        task.links
+    );
+
+    let on_disk = fs::read_to_string(dir.path().join("tasks/a.md")).expect("read");
+    assert!(
+        !on_disk.contains("links:"),
+        "links key should be removed when last entry dropped, got {on_disk:?}"
+    );
+
+    let snap = state.tasks_snapshot().expect("snapshot");
+    let a = snap
+        .iter()
+        .find(|t| t.file_path == "tasks/a.md")
+        .expect("a");
+    assert!(a.links.is_empty());
+}
+
+#[test]
+fn removes_reverse_link_on_target() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // open_project の reverse_links 構築で b.reverse_links に a が入っている前提を確認。
+    let snap_before = state.tasks_snapshot().expect("snap");
+    let b_before = snap_before
+        .iter()
+        .find(|t| t.file_path == "tasks/b.md")
+        .expect("b");
+    assert!(
+        b_before
+            .reverse_links
+            .iter()
+            .any(|p| p.as_str() == "tasks/a.md"),
+        "precondition: b.reverse_links should contain a"
+    );
+
+    let _ = remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/b.md")).expect("ok");
+
+    let snap_after = state.tasks_snapshot().expect("snap");
+    let b_after = snap_after
+        .iter()
+        .find(|t| t.file_path == "tasks/b.md")
+        .expect("b");
+    assert!(
+        !b_after
+            .reverse_links
+            .iter()
+            .any(|p| p.as_str() == "tasks/a.md"),
+        "b.reverse_links should drop a, got {:?}",
+        b_after.reverse_links
+    );
+}
+
+#[test]
+fn noop_when_link_not_present() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let before = fs::read(dir.path().join("tasks/a.md")).unwrap();
+    let snap_before = state.tasks_snapshot().expect("snap");
+
+    let _ = remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/b.md"))
+        .expect("noop returns Ok");
+
+    let after = fs::read(dir.path().join("tasks/a.md")).unwrap();
+    assert_eq!(before, after, "noop must not rewrite file");
+
+    let snap_after = state.tasks_snapshot().expect("snap");
+    assert_eq!(snap_before.len(), snap_after.len());
+
+    assert!(
+        state.write_ignore().is_empty().expect("probe"),
+        "noop must not consume write_ignore slot"
+    );
+}
+
+#[test]
+fn idempotent_double_invocation() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let _ = remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/b.md"))
+        .expect("first call ok (Write)");
+    let _ = remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/b.md"))
+        .expect("second call ok (NoOp)");
+}
+
+#[test]
+fn succeeds_when_target_missing_from_cache() {
+    let dir = tempdir();
+    // target ファイルを seed せず、source.links だけ orphan link を持つ状態を作る。
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/missing.md\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let task = remove_link_impl(
+        &state,
+        &FsTaskIo,
+        args_for("tasks/a.md", "tasks/missing.md"),
+    )
+    .expect("orphan link removal should succeed");
+    assert!(task.links.is_empty());
+
+    let on_disk = fs::read_to_string(dir.path().join("tasks/a.md")).expect("read");
+    assert!(
+        !on_disk.contains("tasks/missing.md"),
+        "orphan link should be removed from disk, got {on_disk:?}"
+    );
+}
+
+#[test]
+fn errors_source_not_found() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let err = remove_link_impl(
+        &state,
+        &FsTaskIo,
+        args_for("tasks/missing.md", "tasks/b.md"),
+    )
+    .expect_err("source absent");
+    assert!(matches!(
+        err,
+        RemoveLinkCommandError::Validation(RemoveLinkError::SourceNotFound { .. })
+    ));
+}
+
+#[test]
+fn errors_parse_failed_on_broken_frontmatter() {
+    let dir = tempdir();
+    // まず正常な frontmatter で seed → open_project で cache に乗せる。
+    // その後ディスク側の source の frontmatter delimiter を欠落させ、
+    // remove_link_impl の io.read + frontmatter::parse_bytes の経路で
+    // ParseFailed を確実に発火させる。
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // open_project 後にディスクの source を壊す（先頭 `---` を除去）。
+    fs::write(
+        dir.path().join("tasks/a.md"),
+        "title: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n",
+    )
+    .unwrap();
+
+    let err = remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/b.md"))
+        .expect_err("parse should fail on broken frontmatter");
+    assert!(
+        matches!(
+            err,
+            RemoveLinkCommandError::Validation(RemoveLinkError::ParseFailed(_))
+        ),
+        "expected ParseFailed, got {err:?}"
+    );
+}
+
+#[test]
+fn self_link_removal_returns_updated_reverse_links() {
+    // self-link（source == target）の境界ケース: 手書き frontmatter で a.md
+    // 自身を links に持つ状態を作る。remove_link 実行後、disk / cache の
+    // a.md は links が空になり、reverse_links からも自分自身が除去される。
+    // 戻り値の Task が cache と一致することを検証する（commit_cache 内で
+    // target update 後に cache から再取得する設計の回帰テスト）。
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/a.md\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let returned =
+        remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/a.md")).expect("ok");
+    assert!(returned.links.is_empty());
+    assert!(
+        !returned
+            .reverse_links
+            .iter()
+            .any(|p| p.as_str() == "tasks/a.md"),
+        "self-link returned task should not contain itself in reverse_links: {:?}",
+        returned.reverse_links
+    );
+
+    let snap = state.tasks_snapshot().expect("snap");
+    let a = snap
+        .iter()
+        .find(|t| t.file_path == "tasks/a.md")
+        .expect("a");
+    assert_eq!(
+        returned.reverse_links, a.reverse_links,
+        "returned task reverse_links must match cache state"
+    );
+}
+
+#[test]
+fn registers_write_ignore_for_write_path() {
+    let dir = tempdir();
+    seed_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n---\n",
+    );
+    seed_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\n",
+    );
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let _ = remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/b.md")).expect("ok");
+
+    assert_eq!(
+        1,
+        state.write_ignore().len().expect("len"),
+        "write_ignore must hold exactly one entry for the source path"
+    );
+}

--- a/src-tauri/src/task/remove_link/error.rs
+++ b/src-tauri/src/task/remove_link/error.rs
@@ -1,0 +1,72 @@
+//! `remove_link` のエラー型。
+//!
+//! 公開 `remove_link` command は `Result<Task, String>` を返すため、
+//! `RemoveLinkCommandError` 自体は Serialize を実装しない。
+//! `remove_link_impl(...).map_err(|e| e.to_string())` で文字列化する
+//! （既存 `add_link` / `update_task` と同型）。
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use crate::state::AppStateError;
+use crate::task::io::TaskIoError;
+use crate::task::task_content::TaskContentError;
+use spec_board_fs::watcher::write_ignore::WriteIgnoreError;
+
+pub use crate::task::create::error::ContentRejectReason;
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum RemoveLinkError {
+    #[error("source task not found: {path}")]
+    SourceNotFound { path: String },
+    /// args 段階で target path が空文字 / traversal / project_root 外だった場合。
+    /// add_link と異なり aggregate で「target が存在するか」は検証しないため、
+    /// 不正 path はここに集約される。
+    #[error("invalid target path: {path}")]
+    InvalidTargetPath { path: String },
+    /// frontmatter parse 失敗。effect 層から渡される。
+    #[error("parse failed: {0}")]
+    ParseFailed(String),
+    /// commit 時点で snapshot にあった source が cache から消えていた場合。
+    #[error("source vanished from cache during commit: {path}")]
+    SourceVanished { path: String },
+    /// `frontmatter::serialize` 後の本文が scanner eligible でない場合。
+    #[error("content not scanner eligible: {reason}")]
+    ContentRejected { reason: ContentRejectReason },
+    /// 効果層側で具体的な NotFound 等を `SourceNotFound` に詰め直す途中で使う path 形式。
+    #[error("file not found: {}", .0.display())]
+    FileNotFound(PathBuf),
+}
+
+#[derive(Debug, Error)]
+pub enum RemoveLinkCommandError {
+    #[error(transparent)]
+    Validation(#[from] RemoveLinkError),
+    #[error("project is not opened")]
+    NoProjectOpen,
+    #[error("internal state lock poisoned")]
+    AppState(#[from] AppStateError),
+    #[error(transparent)]
+    WriteIgnore(#[from] WriteIgnoreError),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<TaskIoError> for RemoveLinkCommandError {
+    fn from(err: TaskIoError) -> Self {
+        match err {
+            TaskIoError::Io(source) => RemoveLinkCommandError::Io(source),
+        }
+    }
+}
+
+impl From<TaskContentError> for RemoveLinkError {
+    fn from(err: TaskContentError) -> Self {
+        let reason = match err {
+            TaskContentError::TooLarge { size, .. } => ContentRejectReason::TooLarge { size },
+            TaskContentError::BinaryDetected { .. } => ContentRejectReason::BinaryDetected,
+        };
+        RemoveLinkError::ContentRejected { reason }
+    }
+}

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -24,6 +24,7 @@ use crate::task::path_lookup::{
     normalize_relative_path_for_input, normalize_task_path_for_lookup, parent_lookup_index,
     task_path_index,
 };
+use crate::task::remove_link::error::RemoveLinkError;
 use crate::task::reverse_links::build_reverse_links;
 use crate::task::task_content::TaskContent;
 use crate::task::task_file_name::{TaskFileName, TaskFileNameError};
@@ -545,6 +546,87 @@ impl TaskIndex {
         })
     }
 
+    /// 既存 source `Task` から target を `links` 上で除去した結果を計算する pure
+    /// aggregate method。
+    ///
+    /// 呼び出し前提:
+    ///
+    /// - `source_existing` は effect 層が cache snapshot から `intent.source` で
+    ///   引き当て済みの `&Task`。
+    /// - `source_parsed` は effect 層が `io.read` + `frontmatter::parse_bytes` 済み。
+    ///
+    /// 振る舞い:
+    ///
+    /// 1. source / target を lookup 用に正規化する。失敗時は `SourceNotFound` /
+    ///    `InvalidTargetPath` を返す（args 段階で reject 済みなので通常到達不可）。
+    /// 2. `source_parsed.frontmatter.links` を走査し、normalize 結果が target_norm と
+    ///    完全一致する要素を **すべて** 除去する。表記揺れで重複登録されている場合は
+    ///    一括で掃除される。
+    /// 3. 1 件も除去されなければ `NoOp { existing_task }` を返す（冪等成功）。
+    /// 4. 除去ありなら `frontmatter::serialize` で書き戻し用 string を生成し、
+    ///    `TaskContent::try_new` で scanner eligible 検証、`task_from_parsed` で
+    ///    `updated_task` を再構築して `Write` Outcome を返す。
+    ///
+    /// add_link との差分: target が aggregate に存在するかは検証しない（dangling
+    /// link 掃除のユースケースを許容する）。self-link チェックも不要（src/tgt が
+    /// 同一の場合、もとから links に含まれていれば NoOp ではなく Write になり
+    /// 1 件除去されるだけ）。parent / children 不変条件は links 削除では影響しないため
+    /// 検証しない。
+    pub(crate) fn plan_remove_link(
+        &self,
+        _project_root: &Path,
+        intent: RemoveLinkIntent,
+        source_existing: &Task,
+        source_parsed: Parsed,
+    ) -> Result<RemoveLinkOutcome, RemoveLinkError> {
+        let source_str = intent.source.to_string_lossy();
+        let _source_norm =
+            normalize_link_path_for_lookup(source_str.as_ref()).ok_or_else(|| {
+                RemoveLinkError::SourceNotFound {
+                    path: source_str.clone().into_owned(),
+                }
+            })?;
+        let target_str = intent.target.to_string_lossy();
+        let target_norm = normalize_link_path_for_lookup(target_str.as_ref()).ok_or_else(|| {
+            RemoveLinkError::InvalidTargetPath {
+                path: target_str.clone().into_owned(),
+            }
+        })?;
+
+        let Parsed {
+            mut frontmatter,
+            body,
+        } = source_parsed;
+
+        let original_len = frontmatter.links.len();
+        frontmatter
+            .links
+            .retain(|l| normalize_link_path_for_lookup(l).as_deref() != Some(target_norm.as_str()));
+        if frontmatter.links.len() == original_len {
+            return Ok(RemoveLinkOutcome::NoOp {
+                existing_task: source_existing.clone(),
+            });
+        }
+
+        let file_content = frontmatter::serialize(&Parsed {
+            frontmatter: frontmatter.clone(),
+            body: body.clone(),
+        });
+        TaskContent::try_new(file_content.clone()).map_err(RemoveLinkError::from)?;
+
+        let context = TaskParseContext {
+            file_path: source_existing.file_path.as_path_buf(),
+            default_status: source_existing.status.clone(),
+        };
+        let updated_task = task_from_parsed(Parsed { frontmatter, body }, &context);
+
+        Ok(RemoveLinkOutcome::Write {
+            updated_task,
+            file_content,
+            target_normalized: target_norm,
+        })
+    }
+
     /// 削除対象 path を parent に持つ直接の子 task の **プロジェクトルート相対** path を
     /// snapshot 順で列挙する pure aggregate query。
     ///
@@ -720,6 +802,16 @@ pub struct AddLinkIntent {
     pub target: PathBuf,
 }
 
+/// `remove_link` IPC 境界から domain に渡される削除意図。
+///
+/// `AddLinkIntent` とは別型で持つ。意味的な混同を避けるためと、aggregate method
+/// の引数型から `add_link` モジュールへの依存を切るため。
+#[derive(Debug, Clone)]
+pub struct RemoveLinkIntent {
+    pub source: PathBuf,
+    pub target: PathBuf,
+}
+
 /// `TaskIndex::plan_add_link` の計算結果。effect 層が消費する。
 #[derive(Debug)]
 pub(crate) enum AddLinkOutcome {
@@ -732,6 +824,26 @@ pub(crate) enum AddLinkOutcome {
     },
     NoOp {
         /// IPC 戻り値に使う既存 source の現在状態（plan_add_link に渡された
+        /// `source_existing` の clone）。
+        existing_task: Task,
+    },
+}
+
+/// `TaskIndex::plan_remove_link` の計算結果。effect 層が消費する。
+///
+/// `Write` は実際に `links` から target エントリを除去した場合。`NoOp` は
+/// 元から含まれていない場合の冪等成功。
+#[derive(Debug)]
+pub(crate) enum RemoveLinkOutcome {
+    Write {
+        updated_task: Task,
+        file_content: String,
+        /// effect 層が cache 上の target エントリを引くための正規化済み相対 path
+        /// （`normalize_link_path_for_lookup` の出力形）。
+        target_normalized: String,
+    },
+    NoOp {
+        /// IPC 戻り値に使う既存 source の現在状態（plan_remove_link に渡された
         /// `source_existing` の clone）。
         existing_task: Task,
     },
@@ -1084,3 +1196,7 @@ mod task_index_plan_delete_abort_tests;
 #[cfg(test)]
 #[path = "task_index_plan_add_link_tests.rs"]
 mod task_index_plan_add_link_tests;
+
+#[cfg(test)]
+#[path = "task_index_plan_remove_link_tests.rs"]
+mod task_index_plan_remove_link_tests;

--- a/src-tauri/src/task/task_index_plan_remove_link_tests.rs
+++ b/src-tauri/src/task/task_index_plan_remove_link_tests.rs
@@ -1,0 +1,271 @@
+//! `TaskIndex::plan_remove_link` の純粋関数ユニットテスト。
+//!
+//! AppState / TaskIo / fs::* に依存せず、すべて in-memory で完結する。
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::{RemoveLinkIntent, RemoveLinkOutcome, Task, TaskIndex};
+use crate::config::column_name::ColumnName;
+use crate::task::frontmatter::{parse as parse_frontmatter, Parsed};
+use crate::task::task_file_path::TaskFilePath;
+
+fn make_task(file_path: &str) -> Task {
+    let fp = TaskFilePath::from_lenient(file_path);
+    Task {
+        id: fp.clone(),
+        file_path: fp,
+        title: "T".into(),
+        status: ColumnName::from_lenient("Todo"),
+        priority: None,
+        labels: Vec::new(),
+        parent: None,
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: BTreeMap::new(),
+        warnings: Vec::new(),
+    }
+}
+
+fn parsed_from_md(md: &str) -> Parsed {
+    parse_frontmatter(md).expect("parse ok").expect("some")
+}
+
+fn intent(source: &str, target: &str) -> RemoveLinkIntent {
+    RemoveLinkIntent {
+        source: PathBuf::from(source),
+        target: PathBuf::from(target),
+    }
+}
+
+fn project_root() -> &'static Path {
+    Path::new("/project")
+}
+
+#[test]
+fn removes_single_existing_link() {
+    let source = make_task("tasks/a.md");
+    let target = make_task("tasks/b.md");
+    let index = TaskIndex::new(vec![source.clone(), target]);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n---\nbody\n");
+
+    let outcome = index
+        .plan_remove_link(
+            project_root(),
+            intent("tasks/a.md", "tasks/b.md"),
+            &source,
+            parsed,
+        )
+        .expect("ok");
+
+    match outcome {
+        RemoveLinkOutcome::Write {
+            updated_task,
+            file_content,
+            target_normalized,
+        } => {
+            assert!(
+                !file_content.contains("links:"),
+                "links key should be removed when last entry is dropped, got {file_content:?}"
+            );
+            assert_eq!(target_normalized, "tasks/b.md");
+            assert!(
+                updated_task.links.is_empty(),
+                "links should be empty, got {:?}",
+                updated_task.links
+            );
+        }
+        RemoveLinkOutcome::NoOp { .. } => panic!("expected Write, got NoOp"),
+    }
+}
+
+#[test]
+fn removes_all_duplicate_entries() {
+    let source = make_task("tasks/a.md");
+    let target = make_task("tasks/b.md");
+    let index = TaskIndex::new(vec![source.clone(), target]);
+    // 同一 target が表記揺れで 2 件登録された状態。両方とも除去されるべき。
+    let parsed = parsed_from_md(
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n  - ./tasks/b.md\n---\n",
+    );
+
+    let outcome = index
+        .plan_remove_link(
+            project_root(),
+            intent("tasks/a.md", "tasks/b.md"),
+            &source,
+            parsed,
+        )
+        .expect("ok");
+
+    match outcome {
+        RemoveLinkOutcome::Write { updated_task, .. } => {
+            assert!(
+                updated_task.links.is_empty(),
+                "all duplicates should be removed, got {:?}",
+                updated_task.links
+            );
+        }
+        RemoveLinkOutcome::NoOp { .. } => panic!("expected Write"),
+    }
+}
+
+#[test]
+fn returns_noop_when_target_absent() {
+    let source = make_task("tasks/a.md");
+    let other = make_task("tasks/c.md");
+    let index = TaskIndex::new(vec![source.clone(), other]);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/c.md\n---\n");
+
+    let outcome = index
+        .plan_remove_link(
+            project_root(),
+            intent("tasks/a.md", "tasks/b.md"),
+            &source,
+            parsed,
+        )
+        .expect("ok");
+
+    match outcome {
+        RemoveLinkOutcome::NoOp { existing_task } => {
+            assert_eq!(existing_task.file_path.as_str(), source.file_path.as_str());
+        }
+        RemoveLinkOutcome::Write { .. } => panic!("expected NoOp, got Write"),
+    }
+}
+
+#[test]
+fn normalizes_path_notation_for_match() {
+    let source = make_task("tasks/a.md");
+    let target = make_task("tasks/b.md");
+    let index = TaskIndex::new(vec![source.clone(), target]);
+    // links 側は `./tasks/b.md`、target は `tasks/b.md`。normalize 後同一。
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\nlinks:\n  - ./tasks/b.md\n---\n");
+
+    let outcome = index
+        .plan_remove_link(
+            project_root(),
+            intent("tasks/a.md", "tasks/b.md"),
+            &source,
+            parsed,
+        )
+        .expect("ok");
+
+    match outcome {
+        RemoveLinkOutcome::Write { updated_task, .. } => {
+            assert!(updated_task.links.is_empty());
+        }
+        RemoveLinkOutcome::NoOp { .. } => panic!("expected Write"),
+    }
+}
+
+#[test]
+fn returns_noop_when_links_empty() {
+    let source = make_task("tasks/a.md");
+    let target = make_task("tasks/b.md");
+    let index = TaskIndex::new(vec![source.clone(), target]);
+    let parsed = parsed_from_md("---\ntitle: A\nstatus: Todo\n---\n");
+
+    let outcome = index
+        .plan_remove_link(
+            project_root(),
+            intent("tasks/a.md", "tasks/b.md"),
+            &source,
+            parsed,
+        )
+        .expect("ok");
+
+    assert!(matches!(outcome, RemoveLinkOutcome::NoOp { .. }));
+}
+
+#[test]
+fn preserves_other_links() {
+    let source = make_task("tasks/a.md");
+    let b = make_task("tasks/b.md");
+    let c = make_task("tasks/c.md");
+    let d = make_task("tasks/d.md");
+    let index = TaskIndex::new(vec![source.clone(), b, c, d]);
+    let parsed = parsed_from_md(
+        "---\ntitle: A\nstatus: Todo\nlinks:\n  - tasks/b.md\n  - tasks/c.md\n  - tasks/d.md\n---\n",
+    );
+
+    let outcome = index
+        .plan_remove_link(
+            project_root(),
+            intent("tasks/a.md", "tasks/c.md"),
+            &source,
+            parsed,
+        )
+        .expect("ok");
+
+    match outcome {
+        RemoveLinkOutcome::Write {
+            updated_task,
+            file_content,
+            ..
+        } => {
+            let links: Vec<String> = updated_task
+                .links
+                .iter()
+                .map(|p| p.as_str().to_string())
+                .collect();
+            assert_eq!(
+                links,
+                vec!["tasks/b.md".to_string(), "tasks/d.md".to_string()]
+            );
+            let b_pos = file_content.find("- tasks/b.md").expect("b");
+            let d_pos = file_content.find("- tasks/d.md").expect("d");
+            assert!(b_pos < d_pos, "order preserved");
+            assert!(
+                !file_content.contains("- tasks/c.md"),
+                "removed entry should not remain"
+            );
+        }
+        RemoveLinkOutcome::NoOp { .. } => panic!("expected Write"),
+    }
+}
+
+#[test]
+fn preserves_body_and_extras() {
+    let source = make_task("tasks/a.md");
+    let target = make_task("tasks/b.md");
+    let index = TaskIndex::new(vec![source.clone(), target]);
+    let parsed = parsed_from_md(
+        "---\ntitle: A\nstatus: Todo\nassignee: alice\nlinks:\n  - tasks/b.md\n---\nhello world\n",
+    );
+
+    let outcome = index
+        .plan_remove_link(
+            project_root(),
+            intent("tasks/a.md", "tasks/b.md"),
+            &source,
+            parsed,
+        )
+        .expect("ok");
+
+    match outcome {
+        RemoveLinkOutcome::Write {
+            updated_task,
+            file_content,
+            ..
+        } => {
+            assert!(
+                file_content.contains("assignee: alice"),
+                "extras preserved: {file_content:?}"
+            );
+            assert!(file_content.contains("hello world"));
+            assert_eq!(
+                updated_task
+                    .extras
+                    .get("assignee")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                Some("alice".to_string())
+            );
+            assert!(updated_task.body.contains("hello world"));
+        }
+        RemoveLinkOutcome::NoOp { .. } => panic!("expected Write"),
+    }
+}


### PR DESCRIPTION
## 概要

source タスクの frontmatter `links` から target エントリを除去する `remove_link` Tauri command を BE に追加した。`add_link` (#92) と対称な機能で、aggregate 中心の 2 段構成 (`TaskIndex::plan_remove_link` + `remove_link_impl`) を踏襲する。

## 変更の種類

- ✨ 新機能（BE のみ。FE 結線は別 Issue）

## 追加した内容

- IPC `remove_link({ sourceFilePath, targetFilePath })` Tauri command
- `TaskIndex::plan_remove_link` aggregate method（pure / I/O なし）
- `RemoveLinkIntent` / `RemoveLinkOutcome` / `RemoveLinkError` / `RemoveLinkCommandError` 型
- `task/remove_link/` モジュール（`args.rs` / `command.rs` / `error.rs` + 各 tests）
- aggregate ユニットテスト 7 件 / args テスト 5 件 / 結合テスト 9 件（self-link 回帰含む）
- 実装メモ `docs/impl/remove_link.md`

## 変更した内容

- `src-tauri/src/lib.rs` の `invoke_handler!` に `task::remove_link::remove_link` を追加
- `src-tauri/src/task.rs` に `pub mod remove_link;` を追加
- `src-tauri/src/task/task_index.rs` に `RemoveLinkIntent` / `RemoveLinkOutcome` / `plan_remove_link` を追加
- `docs/spec-board/task-format-spec.md` の links 章に `remove_link` の挙動を追記

## 仕様ドキュメント更新

- `docs/spec-board/task-format-spec.md`: 更新済み（`remove_link` の冪等性 / 完全一致全削除 / target 実在検証なし / target frontmatter 不変を追記）
- `docs/impl/remove_link.md`: 新規追加（実装判断の散文メモ）

## システム図

```mermaid
flowchart TD
    IPC[IPC invoke remove_link] --> LOCK[ENTER: check_tasks_cache_lock<br/>write_ignore.is_empty]
    LOCK -->|ok| PROJ[RESOLVE_PROJECT]
    PROJ -->|None| ERR1[Err NoProjectOpen]
    PROJ -->|Some root| INT[INTENT: args.into_intent<br/>path normalize]
    INT -->|src ng| ERR2[Err SourceNotFound]
    INT -->|tgt ng| ERR3[Err InvalidTargetPath]
    INT -->|ok| SNAP[SNAPSHOT + FIND source]
    SNAP -->|miss| ERR2
    SNAP -->|found| READ[READ + PARSE source]
    READ -->|parse err| ERR4[Err ParseFailed]
    READ -->|Parsed| PLAN["PLAN_REMOVE_LINK aggregate pure<br/>normalize target + retain links"]
    PLAN -->|含有あり| WRITE[WRITE_OUTCOME]
    PLAN -->|未含有| NOOP[NoOp: return existing]
    WRITE --> REG[write_ignore.register]
    REG --> IOW[io.write_existing]
    IOW -->|err| UNREG1[unregister → Err]
    IOW -->|ok| COMMIT["COMMIT_CACHE<br/>source 存在確認 + 上書き<br/>target.reverse_links.retain"]
    COMMIT -->|SourceVanished| UNREG2[unregister → Err]
    COMMIT -->|ok| DONE[return Task]
    NOOP --> DONE

    style PLAN fill:#cef,stroke:#36c,color:#000
    style NOOP fill:#fec,stroke:#c63,color:#000
    style COMMIT fill:#cef,stroke:#36c,color:#000
```

`add_link` との差分は黄色 (`NoOp`) と青 (`PLAN_REMOVE_LINK` / `COMMIT_CACHE`):
- target が aggregate / cache に居なくても fail にしない（dangling link 掃除）
- self-link チェックなし
- 重複登録は `retain` で完全一致全削除
- `commit_cache` の戻り値は target update 後に cache から再取得（self-link 時の reverse_links 不整合回避）

## 関連Issue

Refs #93

## テスト

- `cargo test -p spec-board task::remove_link` — 14 件 green
  - aggregate `plan_remove_link_tests` — 7 件
  - `args::args_tests` — 5 件
  - `command::command_tests` — 9 件（うち `self_link_removal_returns_updated_reverse_links` は Codex review 指摘での回帰テスト）
- `cargo test -p spec-board` 全体 — **581 件 / 0 failed**（既存 add_link / update_task / create_task / delete_task の回帰なし）
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo check -p spec-board-fs`（サブクレート影響なし）✅

UI 変更なしのため Tauri アプリでの動作確認は省略。FE 結線は別 Issue で対応予定。

## レビューポイント

- **aggregate 中心の 2 段構成**: `TaskIndex::plan_remove_link` に invariant 検証と pure ロジックを集約し、effect 層 `remove_link_impl` は I/O / lock / write_ignore のみを担当。`add_link` / `plan_create` / `plan_update` パターンを完全踏襲。
- **`RemoveLinkError` を `AddLinkError` と別 enum にした理由**: 縮小集合（`TargetNotFound` / `SelfLink` / `TargetVanished` 不要）+ 新規バリアント `InvalidTargetPath` が必要なため。意味の混同回避目的で `RemoveLinkIntent` も別型。
- **target 実在検証なし**: dangling link 掃除を許容するために意図的に検証を外している（`add_link` との非対称）。`succeeds_when_target_missing_from_cache` テストで担保。
- **self-link 戻り値整合性**: AI レビュー (Codex) 指摘により `commit_cache` 内で target update 後に source を cache から再取得する設計に変更。`self_link_removal_returns_updated_reverse_links` で回帰防止。
- **lock 順契約**: `project_path → config → tasks_cache → watcher_handle → write_ignore` を遵守。`register → write → (失敗時 unregister)` パターンも既存と同型。