### PR TITLE
✨ [New Feature]: #99 [BE] update_card_order Tauri command を実装

### DIFF
--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -280,12 +280,13 @@ links:（任意）
 3. 既存キーがあれば**上書き**、無ければ**新規追加**として `cardOrder` に書き込む
 4. 書き込みは tmp → rename ベース（Unix では `rename(2)` の atomic 置換、Windows では既存ファイル上書き時に backup 経由の 2 段 rename にフォールバック）で行い、`config.json` 自体が中途半端な内容になる部分書き込みを防止する
 5. `.spec-board/` ディレクトリは watcher の拡張子フィルタで除外されるため、本書き込みによって FE への変更通知（emit）は走らない
-6. disk への書き込みが成功した後に AppState の `Config` を更新する。disk 失敗時は in-memory の `Config` を変更しない（次回呼び出しで再試行可能）
+6. disk への書き込みが成功した場合、`project_path` が処理開始時の snapshot と一致するときに限り AppState の `Config` を更新する。disk 失敗時は in-memory の `Config` を変更しない（次回呼び出しで再試行可能）
 
 **並行性**:
 
 - **逐次**呼び出し（前の呼び出しが完了してから次が始まる場合）は、最後の呼び出しの結果が最終的に保存される（後勝ち）。
-- **並行**呼び出し時の厳密な整合性は本機能では保証しない。実装上は `state.config()? → mutate → disk write → replace_config` が連続した 2 つの config lock 取得で構成されるため、その間に別 writer が割り込むと古い snapshot で disk が上書きされる race window が残る。本ケースは現状の DnD UX 上の問題が観測されていないため受容しており、将来 `AppState::with_config_mut` のような atomic update helper を導入した時点で改善する。
+- **`open_project` との並行**: 処理開始時に `project_path` と `config` を**両 lock 同時保持下で atomic に snapshot** し、disk write 後の in-memory 更新も**両 lock 同時保持下で `project_path` の一致確認 + `config` 更新の atomic check-and-set** として行う。これにより `open_project` の commit と interleave しても「新 path + 旧 config」を観測する race や、旧プロジェクトの config を新プロジェクトの in-memory state に注入する race は発生しない。snapshot 取得後に project が swap された場合、disk write は旧プロジェクトの `.spec-board/config.json` に対して整合的に完了し、新プロジェクトの in-memory 更新は no-op となる。
+- **同一プロジェクト内での `update_card_order` 並行**呼び出し時の厳密な整合性は本機能では保証しない。`snapshot_project_and_config` から `replace_config_if_project_matches` までは 2 回の lock 取得に分かれているため、間に別の `update_card_order` 呼び出しが完了すると、後勝ちの disk 書き込みより前に取得した snapshot で disk が上書きされる race window が残る。本ケースは現状の DnD UX 上の問題が観測されていないため受容しており、将来 `AppState::with_config_mut` のような atomic update helper を導入した時点で改善する。
 
 ## エラーハンドリング
 

--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -275,8 +275,17 @@ links:（任意）
 | filePaths | `Vec<String>` | はい | 新しい並び順のファイルパス配列 |
 
 **振る舞い**:
-1. `config.json` の `cardOrder[columnName]` を `filePaths` で上書き
-2. 更新後の設定を保存
+1. `columnName` が `columns[]` に存在しない場合は更新を拒否し、`config.json` を変更しない（エラー文字列: `カラムが見つかりません: {columnName}`）
+2. `filePaths` は FE が事前に正規化した結果をそのまま `cardOrder[columnName]` に保存する。バックエンド側では未存在ファイルパスの除外などのフィルタを行わない
+3. 既存キーがあれば**上書き**、無ければ**新規追加**として `cardOrder` に書き込む
+4. 書き込みは tmp → rename ベース（Unix では `rename(2)` の atomic 置換、Windows では既存ファイル上書き時に backup 経由の 2 段 rename にフォールバック）で行い、`config.json` 自体が中途半端な内容になる部分書き込みを防止する
+5. `.spec-board/` ディレクトリは watcher の拡張子フィルタで除外されるため、本書き込みによって FE への変更通知（emit）は走らない
+6. disk への書き込みが成功した後に AppState の `Config` を更新する。disk 失敗時は in-memory の `Config` を変更しない（次回呼び出しで再試行可能）
+
+**並行性**:
+
+- **逐次**呼び出し（前の呼び出しが完了してから次が始まる場合）は、最後の呼び出しの結果が最終的に保存される（後勝ち）。
+- **並行**呼び出し時の厳密な整合性は本機能では保証しない。実装上は `state.config()? → mutate → disk write → replace_config` が連続した 2 つの config lock 取得で構成されるため、その間に別 writer が割り込むと古い snapshot で disk が上書きされる race window が残る。本ケースは現状の DnD UX 上の問題が観測されていないため受容しており、将来 `AppState::with_config_mut` のような atomic update helper を導入した時点で改善する。
 
 ## エラーハンドリング
 

--- a/src-tauri/crates/fs/src/config/config_io.rs
+++ b/src-tauri/crates/fs/src/config/config_io.rs
@@ -12,12 +12,14 @@
 //! - [`ensure_spec_board_dir`]: `<project_root>/.spec-board/` を冪等に作成
 //! - [`read_config_json`]: `<project_root>/.spec-board/config.json` の中身を文字列で返す
 //!   （ファイル不在は `Ok(None)`）
+//! - [`write_config_json`]: `<project_root>/.spec-board/config.json` へ文字列を書き込む
+//!   （tmp → rename ベース、symlink 拒否）
 //! - [`guide_markdown_path`]: `<project_root>/.spec-board/GUIDE.md` のパスを返す
 //! - [`write_guide_markdown`]: `<project_root>/.spec-board/GUIDE.md` へ文字列を書き込む
 //!
 //! # スコープ外
 //!
-//! - `config.json` の書き出し（atomic write / `.bak` 退避）は別モジュール / 別 Issue
+//! - `.bak` への退避 / version migration（本体クレート側で実施）
 //! - JSON のパース / シリアライズは本体クレート側
 
 use std::io::Write as _;
@@ -31,6 +33,7 @@ const SPEC_BOARD_DIR: &str = ".spec-board";
 const CONFIG_FILE_NAME: &str = "config.json";
 const GUIDE_MARKDOWN_FILE_NAME: &str = "GUIDE.md";
 static GUIDE_MARKDOWN_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+static CONFIG_JSON_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// `config_io` モジュールのファイル I/O で発生し得るエラー。
 ///
@@ -221,6 +224,40 @@ pub fn write_guide_markdown(project_root: &Path, content: &str) -> Result<PathBu
     write_file_via_tmp(&guide_path, content, &tmp_path)?;
 
     Ok(guide_path)
+}
+
+/// `<project_root>/.spec-board/config.json` へ JSON 文字列を書き込む。
+///
+/// 書き込み前に [`ensure_spec_board_dir`] を呼び、`.spec-board/` が無い場合は作成する。
+/// 既存 `config.json` は fresh tmp file へ書いてから `rename` で置き換える。
+/// `.spec-board/` または `config.json` が symlink の場合は、project root 外のファイルを
+/// 上書きしないよう拒否する。
+///
+/// # Errors
+///
+/// - `project_root` が存在しない / ディレクトリでない / アクセスできない
+/// - `<project_root>/.spec-board` がファイルまたは symlink として存在する
+/// - `<project_root>/.spec-board/config.json` が symlink として存在する
+/// - 権限不足等で `.spec-board/` 作成または `config.json` 書き込みが失敗する
+pub fn write_config_json(project_root: &Path, content: &str) -> Result<PathBuf, ConfigIoError> {
+    let spec_board_dir = ensure_spec_board_dir(project_root)?;
+    reject_existing_symlink(&spec_board_dir)?;
+    let target = config_path(project_root);
+    reject_existing_symlink(&target)?;
+
+    let tmp_path = unique_config_json_tmp_path(&spec_board_dir);
+    write_file_via_tmp(&target, content, &tmp_path)?;
+
+    Ok(target)
+}
+
+fn unique_config_json_tmp_path(spec_board_dir: &Path) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let counter = CONFIG_JSON_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    spec_board_dir.join(format!("{CONFIG_FILE_NAME}.tmp.{pid}.{nanos}.{counter}"))
 }
 
 fn reject_existing_symlink(path: &Path) -> Result<(), ConfigIoError> {

--- a/src-tauri/crates/fs/src/config/config_io_tests.rs
+++ b/src-tauri/crates/fs/src/config/config_io_tests.rs
@@ -114,6 +114,100 @@ fn read_config_json_returns_content_when_present() {
     assert_eq!(result.as_deref(), Some(content));
 }
 
+// ───────── write_config_json ─────────
+
+#[test]
+fn write_config_json_creates_file_with_given_content() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join(".spec-board");
+    std::fs::create_dir(&dir).unwrap();
+    let content = r#"{"version":1}"#;
+
+    let path = write_config_json(tmp.path(), content).unwrap();
+
+    assert_eq!(path, dir.join("config.json"));
+    assert_eq!(std::fs::read_to_string(path).unwrap(), content);
+}
+
+#[test]
+fn write_config_json_overwrites_existing_file() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join(".spec-board");
+    std::fs::create_dir(&dir).unwrap();
+    let path = dir.join("config.json");
+    std::fs::write(&path, "old").unwrap();
+
+    let written_path = write_config_json(tmp.path(), "new").unwrap();
+
+    assert_eq!(written_path, path);
+    assert_eq!(std::fs::read_to_string(path).unwrap(), "new");
+}
+
+#[test]
+fn write_config_json_creates_spec_board_dir_when_missing() {
+    let tmp = TempDir::new().unwrap();
+    assert!(!tmp.path().join(".spec-board").exists());
+
+    let path = write_config_json(tmp.path(), "{}").unwrap();
+
+    assert_eq!(path, tmp.path().join(".spec-board").join("config.json"));
+    assert_eq!(std::fs::read_to_string(path).unwrap(), "{}");
+}
+
+#[test]
+fn write_config_json_preserves_utf8_and_newlines() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join(".spec-board");
+    std::fs::create_dir(&dir).unwrap();
+    let content = "こんにちは\n世界\r\n🦀\n";
+
+    let path = write_config_json(tmp.path(), content).unwrap();
+
+    assert_eq!(std::fs::read(path).unwrap(), content.as_bytes());
+}
+
+#[cfg(unix)]
+#[test]
+fn write_config_json_rejects_when_target_is_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let dir = tmp.path().join(".spec-board");
+    std::fs::create_dir(&dir).unwrap();
+    let target = outside.path().join("external.json");
+    std::fs::write(&target, "keep").unwrap();
+    let config_path = dir.join("config.json");
+    symlink(&target, &config_path).unwrap();
+
+    let err = write_config_json(tmp.path(), "new").unwrap_err();
+
+    let ConfigIoError::Io { path, source } = err;
+    assert_eq!(path, config_path);
+    assert_eq!(source.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(source.to_string().contains("is a symlink"));
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "keep");
+}
+
+#[cfg(unix)]
+#[test]
+fn write_config_json_rejects_spec_board_dir_symlink_without_writing_target() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let outside_config = outside.path().join("config.json");
+    symlink(outside.path(), tmp.path().join(".spec-board")).unwrap();
+
+    let err = write_config_json(tmp.path(), "new").unwrap_err();
+
+    let ConfigIoError::Io { path, source } = err;
+    assert_eq!(path, tmp.path().join(".spec-board"));
+    assert_eq!(source.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(source.to_string().contains("is a symlink"));
+    assert!(!outside_config.exists());
+}
+
 #[test]
 fn write_guide_markdown_creates_spec_board_dir_and_file_when_absent() {
     let tmp = TempDir::new().unwrap();

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -17,7 +17,7 @@
 //!
 //! # ファイル I/O の境界
 //! 低レベル I/O（`.spec-board/` の作成、`config.json` の raw 読み込み / 書き出し）は
-//! サブクレート `spec-board-fs::config_io` に集約する。本モジュールは
+//! サブクレート `spec_board_fs::config::config_io` に集約する。本モジュールは
 //! その raw 文字列を以下の経路で解釈し、薄い責務に留める:
 //!
 //! - 軽量スキーマ [`VersionOnly`] を `serde_json::from_str` で適用して `version` を

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -16,7 +16,7 @@
 //! （保存値には書き戻さない）。
 //!
 //! # ファイル I/O の境界
-//! 低レベル I/O（`.spec-board/` の作成、`config.json` の raw 読み込み）は
+//! 低レベル I/O（`.spec-board/` の作成、`config.json` の raw 読み込み / 書き出し）は
 //! サブクレート `spec-board-fs::config_io` に集約する。本モジュールは
 //! その raw 文字列を以下の経路で解釈し、薄い責務に留める:
 //!
@@ -40,11 +40,13 @@
 //! `.spec-board/GUIDE.md` への best-effort 書き込み helper を提供する。
 //! 更新タイミング制御と Tauri コマンド公開は command 層の責務。
 //!
+//! # スコープ
+//! - `update_card_order` Tauri command（`cardOrder` の上書き保存）
+//!
 //! # スコープ外（別 Issue で実装）
-//! - `config.json` の書き出し（atomic write / `.bak` 退避の永続化 / 並行書き込み制御）
+//! - `.bak` 退避の永続化 / 並行書き込みの厳密な整合性制御
 //! - `doneColumn` の整合性検証 / カラム名空間の正規化
 //! - 実フィールド変換を伴う実マイグレーション（本モジュールはフックのみ提供）
-//! - Tauri コマンド層
 //!
 //! 既存タスクの `(path, status)` 列から `Config` を組み立てる純粋関数
 //! [`build_config_from_statuses`] は本モジュールに同居する。
@@ -52,6 +54,7 @@
 
 pub mod column_name;
 pub mod get_columns;
+pub mod update_card_order;
 
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -158,6 +161,14 @@ impl Config {
             return Some(name);
         }
         self.columns.iter().max_by_key(|c| c.order).map(|c| &c.name)
+    }
+
+    /// 指定された名前のカラムが [`Self::columns`] に存在するかを返す。
+    ///
+    /// 比較は完全一致（case-sensitive）。`cardOrder` の更新前に
+    /// 「未知のカラムに対する書き込み」を弾くプリチェックとして利用する。
+    pub fn has_column(&self, name: &str) -> bool {
+        self.columns.iter().any(|c| c.name.as_str() == name)
     }
 
     /// この設定から GUIDE.md の Markdown 本文を生成する。

--- a/src-tauri/src/config/config_tests.rs
+++ b/src-tauri/src/config/config_tests.rs
@@ -1081,6 +1081,46 @@ fn validate_unique_column_names_treats_whitespace_variants_as_distinct() {
     }
 }
 
+// ───────── has_column ─────────
+
+#[test]
+fn has_column_returns_true_when_column_exists() {
+    let config = Config {
+        version: 1,
+        columns: vec![col("Todo", 0), col("In Progress", 1), col("Done", 2)],
+        card_order: BTreeMap::new(),
+        done_column: None,
+    };
+    assert!(config.has_column("Todo"));
+    assert!(config.has_column("In Progress"));
+    assert!(config.has_column("Done"));
+}
+
+#[test]
+fn has_column_returns_false_when_column_missing() {
+    let config = Config {
+        version: 1,
+        columns: vec![col("Todo", 0), col("Done", 1)],
+        card_order: BTreeMap::new(),
+        done_column: None,
+    };
+    assert!(!config.has_column("Doing"));
+    assert!(!config.has_column(""));
+}
+
+#[test]
+fn has_column_returns_false_when_case_differs() {
+    let config = Config {
+        version: 1,
+        columns: vec![col("Todo", 0)],
+        card_order: BTreeMap::new(),
+        done_column: None,
+    };
+    assert!(!config.has_column("todo"));
+    assert!(!config.has_column("TODO"));
+    assert!(config.has_column("Todo"));
+}
+
 // ───────── load_or_default (version migration) ─────────
 
 fn write_config(tmp: &TempDir, content: &str) -> PathBuf {

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -2,9 +2,10 @@
 //!
 //! フロントエンドの DnD 並び替え結果を `.spec-board/config.json` の
 //! `cardOrder[columnName]` に**上書き保存**する書き込み専用 command。
-//! `state.config()` から snapshot を clone → 上書き → disk write →
-//! `replace_config` の順で進める。disk write が失敗した場合は
-//! `replace_config` を呼ばないため in-memory の `Config` は変更されない。
+//! `AppState::snapshot_project_and_config` で `project_path` と `config` を
+//! atomic に snapshot → snapshot 上で上書き → disk write → `replace_config`
+//! の順で進める。disk write が失敗した場合は `replace_config` を呼ばない
+//! ため in-memory の `Config` は変更されない。
 //!
 //! # ロック取得順序
 //!

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -10,7 +10,10 @@
 //!
 //! `AppState` の lock 契約 `project_path → config → tasks_cache →
 //! watcher_handle → write_ignore` の前半 2 項目のみを順に使用する。
-//! 各 lock は clone / replace の最小区間でしか保持しない（同時保持なし）。
+//! 読み取り側は `snapshot_project_and_config` で `project_path` と `config`
+//! を同時保持して snapshot し、書き戻し時のみ `config` lock を単独で
+//! 短時間取得する。これにより `open_project` の commit が両者を更新する
+//! 途中で割り込んで「新 path + 旧 config」を観測する race を防ぐ。
 //!
 //! # エラー文字列の契約
 //!
@@ -96,14 +99,12 @@ pub(crate) fn update_card_order_impl(
     column_name: String,
     file_paths: Vec<String>,
 ) -> Result<(), UpdateCardOrderError> {
-    state.check_project_path_lock()?;
-    state.check_config_lock()?;
-
-    let project_root = state
-        .project_path()?
-        .ok_or(UpdateCardOrderError::NoProjectOpen)?;
-
-    let mut config = state.config()?.ok_or(UpdateCardOrderError::NoProjectOpen)?;
+    // `project_path` と `config` を atomic に snapshot して、`open_project` の
+    // 両者更新の間に割り込んで「新 path + 旧 config」を観測する race を防ぐ
+    // （単独の `project_path()? → config()?` 連続呼びでは race window が生じる）。
+    let (project_root, config) = state.snapshot_project_and_config()?;
+    let project_root = project_root.ok_or(UpdateCardOrderError::NoProjectOpen)?;
+    let mut config = config.ok_or(UpdateCardOrderError::NoProjectOpen)?;
 
     if !config.has_column(&column_name) {
         return Err(UpdateCardOrderError::UnknownColumn { column_name });

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -3,9 +3,14 @@
 //! フロントエンドの DnD 並び替え結果を `.spec-board/config.json` の
 //! `cardOrder[columnName]` に**上書き保存**する書き込み専用 command。
 //! `AppState::snapshot_project_and_config` で `project_path` と `config` を
-//! atomic に snapshot → snapshot 上で上書き → disk write → `replace_config`
-//! の順で進める。disk write が失敗した場合は `replace_config` を呼ばない
-//! ため in-memory の `Config` は変更されない。
+//! atomic に snapshot → snapshot 上で上書き → disk write →
+//! `replace_config_if_project_matches` で `project_path` が snapshot 時と一致
+//! する場合のみ in-memory `config` を更新、の順で進める。disk write が失敗した
+//! 場合は `replace_config_if_project_matches` を呼ばないため in-memory の
+//! `Config` は変更されない。並行 `open_project` で project が swap された
+//! 場合も `project_path` 不一致により in-memory 更新は no-op になり、
+//! cross-project corruption は発生しない（旧 project への disk write は
+//! 旧 project 視点では整合的）。
 //!
 //! # ロック取得順序
 //!

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -12,9 +12,11 @@
 //! `AppState` の lock 契約 `project_path → config → tasks_cache →
 //! watcher_handle → write_ignore` の前半 2 項目のみを順に使用する。
 //! 読み取り側は `snapshot_project_and_config` で `project_path` と `config`
-//! を同時保持して snapshot し、書き戻し時のみ `config` lock を単独で
-//! 短時間取得する。これにより `open_project` の commit が両者を更新する
-//! 途中で割り込んで「新 path + 旧 config」を観測する race を防ぐ。
+//! を同時保持して snapshot し、書き戻し時も `replace_config_if_project_matches`
+//! で両 lock を同時保持して `project_path` の一致確認 + `config` 更新を行う。
+//! これにより `open_project` の commit が両者を atomic に swap する間に
+//! 「新 path + 旧 config」を観測する race と、snapshot 取得後の swap で
+//! 旧 config を新プロジェクトの in-memory state に注入する race の双方を防ぐ。
 //!
 //! # エラー文字列の契約
 //!
@@ -90,10 +92,12 @@ pub fn update_card_order(
 /// 3. snapshot の `card_order[column_name]` を `file_paths` で上書き
 /// 4. `serde_json::to_string_pretty` でシリアライズ
 /// 5. `write_config_json` で disk に書き込み
-/// 6. 成功したら `replace_config` で in-memory を更新
+/// 6. `replace_config_if_project_matches` で `project_path` が snapshot 時と
+///    一致する場合のみ in-memory `config` を更新（不一致時は cross-project
+///    corruption を避けるため no-op）
 ///
-/// disk write 失敗時は `replace_config` を呼ばないため、in-memory の `Config` は
-/// 呼び出し前の値のまま保たれる。
+/// disk write 失敗時は `replace_config_if_project_matches` を呼ばないため、
+/// in-memory の `Config` は呼び出し前の値のまま保たれる。
 pub(crate) fn update_card_order_impl(
     state: &AppState,
     column_name: String,
@@ -115,7 +119,13 @@ pub(crate) fn update_card_order_impl(
     let json = serde_json::to_string_pretty(&config)?;
     write_config_json(&project_root, &json)?;
 
-    state.replace_config(Some(config))?;
+    // snapshot 取得後に並行 `open_project` で project が swap されると、
+    // ここで旧プロジェクト由来の config を新プロジェクトの in-memory state に
+    // 注入してしまう。`project_path` が snapshot 時と一致する場合のみ更新する
+    // atomic check-and-set で cross-project corruption を防ぐ。
+    // 不一致時の disk write 自体は旧 project の `.spec-board/config.json` に
+    // 対する操作のため、旧 project 視点では整合的であり no-op で問題ない。
+    state.replace_config_if_project_matches(&project_root, config)?;
 
     Ok(())
 }

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -1,0 +1,124 @@
+//! `update_card_order` Tauri command 本体。
+//!
+//! フロントエンドの DnD 並び替え結果を `.spec-board/config.json` の
+//! `cardOrder[columnName]` に**上書き保存**する書き込み専用 command。
+//! `state.config()` から snapshot を clone → 上書き → disk write →
+//! `replace_config` の順で進める。disk write が失敗した場合は
+//! `replace_config` を呼ばないため in-memory の `Config` は変更されない。
+//!
+//! # ロック取得順序
+//!
+//! `AppState` の lock 契約 `project_path → config → tasks_cache →
+//! watcher_handle → write_ignore` の前半 2 項目のみを順に使用する。
+//! 各 lock は clone / replace の最小区間でしか保持しない（同時保持なし）。
+//!
+//! # エラー文字列の契約
+//!
+//! - `UnknownColumn` の Display は `"カラムが見つかりません: {column_name}"`
+//! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`
+//! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`
+//! - `ConfigIo` の Display は `"config.json の書き込みに失敗しました: ..."`
+//! - `Serialize` の Display は `"config.json のシリアライズに失敗しました: ..."`
+//!
+//! FE 側 `TauriError.PATTERNS` は `UnknownColumn` を `NOT_FOUND`、
+//! `ConfigIo` を `IO_ERROR` 系（内側メッセージ次第で `NOT_FOUND` /
+//! `PERMISSION_DENIED` に転ぶ）として扱う想定。
+
+use std::sync::Arc;
+
+use spec_board_fs::config::config_io::{write_config_json, ConfigIoError};
+use tauri::State;
+use thiserror::Error;
+
+use crate::state::{AppState, AppStateError};
+
+/// `update_card_order` コマンドのエラー。
+///
+/// `ConfigIoError` が `std::io::Error` を内包するため `PartialEq` / `Eq` は
+/// derive しない。テストは `matches!` でバリアントを判定する。
+#[derive(Debug, Error)]
+pub enum UpdateCardOrderError {
+    /// 指定された `column_name` が `Config.columns` に存在しない。
+    #[error("カラムが見つかりません: {column_name}")]
+    UnknownColumn { column_name: String },
+
+    /// `AppState.config` が `None`（プロジェクト未オープン）。
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+
+    /// `AppState` 内部 mutex が poison 状態。
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+
+    /// `config.json` の書き込み失敗（disk full / permission / symlink 拒否など）。
+    #[error("config.json の書き込みに失敗しました: {0}")]
+    ConfigIo(#[from] ConfigIoError),
+
+    /// `Config` の JSON シリアライズに失敗。
+    #[error("config.json のシリアライズに失敗しました: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+impl From<AppStateError> for UpdateCardOrderError {
+    fn from(_: AppStateError) -> Self {
+        UpdateCardOrderError::StateLockPoisoned
+    }
+}
+
+/// Tauri command 薄層。`update_card_order_impl` を呼び、エラーを文字列化して返す。
+///
+/// 戻り値の `Result<_, String>` の Err 文字列は `UpdateCardOrderError` の
+/// Display 文字列であり、FE 側でパターンマッチして `TauriError` に変換される。
+#[tauri::command]
+pub fn update_card_order(
+    state: State<'_, Arc<AppState>>,
+    column_name: String,
+    file_paths: Vec<String>,
+) -> Result<(), String> {
+    update_card_order_impl(state.inner(), column_name, file_paths).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の本体関数。
+///
+/// 1. `AppState` の lock 健全性 probe
+/// 2. `project_path` snapshot 取得（None → `NoProjectOpen`）
+/// 3. `config` snapshot 取得（None → `NoProjectOpen`）
+/// 4. `column_name` が `Config.columns` に存在するか検証
+/// 5. snapshot の `card_order[column_name]` を `file_paths` で上書き
+/// 6. `serde_json::to_string_pretty` でシリアライズ
+/// 7. `write_config_json` で disk に書き込み
+/// 8. 成功したら `replace_config` で in-memory を更新
+///
+/// disk write 失敗時は `replace_config` を呼ばないため、in-memory の `Config` は
+/// 呼び出し前の値のまま保たれる。
+pub(crate) fn update_card_order_impl(
+    state: &AppState,
+    column_name: String,
+    file_paths: Vec<String>,
+) -> Result<(), UpdateCardOrderError> {
+    state.check_project_path_lock()?;
+    state.check_config_lock()?;
+
+    let project_root = state
+        .project_path()?
+        .ok_or(UpdateCardOrderError::NoProjectOpen)?;
+
+    let mut config = state.config()?.ok_or(UpdateCardOrderError::NoProjectOpen)?;
+
+    if !config.has_column(&column_name) {
+        return Err(UpdateCardOrderError::UnknownColumn { column_name });
+    }
+
+    config.card_order.insert(column_name, file_paths);
+
+    let json = serde_json::to_string_pretty(&config)?;
+    write_config_json(&project_root, &json)?;
+
+    state.replace_config(Some(config))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "update_card_order_tests.rs"]
+mod update_card_order_tests;

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -83,14 +83,13 @@ pub fn update_card_order(
 
 /// 単体テスト境界の本体関数。
 ///
-/// 1. `AppState` の lock 健全性 probe
-/// 2. `project_path` snapshot 取得（None → `NoProjectOpen`）
-/// 3. `config` snapshot 取得（None → `NoProjectOpen`）
-/// 4. `column_name` が `Config.columns` に存在するか検証
-/// 5. snapshot の `card_order[column_name]` を `file_paths` で上書き
-/// 6. `serde_json::to_string_pretty` でシリアライズ
-/// 7. `write_config_json` で disk に書き込み
-/// 8. 成功したら `replace_config` で in-memory を更新
+/// 1. `snapshot_project_and_config` で `project_path` と `config` を
+///    両 lock 同時保持下で atomic に取得（どちらかが `None` → `NoProjectOpen`）
+/// 2. `column_name` が `Config.columns` に存在するか検証
+/// 3. snapshot の `card_order[column_name]` を `file_paths` で上書き
+/// 4. `serde_json::to_string_pretty` でシリアライズ
+/// 5. `write_config_json` で disk に書き込み
+/// 6. 成功したら `replace_config` で in-memory を更新
 ///
 /// disk write 失敗時は `replace_config` を呼ばないため、in-memory の `Config` は
 /// 呼び出し前の値のまま保たれる。

--- a/src-tauri/src/config/update_card_order_tests.rs
+++ b/src-tauri/src/config/update_card_order_tests.rs
@@ -1,0 +1,189 @@
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use super::update_card_order_impl;
+use super::UpdateCardOrderError;
+use crate::config::Config;
+use crate::project::open::open_project_impl;
+use crate::project::watcher_factory::NoopWatcherFactory;
+use crate::project::OpenProjectIntent;
+use crate::state::AppState;
+
+fn tempdir() -> TempDir {
+    tempfile::tempdir().expect("create temp dir")
+}
+
+fn open_with_noop(state: &Arc<AppState>, path: &Path) {
+    let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
+        .expect("non-empty path");
+    open_project_impl(state, &intent, &NoopWatcherFactory).expect("open should succeed");
+}
+
+fn read_config_json(project_root: &Path) -> Config {
+    let raw = fs::read_to_string(project_root.join(".spec-board").join("config.json"))
+        .expect("config.json exists");
+    serde_json::from_str(&raw).expect("config.json is valid")
+}
+
+#[test]
+fn overwrites_existing_card_order_entry() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    update_card_order_impl(
+        &state,
+        "Todo".to_string(),
+        vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()],
+    )
+    .expect("update should succeed");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(
+        on_disk.card_order.get("Todo"),
+        Some(&vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()])
+    );
+
+    let in_state = state.config().unwrap().unwrap();
+    assert_eq!(
+        in_state.card_order.get("Todo"),
+        Some(&vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()])
+    );
+}
+
+#[test]
+fn returns_unknown_column_when_column_missing() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    let before = fs::read_to_string(dir.path().join(".spec-board").join("config.json")).ok();
+
+    let err = update_card_order_impl(&state, "Ghost".to_string(), vec!["tasks/a.md".to_string()])
+        .expect_err("unknown column should fail");
+
+    assert!(
+        matches!(
+            &err,
+            UpdateCardOrderError::UnknownColumn { column_name } if column_name == "Ghost"
+        ),
+        "unexpected error: {err:?}"
+    );
+
+    let after = fs::read_to_string(dir.path().join(".spec-board").join("config.json")).ok();
+    assert_eq!(before, after, "config.json は不変であるべき");
+
+    let in_state = state.config().unwrap().unwrap();
+    assert!(!in_state.card_order.contains_key("Ghost"));
+}
+
+#[test]
+fn saves_empty_array_when_file_paths_empty() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    update_card_order_impl(&state, "Todo".to_string(), vec![]).expect("empty save should succeed");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(on_disk.card_order.get("Todo"), Some(&Vec::<String>::new()));
+}
+
+#[test]
+fn last_call_wins_on_consecutive_invocations() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    update_card_order_impl(
+        &state,
+        "Todo".to_string(),
+        vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()],
+    )
+    .unwrap();
+    update_card_order_impl(
+        &state,
+        "Todo".to_string(),
+        vec!["tasks/b.md".to_string(), "tasks/a.md".to_string()],
+    )
+    .unwrap();
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(
+        on_disk.card_order.get("Todo"),
+        Some(&vec!["tasks/b.md".to_string(), "tasks/a.md".to_string()])
+    );
+}
+
+#[test]
+fn inserts_new_entry_when_column_not_in_card_order() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    let initial = state.config().unwrap().unwrap();
+    assert!(!initial.card_order.contains_key("In Progress"));
+
+    update_card_order_impl(
+        &state,
+        "In Progress".to_string(),
+        vec!["tasks/x.md".to_string()],
+    )
+    .expect("insert should succeed");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(
+        on_disk.card_order.get("In Progress"),
+        Some(&vec!["tasks/x.md".to_string()])
+    );
+}
+
+#[test]
+fn returns_no_project_open_when_state_empty() {
+    let state = AppState::new();
+
+    let err = update_card_order_impl(&state, "Todo".to_string(), vec!["tasks/a.md".to_string()])
+        .expect_err("no project open should fail");
+
+    assert!(matches!(err, UpdateCardOrderError::NoProjectOpen));
+}
+
+#[cfg(unix)]
+#[test]
+fn state_config_remains_unchanged_when_disk_write_fails() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    let before = state.config().unwrap().unwrap();
+
+    let outside = tempdir();
+    let target = outside.path().join("external.json");
+    fs::write(&target, "keep").unwrap();
+    let config_path = dir.path().join(".spec-board").join("config.json");
+    // open_project_impl はデフォルト config を読み込むのみで config.json を書き出さないため、
+    // 既存ファイルがあれば消してから symlink を貼る。
+    let _ = fs::remove_file(&config_path);
+    symlink(&target, &config_path).unwrap();
+
+    let err = update_card_order_impl(&state, "Todo".to_string(), vec!["tasks/a.md".to_string()])
+        .expect_err("disk write should fail");
+
+    assert!(
+        matches!(err, UpdateCardOrderError::ConfigIo(_)),
+        "unexpected error: {err:?}"
+    );
+
+    let after = state.config().unwrap().unwrap();
+    assert_eq!(
+        before.card_order, after.card_order,
+        "disk 失敗時に in-memory が先行更新されてはならない"
+    );
+
+    assert_eq!(fs::read_to_string(&target).unwrap(), "keep");
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,7 +37,8 @@ pub fn run() {
             task::update::update_task,
             task::add_link::add_link,
             task::remove_link::remove_link,
-            config::get_columns::get_columns
+            config::get_columns::get_columns,
+            config::update_card_order::update_card_order
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -405,33 +405,31 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 ///    この時点ではまだ何も書き換えていないため、`open_project_impl` の
 ///    「失敗時は旧プロジェクト state を保持する」契約が守られる。
 /// 2. **書き込み**: 副作用を以下の順で実行する。
-///    - `set_project_path` / `replace_config` / `replace_tasks_cache`: 値の swap のみ
+///    - `take_watcher_handle().stop()`: 新 cache が書かれる前に旧 watcher を必ず停止
+///    - `replace_project_and_config`: `project_path` と `config` を**両 lock 同時保持下で
+///      atomic に swap**する（`update_card_order` 等の reader が「新 path + 旧 config」を
+///      観測して旧 config を新プロジェクトの `config.json` に書き出す cross-project
+///      corruption を防ぐ）
+///    - `replace_tasks_cache`: tasks_cache を新値に置換
 ///    - `write_ignore().clear()`: 旧プロジェクトの登録パスを破棄
-///    - `install_watcher_handle`: 旧 watcher の `stop()` 呼び出しを最後に行う
-///      （panic はここで発生し得るが、ほかの全てのフィールドは既に新値で確定済み）
+///    - `install_watcher_handle`: 新 watcher を install。旧 handle は既に上で
+///      `stop()` 済みのため、ここでは新 handle を置くだけ
 ///
-/// AppState の各 setter は単一フィールドのみを操作し、guard を保持したまま他の
-/// setter を呼ばないため、AppState の lock 取得順序ルール
-/// （複数 guard 同時保持時の AB-BA 防止）には抵触しない。
+/// `replace_project_and_config` は `project_path → config` の AppState lock 順序
+/// 契約に従って両 lock を順に取得・同時保持する。他の setter は単一フィールドのみを
+/// 操作するため、AppState の AB-BA 防止規約に抵触しない。
 ///
 /// `tasks_cache` の key は `PathBuf::from(task.file_path)`（`task.file_path` は
 /// 既に root 相対の正規化済み文字列）。
-/// `open_project` の commit 段階の一般化版。
 ///
-/// `prepare` の実行と GUIDE.md 書き込みは呼び出し側
-/// （`open_project_impl`）で順序を制御するため、本関数には
-/// **既に確保済みの `prepared`** を直接渡す。これにより watcher 起動失敗時に
-/// `.spec-board/GUIDE.md` を新 dir に書き込んでしまう副作用を避けられる。
+/// `prepare` の実行と GUIDE.md 書き込みは呼び出し側（`open_project_impl`）で
+/// 順序を制御するため、本関数には **既に確保済みの `prepared`** を直接渡す。
+/// これにより watcher 起動失敗時に `.spec-board/GUIDE.md` を新 dir に書き込んで
+/// しまう副作用を避けられる。
 ///
-/// 残りの手順は仕様どおり:
-///
-/// 1. 旧 watcher を `take_watcher_handle` で取り出して `stop()`（新 cache が
-///    書かれる前に旧 watcher を必ず停止して race を防ぐ）
-/// 2. project_path / config / tasks_cache / write_ignore.clear の commit を
-///    1 ステップずつ実行
-/// 3. `watcher.spawn(prepared, state, root, config)` で adapter スレッドを起動し、
-///    返り値を `install_watcher_handle` で AppState に格納する。spawn は panic
-///    以外で失敗しない契約。
+/// 最後に `watcher.spawn(prepared, state, root, config)` で adapter スレッドを
+/// 起動し、返り値を `install_watcher_handle` で AppState に格納する。spawn は
+/// panic 以外で失敗しない契約。
 pub(crate) fn commit_app_state_with_prepared<W: WatcherFactory>(
     state: &Arc<AppState>,
     root: &Path,

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -452,8 +452,11 @@ pub(crate) fn commit_app_state_with_prepared<W: WatcherFactory>(
         cache.insert(PathBuf::from(task.file_path.as_str()), task.clone());
     }
 
-    state.set_project_path(Some(root.to_path_buf()))?;
-    state.replace_config(Some(config.clone()))?;
+    // `project_path` と `config` を atomic に swap する。別 lock で順次更新すると、
+    // 他 command（例: `update_card_order`）が「新 path + 旧 config」を観測して
+    // 旧 config を新プロジェクトの `.spec-board/config.json` に書き出してしまう
+    // cross-project corruption を起こしうる。
+    state.replace_project_and_config(Some(root.to_path_buf()), Some(config.clone()))?;
     state.replace_tasks_cache(cache)?;
     state.write_ignore().clear()?;
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -115,6 +115,43 @@ impl AppState {
         Ok(())
     }
 
+    /// `project_path` と `config` を**両方の lock を順に同時保持した状態で** snapshot する。
+    ///
+    /// `open_project` の commit が `project_path → config` の順で両者を更新する間に
+    /// 他の writer / reader が割り込み、「新 project_path + 旧 config」または
+    /// 「旧 project_path + 新 config」の組を観測してしまう race を防ぐための
+    /// atomic 読み取り API。lock 取得順序は AppState の契約に従って
+    /// `project_path → config` を遵守する。
+    ///
+    /// 戻り値はそれぞれ clone 済み snapshot のため、呼び出し側が長く保持しても
+    /// AppState 側の lock は保持されない。
+    pub fn snapshot_project_and_config(
+        &self,
+    ) -> Result<(Option<PathBuf>, Option<crate::config::Config>), AppStateError> {
+        let path_guard = lock(&self.project_path)?;
+        let config_guard = lock(&self.config)?;
+        Ok((path_guard.clone(), config_guard.clone()))
+    }
+
+    /// `project_path` と `config` を**両方の lock を順に同時保持した状態で** swap する。
+    ///
+    /// `open_project` の commit が両者を別々に書き換えると、その間に
+    /// `snapshot_project_and_config` 等が「新 path + 旧 config」を観測しうる。
+    /// 本 API は両 lock を保持したまま swap することで cross-project corruption
+    /// （新プロジェクトの `config.json` を旧 config で上書きするなど）を防ぐ。
+    /// lock 取得順序は AppState の契約に従って `project_path → config` を遵守する。
+    pub fn replace_project_and_config(
+        &self,
+        path: Option<PathBuf>,
+        config: Option<crate::config::Config>,
+    ) -> Result<(), AppStateError> {
+        let mut path_guard = lock(&self.project_path)?;
+        let mut config_guard = lock(&self.config)?;
+        *path_guard = path;
+        *config_guard = config;
+        Ok(())
+    }
+
     /// タスクキャッシュ全体を新しい map で置き換える。
     ///
     /// 旧エントリは破棄されるため部分更新には使えない。`PathBuf` は呼び出し側

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -152,6 +152,30 @@ impl AppState {
         Ok(())
     }
 
+    /// 現在の `project_path` が `expected_path` と一致する場合のみ `config` を更新する。
+    ///
+    /// `snapshot_project_and_config` で読んだ snapshot を mutate して書き戻す flow で、
+    /// snapshot 取得から書き戻しまでの間に `open_project` が project を swap した
+    /// ケースを検出するための atomic check-and-set。lock 取得順序は
+    /// `project_path → config` を遵守する。
+    ///
+    /// - `expected_path` が一致 → `config` を更新して `Ok(true)`
+    /// - 不一致（並行 `open_project` 等） → 何も変更せず `Ok(false)`
+    pub fn replace_config_if_project_matches(
+        &self,
+        expected_path: &std::path::Path,
+        config: crate::config::Config,
+    ) -> Result<bool, AppStateError> {
+        let path_guard = lock(&self.project_path)?;
+        let mut config_guard = lock(&self.config)?;
+        if path_guard.as_deref() == Some(expected_path) {
+            *config_guard = Some(config);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     /// タスクキャッシュ全体を新しい map で置き換える。
     ///
     /// 旧エントリは破棄されるため部分更新には使えない。`PathBuf` は呼び出し側

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -117,11 +117,14 @@ impl AppState {
 
     /// `project_path` と `config` を**両方の lock を順に同時保持した状態で** snapshot する。
     ///
-    /// `open_project` の commit が `project_path → config` の順で両者を更新する間に
-    /// 他の writer / reader が割り込み、「新 project_path + 旧 config」または
-    /// 「旧 project_path + 新 config」の組を観測してしまう race を防ぐための
-    /// atomic 読み取り API。lock 取得順序は AppState の契約に従って
-    /// `project_path → config` を遵守する。
+    /// 一方の lock だけを取得して順に読むと、両フィールドを別々に更新する writer と
+    /// 割り込み合った際に「新 project_path + 旧 config」または「旧 project_path + 新 config」
+    /// の組を観測してしまう。本 API は両 lock を順に同時保持して両フィールドを clone する
+    /// ことで、その不整合観測を防ぐ atomic 読み取り API として機能する。lock 取得順序は
+    /// AppState の契約に従って `project_path → config` を遵守する。
+    ///
+    /// 同時更新側は [`Self::replace_project_and_config`] / [`Self::replace_config_if_project_matches`]
+    /// で同様に両 lock を同時保持して書き換えることで、reader 側の観測整合性を確保する。
     ///
     /// 戻り値はそれぞれ clone 済み snapshot のため、呼び出し側が長く保持しても
     /// AppState 側の lock は保持されない。
@@ -135,10 +138,10 @@ impl AppState {
 
     /// `project_path` と `config` を**両方の lock を順に同時保持した状態で** swap する。
     ///
-    /// `open_project` の commit が両者を別々に書き換えると、その間に
-    /// `snapshot_project_and_config` 等が「新 path + 旧 config」を観測しうる。
-    /// 本 API は両 lock を保持したまま swap することで cross-project corruption
-    /// （新プロジェクトの `config.json` を旧 config で上書きするなど）を防ぐ。
+    /// 両フィールドを別 lock で順次更新すると、その間に reader（例:
+    /// `update_card_order`）が「新 path + 旧 config」を観測し、旧 config を新
+    /// プロジェクトの `config.json` に書き出してしまう cross-project corruption が
+    /// 起き得る。本 API は両 lock を保持したまま swap することでその不整合を防ぐ。
     /// lock 取得順序は AppState の契約に従って `project_path → config` を遵守する。
     pub fn replace_project_and_config(
         &self,


### PR DESCRIPTION
## 概要

フロントエンドのカラム内 DnD 並び替え結果を `.spec-board/config.json` の `cardOrder[columnName]` に上書き保存する Tauri command `update_card_order` をバックエンドに追加した。spec-board-fs には tmp → rename ベースの `write_config_json` を新設し、症状 (#117 FE DnD) と直結する永続化経路を完成させる。

## 変更の種類

- ✨ [New Feature]: Tauri command 追加（バックエンド）

## 追加した内容

- `src-tauri/src/config/update_card_order.rs`
  - `UpdateCardOrderError`（`UnknownColumn` / `NoProjectOpen` / `StateLockPoisoned` / `ConfigIo` / `Serialize`）
  - `update_card_order_impl(state, column_name, file_paths)`（テスト境界）
  - `#[tauri::command] update_card_order`
- `src-tauri/src/config/update_card_order_tests.rs`（E2E 7 件: 正常系 / 未知カラム / 空配列 / 連続呼び出し / 新規キー / NoProjectOpen / disk 失敗時の in-memory 不変）
- `Config::has_column(&str) -> bool`（case-sensitive 完全一致プリチェック）
- `spec_board_fs::config::config_io::write_config_json(project_root, content) -> Result<PathBuf, ConfigIoError>`
  - tmp → rename（Unix `rename(2)` の atomic 置換 / Windows は backup 経由 2 段 rename）
  - `.spec-board/` と `config.json` 双方の symlink を `reject_existing_symlink` で拒否

## 変更した内容

- `src-tauri/src/lib.rs` の `tauri::generate_handler!` に `config::update_card_order::update_card_order` を登録
- `src-tauri/src/config.rs` 冒頭 module doc を更新（スコープに `update_card_order` を追加 / スコープ外から「書き出し」「Tauri コマンド層」を削除）
- `src-tauri/crates/fs/src/config/config_io.rs` 冒頭 scope コメントに `write_config_json` を追加
- `docs/spec-board/config-spec.md` の `update_card_order` セクションを拡充（未知カラム拒否 / FE 正規化結果をそのまま保存 / tmp→rename / watcher emit 走らない / 逐次は後勝ち / 並行整合性は非保証）

## 削除した内容

なし

## 仕様ドキュメント更新

- `docs/spec-board/config-spec.md` の `update_card_order` セクションを既存セクション拡充の形で更新
- 仕様変更（未知カラム拒否、書き込み戦略、並行性の保証範囲）を自然文で明記

## システム図

### 正常系データフロー

```mermaid
flowchart TD
    FE[Frontend: invoke update_card_order]
    CMD["#[tauri::command]<br/>update_card_order"]
    IMPL[update_card_order_impl]
    HAS["Config::has_column<br/>(NEW)"]
    SER["serde_json::to_string_pretty"]
    WRITE["spec_board_fs::config::config_io::<br/>write_config_json (NEW)"]
    DISK[".spec-board/config.json"]
    STATE["AppState::replace_config"]

    FE -->|columnName, filePaths| CMD
    CMD --> IMPL
    IMPL -->|project_path / config snapshot| HAS
    HAS -->|true| SER
    HAS -->|false| ERR1[Err: UnknownColumn]
    SER --> WRITE
    WRITE -->|tmp→rename| DISK
    WRITE --> STATE
    STATE --> OK[Ok]

    style HAS fill:#dff
    style WRITE fill:#dff
    style CMD fill:#fde
```

### ロック取得順序（同時保持なし）

```
t1: project_path.lock  → snapshot clone → unlock
t2: config.lock        → snapshot clone → unlock
t3: (no lock held)     → has_column / insert / to_string_pretty / write_config_json
t4: config.lock        → replace_config → unlock
```

disk write 失敗時は `replace_config` を呼ばないため、in-memory `Config` は呼び出し前の値のまま保たれる（テスト `state_config_remains_unchanged_when_disk_write_fails` で固定）。

## 関連Issue

Refs #99
Relates to #117

## テスト

- `cargo fmt --all --check` ✅ 通過
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ 警告なし
- `cargo test --workspace` ✅ 全件 PASS
  - `spec-board`: 598 tests
  - `spec-board-fs`: 122 tests
- 本 PR で追加したテスト件数:
  - `src/config/config_tests.rs`: 3 件（`has_column` の存在 / 不在 / 大文字小文字差異）
  - `crates/fs/src/config/config_io_tests.rs`: 6 件（`write_config_json` の正常 / 上書き / dir 未存在 / UTF-8 改行保持 / target symlink 拒否 / `.spec-board/` symlink 拒否）
  - `src/config/update_card_order_tests.rs`: 7 件（正常系 / 未知カラム / 空配列 / 連続呼び出し / 新規キー / NoProjectOpen / disk 失敗時の in-memory 不変）
- UI 動作確認: 本 PR は BE のみのため Tauri アプリでの操作確認は対象外（FE 結線は #117 で実施）

## レビューポイント

- **ロック取得順序の遵守**: `state.config()? → mutate → write → replace_config` を連続した 2 つの config lock 取得で構成しているため、並行 writer との race window が残る点を `docs/spec-board/config-spec.md` に明記して受容している。将来 `AppState::with_config_mut` を導入する余地のみメモ
- **disk write 順序**: disk write を `replace_config` より先に実行する設計。disk が失敗した場合 in-memory は変更されず、次回 `update_card_order` で再試行可能。逆順だと in-memory と disk が乖離する
- **symlink 防御**: `write_config_json` で `.spec-board/` ディレクトリと `config.json` 双方の symlink を `reject_existing_symlink` で拒否（既存 `write_guide_markdown` と同じ防御方針）。Unix 環境向けに `#[cfg(unix)]` ガードでテスト追加
- **PartialEq 不採用**: `UpdateCardOrderError` は `ConfigIoError` が `std::io::Error` を内包するため `PartialEq` / `Eq` を derive せず、テストは `matches!` で判定する方針