### PR TITLE
✨ [New Feature]: #96 [BE] update_columns Tauri command を実装

### DIFF
--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -270,6 +270,7 @@ links:（任意）
 | rename.to が新 columns に欠落 | `args.columns` と `renames` を同時指定したが `rename.to` が新 columns に含まれない | リネーム後のカラム名が新しい columns に含まれていません: {name} |
 | md frontmatter パース失敗 | rename 対象 md の YAML パースに失敗 | カラム名の変更中にフロントマターのパースに失敗しました |
 | md frontmatter 不在 | rename 対象 md に frontmatter が無い | カラム名の変更対象 md にフロントマターがありません: {path} |
+| 原本読み込み失敗 | rename 対象 md の読み込みに失敗（書き換え開始前） | カラム名の変更対象 md の読み込みに失敗しました: {path} |
 | 一括更新失敗 | リネーム中のファイル書き込み失敗 | カラム名の変更中にエラーが発生しました。変更を元に戻しました |
 | ロールバック失敗 | rollback 中の書き戻しに失敗（二重失敗） | カラム名の変更失敗後のロールバックに失敗しました: {path} |
 | config.json シリアライズ失敗 | `serde_json::to_string_pretty` 失敗 | config.json のシリアライズに失敗しました |

--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -246,20 +246,34 @@ links:（任意）
 | doneColumn | `String` | いいえ | 完了カラム名。**rename 適用後の名前空間**で指定する。未指定時は変更しない |
 
 **振る舞い**:
-1. `renames` が指定され、かつ空でない場合、該当するタスクのmdファイルの `status` を一括更新（空配列または未指定の場合はこのステップをスキップ）
+1. すべての引数が未指定（`columns`/`doneColumn`/`renames` のいずれも `None`）の場合は no-op として `Ok(())` を返し、ファイルや state を一切変更しない
+2. `renames` 内で `from == to` の項目は冪等にスキップ
+3. `renames` が指定され、かつ空でない場合、該当するタスクのmdファイルの `status` を一括更新（空配列または未指定の場合はこのステップをスキップ）
    - 一括更新は**トランザクション的**に処理。途中で1件でも失敗した場合、変更済みファイルを元に戻してエラーを返却
-2. `columns` が指定されている場合、カラム集合を上書きして `config.json` に保存
-3. `doneColumn` が指定されている場合、完了カラム名を更新して `config.json` に保存
-4. `GUIDE.md` を再生成
-5. 戻り値なし（更新後の設定が必要な場合は呼び出し側が `get_columns` で取得する）
+4. `columns` が指定されている場合、カラム集合を上書きして `config.json` に保存
+5. `doneColumn` が指定されている場合、完了カラム名を更新して `config.json` に保存
+6. `GUIDE.md` を再生成
+7. 戻り値なし（更新後の設定が必要な場合は呼び出し側が `get_columns` で取得する）
 
 **エラー**:
 
 | ケース | 条件 | エラーメッセージ |
 |:-------|:-----|:---------------|
+| プロジェクト未オープン | `AppState` に project_path / config が無い | プロジェクトが開かれていません |
+| 内部 lock 破損 | `AppState` または `WriteIgnoreRegistry` の Mutex が poison | 内部状態のロックが破損しました |
 | カラム全削除 | `columns: []`（空配列）が指定された | カラムを 0 件にすることはできません |
 | カラム名重複 | 同名のカラムが存在する | カラム名が重複しています: {name} |
+| 不在 rename from | `rename.from` が現在の columns に無い | 存在しないカラム名のリネームが指定されました: {name} |
+| 重複 rename from | 同じ `from` を複数 rename で指定 | 同じカラム名のリネームが複数指定されました: {name} |
+| 空 rename to | `rename.to` が空文字列 | リネーム後のカラム名が空です |
+| 不在 doneColumn | `doneColumn` が新 columns に無い | 指定された完了カラムが存在しません: {name} |
+| rename.to が新 columns に欠落 | `args.columns` と `renames` を同時指定したが `rename.to` が新 columns に含まれない | リネーム後のカラム名が新しい columns に含まれていません: {name} |
+| md frontmatter パース失敗 | rename 対象 md の YAML パースに失敗 | カラム名の変更中にフロントマターのパースに失敗しました |
+| md frontmatter 不在 | rename 対象 md に frontmatter が無い | カラム名の変更対象 md にフロントマターがありません: {path} |
 | 一括更新失敗 | リネーム中のファイル書き込み失敗 | カラム名の変更中にエラーが発生しました。変更を元に戻しました |
+| ロールバック失敗 | rollback 中の書き戻しに失敗（二重失敗） | カラム名の変更失敗後のロールバックに失敗しました: {path} |
+| config.json シリアライズ失敗 | `serde_json::to_string_pretty` 失敗 | config.json のシリアライズに失敗しました |
+| config.json 書き込み失敗 | atomic write 失敗（権限・ディスク容量等） | config.json の書き込みに失敗しました: {path} |
 
 ---
 

--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -261,6 +261,7 @@ links:（任意）
 |:-------|:-----|:---------------|
 | プロジェクト未オープン | `AppState` に project_path / config が無い | プロジェクトが開かれていません |
 | 内部 lock 破損 | `AppState` または `WriteIgnoreRegistry` の Mutex が poison | 内部状態のロックが破損しました |
+| watcher 補助スレッド起動失敗 | `WriteIgnoreRegistry` の cleanup worker 起動失敗 | watcher の補助スレッド起動に失敗しました |
 | カラム全削除 | `columns: []`（空配列）が指定された | カラムを 0 件にすることはできません |
 | カラム名重複 | 同名のカラムが存在する | カラム名が重複しています: {name} |
 | 不在 rename from | `rename.from` が現在の columns に無い | 存在しないカラム名のリネームが指定されました: {name} |

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,3 +34,4 @@ spec-board-fs = { path = "crates/fs" }
 
 [dev-dependencies]
 tempfile = "3"
+spec-board-fs = { path = "crates/fs", features = ["test-utils"] }

--- a/src-tauri/crates/fs/Cargo.toml
+++ b/src-tauri/crates/fs/Cargo.toml
@@ -12,3 +12,8 @@ notify = "8"
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+# テスト専用 API（mutex poison ヘルパ等）。本番 build では無効。
+# spec-board 側の `[dev-dependencies]` で `features = ["test-utils"]` を有効化する。
+test-utils = []

--- a/src-tauri/crates/fs/src/watcher/write_ignore.rs
+++ b/src-tauri/crates/fs/src/watcher/write_ignore.rs
@@ -39,6 +39,26 @@ impl WriteIgnoreRegistry {
         Ok(ignored_paths.insert(path.as_ref().to_path_buf()))
     }
 
+    /// Registers multiple paths atomically under a single lock.
+    ///
+    /// 空スライスは何もせず即座に `Ok(())` を返す。重複は HashSet によって自然に
+    /// 1 件に丸まる。register と同じく path の正規化は行わない。
+    ///
+    /// # Errors
+    ///
+    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
+    pub fn register_bulk(&self, paths: &[PathBuf]) -> Result<(), WriteIgnoreError> {
+        if paths.is_empty() {
+            return Ok(());
+        }
+
+        let mut ignored_paths = self.lock()?;
+        for path in paths {
+            ignored_paths.insert(path.clone());
+        }
+        Ok(())
+    }
+
     /// Returns whether the path is currently registered.
     ///
     /// # Errors
@@ -104,6 +124,23 @@ impl WriteIgnoreRegistry {
         let mut ignored_paths = self.lock()?;
         ignored_paths.clear();
         Ok(())
+    }
+
+    /// Test 用に内部 Mutex を poison させる。
+    ///
+    /// `update_columns_impl` の preflight / register 経路で `WriteIgnoreError::LockPoisoned`
+    /// → `StateLockPoisoned` 変換を effect 層レベルで再現するために公開する。
+    /// `cfg(test)` 内または `test-utils` feature 有効時のみコンパイルされ、本番 build では存在しない。
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn poison_lock_for_testing(&self) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            std::thread::scope(|s| {
+                s.spawn(|| {
+                    let _guard = self.ignored_paths.lock().expect("lock before poison");
+                    panic!("poison write_ignore lock for testing");
+                });
+            });
+        }));
     }
 
     /// Locks the registry and maps poisoned mutex errors into the module error type.

--- a/src-tauri/crates/fs/src/watcher/write_ignore_tests.rs
+++ b/src-tauri/crates/fs/src/watcher/write_ignore_tests.rs
@@ -283,6 +283,79 @@ fn clear_returns_error_when_lock_is_poisoned() {
 }
 
 #[test]
+fn register_bulk_inserts_all_paths_in_one_lock() {
+    let registry = WriteIgnoreRegistry::new();
+    let paths = vec![
+        PathBuf::from("tasks/a.md"),
+        PathBuf::from("tasks/b.md"),
+        PathBuf::from("tasks/c.md"),
+    ];
+
+    registry
+        .register_bulk(&paths)
+        .expect("register_bulk should succeed");
+
+    assert_eq!(3, registry.len().expect("registry should be readable"));
+    for path in &paths {
+        assert!(registry
+            .should_ignore(path)
+            .expect("registry should be readable"));
+    }
+}
+
+#[test]
+fn register_bulk_with_duplicates_within_input_is_idempotent() {
+    let registry = WriteIgnoreRegistry::new();
+    let paths = vec![
+        PathBuf::from("tasks/a.md"),
+        PathBuf::from("tasks/a.md"),
+        PathBuf::from("tasks/b.md"),
+    ];
+
+    registry
+        .register_bulk(&paths)
+        .expect("register_bulk should succeed");
+
+    assert_eq!(2, registry.len().expect("registry should be readable"));
+}
+
+#[test]
+fn register_bulk_empty_slice_returns_ok() {
+    let registry = WriteIgnoreRegistry::new();
+
+    registry
+        .register_bulk(&[])
+        .expect("register_bulk on empty input should be Ok");
+
+    assert!(registry.is_empty().expect("registry should be readable"));
+}
+
+#[test]
+fn register_bulk_returns_lock_poisoned_when_mutex_poisoned() {
+    let registry = Arc::new(WriteIgnoreRegistry::new());
+    let poisoned_registry = Arc::clone(&registry);
+
+    let handle = thread::spawn(move || {
+        let _guard = poisoned_registry
+            .ignored_paths
+            .lock()
+            .expect("registry should be lockable before poison");
+
+        panic!("poison write_ignore registry lock");
+    });
+
+    assert!(handle.join().is_err());
+
+    let paths = vec![PathBuf::from("tasks/a.md")];
+    assert_eq!(
+        WriteIgnoreError::LockPoisoned,
+        registry
+            .register_bulk(&paths)
+            .expect_err("poisoned lock should be reported")
+    );
+}
+
+#[test]
 fn returns_error_when_lock_is_poisoned() {
     let registry = Arc::new(WriteIgnoreRegistry::new());
     let poisoned_registry = Arc::clone(&registry);

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -52,13 +52,17 @@
 
 pub mod column_name;
 pub mod get_columns;
+pub mod update_columns;
 
 use log::warn;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::config::column_name::ColumnName;
+use crate::config::update_columns::{ColumnRename, UpdateColumnsArgs, UpdateColumnsError};
+use crate::task::task_file_path::TaskFilePath;
+use crate::task::task_index::Task;
 use spec_board_fs::config::config_io::{self, write_guide_markdown, ConfigIoError};
 use thiserror::Error;
 
@@ -168,6 +172,190 @@ impl Config {
     pub fn guide_markdown(&self) -> String {
         generate_guide_markdown(self)
     }
+
+    /// `update_columns` の純粋計算部。引数と現在のタスクスナップショットから
+    /// 新しい `Config`・rename 対象タスク・no-op フラグを組み立てる。
+    ///
+    /// 検証順序は renames → columns → doneColumn。`args.columns` 指定時は
+    /// FE 提供の最終形をそのまま採用し、aggregate 側で order の再採番は行わない。
+    ///
+    /// # Errors
+    ///
+    /// - `EmptyColumns` — 最終 columns 候補が空
+    /// - `DuplicateColumnName` — rename 適用後の名前空間で重複
+    /// - `UnknownRenameFrom` — `rename.from` が現在の columns に存在しない
+    /// - `DuplicateRenameFrom` — 同じ `from` を複数 rename で指定
+    /// - `EmptyRenameTo` — `rename.to` が空
+    /// - `UnknownDoneColumn` — `doneColumn` が新 columns に存在しない
+    /// - `RenameToMissingFromColumns` — `args.columns` と renames を同時指定した
+    ///   際に `rename.to` が新 columns に含まれていない
+    pub fn plan_update_columns(
+        &self,
+        args: &UpdateColumnsArgs,
+        tasks: &[Task],
+    ) -> Result<UpdateColumnsPlan, UpdateColumnsError> {
+        if args.columns.is_none() && args.done_column.is_none() && args.renames.is_none() {
+            return Ok(UpdateColumnsPlan {
+                new_config: self.clone(),
+                rename_targets: Vec::new(),
+                is_noop: true,
+            });
+        }
+
+        let rename_map = build_rename_map(self, args.renames.as_deref().unwrap_or(&[]))?;
+
+        let candidate_columns = match args.columns.as_ref() {
+            Some(cols) => cols.clone(),
+            None => apply_renames_to_columns(&self.columns, &rename_map),
+        };
+
+        if candidate_columns.is_empty() {
+            return Err(UpdateColumnsError::EmptyColumns);
+        }
+
+        validate_unique_column_names(&candidate_columns)
+            .map_err(|name| UpdateColumnsError::DuplicateColumnName { name })?;
+
+        if args.columns.is_some() && !rename_map.is_empty() {
+            for to in rename_map.values() {
+                if !candidate_columns
+                    .iter()
+                    .any(|c| c.name.as_str() == to.as_str())
+                {
+                    return Err(UpdateColumnsError::RenameToMissingFromColumns {
+                        name: to.clone(),
+                    });
+                }
+            }
+        }
+
+        let new_done: Option<ColumnName> = match args.done_column.as_deref() {
+            Some(name) => Some(ColumnName::from_lenient(name)),
+            None => self
+                .done_column
+                .as_ref()
+                .map(|c| match rename_map.get(c.as_str()) {
+                    Some(new_name) => ColumnName::from_lenient(new_name),
+                    None => c.clone(),
+                }),
+        };
+
+        if let Some(d) = &new_done {
+            if !candidate_columns
+                .iter()
+                .any(|c| c.name.as_str() == d.as_str())
+            {
+                return Err(UpdateColumnsError::UnknownDoneColumn {
+                    name: d.as_str().to_string(),
+                });
+            }
+        }
+
+        let valid_names: HashSet<&str> =
+            candidate_columns.iter().map(|c| c.name.as_str()).collect();
+        let mut new_card_order: CardOrder = BTreeMap::new();
+        for (key, paths) in &self.card_order {
+            let new_key = rename_map
+                .get(key.as_str())
+                .cloned()
+                .unwrap_or_else(|| key.clone());
+            if !valid_names.contains(new_key.as_str()) {
+                continue;
+            }
+            new_card_order.insert(new_key, paths.clone());
+        }
+
+        let mut rename_targets: Vec<RenameTarget> = Vec::new();
+        for task in tasks {
+            let status_str = task.status.as_str();
+            if let Some(new_status) = rename_map.get(status_str) {
+                rename_targets.push(RenameTarget {
+                    rel_path: task.file_path.clone(),
+                    old_status: status_str.to_string(),
+                    new_status: new_status.clone(),
+                });
+            }
+        }
+
+        Ok(UpdateColumnsPlan {
+            new_config: Config {
+                version: self.version,
+                columns: candidate_columns,
+                card_order: new_card_order,
+                done_column: new_done,
+            },
+            rename_targets,
+            is_noop: false,
+        })
+    }
+}
+
+/// `Config::plan_update_columns` の戻り値。
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdateColumnsPlan {
+    /// 書き出し対象の新しい Config（columns / done_column / card_order すべて反映済み）
+    pub new_config: Config,
+    /// rename 対象タスクと書き換え後の status 文字列
+    pub rename_targets: Vec<RenameTarget>,
+    /// 何も変更しない no-op フラグ（args 全 None 時 true）
+    pub is_noop: bool,
+}
+
+/// rename 対象 1 件分。`rel_path` はプロジェクトルートからの相対パス。
+/// effect 層が `project_root.join(rel_path.as_str())` で絶対パスを組み立てる。
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenameTarget {
+    pub rel_path: TaskFilePath,
+    pub old_status: String,
+    pub new_status: String,
+}
+
+/// rename 指示列を `HashMap<from, to>` に正規化する。
+///
+/// `from == to` は冪等 skip、`to` 空は `EmptyRenameTo`、重複 `from` は
+/// `DuplicateRenameFrom`、存在しない `from` は `UnknownRenameFrom` を返す。
+fn build_rename_map(
+    config: &Config,
+    renames: &[ColumnRename],
+) -> Result<HashMap<String, String>, UpdateColumnsError> {
+    let mut map: HashMap<String, String> = HashMap::new();
+    for r in renames {
+        if r.from == r.to {
+            continue;
+        }
+        if r.to.is_empty() {
+            return Err(UpdateColumnsError::EmptyRenameTo);
+        }
+        if map.contains_key(&r.from) {
+            return Err(UpdateColumnsError::DuplicateRenameFrom {
+                name: r.from.clone(),
+            });
+        }
+        if !config.columns.iter().any(|c| c.name.as_str() == r.from) {
+            return Err(UpdateColumnsError::UnknownRenameFrom {
+                name: r.from.clone(),
+            });
+        }
+        map.insert(r.from.clone(), r.to.clone());
+    }
+    Ok(map)
+}
+
+/// `args.columns` 未指定時の候補 columns を rename_map を適用して派生する。
+fn apply_renames_to_columns(
+    columns: &[Column],
+    rename_map: &HashMap<String, String>,
+) -> Vec<Column> {
+    columns
+        .iter()
+        .map(|c| match rename_map.get(c.name.as_str()) {
+            Some(new_name) => Column {
+                name: ColumnName::from_lenient(new_name),
+                order: c.order,
+            },
+            None => c.clone(),
+        })
+        .collect()
 }
 
 /// [`Config`] から GUIDE.md の Markdown 本文を生成する。
@@ -654,7 +842,10 @@ fn backup_config_json(project_root: &Path, content: &str) -> Result<(), LoadConf
     let pid = std::process::id();
     let tmp = spec_board_dir.join(format!("config.json.bak.tmp.{pid}.{nanos}.{counter}"));
 
-    write_backup_to_path(&dst, content, &tmp)
+    write_atomic_to_path(&dst, content, &tmp).map_err(|source| LoadConfigError::BackupFailed {
+        path: dst.clone(),
+        source,
+    })
 }
 
 /// `backup_config_json` 内の tmp パス生成で使う process-local 連番カウンタ。
@@ -662,12 +853,11 @@ fn backup_config_json(project_root: &Path, content: &str) -> Result<(), LoadConf
 static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 use std::sync::atomic::Ordering;
 
-/// `tmp` に `content` を書き出してから `rename(tmp, dst)` で atomic に置き換える。
+/// `tmp` に `content` を書き出してから `rename(tmp, dst)` で atomic に置き換える低レベル io 関数。
 ///
-/// [`backup_config_json`] の中核ロジック。本関数は **`tmp` パスをパラメータとして受け取る**
-/// ため、テストから固定パス（例: `config.json.bak.tmp`）を渡して unlink + create_new
-/// 防御を直接 exercise できる。プロダクションコードは [`backup_config_json`] が
-/// `pid + nanos + counter` から派生した unique パスを渡す。
+/// 本関数は **`tmp` パスをパラメータとして受け取る**ため、テストから固定パス
+/// （例: `config.json.bak.tmp`）を渡して unlink + create_new 防御を直接 exercise できる。
+/// プロダクションコードは呼び出し側が `pid + nanos + counter` から派生した unique パスを渡す。
 ///
 /// # 手順
 ///
@@ -677,68 +867,87 @@ use std::sync::atomic::Ordering;
 /// 3. `write_all` で `content` を書き込み。失敗時は tmp ファイルを best-effort で削除して
 ///    orphan ガベージを残さない。
 /// 4. `rename(tmp, dst)` で atomic 置換。失敗時も tmp を best-effort 削除。
-fn write_backup_to_path(dst: &Path, content: &str, tmp: &Path) -> Result<(), LoadConfigError> {
+///
+/// 戻り値の `io::Result<()>` をどう詰め替えるかは呼び出し側の責務。
+/// `backup_config_json` は [`LoadConfigError::BackupFailed`] に、
+/// `update_columns` 経路は `UpdateColumnsError::ConfigWriteFailed` に詰める。
+pub(crate) fn write_atomic_to_path(dst: &Path, content: &str, tmp: &Path) -> std::io::Result<()> {
     use std::io::Write as _;
 
-    // ディレクトリエントリレベルで stale / 攻撃者が事前作成した tmp を除去する。
-    // symlink / hard link の場合もディレクトリエントリだけを削除し、リンク先や
-    // inode は破壊しない。
     match std::fs::remove_file(tmp) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(source) => {
-            return Err(LoadConfigError::BackupFailed {
-                path: tmp.to_path_buf(),
-                source,
-            });
-        }
+        Err(source) => return Err(source),
     }
 
-    // O_CREAT | O_EXCL semantics: 直前 unlink との race で誰かが再作成していたら
-    // 失敗する（攻撃者が race で再作成しても fresh inode への書き込みは確保される）。
     let mut tmp_file = std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .open(tmp)
-        .map_err(|source| LoadConfigError::BackupFailed {
-            path: tmp.to_path_buf(),
-            source,
-        })?;
+        .open(tmp)?;
     if let Err(source) = tmp_file.write_all(content.as_bytes()) {
-        // write_all 失敗時に partially written な tmp が残ると、tmp 名は呼び出しごとに
-        // unique なため後続 load では再利用 / cleanup されず orphan ガベージとして
-        // `.spec-board/` に蓄積する。best-effort で削除する。
         drop(tmp_file);
         let _ = std::fs::remove_file(tmp);
-        return Err(LoadConfigError::BackupFailed {
-            path: tmp.to_path_buf(),
-            source,
-        });
+        return Err(source);
     }
-    // ENOSPC / EIO 等は flush / close で初めて表面化することがある。`sync_all` で
-    // データ + メタデータの永続化を強制し、その失敗を明示的にエラーとして扱う
-    // （`drop(tmp_file)` は close エラーを無視するため、ここで観測しないと
-    // 「rename 後の `.bak` が truncate / 破損していたのに Ok(()) が返る」事象を
-    // 引き起こしうる）。失敗時は `write_all` 失敗時と同様に best-effort で tmp を削除。
     if let Err(source) = tmp_file.sync_all() {
         drop(tmp_file);
         let _ = std::fs::remove_file(tmp);
-        return Err(LoadConfigError::BackupFailed {
-            path: tmp.to_path_buf(),
-            source,
-        });
+        return Err(source);
     }
     drop(tmp_file);
 
-    std::fs::rename(tmp, dst).map_err(|source| {
-        // Best-effort: rename 失敗時にも tmp を消す（次回 load 時の冪等性確保）。
+    std::fs::rename(tmp, dst).inspect_err(|_| {
         let _ = std::fs::remove_file(tmp);
-        LoadConfigError::BackupFailed {
-            path: dst.to_path_buf(),
-            source,
-        }
-    })?;
-    Ok(())
+    })
+}
+
+/// `update_columns` などが `config.json` を atomic write するためのポート。
+///
+/// 本番実装は [`FsConfigWriter`]。テストでは failure injection 用の mock を実装する。
+pub trait ConfigWriter {
+    /// `dst` に `content` を atomic に書き出す。
+    ///
+    /// # Errors
+    ///
+    /// - 中間 tmp ファイルの作成 / 書き込み / sync / rename に失敗した場合
+    ///   `std::io::Error` を返す。
+    fn write_atomic(&self, dst: &Path, content: &str) -> std::io::Result<()>;
+}
+
+/// 本番実装。内部で [`write_atomic_to_path`] と [`unique_atomic_tmp_path`] を呼ぶ。
+pub struct FsConfigWriter;
+
+impl ConfigWriter for FsConfigWriter {
+    fn write_atomic(&self, dst: &Path, content: &str) -> std::io::Result<()> {
+        let tmp = unique_atomic_tmp_path(dst);
+        write_atomic_to_path(dst, content, &tmp)
+    }
+}
+
+/// `<dst>` に対して呼び出しごとに unique な tmp パスを生成する。
+///
+/// `update_columns` から `config.json` の atomic write を行う際にも使用するため
+/// pub(crate) 公開。`backup_config_json` 内の tmp 命名規約と同じ形式
+/// （`{dst}.tmp.{pid}.{nanos}.{counter}`）を共有し、
+/// process-local AtomicU64 counter で in-process 一意性を担保する。
+pub(crate) fn unique_atomic_tmp_path(dst: &Path) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+
+    let file_name = dst
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("atomic");
+    let tmp_name = format!("{file_name}.tmp.{pid}.{nanos}.{counter}");
+
+    match dst.parent() {
+        Some(parent) => parent.join(tmp_name),
+        None => PathBuf::from(tmp_name),
+    }
 }
 
 /// `<project_root>/.spec-board/` 配下に残っている orphan `config.json.bak.tmp.*`

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -262,7 +262,16 @@ impl Config {
             if !valid_names.contains(new_key.as_str()) {
                 continue;
             }
-            new_card_order.insert(new_key, paths.clone());
+            // 複数の旧キーが同じ new_key に collapse する場合（例: args.columns で
+            // 残す側として B のみ指定 + rename A→B が指定され、旧 card_order に
+            // A と B 両方の entry がある）に paths を後勝ち上書きしないよう、
+            // 既存 Vec へ append + 重複除去（first-occurrence wins）でマージする。
+            let entry = new_card_order.entry(new_key).or_default();
+            for path in paths {
+                if !entry.contains(path) {
+                    entry.push(path.clone());
+                }
+            }
         }
 
         let mut rename_targets: Vec<RenameTarget> = Vec::new();

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -208,10 +208,7 @@ impl Config {
         // 空配列の `renames: []` は「未指定」と同義扱いにする。
         // `is_some()` のままだと空配列だけが送られた場合に no-op 判定にならず、
         // config.json / GUIDE.md が無意味に再書き込みされてしまうため。
-        let has_renames = args
-            .renames
-            .as_ref()
-            .is_some_and(|v| !v.is_empty());
+        let has_renames = args.renames.as_ref().is_some_and(|v| !v.is_empty());
         if args.columns.is_none() && args.done_column.is_none() && !has_renames {
             return Ok(UpdateColumnsPlan {
                 new_config: self.clone(),

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -205,7 +205,14 @@ impl Config {
         args: &UpdateColumnsArgs,
         tasks: &[Task],
     ) -> Result<UpdateColumnsPlan, UpdateColumnsError> {
-        if args.columns.is_none() && args.done_column.is_none() && args.renames.is_none() {
+        // 空配列の `renames: []` は「未指定」と同義扱いにする。
+        // `is_some()` のままだと空配列だけが送られた場合に no-op 判定にならず、
+        // config.json / GUIDE.md が無意味に再書き込みされてしまうため。
+        let has_renames = args
+            .renames
+            .as_ref()
+            .is_some_and(|v| !v.is_empty());
+        if args.columns.is_none() && args.done_column.is_none() && !has_renames {
             return Ok(UpdateColumnsPlan {
                 new_config: self.clone(),
                 rename_targets: Vec::new(),

--- a/src-tauri/src/config/config_tests.rs
+++ b/src-tauri/src/config/config_tests.rs
@@ -1374,7 +1374,7 @@ fn load_or_default_returns_backup_failed_when_bak_path_is_directory() {
 
 #[cfg(unix)]
 #[test]
-fn write_backup_to_path_does_not_truncate_external_file_via_pre_created_tmp_symlink() {
+fn write_atomic_to_path_does_not_truncate_external_file_via_pre_created_tmp_symlink() {
     let dir = TempDir::new().unwrap();
     let dst = dir.path().join("config.json.bak");
     let tmp = dir.path().join("config.json.bak.tmp");
@@ -1384,7 +1384,7 @@ fn write_backup_to_path_does_not_truncate_external_file_via_pre_created_tmp_syml
     std::fs::write(&target, "untouched").unwrap();
     std::os::unix::fs::symlink(&target, &tmp).unwrap();
 
-    write_backup_to_path(&dst, "fresh content", &tmp).unwrap();
+    write_atomic_to_path(&dst, "fresh content", &tmp).unwrap();
 
     let target_content = std::fs::read_to_string(&target).unwrap();
     assert_eq!(
@@ -1491,7 +1491,7 @@ fn load_or_default_does_not_cleanup_when_spec_board_is_symlink() {
 }
 
 #[test]
-fn write_backup_to_path_does_not_truncate_external_file_via_pre_created_tmp_hard_link() {
+fn write_atomic_to_path_does_not_truncate_external_file_via_pre_created_tmp_hard_link() {
     let dir = TempDir::new().unwrap();
     let dst = dir.path().join("config.json.bak");
     let tmp = dir.path().join("config.json.bak.tmp");
@@ -1501,7 +1501,7 @@ fn write_backup_to_path_does_not_truncate_external_file_via_pre_created_tmp_hard
     std::fs::write(&target, "untouched").unwrap();
     std::fs::hard_link(&target, &tmp).unwrap();
 
-    write_backup_to_path(&dst, "fresh content", &tmp).unwrap();
+    write_atomic_to_path(&dst, "fresh content", &tmp).unwrap();
 
     let target_content = std::fs::read_to_string(&target).unwrap();
     assert_eq!(

--- a/src-tauri/src/config/update_columns.rs
+++ b/src-tauri/src/config/update_columns.rs
@@ -122,6 +122,9 @@ pub enum UpdateColumnsError {
         #[source]
         source: std::io::Error,
     },
+
+    #[error("watcher の補助スレッド起動に失敗しました")]
+    WriteIgnoreWorkerSpawnFailed,
 }
 
 impl From<AppStateError> for UpdateColumnsError {
@@ -131,8 +134,15 @@ impl From<AppStateError> for UpdateColumnsError {
 }
 
 impl From<WriteIgnoreError> for UpdateColumnsError {
-    fn from(_: WriteIgnoreError) -> Self {
-        UpdateColumnsError::StateLockPoisoned
+    fn from(err: WriteIgnoreError) -> Self {
+        // 将来 `WriteIgnoreError` に variant が追加されても誤って StateLockPoisoned に
+        // 潰さないよう、variant ごとに明示マッピングする。
+        match err {
+            WriteIgnoreError::LockPoisoned => UpdateColumnsError::StateLockPoisoned,
+            WriteIgnoreError::CleanupWorkerSpawnFailed => {
+                UpdateColumnsError::WriteIgnoreWorkerSpawnFailed
+            }
+        }
     }
 }
 

--- a/src-tauri/src/config/update_columns.rs
+++ b/src-tauri/src/config/update_columns.rs
@@ -89,6 +89,13 @@ pub enum UpdateColumnsError {
     #[error("カラム名の変更対象 md にフロントマターがありません: {path}", path = path.display())]
     RenameMissingFrontmatter { path: PathBuf },
 
+    #[error("カラム名の変更対象 md の読み込みに失敗しました: {path}", path = path.display())]
+    RenameReadFailed {
+        path: PathBuf,
+        #[source]
+        source: TaskIoError,
+    },
+
     #[error("カラム名の変更中にエラーが発生しました。変更を元に戻しました")]
     RenameWriteFailed {
         path: PathBuf,
@@ -178,12 +185,14 @@ pub(crate) fn update_columns_impl(
     let abs_for = |target: &RenameTarget| project_root.join(target.rel_path.as_str());
 
     // (4) 原本 bytes を読み込んで HashMap に保持（key = abs_path）
+    //     ここで失敗してもまだ書き換えていないため `RenameReadFailed` を使う
+    //     （「変更を元に戻しました」を含む `RenameWriteFailed` は誤解を招く）。
     let mut originals: HashMap<PathBuf, Vec<u8>> = HashMap::new();
     for target in &plan.rename_targets {
         let abs = abs_for(target);
         let bytes = io
             .read(&abs)
-            .map_err(|source| UpdateColumnsError::RenameWriteFailed {
+            .map_err(|source| UpdateColumnsError::RenameReadFailed {
                 path: abs.clone(),
                 source,
             })?;

--- a/src-tauri/src/config/update_columns.rs
+++ b/src-tauri/src/config/update_columns.rs
@@ -191,11 +191,16 @@ pub(crate) fn update_columns_impl(
     }
 
     // (5) watcher 起動有無に応じて write_ignore を bulk 登録
+    //     登録した path は失敗パスで unregister し、後続の本物のユーザー編集イベントが
+    //     stale な ignore エントリで抑止されないようにする。
     let watcher_active = state.is_watcher_installed()?;
-    if watcher_active && !plan.rename_targets.is_empty() {
-        let paths: Vec<PathBuf> = plan.rename_targets.iter().map(abs_for).collect();
+    let registered_paths: Vec<PathBuf> = if watcher_active && !plan.rename_targets.is_empty() {
+        let paths: Vec<PathBuf> = plan.rename_targets.iter().map(&abs_for).collect();
         state.write_ignore().register_bulk(&paths)?;
-    }
+        paths
+    } else {
+        Vec::new()
+    };
 
     // (6) rename 対象 md を順次 atomic write。失敗時は rollback
     let mut written: Vec<PathBuf> = Vec::new();
@@ -210,15 +215,18 @@ pub(crate) fn update_columns_impl(
                 Ok(()) => written.push(abs),
                 Err(source) => {
                     rollback_md(&written, &originals, io)?;
+                    cleanup_registered_write_ignores(state, &registered_paths);
                     return Err(UpdateColumnsError::RenameWriteFailed { path: abs, source });
                 }
             },
             Ok(None) => {
                 rollback_md(&written, &originals, io)?;
+                cleanup_registered_write_ignores(state, &registered_paths);
                 return Err(UpdateColumnsError::RenameMissingFrontmatter { path: abs });
             }
             Err(source) => {
                 rollback_md(&written, &originals, io)?;
+                cleanup_registered_write_ignores(state, &registered_paths);
                 return Err(UpdateColumnsError::RenameParseFailed { path: abs, source });
             }
         }
@@ -230,11 +238,13 @@ pub(crate) fn update_columns_impl(
         Ok(s) => s,
         Err(source) => {
             rollback_md(&written, &originals, io)?;
+            cleanup_registered_write_ignores(state, &registered_paths);
             return Err(UpdateColumnsError::ConfigSerializeFailed { source });
         }
     };
     if let Err(source) = config_writer.write_atomic(&config_path, &content) {
         rollback_md(&written, &originals, io)?;
+        cleanup_registered_write_ignores(state, &registered_paths);
         return Err(UpdateColumnsError::ConfigWriteFailed {
             path: config_path,
             source,
@@ -254,6 +264,18 @@ pub(crate) fn update_columns_impl(
     write_guide_markdown_best_effort(&project_root, &plan.new_config);
 
     Ok(())
+}
+
+/// 失敗パスで `register_bulk` 済み path の write_ignore エントリを掃除する best-effort helper。
+///
+/// 一括登録した path をそのまま放置すると、watcher の consume が one-shot のため
+/// 後続の本物のユーザー編集イベントが stale な ignore エントリに飲まれてしまう。
+/// 失敗時は明示的に unregister し、cache と fs の整合性は別途 `rollback_md` で復元する。
+/// 内部 Mutex の poison 等は無視する（既に別エラーで失敗パスにいるため）。
+fn cleanup_registered_write_ignores(state: &AppState, paths: &[PathBuf]) {
+    for path in paths {
+        let _ = state.write_ignore().unregister(path);
+    }
 }
 
 /// rollback ループ。既に書き換え済みの md を `originals` の内容で書き戻す。

--- a/src-tauri/src/config/update_columns.rs
+++ b/src-tauri/src/config/update_columns.rs
@@ -1,0 +1,308 @@
+//! `update_columns` Tauri command 本体。
+//!
+//! カラムの追加・削除・並び替え・名前変更・完了カラム変更を 1 コマンドで処理する。
+//! コア計算は `Config::plan_update_columns` aggregate method に集約し、
+//! effect 層 `update_columns_impl` で md 一括書き換え（トランザクション的ロールバック付き）
+//! → `config.json` atomic write → `AppState` commit → `tasks_cache` in-place 更新
+//! → GUIDE.md 再生成、の順で適用する。
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde_yaml_ng::Value as YamlValue;
+use thiserror::Error;
+
+use std::sync::Arc;
+
+use tauri::State;
+
+use crate::config::column_name::ColumnName;
+use crate::config::{write_guide_markdown_best_effort, ConfigWriter, FsConfigWriter, RenameTarget};
+use crate::state::{AppState, AppStateError};
+use crate::task::frontmatter::{self, FrontmatterError};
+use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
+use spec_board_fs::config::config_io;
+use spec_board_fs::watcher::write_ignore::WriteIgnoreError;
+
+/// `update_columns` の引数 DTO。
+///
+/// 全フィールド `Option` のため、FE 側は変更したい項目のみ送る。
+/// すべて `None` の場合は no-op として `Ok(())` を返す。
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateColumnsArgs {
+    /// 新しい columns 配列。指定があれば config の columns はこの値で完全置換される。
+    pub columns: Option<Vec<crate::config::Column>>,
+    /// 新しい完了カラム名。`None` は「変更しない」を意味する。
+    pub done_column: Option<String>,
+    /// カラム名のリネーム指示。`from == to` は冪等 skip。
+    pub renames: Option<Vec<ColumnRename>>,
+}
+
+/// カラム名リネームの 1 件分。
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnRename {
+    pub from: String,
+    pub to: String,
+}
+
+/// `update_columns` のエラー。FE 側 `TauriError.PATTERNS` で文字列マッチされる
+/// ため、Display 文字列は変更しない。
+#[derive(Debug, Error)]
+pub enum UpdateColumnsError {
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+
+    #[error("カラムを 0 件にすることはできません")]
+    EmptyColumns,
+
+    #[error("カラム名が重複しています: {name}")]
+    DuplicateColumnName { name: String },
+
+    #[error("存在しないカラム名のリネームが指定されました: {name}")]
+    UnknownRenameFrom { name: String },
+
+    #[error("同じカラム名のリネームが複数指定されました: {name}")]
+    DuplicateRenameFrom { name: String },
+
+    #[error("リネーム後のカラム名が空です")]
+    EmptyRenameTo,
+
+    #[error("指定された完了カラムが存在しません: {name}")]
+    UnknownDoneColumn { name: String },
+
+    #[error("リネーム後のカラム名が新しい columns に含まれていません: {name}")]
+    RenameToMissingFromColumns { name: String },
+
+    #[error("カラム名の変更中にフロントマターのパースに失敗しました")]
+    RenameParseFailed {
+        path: PathBuf,
+        #[source]
+        source: FrontmatterError,
+    },
+
+    #[error("カラム名の変更対象 md にフロントマターがありません: {path}", path = path.display())]
+    RenameMissingFrontmatter { path: PathBuf },
+
+    #[error("カラム名の変更中にエラーが発生しました。変更を元に戻しました")]
+    RenameWriteFailed {
+        path: PathBuf,
+        #[source]
+        source: TaskIoError,
+    },
+
+    #[error("カラム名の変更失敗後のロールバックに失敗しました: {path}", path = path.display())]
+    RenameRollbackFailed {
+        path: PathBuf,
+        #[source]
+        source: TaskIoError,
+    },
+
+    #[error("config.json のシリアライズに失敗しました")]
+    ConfigSerializeFailed {
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("config.json の書き込みに失敗しました: {path}", path = path.display())]
+    ConfigWriteFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl From<AppStateError> for UpdateColumnsError {
+    fn from(_: AppStateError) -> Self {
+        UpdateColumnsError::StateLockPoisoned
+    }
+}
+
+impl From<WriteIgnoreError> for UpdateColumnsError {
+    fn from(_: WriteIgnoreError) -> Self {
+        UpdateColumnsError::StateLockPoisoned
+    }
+}
+
+/// `update_columns` Tauri command 薄層。
+///
+/// `update_columns_impl` を呼び、エラーを文字列化して FE へ返す。
+///
+/// # Errors
+///
+/// `UpdateColumnsError::Display` で定義された各種エラー文字列を返す。
+#[tauri::command]
+pub fn update_columns(
+    state: State<'_, Arc<AppState>>,
+    args: UpdateColumnsArgs,
+) -> Result<(), String> {
+    update_columns_impl(state.inner(), &FsTaskIo, &FsConfigWriter, args).map_err(|e| e.to_string())
+}
+
+/// `update_columns` の effect 層本体。
+///
+/// `plan_update_columns` aggregate の Plan を実 fs / state に適用する。
+/// 失敗時は既に書き換えた md を原本に戻すロールバックを行う。
+///
+/// # Errors
+///
+/// 詳細は [`UpdateColumnsError`] の各 variant を参照。
+pub(crate) fn update_columns_impl(
+    state: &AppState,
+    io: &dyn TaskIo,
+    config_writer: &dyn ConfigWriter,
+    args: UpdateColumnsArgs,
+) -> Result<(), UpdateColumnsError> {
+    // (1) preflight
+    state.check_tasks_cache_lock()?;
+    let _ = state.write_ignore().is_empty()?;
+
+    // (2) snapshot
+    let project_root = state
+        .project_path()?
+        .ok_or(UpdateColumnsError::NoProjectOpen)?;
+    let config = state.config()?.ok_or(UpdateColumnsError::NoProjectOpen)?;
+    let tasks_snapshot = state.tasks_snapshot()?;
+
+    // (3) aggregate planning（pure）
+    let plan = config.plan_update_columns(&args, &tasks_snapshot)?;
+    if plan.is_noop {
+        return Ok(());
+    }
+
+    let abs_for = |target: &RenameTarget| project_root.join(target.rel_path.as_str());
+
+    // (4) 原本 bytes を読み込んで HashMap に保持（key = abs_path）
+    let mut originals: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+    for target in &plan.rename_targets {
+        let abs = abs_for(target);
+        let bytes = io
+            .read(&abs)
+            .map_err(|source| UpdateColumnsError::RenameWriteFailed {
+                path: abs.clone(),
+                source,
+            })?;
+        originals.insert(abs, bytes);
+    }
+
+    // (5) watcher 起動有無に応じて write_ignore を bulk 登録
+    let watcher_active = state.is_watcher_installed()?;
+    if watcher_active && !plan.rename_targets.is_empty() {
+        let paths: Vec<PathBuf> = plan.rename_targets.iter().map(abs_for).collect();
+        state.write_ignore().register_bulk(&paths)?;
+    }
+
+    // (6) rename 対象 md を順次 atomic write。失敗時は rollback
+    let mut written: Vec<PathBuf> = Vec::new();
+    for target in &plan.rename_targets {
+        let abs = abs_for(target);
+        let original_bytes = originals
+            .get(&abs)
+            .expect("originals must contain abs path");
+
+        match rewrite_status_in_md(original_bytes, &target.new_status) {
+            Ok(Some(new_bytes)) => match io.write_existing(&abs, &new_bytes) {
+                Ok(()) => written.push(abs),
+                Err(source) => {
+                    rollback_md(&written, &originals, io)?;
+                    return Err(UpdateColumnsError::RenameWriteFailed { path: abs, source });
+                }
+            },
+            Ok(None) => {
+                rollback_md(&written, &originals, io)?;
+                return Err(UpdateColumnsError::RenameMissingFrontmatter { path: abs });
+            }
+            Err(source) => {
+                rollback_md(&written, &originals, io)?;
+                return Err(UpdateColumnsError::RenameParseFailed { path: abs, source });
+            }
+        }
+    }
+
+    // (7) config.json atomic write
+    let config_path = config_io::config_path(&project_root);
+    let content = match serde_json::to_string_pretty(&plan.new_config) {
+        Ok(s) => s,
+        Err(source) => {
+            rollback_md(&written, &originals, io)?;
+            return Err(UpdateColumnsError::ConfigSerializeFailed { source });
+        }
+    };
+    if let Err(source) = config_writer.write_atomic(&config_path, &content) {
+        rollback_md(&written, &originals, io)?;
+        return Err(UpdateColumnsError::ConfigWriteFailed {
+            path: config_path,
+            source,
+        });
+    }
+
+    // (8) commit: AppState.config 差し替え → tasks_cache in-place 更新 → GUIDE.md 再生成
+    state.replace_config(Some(plan.new_config.clone()))?;
+    state.with_tasks_cache_mut(|cache| {
+        for target in &plan.rename_targets {
+            let rel = PathBuf::from(target.rel_path.as_str());
+            if let Some(task) = cache.get_mut(&rel) {
+                task.status = ColumnName::from_lenient(&target.new_status);
+            }
+        }
+    })?;
+    write_guide_markdown_best_effort(&project_root, &plan.new_config);
+
+    Ok(())
+}
+
+/// rollback ループ。既に書き換え済みの md を `originals` の内容で書き戻す。
+fn rollback_md(
+    written: &[PathBuf],
+    originals: &HashMap<PathBuf, Vec<u8>>,
+    io: &dyn TaskIo,
+) -> Result<(), UpdateColumnsError> {
+    for path in written {
+        let bytes = originals
+            .get(path)
+            .expect("originals must contain written path");
+        if let Err(source) = io.write_existing(path, bytes) {
+            return Err(UpdateColumnsError::RenameRollbackFailed {
+                path: path.clone(),
+                source,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// md バイト列のフロントマター `status` を `new_status` に書き換えて新しいバイト列を返す。
+///
+/// 戻り値:
+/// - `Ok(Some(bytes))` — frontmatter を持つ md で書き換えに成功
+/// - `Ok(None)` — frontmatter が無い md（先頭 `---` で始まらない / 閉じ `---` が無い）。
+///   effect 層側で `UpdateColumnsError::RenameMissingFrontmatter` に詰めて hard-fail し、
+///   既書き換え分を rollback する責務とする。helper 自体は判定のみ。
+///
+/// # Errors
+///
+/// - YAML パース失敗 / UTF-8 非互換などは [`FrontmatterError`] をそのまま伝播する。
+pub(crate) fn rewrite_status_in_md(
+    bytes: &[u8],
+    new_status: &str,
+) -> Result<Option<Vec<u8>>, FrontmatterError> {
+    let Some(mut parsed) = frontmatter::parse_bytes(bytes)? else {
+        return Ok(None);
+    };
+
+    parsed.frontmatter.extras.insert(
+        YamlValue::String("status".into()),
+        YamlValue::String(new_status.to_string()),
+    );
+
+    Ok(Some(frontmatter::serialize(&parsed).into_bytes()))
+}
+
+#[cfg(test)]
+#[path = "update_columns_tests.rs"]
+mod update_columns_tests;

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -11,8 +11,6 @@ use crate::config::column_name::ColumnName;
 use crate::config::Column;
 use crate::config::Config;
 use crate::config::FsConfigWriter;
-use crate::config::RenameTarget;
-use crate::config::UpdateColumnsPlan;
 use crate::project::open::open_project_impl;
 use crate::project::watcher_factory::NoopWatcherFactory;
 use crate::project::OpenProjectIntent;
@@ -731,17 +729,6 @@ fn plan_rename_targets_includes_old_and_new_status() {
     let plan = config.plan_update_columns(&args, &tasks).expect("ok");
     assert_eq!(plan.rename_targets[0].old_status, "A");
     assert_eq!(plan.rename_targets[0].new_status, "Alpha");
-}
-
-// Reference unused imports to silence dead-code (will be exercised by Tasks 6-7).
-#[allow(dead_code)]
-fn _silence_unused() {
-    let _ = std::marker::PhantomData::<FrontmatterError>;
-    let _ = UpdateColumnsPlan {
-        new_config: Config::default(),
-        rename_targets: Vec::<RenameTarget>::new(),
-        is_noop: true,
-    };
 }
 
 // ───── rewrite_status_in_md tests ─────

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -301,6 +301,21 @@ fn plan_args_all_none_returns_noop_plan() {
 }
 
 #[test]
+fn plan_empty_renames_array_is_treated_as_noop() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs {
+        renames: Some(Vec::new()),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert!(
+        plan.is_noop,
+        "空配列の renames は未指定と同義として no-op 扱いにすべき"
+    );
+    assert_eq!(plan.new_config, config);
+}
+
+#[test]
 fn plan_columns_only_reorder_returns_new_config_with_same_names() {
     let config = config_with(
         vec![col("Todo", 0), col("In Progress", 1), col("Done", 2)],

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -289,7 +289,7 @@ fn column_rename_deserializes_camel_case() {
 }
 
 #[test]
-fn column_in_args_serializes_with_camel_case_name() {
+fn column_in_args_deserializes_from_camel_case_name() {
     let json = r#"{ "columns": [{ "name": "In Progress", "order": 1 }] }"#;
     let args: UpdateColumnsArgs = serde_json::from_str(json).expect("should deserialize");
     let columns = args.columns.expect("columns");

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -1173,11 +1173,23 @@ fn fault_read_original_fails_does_not_modify_anything() {
     )
     .unwrap_err();
 
-    assert!(matches!(err, UpdateColumnsError::RenameWriteFailed { .. }));
+    assert!(matches!(err, UpdateColumnsError::RenameReadFailed { .. }));
     let after_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
     let after_md = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
     assert_eq!(before_cfg, after_cfg);
     assert_eq!(before_md, after_md);
+}
+
+#[test]
+fn rename_read_failed_display() {
+    let err = UpdateColumnsError::RenameReadFailed {
+        path: PathBuf::from("tasks/x.md"),
+        source: TaskIoError::from(std::io::Error::other("boom")),
+    };
+    assert_eq!(
+        err.to_string(),
+        "カラム名の変更対象 md の読み込みに失敗しました: tasks/x.md"
+    );
 }
 
 #[test]

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -269,6 +269,20 @@ fn write_ignore_lock_poisoned_converts_to_state_lock_poisoned() {
 }
 
 #[test]
+fn write_ignore_cleanup_worker_spawn_failed_maps_to_dedicated_variant() {
+    let err: UpdateColumnsError = WriteIgnoreError::CleanupWorkerSpawnFailed.into();
+    assert!(matches!(err, UpdateColumnsError::WriteIgnoreWorkerSpawnFailed));
+}
+
+#[test]
+fn write_ignore_worker_spawn_failed_display() {
+    assert_eq!(
+        UpdateColumnsError::WriteIgnoreWorkerSpawnFailed.to_string(),
+        "watcher の補助スレッド起動に失敗しました"
+    );
+}
+
+#[test]
 fn column_rename_deserializes_camel_case() {
     let json = r#"{ "from": "A", "to": "B" }"#;
     let r: ColumnRename = serde_json::from_str(json).expect("should deserialize");

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -1,0 +1,1660 @@
+use super::*;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use crate::config::column_name::ColumnName;
+use crate::config::Column;
+use crate::config::Config;
+use crate::config::FsConfigWriter;
+use crate::config::RenameTarget;
+use crate::config::UpdateColumnsPlan;
+use crate::project::open::open_project_impl;
+use crate::project::watcher_factory::NoopWatcherFactory;
+use crate::project::OpenProjectIntent;
+use crate::state::AppState;
+use crate::task::frontmatter::FrontmatterError;
+use crate::task::io::FsTaskIo;
+use crate::task::task_file_path::TaskFilePath;
+use crate::task::task_index::Task;
+use crate::task::task_title::TaskTitle;
+
+fn col(name: &str, order: u32) -> Column {
+    Column {
+        name: ColumnName::from_lenient(name),
+        order,
+    }
+}
+
+fn config_with(columns: Vec<Column>, done: Option<&str>) -> Config {
+    Config {
+        version: 1,
+        columns,
+        card_order: BTreeMap::new(),
+        done_column: done.map(ColumnName::from_lenient),
+    }
+}
+
+fn config_with_card_order(
+    columns: Vec<Column>,
+    done: Option<&str>,
+    card_order: BTreeMap<String, Vec<String>>,
+) -> Config {
+    Config {
+        version: 1,
+        columns,
+        card_order,
+        done_column: done.map(ColumnName::from_lenient),
+    }
+}
+
+fn task(path: &str, status: &str) -> Task {
+    Task {
+        id: TaskFilePath::from_lenient(path),
+        file_path: TaskFilePath::from_lenient(path),
+        title: TaskTitle::from_lenient("t"),
+        status: ColumnName::from_lenient(status),
+        priority: None,
+        labels: Vec::new(),
+        parent: None,
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: BTreeMap::new(),
+        warnings: Vec::new(),
+    }
+}
+
+fn rename(from: &str, to: &str) -> ColumnRename {
+    ColumnRename {
+        from: from.into(),
+        to: to.into(),
+    }
+}
+
+#[test]
+fn update_columns_args_deserializes_from_camel_case_json() {
+    let json = r#"{
+        "columns": [{ "name": "Todo", "order": 0 }],
+        "doneColumn": "Done",
+        "renames": [{ "from": "Old", "to": "New" }]
+    }"#;
+    let args: UpdateColumnsArgs = serde_json::from_str(json).expect("should deserialize");
+    assert_eq!(args.done_column.as_deref(), Some("Done"));
+    let renames = args.renames.expect("renames");
+    assert_eq!(renames.len(), 1);
+    assert_eq!(renames[0].from, "Old");
+    assert_eq!(renames[0].to, "New");
+    let columns = args.columns.expect("columns");
+    assert_eq!(columns.len(), 1);
+    assert_eq!(columns[0].name.as_str(), "Todo");
+}
+
+#[test]
+fn update_columns_args_all_fields_optional() {
+    let args: UpdateColumnsArgs = serde_json::from_str("{}").expect("should deserialize empty");
+    assert!(args.columns.is_none());
+    assert!(args.done_column.is_none());
+    assert!(args.renames.is_none());
+}
+
+#[test]
+fn no_project_open_display() {
+    assert_eq!(
+        UpdateColumnsError::NoProjectOpen.to_string(),
+        "プロジェクトが開かれていません"
+    );
+}
+
+#[test]
+fn state_lock_poisoned_display() {
+    assert_eq!(
+        UpdateColumnsError::StateLockPoisoned.to_string(),
+        "内部状態のロックが破損しました"
+    );
+}
+
+#[test]
+fn empty_columns_display() {
+    assert_eq!(
+        UpdateColumnsError::EmptyColumns.to_string(),
+        "カラムを 0 件にすることはできません"
+    );
+}
+
+#[test]
+fn duplicate_column_name_display() {
+    assert_eq!(
+        UpdateColumnsError::DuplicateColumnName {
+            name: "Todo".into()
+        }
+        .to_string(),
+        "カラム名が重複しています: Todo"
+    );
+}
+
+#[test]
+fn unknown_rename_from_display() {
+    assert_eq!(
+        UpdateColumnsError::UnknownRenameFrom {
+            name: "Missing".into()
+        }
+        .to_string(),
+        "存在しないカラム名のリネームが指定されました: Missing"
+    );
+}
+
+#[test]
+fn duplicate_rename_from_display() {
+    assert_eq!(
+        UpdateColumnsError::DuplicateRenameFrom {
+            name: "Todo".into()
+        }
+        .to_string(),
+        "同じカラム名のリネームが複数指定されました: Todo"
+    );
+}
+
+#[test]
+fn empty_rename_to_display() {
+    assert_eq!(
+        UpdateColumnsError::EmptyRenameTo.to_string(),
+        "リネーム後のカラム名が空です"
+    );
+}
+
+#[test]
+fn unknown_done_column_display() {
+    assert_eq!(
+        UpdateColumnsError::UnknownDoneColumn {
+            name: "Ghost".into()
+        }
+        .to_string(),
+        "指定された完了カラムが存在しません: Ghost"
+    );
+}
+
+#[test]
+fn rename_to_missing_from_columns_display() {
+    assert_eq!(
+        UpdateColumnsError::RenameToMissingFromColumns { name: "New".into() }.to_string(),
+        "リネーム後のカラム名が新しい columns に含まれていません: New"
+    );
+}
+
+#[test]
+fn rename_parse_failed_display() {
+    let err = UpdateColumnsError::RenameParseFailed {
+        path: PathBuf::from("tasks/broken.md"),
+        source: serde_yaml_ng::from_str::<serde_yaml_ng::Value>("k: [unclosed")
+            .map(|_| panic!("must fail"))
+            .map_err(FrontmatterError::from)
+            .unwrap_err(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "カラム名の変更中にフロントマターのパースに失敗しました"
+    );
+}
+
+#[test]
+fn rename_missing_frontmatter_display() {
+    assert_eq!(
+        UpdateColumnsError::RenameMissingFrontmatter {
+            path: PathBuf::from("tasks/x.md"),
+        }
+        .to_string(),
+        "カラム名の変更対象 md にフロントマターがありません: tasks/x.md"
+    );
+}
+
+#[test]
+fn rename_write_failed_display() {
+    let err = UpdateColumnsError::RenameWriteFailed {
+        path: PathBuf::from("tasks/x.md"),
+        source: TaskIoError::from(std::io::Error::other("boom")),
+    };
+    assert_eq!(
+        err.to_string(),
+        "カラム名の変更中にエラーが発生しました。変更を元に戻しました"
+    );
+}
+
+#[test]
+fn rename_rollback_failed_display() {
+    let err = UpdateColumnsError::RenameRollbackFailed {
+        path: PathBuf::from("tasks/x.md"),
+        source: TaskIoError::from(std::io::Error::other("boom")),
+    };
+    assert_eq!(
+        err.to_string(),
+        "カラム名の変更失敗後のロールバックに失敗しました: tasks/x.md"
+    );
+}
+
+#[test]
+fn config_serialize_failed_display() {
+    let serde_err = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+    let err = UpdateColumnsError::ConfigSerializeFailed { source: serde_err };
+    assert_eq!(err.to_string(), "config.json のシリアライズに失敗しました");
+}
+
+#[test]
+fn config_write_failed_display() {
+    let err = UpdateColumnsError::ConfigWriteFailed {
+        path: PathBuf::from(".spec-board/config.json"),
+        source: std::io::Error::other("boom"),
+    };
+    assert_eq!(
+        err.to_string(),
+        "config.json の書き込みに失敗しました: .spec-board/config.json"
+    );
+}
+
+#[test]
+fn app_state_error_converts_to_state_lock_poisoned() {
+    let err: UpdateColumnsError = AppStateError::LockPoisoned.into();
+    assert!(matches!(err, UpdateColumnsError::StateLockPoisoned));
+}
+
+#[test]
+fn write_ignore_lock_poisoned_converts_to_state_lock_poisoned() {
+    let err: UpdateColumnsError = WriteIgnoreError::LockPoisoned.into();
+    assert!(matches!(err, UpdateColumnsError::StateLockPoisoned));
+}
+
+#[test]
+fn column_rename_deserializes_camel_case() {
+    let json = r#"{ "from": "A", "to": "B" }"#;
+    let r: ColumnRename = serde_json::from_str(json).expect("should deserialize");
+    assert_eq!(r.from, "A");
+    assert_eq!(r.to, "B");
+}
+
+#[test]
+fn column_in_args_serializes_with_camel_case_name() {
+    let json = r#"{ "columns": [{ "name": "In Progress", "order": 1 }] }"#;
+    let args: UpdateColumnsArgs = serde_json::from_str(json).expect("should deserialize");
+    let columns = args.columns.expect("columns");
+    let expected = Column {
+        name: ColumnName::from_lenient("In Progress"),
+        order: 1,
+    };
+    assert_eq!(columns[0], expected);
+}
+
+// ───── plan_update_columns aggregate tests ─────
+
+#[test]
+fn plan_args_all_none_returns_noop_plan() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs::default();
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert!(plan.is_noop);
+    assert_eq!(plan.new_config, config);
+    assert!(plan.rename_targets.is_empty());
+}
+
+#[test]
+fn plan_columns_only_reorder_returns_new_config_with_same_names() {
+    let config = config_with(
+        vec![col("Todo", 0), col("In Progress", 1), col("Done", 2)],
+        Some("Done"),
+    );
+    let new_cols = vec![col("Done", 0), col("In Progress", 1), col("Todo", 2)];
+    let args = UpdateColumnsArgs {
+        columns: Some(new_cols.clone()),
+        ..Default::default()
+    };
+
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert!(!plan.is_noop);
+    assert_eq!(plan.new_config.columns, new_cols);
+    assert!(plan.rename_targets.is_empty());
+}
+
+#[test]
+fn plan_columns_only_add_appends_new_column() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let new_cols = vec![col("Todo", 0), col("Doing", 1), col("Done", 2)];
+    let args = UpdateColumnsArgs {
+        columns: Some(new_cols.clone()),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(plan.new_config.columns, new_cols);
+}
+
+#[test]
+fn plan_columns_only_remove_drops_column_and_cleans_card_order() {
+    let mut card_order = BTreeMap::new();
+    card_order.insert("Todo".into(), vec!["a.md".into()]);
+    card_order.insert("Doing".into(), vec!["b.md".into()]);
+    card_order.insert("Done".into(), vec!["c.md".into()]);
+    let config = config_with_card_order(
+        vec![col("Todo", 0), col("Doing", 1), col("Done", 2)],
+        Some("Done"),
+        card_order,
+    );
+    let new_cols = vec![col("Todo", 0), col("Done", 1)];
+    let args = UpdateColumnsArgs {
+        columns: Some(new_cols.clone()),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(plan.new_config.columns, new_cols);
+    assert!(plan.new_config.card_order.contains_key("Todo"));
+    assert!(plan.new_config.card_order.contains_key("Done"));
+    assert!(!plan.new_config.card_order.contains_key("Doing"));
+}
+
+#[test]
+fn plan_done_column_only_updates_done_column() {
+    let config = config_with(
+        vec![col("Todo", 0), col("Doing", 1), col("Done", 2)],
+        Some("Done"),
+    );
+    let args = UpdateColumnsArgs {
+        done_column: Some("Doing".into()),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(
+        plan.new_config.done_column.as_ref().map(|d| d.as_str()),
+        Some("Doing")
+    );
+}
+
+#[test]
+fn plan_renames_only_swaps_card_order_keys() {
+    let mut card_order = BTreeMap::new();
+    card_order.insert("Todo".into(), vec!["a.md".into()]);
+    card_order.insert("Doing".into(), vec!["b.md".into()]);
+    let config = config_with_card_order(
+        vec![col("Todo", 0), col("Doing", 1)],
+        Some("Doing"),
+        card_order,
+    );
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Doing", "In Progress")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert!(plan.new_config.card_order.contains_key("In Progress"));
+    assert_eq!(
+        plan.new_config.card_order.get("In Progress").unwrap(),
+        &vec!["b.md".to_string()]
+    );
+    assert!(!plan.new_config.card_order.contains_key("Doing"));
+    assert!(plan
+        .new_config
+        .columns
+        .iter()
+        .any(|c| c.name.as_str() == "In Progress"));
+    assert_eq!(
+        plan.new_config.done_column.as_ref().map(|d| d.as_str()),
+        Some("In Progress")
+    );
+}
+
+#[test]
+fn plan_renames_with_columns_uses_columns_as_final_shape() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let final_cols = vec![col("Todo", 0), col("Finished", 1)];
+    let args = UpdateColumnsArgs {
+        columns: Some(final_cols.clone()),
+        renames: Some(vec![rename("Done", "Finished")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(plan.new_config.columns, final_cols);
+}
+
+#[test]
+fn plan_done_column_none_args_with_existing_done_in_renames_follows_rename() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Done", "Finished")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(
+        plan.new_config.done_column.as_ref().map(|d| d.as_str()),
+        Some("Finished")
+    );
+}
+
+#[test]
+fn plan_rename_from_equals_to_is_skipped_idempotently() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Todo", "Todo")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(plan.new_config.columns, config.columns);
+    assert!(plan.rename_targets.is_empty());
+}
+
+#[test]
+fn plan_card_order_swap_a_to_b_and_b_to_a_preserves_both_entries() {
+    let mut card_order = BTreeMap::new();
+    card_order.insert("A".into(), vec!["a.md".into()]);
+    card_order.insert("B".into(), vec!["b.md".into()]);
+    let config = config_with_card_order(vec![col("A", 0), col("B", 1)], Some("B"), card_order);
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("A", "B"), rename("B", "A")]),
+        ..Default::default()
+    };
+    // Both columns "A" → "B" and "B" → "A" yields renamed columns [B, A]; but
+    // this creates DuplicateColumnName because two columns share a name after
+    // applying renames. Actually wait: rename A→B and B→A means we keep two
+    // distinct names. Let's compute:
+    //   columns ["A", "B"] applies rename_map {"A":"B","B":"A"} → ["B","A"]
+    // No duplicates. The card_order keys are translated to {"B":[a.md], "A":[b.md]}.
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(
+        plan.new_config.card_order.get("B").unwrap(),
+        &vec!["a.md".to_string()]
+    );
+    assert_eq!(
+        plan.new_config.card_order.get("A").unwrap(),
+        &vec!["b.md".to_string()]
+    );
+}
+
+#[test]
+fn plan_done_column_none_args_keeps_existing_done_column_when_not_renamed() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Todo", "To Do")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(
+        plan.new_config.done_column.as_ref().map(|d| d.as_str()),
+        Some("Done")
+    );
+}
+
+#[test]
+fn plan_done_column_none_args_with_existing_done_column_none_returns_none() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], None);
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Todo", "To Do")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert!(plan.new_config.done_column.is_none());
+}
+
+#[test]
+fn plan_new_config_keeps_self_version() {
+    let mut config = config_with(vec![col("Todo", 0)], Some("Todo"));
+    config.version = 42;
+    let args = UpdateColumnsArgs {
+        columns: Some(vec![col("Todo", 0), col("Done", 1)]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert_eq!(plan.new_config.version, 42);
+}
+
+#[test]
+fn plan_empty_columns_returns_empty_columns_error() {
+    let config = config_with(vec![col("Todo", 0)], Some("Todo"));
+    let args = UpdateColumnsArgs {
+        columns: Some(vec![]),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    assert!(matches!(err, UpdateColumnsError::EmptyColumns));
+}
+
+#[test]
+fn plan_duplicate_column_name_returns_duplicate_error() {
+    let config = config_with(vec![col("Todo", 0)], Some("Todo"));
+    let args = UpdateColumnsArgs {
+        columns: Some(vec![col("Todo", 0), col("Todo", 1)]),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    match err {
+        UpdateColumnsError::DuplicateColumnName { name } => assert_eq!(name, "Todo"),
+        other => panic!("expected DuplicateColumnName, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_unknown_rename_from_returns_unknown_rename_from_error() {
+    let config = config_with(vec![col("Todo", 0)], Some("Todo"));
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Missing", "New")]),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    match err {
+        UpdateColumnsError::UnknownRenameFrom { name } => assert_eq!(name, "Missing"),
+        other => panic!("expected UnknownRenameFrom, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_duplicate_rename_from_returns_duplicate_rename_from_error() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Todo", "A"), rename("Todo", "B")]),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    match err {
+        UpdateColumnsError::DuplicateRenameFrom { name } => assert_eq!(name, "Todo"),
+        other => panic!("expected DuplicateRenameFrom, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_empty_rename_to_returns_empty_rename_to_error() {
+    let config = config_with(vec![col("Todo", 0)], Some("Todo"));
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Todo", "")]),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    assert!(matches!(err, UpdateColumnsError::EmptyRenameTo));
+}
+
+#[test]
+fn plan_unknown_done_column_returns_unknown_done_column_error() {
+    let config = config_with(vec![col("Todo", 0)], Some("Todo"));
+    let args = UpdateColumnsArgs {
+        done_column: Some("Ghost".into()),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    match err {
+        UpdateColumnsError::UnknownDoneColumn { name } => assert_eq!(name, "Ghost"),
+        other => panic!("expected UnknownDoneColumn, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_done_column_pointing_to_removed_column_returns_unknown_done_column_error() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs {
+        columns: Some(vec![col("Todo", 0)]),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    match err {
+        UpdateColumnsError::UnknownDoneColumn { name } => assert_eq!(name, "Done"),
+        other => panic!("expected UnknownDoneColumn, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_rename_targets_excludes_tasks_with_non_renamed_status() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let tasks = vec![task("tasks/a.md", "Todo"), task("tasks/b.md", "Done")];
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Todo", "To Do")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &tasks).expect("ok");
+    assert_eq!(plan.rename_targets.len(), 1);
+    assert_eq!(plan.rename_targets[0].rel_path.as_str(), "tasks/a.md");
+    assert_eq!(plan.rename_targets[0].new_status, "To Do");
+    assert_eq!(plan.rename_targets[0].old_status, "Todo");
+}
+
+#[test]
+fn plan_card_order_orphan_key_is_dropped_after_rename() {
+    let mut card_order = BTreeMap::new();
+    card_order.insert("Old".into(), vec!["x.md".into()]);
+    let config = config_with_card_order(vec![col("Todo", 0)], Some("Todo"), card_order);
+    let args = UpdateColumnsArgs {
+        columns: Some(vec![col("Todo", 0), col("Done", 1)]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    assert!(!plan.new_config.card_order.contains_key("Old"));
+}
+
+#[test]
+fn plan_renames_with_columns_lacking_rename_to_returns_rename_to_missing_from_columns() {
+    let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
+    let args = UpdateColumnsArgs {
+        columns: Some(vec![col("Todo", 0), col("Done", 1)]),
+        renames: Some(vec![rename("Done", "Archived")]),
+        ..Default::default()
+    };
+    let err = config.plan_update_columns(&args, &[]).unwrap_err();
+    match err {
+        UpdateColumnsError::RenameToMissingFromColumns { name } => assert_eq!(name, "Archived"),
+        other => panic!("expected RenameToMissingFromColumns, got {other:?}"),
+    }
+}
+
+#[test]
+fn plan_renames_only_rename_targets_collected_for_matching_status() {
+    let config = config_with(vec![col("Todo", 0), col("Doing", 1)], Some("Doing"));
+    let tasks = vec![
+        task("tasks/a.md", "Todo"),
+        task("tasks/b.md", "Doing"),
+        task("tasks/c.md", "Todo"),
+    ];
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("Todo", "To Do")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &tasks).expect("ok");
+    assert_eq!(plan.rename_targets.len(), 2);
+    let paths: Vec<&str> = plan
+        .rename_targets
+        .iter()
+        .map(|t| t.rel_path.as_str())
+        .collect();
+    assert!(paths.contains(&"tasks/a.md"));
+    assert!(paths.contains(&"tasks/c.md"));
+}
+
+#[test]
+fn plan_rename_targets_includes_old_and_new_status() {
+    let config = config_with(vec![col("A", 0), col("B", 1)], Some("B"));
+    let tasks = vec![task("a.md", "A")];
+    let args = UpdateColumnsArgs {
+        renames: Some(vec![rename("A", "Alpha")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &tasks).expect("ok");
+    assert_eq!(plan.rename_targets[0].old_status, "A");
+    assert_eq!(plan.rename_targets[0].new_status, "Alpha");
+}
+
+// Reference unused imports to silence dead-code (will be exercised by Tasks 6-7).
+#[allow(dead_code)]
+fn _silence_unused() {
+    let _ = std::marker::PhantomData::<FrontmatterError>;
+    let _ = UpdateColumnsPlan {
+        new_config: Config::default(),
+        rename_targets: Vec::<RenameTarget>::new(),
+        is_noop: true,
+    };
+}
+
+// ───── rewrite_status_in_md tests ─────
+
+#[test]
+fn rewrite_status_in_md_replaces_status_in_extras() {
+    let input = b"---\ntitle: Foo\nstatus: Todo\n---\nbody text\n";
+    let out = rewrite_status_in_md(input, "Doing")
+        .expect("ok")
+        .expect("frontmatter present");
+
+    let parsed = crate::task::frontmatter::parse_bytes(&out)
+        .expect("re-parse ok")
+        .expect("frontmatter present");
+    let status_val = parsed
+        .frontmatter
+        .extras
+        .get(serde_yaml_ng::Value::String("status".into()))
+        .expect("status key present");
+    assert_eq!(status_val.as_str(), Some("Doing"));
+}
+
+#[test]
+fn rewrite_status_in_md_without_frontmatter_returns_ok_none() {
+    let input = b"no frontmatter here\n";
+    let out = rewrite_status_in_md(input, "Doing").expect("ok");
+    assert!(out.is_none());
+}
+
+#[test]
+fn rewrite_status_in_md_inserts_status_when_missing() {
+    let input = b"---\ntitle: Foo\n---\nbody\n";
+    let out = rewrite_status_in_md(input, "New")
+        .expect("ok")
+        .expect("frontmatter present");
+
+    let parsed = crate::task::frontmatter::parse_bytes(&out)
+        .expect("re-parse ok")
+        .expect("frontmatter present");
+    let status_val = parsed
+        .frontmatter
+        .extras
+        .get(serde_yaml_ng::Value::String("status".into()))
+        .expect("status key inserted");
+    assert_eq!(status_val.as_str(), Some("New"));
+}
+
+#[test]
+fn rewrite_status_in_md_propagates_frontmatter_parse_error() {
+    let input = b"---\ntitle: [unclosed\n---\nbody\n";
+    let err = rewrite_status_in_md(input, "Doing").unwrap_err();
+    assert!(matches!(err, FrontmatterError::InvalidYaml(_)));
+}
+
+// ───── E2E tests for update_columns_impl ─────
+
+fn tempdir() -> TempDir {
+    tempfile::tempdir().expect("create temp dir")
+}
+
+fn write_md(root: &Path, rel: &str, content: &str) {
+    let abs = root.join(rel);
+    if let Some(parent) = abs.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(abs, content).unwrap();
+}
+
+fn write_initial_config(root: &Path, json: &str) {
+    let dir = root.join(".spec-board");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("config.json"), json).unwrap();
+}
+
+fn open_with_noop(state: Arc<AppState>, path: &Path) {
+    let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
+        .expect("non-empty path");
+    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+}
+
+fn read_config_json(root: &Path) -> Config {
+    let raw = fs::read_to_string(root.join(".spec-board/config.json")).unwrap();
+    serde_json::from_str(&raw).unwrap()
+}
+
+fn read_status(root: &Path, rel: &str) -> String {
+    let content = fs::read_to_string(root.join(rel)).unwrap();
+    let parsed = crate::task::frontmatter::parse(&content)
+        .expect("ok")
+        .expect("frontmatter present");
+    parsed
+        .frontmatter
+        .extras
+        .get(serde_yaml_ng::Value::String("status".into()))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_default()
+}
+
+#[test]
+fn fs_config_writer_writes_via_atomic_tmp_and_rename() {
+    let dir = tempdir();
+    let dst = dir.path().join("config.json");
+    let writer = FsConfigWriter;
+    writer.write_atomic(&dst, "{\"hello\":1}").unwrap();
+    assert_eq!(fs::read_to_string(&dst).unwrap(), "{\"hello\":1}");
+}
+
+#[test]
+fn e2e_args_all_none_is_noop_and_does_not_write_files() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(dir.path(), "tasks/a.md", "---\nstatus: Todo\n---\n");
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let before_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
+    let before_md = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+
+    update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs::default(),
+    )
+    .expect("noop ok");
+
+    let after_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
+    let after_md = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert_eq!(before_cfg, after_cfg);
+    assert_eq!(before_md, after_md);
+}
+
+#[test]
+fn e2e_columns_reorder_writes_config_json_and_guide_md() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Doing", "order": 1 },
+                { "name": "Done", "order": 2 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let new_cols = vec![
+        Column {
+            name: ColumnName::from_lenient("Done"),
+            order: 0,
+        },
+        Column {
+            name: ColumnName::from_lenient("Doing"),
+            order: 1,
+        },
+        Column {
+            name: ColumnName::from_lenient("Todo"),
+            order: 2,
+        },
+    ];
+    update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            columns: Some(new_cols.clone()),
+            ..Default::default()
+        },
+    )
+    .expect("ok");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(on_disk.columns, new_cols);
+    let state_cfg = state.config().unwrap().unwrap();
+    assert_eq!(state_cfg.columns, new_cols);
+
+    let guide = fs::read_to_string(dir.path().join(".spec-board/GUIDE.md")).unwrap();
+    assert!(guide.contains("- Done"));
+    assert!(guide.contains("- Doing"));
+    assert!(guide.contains("- Todo"));
+}
+
+#[test]
+fn e2e_done_column_update_persists() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Doing", "order": 1 },
+                { "name": "Done", "order": 2 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            done_column: Some("Doing".into()),
+            ..Default::default()
+        },
+    )
+    .expect("ok");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(
+        on_disk.done_column.as_ref().map(|c| c.as_str()),
+        Some("Doing")
+    );
+}
+
+#[test]
+fn e2e_renames_updates_md_status_and_tasks_cache() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Doing", "order": 1 },
+                { "name": "Done", "order": 2 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    write_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Doing\n---\nbody\n",
+    );
+    write_md(
+        dir.path(),
+        "tasks/c.md",
+        "---\ntitle: C\nstatus: Done\n---\nbody\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .expect("ok");
+
+    assert_eq!(read_status(dir.path(), "tasks/a.md"), "To Do");
+    assert_eq!(read_status(dir.path(), "tasks/b.md"), "Doing");
+    assert_eq!(read_status(dir.path(), "tasks/c.md"), "Done");
+
+    let snapshot = state.tasks_snapshot().unwrap();
+    let a = snapshot
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .unwrap();
+    assert_eq!(a.status.as_str(), "To Do");
+
+    let on_disk = read_config_json(dir.path());
+    assert!(on_disk.columns.iter().any(|c| c.name.as_str() == "To Do"));
+    assert!(!on_disk.columns.iter().any(|c| c.name.as_str() == "Todo"));
+}
+
+#[test]
+fn e2e_renames_with_card_order_swap_persists_in_config_json() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {
+                "Todo": ["tasks/a.md"],
+                "Done": ["tasks/c.md"]
+            },
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(dir.path(), "tasks/a.md", "---\nstatus: Todo\n---\n");
+    write_md(dir.path(), "tasks/c.md", "---\nstatus: Done\n---\n");
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .expect("ok");
+
+    let on_disk = read_config_json(dir.path());
+    assert!(on_disk.card_order.contains_key("To Do"));
+    assert_eq!(
+        on_disk.card_order.get("To Do").unwrap(),
+        &vec!["tasks/a.md".to_string()]
+    );
+    assert!(!on_disk.card_order.contains_key("Todo"));
+}
+
+// ───── fault injection mocks ─────
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use crate::config::ConfigWriter;
+use crate::task::io::{TaskIo, TaskIoError};
+
+/// 指定回数目の write_existing で `io::Error` を返す test-only `TaskIo`。
+/// それ以外の操作 (read / ensure_dir / write_new / remove) は `FsTaskIo` に委譲する。
+struct FailingTaskIo {
+    inner: FsTaskIo,
+    fail_write_indices: Mutex<HashSet<usize>>,
+    write_existing_calls: AtomicUsize,
+    fail_read_for: Mutex<HashSet<PathBuf>>,
+}
+
+impl FailingTaskIo {
+    fn new() -> Self {
+        Self {
+            inner: FsTaskIo,
+            fail_write_indices: Mutex::new(HashSet::new()),
+            write_existing_calls: AtomicUsize::new(0),
+            fail_read_for: Mutex::new(HashSet::new()),
+        }
+    }
+
+    fn fail_write_at_indices<I: IntoIterator<Item = usize>>(self, indices: I) -> Self {
+        self.fail_write_indices.lock().unwrap().extend(indices);
+        self
+    }
+
+    fn fail_read_for(self, path: PathBuf) -> Self {
+        self.fail_read_for.lock().unwrap().insert(path);
+        self
+    }
+}
+
+impl TaskIo for FailingTaskIo {
+    fn ensure_dir(&self, dir: &Path) -> Result<(), TaskIoError> {
+        self.inner.ensure_dir(dir)
+    }
+    fn write_new(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError> {
+        self.inner.write_new(path, bytes)
+    }
+    fn write_existing(&self, path: &Path, bytes: &[u8]) -> Result<(), TaskIoError> {
+        let nth = self.write_existing_calls.fetch_add(1, Ordering::Relaxed);
+        if self.fail_write_indices.lock().unwrap().contains(&nth) {
+            return Err(TaskIoError::from(std::io::Error::other(format!(
+                "injected fault on write #{nth}"
+            ))));
+        }
+        self.inner.write_existing(path, bytes)
+    }
+    fn remove(&self, path: &Path) -> Result<(), TaskIoError> {
+        self.inner.remove(path)
+    }
+    fn read(&self, path: &Path) -> Result<Vec<u8>, TaskIoError> {
+        if self.fail_read_for.lock().unwrap().contains(path) {
+            return Err(TaskIoError::from(std::io::Error::other(format!(
+                "injected read fault for {}",
+                path.display()
+            ))));
+        }
+        self.inner.read(path)
+    }
+}
+
+/// `write_atomic` を必ず失敗させる test-only `ConfigWriter`。
+struct FailingConfigWriter {
+    force_failure: bool,
+}
+
+impl ConfigWriter for FailingConfigWriter {
+    fn write_atomic(&self, _dst: &Path, _content: &str) -> std::io::Result<()> {
+        if self.force_failure {
+            Err(std::io::Error::other("injected config write fault"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn fault_read_original_fails_does_not_modify_anything() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(dir.path(), "tasks/a.md", "---\nstatus: Todo\n---\n");
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let before_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
+    let before_md = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+
+    let io = FailingTaskIo::new().fail_read_for(dir.path().join("tasks/a.md"));
+    let err = update_columns_impl(
+        &state,
+        &io,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, UpdateColumnsError::RenameWriteFailed { .. }));
+    let after_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
+    let after_md = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    assert_eq!(before_cfg, after_cfg);
+    assert_eq!(before_md, after_md);
+}
+
+#[test]
+fn fault_rewrite_fails_at_index_2_rolls_back_first_two_files() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    write_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\nbody\n",
+    );
+    write_md(
+        dir.path(),
+        "tasks/c.md",
+        "---\ntitle: C\nstatus: Todo\n---\nbody\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let before_a = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    let before_b = fs::read_to_string(dir.path().join("tasks/b.md")).unwrap();
+    let before_c = fs::read_to_string(dir.path().join("tasks/c.md")).unwrap();
+    let before_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
+
+    // 3rd write (index 2) fails. We don't know order of HashSet snapshot iteration
+    // so just verify "all 3 files end up at original content" + cfg unchanged.
+    let io = FailingTaskIo::new().fail_write_at_indices([2]);
+    let err = update_columns_impl(
+        &state,
+        &io,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, UpdateColumnsError::RenameWriteFailed { .. }));
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/a.md")).unwrap(),
+        before_a
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/b.md")).unwrap(),
+        before_b
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/c.md")).unwrap(),
+        before_c
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap(),
+        before_cfg
+    );
+
+    let snap = state.tasks_snapshot().unwrap();
+    for t in &snap {
+        assert_eq!(t.status.as_str(), "Todo");
+    }
+}
+
+#[test]
+fn fault_rewrite_fails_then_rollback_also_fails_returns_rename_rollback_failed() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    write_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\nbody\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    // 2nd write (index 1) fails. Then rollback writes the 1st file back (index 2), which also fails.
+    let io = FailingTaskIo::new().fail_write_at_indices([1, 2]);
+
+    let err = update_columns_impl(
+        &state,
+        &io,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        UpdateColumnsError::RenameRollbackFailed { .. }
+    ));
+}
+
+#[test]
+fn fault_config_write_fails_after_all_md_rewritten_rolls_back_all_md() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    write_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\nbody\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let before_a = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    let before_b = fs::read_to_string(dir.path().join("tasks/b.md")).unwrap();
+    let before_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
+
+    let err = update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FailingConfigWriter {
+            force_failure: true,
+        },
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, UpdateColumnsError::ConfigWriteFailed { .. }));
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/a.md")).unwrap(),
+        before_a
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/b.md")).unwrap(),
+        before_b
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap(),
+        before_cfg
+    );
+
+    // cache 未更新
+    let snap = state.tasks_snapshot().unwrap();
+    for t in &snap {
+        assert_eq!(t.status.as_str(), "Todo");
+    }
+}
+
+// WriteIgnoreError::LockPoisoned → StateLockPoisoned の変換は
+// `write_ignore_lock_poisoned_converts_to_state_lock_poisoned` で単体的に検証済み。
+// AppState 経由の poison は registry の private 内部に直接アクセスできないため
+// integration として再現するのではなく From 変換側で担保する。
+
+#[test]
+fn fault_frontmatter_parse_error_returns_rename_parse_failed_and_rolls_back() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    // 壊れた frontmatter（YAML パース失敗）
+    write_md(
+        dir.path(),
+        "tasks/broken.md",
+        "---\ntitle: [unclosed\nstatus: Todo\n---\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    // 壊れた frontmatter は open_project の parse でスキップされる可能性があるため
+    // 直接 AppState を組み立てて Task をキャッシュに注入する。簡略化として `task` factory を使い、
+    // tasks_cache に Todo な Task を 2 つ入れる。
+    let cfg: Config = serde_json::from_str(
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    )
+    .unwrap();
+    state
+        .set_project_path(Some(dir.path().to_path_buf()))
+        .unwrap();
+    state.replace_config(Some(cfg)).unwrap();
+    let mut cache = std::collections::HashMap::new();
+    cache.insert(PathBuf::from("tasks/a.md"), task("tasks/a.md", "Todo"));
+    cache.insert(
+        PathBuf::from("tasks/broken.md"),
+        task("tasks/broken.md", "Todo"),
+    );
+    state.replace_tasks_cache(cache).unwrap();
+
+    let before_a = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    let before_broken = fs::read_to_string(dir.path().join("tasks/broken.md")).unwrap();
+    let before_cfg = fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap();
+
+    let err = update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    match err {
+        UpdateColumnsError::RenameParseFailed { path, .. } => {
+            assert!(path.ends_with("tasks/broken.md"));
+        }
+        UpdateColumnsError::RenameWriteFailed { .. } => {
+            // 壊れた frontmatter file の order によっては write 経路に乗らず終わる可能性もあるが、
+            // 本テストでは parse error が出る経路を期待する。Ok(None) 経路は別テストに分離。
+            panic!("expected RenameParseFailed but got RenameWriteFailed");
+        }
+        other => panic!("expected RenameParseFailed, got {other:?}"),
+    }
+
+    // rollback で a.md は元に戻る（broken.md は parse fail なので元のまま）
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/a.md")).unwrap(),
+        before_a
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/broken.md")).unwrap(),
+        before_broken
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join(".spec-board/config.json")).unwrap(),
+        before_cfg
+    );
+}
+
+#[test]
+fn fault_missing_frontmatter_returns_rename_missing_frontmatter_and_rolls_back() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    // frontmatter 区切りなしの md（防御パス）
+    write_md(dir.path(), "tasks/plain.md", "no frontmatter here\n");
+
+    let state = Arc::new(AppState::new());
+    let cfg: Config = serde_json::from_str(
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    )
+    .unwrap();
+    state
+        .set_project_path(Some(dir.path().to_path_buf()))
+        .unwrap();
+    state.replace_config(Some(cfg)).unwrap();
+    let mut cache = std::collections::HashMap::new();
+    cache.insert(PathBuf::from("tasks/a.md"), task("tasks/a.md", "Todo"));
+    cache.insert(
+        PathBuf::from("tasks/plain.md"),
+        task("tasks/plain.md", "Todo"),
+    );
+    state.replace_tasks_cache(cache).unwrap();
+
+    let before_a = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    let before_plain = fs::read_to_string(dir.path().join("tasks/plain.md")).unwrap();
+
+    let err = update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    match err {
+        UpdateColumnsError::RenameMissingFrontmatter { path } => {
+            assert!(path.ends_with("tasks/plain.md"));
+        }
+        other => panic!("expected RenameMissingFrontmatter, got {other:?}"),
+    }
+
+    // rollback により a.md は元に戻る
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/a.md")).unwrap(),
+        before_a
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/plain.md")).unwrap(),
+        before_plain
+    );
+}
+
+#[test]
+fn e2e_combined_columns_renames_done_column_applied_in_order() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(dir.path(), "tasks/a.md", "---\nstatus: Todo\n---\n");
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    let final_cols = vec![
+        Column {
+            name: ColumnName::from_lenient("To Do"),
+            order: 0,
+        },
+        Column {
+            name: ColumnName::from_lenient("In Review"),
+            order: 1,
+        },
+        Column {
+            name: ColumnName::from_lenient("Done"),
+            order: 2,
+        },
+    ];
+
+    update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            columns: Some(final_cols.clone()),
+            done_column: Some("Done".into()),
+            renames: Some(vec![rename("Todo", "To Do")]),
+        },
+    )
+    .expect("ok");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(on_disk.columns, final_cols);
+    assert_eq!(read_status(dir.path(), "tasks/a.md"), "To Do");
+}
+
+#[test]
+fn e2e_guide_md_contains_renamed_column_name_after_update() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Doing", "order": 1 },
+                { "name": "Done", "order": 2 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(dir.path(), "tasks/a.md", "---\nstatus: Doing\n---\n");
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Doing", "In Progress")]),
+            ..Default::default()
+        },
+    )
+    .expect("ok");
+
+    let guide = fs::read_to_string(dir.path().join(".spec-board/GUIDE.md")).unwrap();
+    assert!(
+        guide.contains("- In Progress"),
+        "GUIDE.md must contain renamed column 'In Progress': {guide}"
+    );
+    assert!(
+        !guide.contains("- Doing\n"),
+        "GUIDE.md must not contain old column 'Doing': {guide}"
+    );
+}
+
+#[test]
+fn fault_write_ignore_lock_poisoned_returns_state_lock_poisoned() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(dir.path(), "tasks/a.md", "---\nstatus: Todo\n---\n");
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    state.write_ignore().poison_lock_for_testing();
+
+    let err = update_columns_impl(
+        &state,
+        &FsTaskIo,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, UpdateColumnsError::StateLockPoisoned));
+}

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -269,7 +269,10 @@ fn write_ignore_lock_poisoned_converts_to_state_lock_poisoned() {
 #[test]
 fn write_ignore_cleanup_worker_spawn_failed_maps_to_dedicated_variant() {
     let err: UpdateColumnsError = WriteIgnoreError::CleanupWorkerSpawnFailed.into();
-    assert!(matches!(err, UpdateColumnsError::WriteIgnoreWorkerSpawnFailed));
+    assert!(matches!(
+        err,
+        UpdateColumnsError::WriteIgnoreWorkerSpawnFailed
+    ));
 }
 
 #[test]

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -488,7 +488,11 @@ fn plan_card_order_collapse_merges_paths_first_occurrence_wins() {
     // 1 つだけ残る。順序は BTreeMap の iteration 順（A, B）に従う。
     assert_eq!(
         merged,
-        &vec!["a.md".to_string(), "shared.md".to_string(), "b.md".to_string()]
+        &vec![
+            "a.md".to_string(),
+            "shared.md".to_string(),
+            "b.md".to_string()
+        ]
     );
 }
 

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -469,6 +469,30 @@ fn plan_card_order_swap_a_to_b_and_b_to_a_preserves_both_entries() {
 }
 
 #[test]
+fn plan_card_order_collapse_merges_paths_first_occurrence_wins() {
+    // 旧 card_order に A と B 両方の entry がある状態で、args.columns で B のみを残し
+    // rename A→B を指定すると、A の paths と B の paths が同じ new_key="B" に集約される。
+    // 後勝ち上書きで一方のリストが消えないよう、append + first-occurrence wins でマージされる。
+    let mut card_order = BTreeMap::new();
+    card_order.insert("A".into(), vec!["a.md".into(), "shared.md".into()]);
+    card_order.insert("B".into(), vec!["b.md".into(), "shared.md".into()]);
+    let config = config_with_card_order(vec![col("A", 0), col("B", 1)], Some("B"), card_order);
+    let args = UpdateColumnsArgs {
+        columns: Some(vec![col("B", 0)]),
+        renames: Some(vec![rename("A", "B")]),
+        ..Default::default()
+    };
+    let plan = config.plan_update_columns(&args, &[]).expect("ok");
+    let merged = plan.new_config.card_order.get("B").expect("B exists");
+    // A の entries (a.md, shared.md) → B の entries (b.md) の順で、shared.md は重複除去で
+    // 1 つだけ残る。順序は BTreeMap の iteration 順（A, B）に従う。
+    assert_eq!(
+        merged,
+        &vec!["a.md".to_string(), "shared.md".to_string(), "b.md".to_string()]
+    );
+}
+
+#[test]
 fn plan_done_column_none_args_keeps_existing_done_column_when_not_renamed() {
     let config = config_with(vec![col("Todo", 0), col("Done", 1)], Some("Done"));
     let args = UpdateColumnsArgs {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,7 +37,8 @@ pub fn run() {
             task::update::update_task,
             task::add_link::add_link,
             task::remove_link::remove_link,
-            config::get_columns::get_columns
+            config::get_columns::get_columns,
+            config::update_columns::update_columns
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## 概要
カラムの追加・削除・並び替え・名前変更・完了カラム変更を 1 コマンドで処理する `update_columns` Tauri command を実装した。コア計算は `Config::plan_update_columns` aggregate method に集約し、effect 層 `update_columns_impl` で md 一括書き換え（トランザクション的ロールバック付き）→ `config.json` atomic write → `AppState` commit → `tasks_cache` in-place 更新 → GUIDE.md 再生成、の順で適用する。

## 変更の種類
- ✨ New Feature
- 🐛 Bug Fix（レビュー指摘対応）
- 🧪 Tests
- 📝 Doc（`config-spec.md`）

## 追加した内容
- `src-tauri/src/config/update_columns.rs`
  - `UpdateColumnsArgs` / `ColumnRename` DTO + `UpdateColumnsError`（16 variants） + `From<AppStateError>` / `From<WriteIgnoreError>`
  - `#[tauri::command] update_columns` 薄層 + `update_columns_impl` effect 層
  - `rewrite_status_in_md` / `rollback_md` / `cleanup_registered_write_ignores` leaf helper
- `src-tauri/src/config/update_columns_tests.rs`
  - aggregate / pure helper / E2E / fault injection 計 68 件のテスト
  - `FailingTaskIo` / `FailingConfigWriter` mock
- `src-tauri/src/config.rs`
  - `Config::plan_update_columns` aggregate method（pure 計算）
  - `UpdateColumnsPlan` / `RenameTarget`
  - `ConfigWriter` trait + `FsConfigWriter`
  - `pub(crate) write_atomic_to_path` + `unique_atomic_tmp_path` helper
- `src-tauri/crates/fs/src/watcher/write_ignore.rs`
  - `WriteIgnoreRegistry::register_bulk`（単一 lock で N パス一括登録）
  - `poison_lock_for_testing`（`test-utils` feature gate）

## 変更した内容
- `src-tauri/src/lib.rs`: `tauri::generate_handler!` に `config::update_columns::update_columns` を追加
- `src-tauri/Cargo.toml`: dev-dependencies で `spec-board-fs` に `test-utils` feature を有効化
- `src-tauri/crates/fs/Cargo.toml`: `test-utils` feature を追加
- `src-tauri/crates/fs/src/watcher/write_ignore_tests.rs`: `register_bulk` の 4 ケース追加
- `src-tauri/src/config/config_tests.rs`: `write_backup_to_path` → `write_atomic_to_path` リネーム追従

## 仕様ドキュメント更新
- `docs/spec-board/config-spec.md` の `update_columns` セクションを更新
  - 振る舞いに「args 全 None で no-op」「`from == to` の冪等 skip」を明記
  - エラー表に `RenameReadFailed`（原本読み込み失敗）を追加
  - 既存エラー文字列は実装と完全一致するよう微調整

## システム図

### 状態遷移（成功・失敗時のロールバック動作）

\`\`\`mermaid
flowchart TD
    Start([update_columns]) --> Preflight[PREFLIGHT<br/>lock 健全性]
    Preflight --> Plan[VALIDATING<br/>plan_update_columns]
    Plan -->|args 全 None| Noop([Ok &#40;noop&#41;])
    Plan -->|validation NG| ValidationErr([Empty/Dup/Unknown* Err])
    Plan -->|OK| ReadOriginals[READ_ORIGINALS<br/>原本 bytes 保持]
    ReadOriginals -->|read 失敗| RReadFail([RenameReadFailed])
    ReadOriginals --> RegisterIgnore[REGISTER_IGNORE<br/>register_bulk]
    RegisterIgnore --> RewriteLoop[REWRITE_MD_LOOP<br/>順次 atomic write]
    RewriteLoop -->|write 失敗| Rollback1[ROLLBACK_MD<br/>+ cleanup_write_ignore]
    RewriteLoop --> WriteConfig[WRITE_CONFIG_JSON<br/>atomic write]
    Rollback1 --> RWFail([RenameWriteFailed])
    WriteConfig -->|write 失敗| Rollback2[ROLLBACK_MD<br/>+ cleanup_write_ignore]
    WriteConfig --> Commit[COMMIT_CACHE<br/>replace_config + tasks_cache 更新]
    Rollback2 --> ConfigWriteFailed([ConfigWriteFailed])
    Commit --> Guide[WRITE_GUIDE_MD<br/>best-effort]
    Guide --> Done([Ok])

    style Plan fill:#bff
    style RewriteLoop fill:#ffb
    style Rollback1 fill:#fbb
    style Rollback2 fill:#fbb
\`\`\`

## 関連Issue
Closes #96

## テスト
- \`cargo test --workspace\`: **全 pass**
  - update_columns: 68 件（DTO/Error display / plan aggregate 27 件 / rewrite helper 4 件 / E2E 7 件 / fault injection 8 件 / Tauri 薄層含む）
  - write_ignore: 4 件追加（register_bulk）
- \`cargo clippy --workspace --all-targets -- -D warnings\`: クリーン
- \`cargo fmt --all -- --check\`: クリーン
- Codex CLI コードレビュー: 3 ラウンドで「問題なし」確認
- 本番 build で \`poison_lock_for_testing\` がコンパイル除外されることを \`cargo tree --edges normal,build\` で確認
- Copilot レビュー指摘 5 件すべて修正済み（card_order merge / write_ignore cleanup / RenameReadFailed 分離 / PR 説明訂正）

## レビューポイント
- **memory feedback \`spec-board-aggregate-method\` 準拠**: `Config::plan_update_columns` を aggregate method として実装し、effect は `update_columns_impl` 1 本に閉じている。free function 3 段分離（pure/read/write）は採用していない
- **トランザクション的 md 書き換え**: rewrite 途中で 1 件でも失敗すると既書き換え分を `originals` から書き戻す。二重失敗時は `RenameRollbackFailed` で報告
- **write_ignore 失敗時クリーンアップ**: `register_bulk` 済み path は失敗パスで明示 unregister し、stale エントリで後続のユーザー編集イベントを抑止しないようにしている
- **card_order rename 衝突マージ**: 複数の旧キーが同じ new_key に collapse する場合、`entry().or_default()` で paths を append + first-occurrence wins で重複除去
- **`tasks_cache` の key**: project_root 相対 `PathBuf`（`PathBuf::from(task.file_path.as_str())`）。effect 層の commit ステップで in-place 更新
- **`poison_lock_for_testing` の安全性**: `cfg(any(test, feature = "test-utils"))` でゲート。本番 build には含まれない

🤖 Generated with [Claude Code](https://claude.com/claude-code)