### PR TITLE
✨ [New Feature]: #119 [FE] useTaskCreate フック新設 + invoke 接続

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,11 @@ import {
   useProject,
 } from "./features/board";
 import { DetailPanel } from "./features/detail";
-import { TaskCreateModal, type TaskFormValues } from "./features/task-form";
+import {
+  TaskCreateModal,
+  type TaskFormValues,
+  useTaskCreate,
+} from "./features/task-form";
 import type { Column } from "./types/column";
 import type { Task } from "./types/task";
 
@@ -99,6 +103,7 @@ export const App = () => {
       showToast(projectErrorMessage(err), "error");
     },
   });
+  const { submit: submitCreateTask } = useTaskCreate({ createTask });
 
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [createModalStatus, setCreateModalStatus] = useState<string | null>(
@@ -389,7 +394,7 @@ export const App = () => {
 
   const handleCreateTask = useCallback(
     async (values: TaskFormValues): Promise<void> => {
-      const result = await createTask(values);
+      const result = await submitCreateTask(values);
       if (!result.ok) {
         // モーダルを閉じない: TaskCreateModal は onSubmit reject で開いたままになる
         const message = projectErrorMessage(result.error);
@@ -398,7 +403,7 @@ export const App = () => {
       }
       showToast("タスクを作成しました", "success");
     },
-    [createTask, showToast],
+    [submitCreateTask, showToast],
   );
 
   const handleTaskDrop = useCallback(

--- a/src/features/board/hooks/useProject/index.ts
+++ b/src/features/board/hooks/useProject/index.ts
@@ -46,7 +46,7 @@ import type {
 } from "./types";
 
 export { PROJECT_SWITCHED_MESSAGE } from "./actions/updateColumns";
-export type { ProjectError } from "./errors";
+export { ProjectError } from "./errors";
 export type { ProjectData, ProjectState } from "./reducer";
 export type {
   ColumnsCommand,

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -7,7 +7,6 @@ export type {
   MoveTaskCallbacks,
   MoveTaskParams,
   ProjectData,
-  ProjectError,
   ProjectState,
   ReorderColumnsCallbacks,
   ReorderColumnsEvent,
@@ -17,4 +16,8 @@ export type {
   UseProjectOptions,
   UseProjectResult,
 } from "./hooks/useProject";
-export { PROJECT_SWITCHED_MESSAGE, useProject } from "./hooks/useProject";
+export {
+  PROJECT_SWITCHED_MESSAGE,
+  ProjectError,
+  useProject,
+} from "./hooks/useProject";

--- a/src/features/task-form/hooks/useTaskCreate/__tests__/useTaskCreate.behavior.test.tsx
+++ b/src/features/task-form/hooks/useTaskCreate/__tests__/useTaskCreate.behavior.test.tsx
@@ -1,0 +1,249 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, expect, test, vi } from "vitest";
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+let hadIsReactActEnvironment = false;
+
+beforeAll(() => {
+  hadIsReactActEnvironment =
+    "IS_REACT_ACT_ENVIRONMENT" in reactActEnvironmentGlobal;
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+  const keysToDelete = hadIsReactActEnvironment
+    ? []
+    : (["IS_REACT_ACT_ENVIRONMENT"] as const);
+  for (const key of keysToDelete) {
+    Reflect.deleteProperty(reactActEnvironmentGlobal, key);
+  }
+});
+
+import { ProjectError } from "@/features/board";
+import type { TaskFormValues } from "@/features/task-form/types";
+import { TauriError } from "@/lib/tauri";
+import { Task } from "@/types/task";
+import { Result } from "@/utils/result";
+import {
+  type UseTaskCreateOptions,
+  type UseTaskCreateResult,
+  useTaskCreate,
+} from "../index";
+
+const taskFixture = Task.fromPayload({
+  id: "task-1",
+  title: "fixture",
+  status: "TODO",
+  labels: [],
+  body: "",
+  filePath: "/proj/tasks/task-1.md",
+  links: [],
+  children: [],
+  reverseLinks: [],
+});
+
+const valuesFixture: TaskFormValues = {
+  title: "fixture",
+  status: "TODO",
+  labels: [],
+  body: "",
+};
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+/**
+ * useTaskCreate の戻り値を観測する Probe。
+ * @param props フック引数 + 観測コールバック
+ * @returns null
+ */
+const Probe = (
+  props: UseTaskCreateOptions & {
+    onResult: (r: UseTaskCreateResult) => void;
+  },
+) => {
+  const { onResult, ...args } = props;
+  const result = useTaskCreate(args);
+  useEffect(() => {
+    onResult(result);
+  });
+  return null;
+};
+
+/**
+ * Probe をマウントし、最新戻り値にアクセスする accessor を返す。
+ * @param args useTaskCreate の引数
+ * @returns latest accessor
+ */
+const renderHook = (args: UseTaskCreateOptions) => {
+  let latest: UseTaskCreateResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      createElement(Probe, {
+        ...args,
+        onResult: (r) => {
+          latest = r;
+        },
+      }),
+    );
+  });
+  return {
+    get latest(): UseTaskCreateResult {
+      return latest as UseTaskCreateResult;
+    },
+  };
+};
+
+test("T1: 初期 state は isSubmitting=false で submit が関数である", () => {
+  const probe = renderHook({ createTask: vi.fn() });
+  expect(probe.latest.isSubmitting).toBe(false);
+  expect(typeof probe.latest.submit).toBe("function");
+});
+
+test("T2: 成功時に Result.ok が pass-through され、isSubmitting が true→false で遷移する", async () => {
+  let resolveCreate!: (
+    r: Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>,
+  ) => void;
+  const createTask = vi.fn(
+    () =>
+      new Promise<Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>>(
+        (r) => {
+          resolveCreate = r;
+        },
+      ),
+  );
+  const probe = renderHook({ createTask });
+
+  let pending!: ReturnType<UseTaskCreateResult["submit"]>;
+  act(() => {
+    pending = probe.latest.submit(valuesFixture);
+  });
+  expect(probe.latest.isSubmitting).toBe(true);
+
+  await act(async () => {
+    resolveCreate(Result.ok(taskFixture));
+    await pending;
+  });
+  expect(probe.latest.isSubmitting).toBe(false);
+  const result = await pending;
+  expect(result).toEqual(Result.ok(taskFixture));
+});
+
+test("T5: 送信中の再 submit は invalid-state で短絡し、createTask は 1 回しか呼ばれない", async () => {
+  let resolveCreate!: (
+    r: Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>,
+  ) => void;
+  const createTask = vi.fn(
+    () =>
+      new Promise<Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>>(
+        (r) => {
+          resolveCreate = r;
+        },
+      ),
+  );
+  const probe = renderHook({ createTask });
+
+  let first!: ReturnType<UseTaskCreateResult["submit"]>;
+  act(() => {
+    first = probe.latest.submit(valuesFixture);
+  });
+  expect(probe.latest.isSubmitting).toBe(true);
+
+  let second!: Awaited<ReturnType<UseTaskCreateResult["submit"]>>;
+  await act(async () => {
+    second = await probe.latest.submit(valuesFixture);
+  });
+  expect(second).toEqual(Result.err(ProjectError.invalidState("送信中です")));
+  expect(createTask).toHaveBeenCalledTimes(1);
+
+  await act(async () => {
+    resolveCreate(Result.ok(taskFixture));
+    await first;
+  });
+});
+
+test("T6: 1 回目完了後の再 submit は再度 createTask を呼んで Result.ok を返す", async () => {
+  const createTask = vi.fn().mockResolvedValue(Result.ok(taskFixture));
+  const probe = renderHook({ createTask });
+
+  await act(async () => {
+    await probe.latest.submit(valuesFixture);
+  });
+  expect(probe.latest.isSubmitting).toBe(false);
+
+  let second!: Awaited<ReturnType<UseTaskCreateResult["submit"]>>;
+  await act(async () => {
+    second = await probe.latest.submit(valuesFixture);
+  });
+  expect(second).toEqual(Result.ok(taskFixture));
+  expect(createTask).toHaveBeenCalledTimes(2);
+});
+
+test("T4: 失敗時に Result.err が pass-through され、finally で isSubmitting が false に戻る", async () => {
+  const tauriErrorFixture = TauriError.from("見つかりません");
+  const projectErrorFixture = ProjectError.tauri(tauriErrorFixture);
+  const createTask = vi.fn().mockResolvedValue(Result.err(projectErrorFixture));
+  const probe = renderHook({ createTask });
+
+  let result!: Awaited<ReturnType<UseTaskCreateResult["submit"]>>;
+  await act(async () => {
+    result = await probe.latest.submit(valuesFixture);
+  });
+  expect(result).toEqual(Result.err(projectErrorFixture));
+  expect(probe.latest.isSubmitting).toBe(false);
+});
+
+test("T7: injected createTask が reject すると submit も reject し、isSubmitting が false に戻る", async () => {
+  const boom = new Error("boom");
+  const createTask = vi.fn().mockRejectedValueOnce(boom);
+  const probe = renderHook({ createTask });
+
+  await act(async () => {
+    await expect(probe.latest.submit(valuesFixture)).rejects.toThrow("boom");
+  });
+  expect(probe.latest.isSubmitting).toBe(false);
+});
+
+test("T3: TaskFormValues が CreateTaskParams にそのまま pass-through される", async () => {
+  const createTask = vi.fn().mockResolvedValue(Result.ok(taskFixture));
+  const probe = renderHook({ createTask });
+  const values: TaskFormValues = {
+    title: "T",
+    status: "TODO",
+    labels: [],
+    body: "",
+  };
+  await act(async () => {
+    await probe.latest.submit(values);
+  });
+  expect(createTask).toHaveBeenCalledTimes(1);
+  expect(createTask).toHaveBeenCalledWith({
+    title: "T",
+    status: "TODO",
+    priority: undefined,
+    labels: [],
+    parent: undefined,
+    body: "",
+  });
+});

--- a/src/features/task-form/hooks/useTaskCreate/index.ts
+++ b/src/features/task-form/hooks/useTaskCreate/index.ts
@@ -1,0 +1,75 @@
+import { useCallback, useState } from "react";
+import { ProjectError } from "@/features/board";
+import type { TaskFormValues } from "@/features/task-form/types";
+import type { CreateTaskParams } from "@/lib/tauri";
+import type { Task } from "@/types/task";
+import { Result } from "@/utils/result";
+
+export type UseTaskCreateOptions = {
+  /**
+   * 実行する create 関数。通常は useProject().createTask を渡す。
+   * 引数で受けることで queue / projectVersion 保護を流用しつつ、
+   * hook 自体を toast / modal 非依存に保つ。
+   * @param params create_task に渡すパラメータ
+   * @returns 成功時 Task、失敗時 ProjectError を含む Result
+   */
+  createTask: (params: CreateTaskParams) => Promise<Result<Task, ProjectError>>;
+};
+
+export type UseTaskCreateResult = {
+  /**
+   * フォーム値を CreateTaskParams に変換し createTask を呼ぶ。
+   * 送信中は isSubmitting=true。
+   * injected createTask が契約通り Result を返す限り throw しない。
+   * 契約違反（reject/throw）時は finally で isSubmitting を戻したうえで再 throw する。
+   * 送信中の再呼び出しは Result.err(invalidState) で短絡する。
+   * @param values TaskCreateModal が submit したフォーム値
+   * @returns 成功時 Task、失敗時 ProjectError を含む Result
+   */
+  submit: (values: TaskFormValues) => Promise<Result<Task, ProjectError>>;
+  /** 送信中フラグ。表示専用。 */
+  isSubmitting: boolean;
+};
+
+/**
+ * TaskFormValues を BE 仕様の CreateTaskParams にそのまま pass-through する。
+ * @param values フォーム値
+ * @returns BE invoke 用のパラメータ
+ */
+const toCreateTaskParams = (values: TaskFormValues): CreateTaskParams => ({
+  title: values.title,
+  status: values.status,
+  priority: values.priority,
+  labels: values.labels,
+  parent: values.parent,
+  body: values.body,
+});
+
+/**
+ * タスク作成 invoke を呼び出すパラメトリックフック。
+ * @param options createTask を含む依存
+ * @returns submit 関数と isSubmitting フラグ
+ */
+export const useTaskCreate = (
+  options: UseTaskCreateOptions,
+): UseTaskCreateResult => {
+  const { createTask } = options;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const submit = useCallback(
+    async (values: TaskFormValues): Promise<Result<Task, ProjectError>> => {
+      if (isSubmitting) {
+        return Result.err(ProjectError.invalidState("送信中です"));
+      }
+      setIsSubmitting(true);
+      try {
+        return await createTask(toCreateTaskParams(values));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [createTask, isSubmitting],
+  );
+
+  return { submit, isSubmitting };
+};

--- a/src/features/task-form/index.ts
+++ b/src/features/task-form/index.ts
@@ -1,2 +1,7 @@
 export { TaskCreateModal } from "./components/TaskCreateModal";
+export type {
+  UseTaskCreateOptions,
+  UseTaskCreateResult,
+} from "./hooks/useTaskCreate";
+export { useTaskCreate } from "./hooks/useTaskCreate";
 export type { TaskFormValues } from "./types";


### PR DESCRIPTION
## 概要

`App.tsx` に直書きされていた `handleCreateTask`（タスク作成の invoke 呼び出し + Result ハンドリング）を、再利用可能なカスタムフック `useTaskCreate` として `src/features/task-form/hooks/useTaskCreate/` に切り出した。

## 変更の種類

- ✨ 新機能 (`useTaskCreate` フック新設)
- ♻️ リファクタリング (App.tsx 結線置換 / `ProjectError` value 公開)
- 🧪 テスト (Probe pattern による T1-T7 の hook 単体テスト)

## 追加した内容

- `src/features/task-form/hooks/useTaskCreate/index.ts` — `useTaskCreate` 本体（`{ submit, isSubmitting }` を返すパラメトリック hook）
- `src/features/task-form/hooks/useTaskCreate/__tests__/useTaskCreate.behavior.test.tsx` — Probe pattern による単体テスト 7 ケース（T1-T7）

## 変更した内容

- `src/features/board/hooks/useProject/index.ts` / `src/features/board/index.ts` — `ProjectError` を value+type 兼用 export に切替（useTaskCreate から `ProjectError.invalidState(...)` を value 参照可能にするため）
- `src/features/task-form/index.ts` — `useTaskCreate` / `UseTaskCreateOptions` / `UseTaskCreateResult` を re-export
- `src/App.tsx` — `handleCreateTask` の本体を `useTaskCreate({ createTask })` から取り出した `submitCreateTask` に委譲

## 仕様ドキュメント更新

不要（純粋な内部リファクタリング / 責務分離）。公開仕様・データ形式・画面挙動・設定項目に変更なし。

## システム図

### useTaskCreate.submit のデータフロー

```mermaid
flowchart TD
    Modal[TaskCreateModal] -->|onSubmit values| App[App.handleCreateTask]
    App -->|submitCreateTask values| Submit[useTaskCreate.submit]
    Submit -->|isSubmitting=true なら<br/>Result.err invalidState で短絡| ShortCircuit[早期 return]
    Submit -->|setIsSubmitting true| Create[injected createTask<br/>= useProject.createTask]
    Create -->|enqueue + invoke| BE[Tauri create_task]
    BE -->|Result Task ProjectError| Create
    Create --> Finally[finally:<br/>setIsSubmitting false]
    Finally --> App
    App -->|ok| ToastOk[showToast 成功]
    App -->|err| ToastErr[showToast 失敗 + throw]

    style Submit fill:#fff3b0,stroke:#333
    style ShortCircuit fill:#ffd6d6,stroke:#933
```

> hook 層は **render またぎ** の double-submit ガード（state ベース）のみを担当。UI 段の多重クリック防止は `TaskCreateModal` の `submittingRef` が第一防壁。

## 関連Issue

Closes #119

## テスト

- `pnpm typecheck`: ✅ pass
- `pnpm lint` (oxlint): ✅ 0 warnings / 0 errors
- `pnpm exec biome check src`: ✅ no fixes applied
- `pnpm test:run`: ✅ 96 files / **832 tests** pass
  - `useTaskCreate.behavior.test.tsx`: T1-T7 全 7 ケース pass
  - `App.interaction.test.tsx`: 既存 19 ケース pass（リグレッションなし）
- AI レビュー (Codex CLI): **問題なし**

## レビューポイント

1. **`createTask` を DI で受ける設計** — `useTaskCreate` が `useProject` を直接呼ばず引数で受け取る理由は実装計画 §4-1 参照。queue / projectVersion 保護を流用しつつ hook 自体を toast / modal 非依存に保つトレードオフ。
2. **double-submit の防衛境界** — hook の `isSubmitting` ガードは render またぎの保険であり、同期 race（同一 closure での await なし連続呼び出し）は守らない仕様。重複作成防止の第一防壁は `TaskCreateModal.submittingRef`（`enqueueProjectCommand` は直列化のみで重複作成は防がない）。
3. **`ProjectError` を features/board の value export 化** — feature 境界規約を維持しつつ `ProjectError.invalidState(...)` を value 参照するための変更。既存利用箇所（type のみ参照）は無回帰。
4. **App.tsx の命名衝突回避** — `useProject().createTask` と命名衝突しないよう hook 戻り値を `submit` 名にして App 側で `submitCreateTask` に alias。`isSubmitting` は本 PR では UI 接続しないため destructure しない（`noUnusedLocals=true` 対策）。