### PR TITLE
✨ [New Feature]: #95 [BE] get_columns Tauri command を実装

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -51,6 +51,7 @@
 //! md ファイルの走査・フロントマター抽出・`config.json` への書き出しは別レイヤの責務。
 
 pub mod column_name;
+pub mod get_columns;
 
 use log::warn;
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/config/get_columns.rs
+++ b/src-tauri/src/config/get_columns.rs
@@ -88,9 +88,6 @@ pub(crate) fn get_columns_impl(state: &AppState) -> Result<GetColumnsPayload, Ge
         "config invariant violation: columns must be non-empty"
     );
 
-    let mut columns: Vec<Column> = config.columns.clone();
-    columns.sort_by_key(|column| column.order);
-
     let done_column = config
         .resolved_done_column()
         .expect(
@@ -98,6 +95,9 @@ pub(crate) fn get_columns_impl(state: &AppState) -> Result<GetColumnsPayload, Ge
         )
         .as_str()
         .to_string();
+
+    let mut columns: Vec<Column> = config.columns;
+    columns.sort_by_key(|column| column.order);
 
     Ok(GetColumnsPayload {
         columns,

--- a/src-tauri/src/config/get_columns.rs
+++ b/src-tauri/src/config/get_columns.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use super::Column;
-use crate::state::AppState;
+use crate::state::{AppState, AppStateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,8 +21,15 @@ pub enum GetColumnsError {
     StateLockPoisoned,
 }
 
-pub(crate) fn get_columns_impl(_state: &AppState) -> Result<GetColumnsPayload, GetColumnsError> {
-    unimplemented!()
+impl From<AppStateError> for GetColumnsError {
+    fn from(_: AppStateError) -> Self {
+        GetColumnsError::StateLockPoisoned
+    }
+}
+
+pub(crate) fn get_columns_impl(state: &AppState) -> Result<GetColumnsPayload, GetColumnsError> {
+    let _config = state.config()?.ok_or(GetColumnsError::NoProjectOpen)?;
+    unimplemented!("happy path is implemented in the next cycle")
 }
 
 #[cfg(test)]

--- a/src-tauri/src/config/get_columns.rs
+++ b/src-tauri/src/config/get_columns.rs
@@ -28,8 +28,33 @@ impl From<AppStateError> for GetColumnsError {
 }
 
 pub(crate) fn get_columns_impl(state: &AppState) -> Result<GetColumnsPayload, GetColumnsError> {
-    let _config = state.config()?.ok_or(GetColumnsError::NoProjectOpen)?;
-    unimplemented!("happy path is implemented in the next cycle")
+    let config = state.config()?.ok_or(GetColumnsError::NoProjectOpen)?;
+
+    // columns 非空は `Config` aggregate 側の不変条件として
+    // `Config::load_or_default` が `EmptyColumns` で担保している。
+    // `replace_config` 経由で空注入された場合は不変条件違反のため即時 panic で
+    // 検出する（`resolved_done_column()` は done_column=Some なら columns 空でも
+    // Some を返すため、空 columns チェックを独立に行う必要がある）。
+    assert!(
+        !config.columns.is_empty(),
+        "config invariant violation: columns must be non-empty"
+    );
+
+    let mut columns: Vec<Column> = config.columns.clone();
+    columns.sort_by_key(|column| column.order);
+
+    let done_column = config
+        .resolved_done_column()
+        .expect(
+            "config invariant violation: done column must be resolvable when columns is non-empty",
+        )
+        .as_str()
+        .to_string();
+
+    Ok(GetColumnsPayload {
+        columns,
+        done_column,
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/config/get_columns.rs
+++ b/src-tauri/src/config/get_columns.rs
@@ -1,0 +1,30 @@
+//! `get_columns` Tauri command 本体（スケルトン）。
+
+use serde::Serialize;
+use thiserror::Error;
+
+use super::Column;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetColumnsPayload {
+    pub columns: Vec<Column>,
+    pub done_column: String,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GetColumnsError {
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+}
+
+pub(crate) fn get_columns_impl(_state: &AppState) -> Result<GetColumnsPayload, GetColumnsError> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+#[path = "get_columns_tests.rs"]
+mod get_columns_tests;

--- a/src-tauri/src/config/get_columns.rs
+++ b/src-tauri/src/config/get_columns.rs
@@ -1,11 +1,35 @@
-//! `get_columns` Tauri command 本体（スケルトン）。
+//! `get_columns` Tauri command 本体。
+//!
+//! `AppState.config` に commit 済みの `Config` から columns 一覧と doneColumn
+//! 名を取得し、FE のボードビュー描画用 payload として返す読み取り専用 command。
+//! `open_project` で commit された state を消費する後続 API としての位置付け
+//! で、`get_tasks` と同じ 3 段構成（エラー型 + Tauri 薄層 + impl）を採用する。
+//!
+//! columns は `order` 昇順 sort して返す（FE は受け取った順を表示順とする）。
+//! doneColumn は `Config::resolved_done_column()` を通じて、`done_column`
+//! 未設定時は `order` 最大カラム名へフォールバックさせ、必須 `String` で返す。
+//!
+//! # エラー文字列の契約
+//!
+//! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`
+//! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`
+//!
+//! `StateLockPoisoned` は `OpenProjectError` / `GetTasksError` と完全一致させる。
+//! FE 側 `TauriError.PATTERNS` 未対応のため `UNKNOWN` 分類になる。
+
+use std::sync::Arc;
 
 use serde::Serialize;
+use tauri::State;
 use thiserror::Error;
 
 use super::Column;
 use crate::state::{AppState, AppStateError};
 
+/// `get_columns` コマンドが FE へ返す payload。
+///
+/// `columns` は `order` 昇順 sort 済み。`doneColumn` は
+/// `Config::resolved_done_column()` を通じて解決された **必須**カラム名。
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetColumnsPayload {
@@ -13,10 +37,13 @@ pub struct GetColumnsPayload {
     pub done_column: String,
 }
 
+/// `get_columns` コマンドのエラー。
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum GetColumnsError {
+    /// `AppState.config` が `None`（プロジェクト未オープン）。
     #[error("プロジェクトが開かれていません")]
     NoProjectOpen,
+    /// `AppState` 内部 mutex (`config`) が poison 状態。
     #[error("内部状態のロックが破損しました")]
     StateLockPoisoned,
 }
@@ -27,6 +54,27 @@ impl From<AppStateError> for GetColumnsError {
     }
 }
 
+/// Tauri command 薄層。`get_columns_impl` を呼び、エラーを文字列化して返す。
+///
+/// # Errors
+///
+/// - プロジェクト未オープン時に `"プロジェクトが開かれていません"`
+/// - `config` の `Mutex` が poison している場合に
+///   `"内部状態のロックが破損しました"`
+#[tauri::command]
+pub fn get_columns(state: State<'_, Arc<AppState>>) -> Result<GetColumnsPayload, String> {
+    get_columns_impl(state.inner()).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の本体関数。
+///
+/// `AppState::config` から `Config` を取得し、columns を `order` 昇順に sort、
+/// doneColumn を `Config::resolved_done_column()` で解決して payload を組み立てる。
+///
+/// # Errors
+///
+/// - `AppState.config` が `None` の場合 `GetColumnsError::NoProjectOpen`
+/// - `config` の `Mutex` が poison している場合 `GetColumnsError::StateLockPoisoned`
 pub(crate) fn get_columns_impl(state: &AppState) -> Result<GetColumnsPayload, GetColumnsError> {
     let config = state.config()?.ok_or(GetColumnsError::NoProjectOpen)?;
 

--- a/src-tauri/src/config/get_columns_tests.rs
+++ b/src-tauri/src/config/get_columns_tests.rs
@@ -1,9 +1,48 @@
-use super::{get_columns_impl, GetColumnsError};
+use std::collections::BTreeMap;
+
+use super::{get_columns_impl, GetColumnsError, GetColumnsPayload};
+use crate::config::column_name::ColumnName;
+use crate::config::{Column, Config};
 use crate::state::AppState;
+
+fn column(name: &str, order: u32) -> Column {
+    Column {
+        name: ColumnName::from(name),
+        order,
+    }
+}
+
+fn make_config(columns: Vec<Column>, done_column: Option<ColumnName>) -> Config {
+    Config {
+        version: 1,
+        columns,
+        card_order: BTreeMap::new(),
+        done_column,
+    }
+}
 
 #[test]
 fn returns_err_when_no_project_open() {
     let state = AppState::new();
     let err = get_columns_impl(&state).expect_err("config 未注入時は Err");
     assert_eq!(err, GetColumnsError::NoProjectOpen);
+}
+
+#[test]
+fn returns_columns_with_explicit_done_column() {
+    let state = AppState::new();
+    let cfg = make_config(
+        vec![column("Todo", 0), column("Doing", 1), column("Done", 2)],
+        Some(ColumnName::from("Done")),
+    );
+    state.replace_config(Some(cfg)).expect("writable");
+
+    let payload = get_columns_impl(&state).expect("正常系");
+    assert_eq!(
+        payload,
+        GetColumnsPayload {
+            columns: vec![column("Todo", 0), column("Doing", 1), column("Done", 2)],
+            done_column: "Done".to_string(),
+        }
+    );
 }

--- a/src-tauri/src/config/get_columns_tests.rs
+++ b/src-tauri/src/config/get_columns_tests.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use super::{get_columns_impl, GetColumnsError, GetColumnsPayload};
 use crate::config::column_name::ColumnName;
 use crate::config::{Column, Config};
-use crate::state::AppState;
+use crate::state::{AppState, AppStateError};
 
 fn column(name: &str, order: u32) -> Column {
     Column {
@@ -45,4 +45,68 @@ fn returns_columns_with_explicit_done_column() {
             done_column: "Done".to_string(),
         }
     );
+}
+
+#[test]
+fn returns_columns_sorted_by_order() {
+    let state = AppState::new();
+    let cfg = make_config(
+        vec![column("Done", 2), column("Todo", 0), column("Doing", 1)],
+        Some(ColumnName::from("Done")),
+    );
+    state.replace_config(Some(cfg)).expect("writable");
+
+    let payload = get_columns_impl(&state).expect("正常系");
+    let names: Vec<String> = payload
+        .columns
+        .iter()
+        .map(|c| c.name.to_string())
+        .collect();
+    assert_eq!(names, vec!["Todo", "Doing", "Done"]);
+}
+
+#[test]
+fn falls_back_to_order_max_column_when_done_column_is_none() {
+    let state = AppState::new();
+    // 入力順を崩し、配列末尾 != order 最大としておくことで
+    // 実装が誤って `columns.last()` を返すと検出できる。
+    let cfg = make_config(
+        vec![column("Archive", 5), column("Todo", 0), column("Doing", 1)],
+        None,
+    );
+    state.replace_config(Some(cfg)).expect("writable");
+
+    let payload = get_columns_impl(&state).expect("正常系");
+    assert_eq!(payload.done_column, "Archive");
+}
+
+#[test]
+fn state_lock_poisoned_display_matches_contract() {
+    assert_eq!(
+        GetColumnsError::StateLockPoisoned.to_string(),
+        "内部状態のロックが破損しました"
+    );
+    assert_eq!(
+        GetColumnsError::NoProjectOpen.to_string(),
+        "プロジェクトが開かれていません"
+    );
+}
+
+#[test]
+fn from_app_state_error_maps_to_state_lock_poisoned() {
+    let err: GetColumnsError = AppStateError::LockPoisoned.into();
+    assert_eq!(err, GetColumnsError::StateLockPoisoned);
+}
+
+#[test]
+#[should_panic(expected = "config invariant violation: columns must be non-empty")]
+fn panics_when_columns_empty_even_if_done_column_is_some() {
+    let state = AppState::new();
+    // columns: [] かつ done_column: Some(_) では `resolved_done_column()` が
+    // `Some` を返してしまうため、空 columns チェックは `assert!` で独立に行う
+    // 必要がある。本テストはその不変条件防御の回帰を防ぐ。
+    let cfg = make_config(vec![], Some(ColumnName::from("Done")));
+    state.replace_config(Some(cfg)).expect("writable");
+
+    let _ = get_columns_impl(&state);
 }

--- a/src-tauri/src/config/get_columns_tests.rs
+++ b/src-tauri/src/config/get_columns_tests.rs
@@ -57,11 +57,7 @@ fn returns_columns_sorted_by_order() {
     state.replace_config(Some(cfg)).expect("writable");
 
     let payload = get_columns_impl(&state).expect("正常系");
-    let names: Vec<String> = payload
-        .columns
-        .iter()
-        .map(|c| c.name.to_string())
-        .collect();
+    let names: Vec<String> = payload.columns.iter().map(|c| c.name.to_string()).collect();
     assert_eq!(names, vec!["Todo", "Doing", "Done"]);
 }
 

--- a/src-tauri/src/config/get_columns_tests.rs
+++ b/src-tauri/src/config/get_columns_tests.rs
@@ -1,0 +1,9 @@
+use super::{get_columns_impl, GetColumnsError};
+use crate::state::AppState;
+
+#[test]
+fn returns_err_when_no_project_open() {
+    let state = AppState::new();
+    let err = get_columns_impl(&state).expect_err("config 未注入時は Err");
+    assert_eq!(err, GetColumnsError::NoProjectOpen);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,7 +36,8 @@ pub fn run() {
             task::create::create_task,
             task::update::update_task,
             task::add_link::add_link,
-            task::remove_link::remove_link
+            task::remove_link::remove_link,
+            config::get_columns::get_columns
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## 概要

ボードビュー描画に必要な `columns` 一覧 + `doneColumn` 名を返す読み取り専用 Tauri command `get_columns` を新規実装。`AppState.config` から `Config` を取得し、`order` 昇順 sort + `Config::resolved_done_column()` 解決を経て payload を組み立てる。FE 側 `useProject.openProject` が `openProject` 成功直後に `get_columns` invoke 失敗で常に bailout していた状態を解消する。

## 変更の種類

- ✨ New Feature [BE]

## 追加した内容

- `src-tauri/src/config/get_columns.rs` — `GetColumnsPayload` / `GetColumnsError` / `get_columns`（Tauri 薄層）/ `get_columns_impl`（effect 境界）
- `src-tauri/src/config/get_columns_tests.rs` — テスト 7 件（うち 1 件は `#[should_panic]` で空 columns 不変条件防御）

## 変更した内容

- `src-tauri/src/config.rs` — `pub mod get_columns;` 追加
- `src-tauri/src/lib.rs` — `invoke_handler!` 末尾に `config::get_columns::get_columns` を登録（trailing comma なし）

## 仕様ドキュメント更新

**不要**。`docs/spec-board/config-spec.md` の `get_columns` 仕様セクション (L216-232) と実装挙動が一致しており、`doneColumn` 採用規則 + `order` 昇順返却は既存仕様 + `Config::resolved_done_column()` への委譲で担保される。新規挙動の導入はなし。

## システム図

```mermaid
flowchart LR
    FE["FE<br/>invoke('get_columns')"] -- IPC --> Handler["invoke_handler"]
    Handler --> Shim["get_columns<br/>(Tauri 薄層)"]
    Shim --> Impl["get_columns_impl<br/>(effect 境界)"]
    Impl --> Config{"AppState.config"}
    Config -- None --> NoProj["Err(NoProjectOpen)"]
    Config -- "Some(Config)" --> Assert["assert!(columns 非空)"]
    Assert --> Sort["columns.clone()<br/>+ sort_by_key(order)"]
    Sort --> Resolve["Config::resolved_done_column()"]
    Resolve --> Payload["Ok(GetColumnsPayload<br/>{ columns, doneColumn })"]
    Impl -. lock poison .-> Poison["Err(StateLockPoisoned)"]

    style Shim fill:#e0f7fa,stroke:#00838f
    style Impl fill:#e0f7fa,stroke:#00838f
    style Assert fill:#fff3e0,stroke:#ef6c00
    style Payload fill:#e8f5e9,stroke:#2e7d32
```

## 関連Issue

Closes #95

## テスト

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ 警告ゼロ
- `cargo test --workspace` ✅ spec-board lib 588 件 / spec-board-fs 116 件すべて pass（新規 7 件含む）

新規テスト一覧（`src-tauri/src/config/get_columns_tests.rs`）:

| # | テスト名 | 観点 |
|:-:|:--|:--|
| 1 | `returns_err_when_no_project_open` | `AppState.config = None` → `NoProjectOpen` |
| 2 | `returns_columns_with_explicit_done_column` | explicit `done_column` の素通し + payload 全体一致 |
| 3 | `returns_columns_sorted_by_order` | 入力逆順 → 出力 `order` 昇順 |
| 4 | `falls_back_to_order_max_column_when_done_column_is_none` | 配列末尾 ≠ order 最大の入力で fallback 検証（`columns.last()` 誤実装も検出可） |
| 5 | `state_lock_poisoned_display_matches_contract` | エラー文字列 2 種が既存 command と一致 |
| 6 | `from_app_state_error_maps_to_state_lock_poisoned` | `From<AppStateError>` 単体マッピング |
| 7 | `panics_when_columns_empty_even_if_done_column_is_some` | `columns: []` 注入時に `assert!` panic（不変条件回帰防止、`#[should_panic]`） |

`pnpm tauri dev` での FE 統合動作確認は手動レビュー時にお願いします（自動 CI 範囲外）。

## レビューポイント

- **設計方針**: `get_tasks` と同じ 3 段構成（エラー型 + Tauri 薄層 + impl）。`task_index.rs` の `plan_xxx` のような aggregate method 切り出しは行わず、aggregate（`Config`）の既存 `resolved_done_column()` を application 層 (`get_columns_impl`) から呼ぶだけのドメイン中心構成（過剰設計を回避）
- **エラー文字列契約**: `NoProjectOpen` / `StateLockPoisoned` の Display を `OpenProjectError` / `GetTasksError` と完全一致させ、FE 側 `TauriError.PATTERNS` の `UNKNOWN` 分類に統一
- **不変条件防御**: `Config::resolved_done_column()` は `done_column = Some(_)` のとき columns 空でも `Some` を返してしまうため、`get_columns_impl` 冒頭で `assert!(!config.columns.is_empty(), ...)` を独立に行い `replace_config` 経由の空注入を即時 panic で検出
- **doneColumn fallback テスト**: 配列順を `[Archive(5), Todo(0), Doing(1)]` のように崩し、`columns.last()` の誤実装も検出できる構成
- **invoke_handler 登録順**: trailing comma を付けないスタイルを既存に合わせて維持