### PR TITLE
🧪 [Tests]: #97 [BE] update_columns rename 失敗時の write_ignore cleanup を検証

### DIFF
--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -248,11 +248,13 @@ links:（任意）
 **振る舞い**:
 1. すべての引数が未指定（`columns`/`doneColumn`/`renames` のいずれも `None`）の場合は no-op として `Ok(())` を返し、ファイルや state を一切変更しない
 2. `renames` 内で `from == to` の項目は冪等にスキップ
-3. `renames` が指定され、かつ空でない場合、該当するタスクのmdファイルの `status` を一括更新（空配列または未指定の場合はこのステップをスキップ）
-   - 一括更新は**トランザクション的**に処理。途中で1件でも失敗した場合、変更済みファイルを元に戻してエラーを返却
+3. `renames` が指定され、かつ空でない場合、該当するタスクの md ファイルの `status` を一括更新（空配列または未指定の場合はこのステップをスキップ）。`from == to` の項目は冪等にスキップされ、md にも `WriteIgnoreRegistry` にも一切触らない。一括更新はトランザクション的に処理され、以下の段階で進行する:
+   - **(a) pre-read**: 対象 md 全件の原本 bytes をメモリに読み込む。1 件でも読み込み失敗した場合は `RenameReadFailed` を返し、disk を一切変更せず終了する。
+   - **(b) write_ignore 登録**: watcher 起動中 (`is_watcher_installed() == true`) のみ、対象 md のパスを `WriteIgnoreRegistry` に bulk 登録する。watcher 未起動時は登録をスキップ。
+   - **(c) 順次 write**: 各 md の frontmatter `status` を新カラム名に書き換えて atomic write。途中で 1 件でも失敗した場合、書き込み完了済み md を原本 bytes で書き戻し、**rollback が成功した場合に限り** 登録済み write_ignore エントリを解除してから失敗エラーを返す。rollback 自体が失敗した場合は `RenameRollbackFailed` を返し、その時点で early return するため write_ignore の解除は行われない（現状仕様）。
 4. `columns` が指定されている場合、カラム集合を上書きして `config.json` に保存
 5. `doneColumn` が指定されている場合、完了カラム名を更新して `config.json` に保存
-6. `GUIDE.md` を再生成
+6. `GUIDE.md` を再生成（**best-effort**。書き込み失敗時はログ (WARN + stderr fallback) のみ出力し、`update_columns` 自体は成功扱いとする）
 7. 戻り値なし（更新後の設定が必要な場合は呼び出し側が `get_columns` で取得する）
 
 **エラー**:
@@ -276,6 +278,8 @@ links:（任意）
 | ロールバック失敗 | rollback 中の書き戻しに失敗（二重失敗） | カラム名の変更失敗後のロールバックに失敗しました: {path} |
 | config.json シリアライズ失敗 | `serde_json::to_string_pretty` 失敗 | config.json のシリアライズに失敗しました |
 | config.json 書き込み失敗 | atomic write 失敗（権限・ディスク容量等） | config.json の書き込みに失敗しました: {path} |
+
+**rollback 時の副作用**: 失敗時のロールバックは原本 bytes による書き戻しを行い、**rollback が成功した場合のみ** `WriteIgnoreRegistry` への登録解除も併せて実施する。これにより通常の rename 途中失敗パスでは watcher 由来の自己 write イベント抑止状態が残らず、後続の `update_columns` 呼び出しに副作用を残さない。rollback 自体が失敗した場合 (`RenameRollbackFailed`) は early return するため write_ignore の解除は行われない（実装の現状仕様。改修は本 PR スコープ外として別 Issue 化候補）。
 
 ---
 

--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -248,7 +248,7 @@ links:（任意）
 **振る舞い**:
 1. すべての引数が未指定（`columns`/`doneColumn`/`renames` のいずれも `None`）の場合は no-op として `Ok(())` を返し、ファイルや state を一切変更しない
 2. `renames` 内で `from == to` の項目は冪等にスキップ
-3. `renames` が指定され、かつ空でない場合、該当するタスクの md ファイルの `status` を一括更新（空配列または未指定の場合はこのステップをスキップ）。`from == to` の項目は冪等にスキップされ、md にも `WriteIgnoreRegistry` にも一切触らない。一括更新はトランザクション的に処理され、以下の段階で進行する:
+3. `renames` が指定され、かつ空でない場合、該当するタスクの md ファイルの `status` を一括更新（空配列または未指定の場合はこのステップをスキップ）。`from == to` の項目は冪等にスキップされ、md への書き込みも `WriteIgnoreRegistry` の登録/解除も行わない（preflight 時の `write_ignore` 健全性 probe は通常通り走る）。一括更新はトランザクション的に処理され、以下の段階で進行する:
    - **(a) pre-read**: 対象 md 全件の原本 bytes をメモリに読み込む。1 件でも読み込み失敗した場合は `RenameReadFailed` を返し、disk を一切変更せず終了する。
    - **(b) write_ignore 登録**: watcher 起動中 (`is_watcher_installed() == true`) のみ、対象 md のパスを `WriteIgnoreRegistry` に bulk 登録する。watcher 未起動時は登録をスキップ。
    - **(c) 順次 write**: 各 md の frontmatter `status` を新カラム名に書き換えて atomic write。途中で 1 件でも失敗した場合、書き込み完了済み md を原本 bytes で書き戻し、**rollback が成功した場合に限り** 登録済み write_ignore エントリを解除してから失敗エラーを返す。rollback 自体が失敗した場合は `RenameRollbackFailed` を返し、その時点で early return するため write_ignore の解除は行われない（現状仕様）。

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 
 use tempfile::TempDir;
 
-use spec_board_fs::watcher::handle::NoopWatcherHandle;
-
 use crate::config::column_name::ColumnName;
 use crate::config::Column;
 use crate::config::Config;
@@ -1749,9 +1747,6 @@ fn fault_rewrite_fails_with_watcher_installed_clears_write_ignore_registry() {
     let state = Arc::new(AppState::new());
     open_with_noop(Arc::clone(&state), dir.path());
 
-    state
-        .install_watcher_handle(Box::new(NoopWatcherHandle::new()))
-        .expect("install noop watcher handle");
     assert!(state.is_watcher_installed().unwrap());
 
     let before_a = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -1781,6 +1781,21 @@ fn fault_rewrite_fails_with_watcher_installed_clears_write_ignore_registry() {
     );
 
     let snap = state.tasks_snapshot().unwrap();
+    assert_eq!(
+        snap.len(),
+        2,
+        "expected 2 tasks in snapshot, got {}",
+        snap.len()
+    );
+    let mut paths: Vec<String> = snap
+        .iter()
+        .map(|t| t.file_path.as_str().to_string())
+        .collect();
+    paths.sort();
+    assert_eq!(
+        paths,
+        vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()],
+    );
     for t in &snap {
         assert_eq!(t.status.as_str(), "Todo");
     }

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use tempfile::TempDir;
 
+use spec_board_fs::watcher::handle::NoopWatcherHandle;
+
 use crate::config::column_name::ColumnName;
 use crate::config::Column;
 use crate::config::Config;
@@ -1716,4 +1718,75 @@ fn fault_write_ignore_lock_poisoned_returns_state_lock_poisoned() {
     )
     .unwrap_err();
     assert!(matches!(err, UpdateColumnsError::StateLockPoisoned));
+}
+
+#[test]
+fn fault_rewrite_fails_with_watcher_installed_clears_write_ignore_registry() {
+    let dir = tempdir();
+    write_initial_config(
+        dir.path(),
+        r#"{
+            "version": 1,
+            "columns": [
+                { "name": "Todo", "order": 0 },
+                { "name": "Done", "order": 1 }
+            ],
+            "cardOrder": {},
+            "doneColumn": "Done"
+        }"#,
+    );
+    write_md(
+        dir.path(),
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\n---\nbody\n",
+    );
+    write_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\n---\nbody\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), dir.path());
+
+    state
+        .install_watcher_handle(Box::new(NoopWatcherHandle::new()))
+        .expect("install noop watcher handle");
+    assert!(state.is_watcher_installed().unwrap());
+
+    let before_a = fs::read_to_string(dir.path().join("tasks/a.md")).unwrap();
+    let before_b = fs::read_to_string(dir.path().join("tasks/b.md")).unwrap();
+
+    let io = FailingTaskIo::new().fail_write_at_indices([1]);
+    let err = update_columns_impl(
+        &state,
+        &io,
+        &FsConfigWriter,
+        UpdateColumnsArgs {
+            renames: Some(vec![rename("Todo", "To Do")]),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, UpdateColumnsError::RenameWriteFailed { .. }));
+
+    assert!(
+        state.write_ignore().is_empty().unwrap(),
+        "write_ignore registry must be empty after failed rename"
+    );
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/a.md")).unwrap(),
+        before_a
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("tasks/b.md")).unwrap(),
+        before_b
+    );
+
+    let snap = state.tasks_snapshot().unwrap();
+    for t in &snap {
+        assert_eq!(t.status.as_str(), "Todo");
+    }
 }


### PR DESCRIPTION
## 概要

Issue #97 [BE] columns - update_columns: rename トランザクション + GUIDE.md 再生成 のクローズに向けた**追補 PR**。本機能の主要実装は先行 PR #226 (commit 2b6c7a9) で完了しており、本 PR は差分監査で検出された 2 つの不足のみを補完する。

## 変更の種類

- 🧪 [Tests]: characterization / regression test を 1 件追加
- 📝 [Doc]: `docs/spec-board/config-spec.md` への仕様追補

## 追加した内容

- `src-tauri/src/config/update_columns_tests.rs`
  - `fault_rewrite_fails_with_watcher_installed_clears_write_ignore_registry` を新規追加
  - `is_watcher_installed() == true` 状態で `FailingTaskIo` により 2 件目の `write` を失敗させ、以下を assert する E2E テスト:
    - 戻り値が `UpdateColumnsError::RenameWriteFailed`
    - `state.write_ignore().is_empty() == true` (registry 残留なし)
    - md 全ファイルが原本一致 (rollback 成功)
    - `tasks_snapshot()` の全 status が `"Todo"` (tasks_cache 不変)

## 変更した内容

- `docs/spec-board/config-spec.md` の `### update_columns` 章
  - 振る舞い 項 3 を rename トランザクション 3 段階 (pre-read / write_ignore 登録 / 順次 write) に詳細化
  - `from == to` の冪等 skip を明文化
  - 項 6 で GUIDE.md 再生成が **best-effort** であり書き込み失敗時はログ (WARN + stderr fallback) のみ出力する挙動を追記
  - エラー表の直後に `rollback 時の副作用` (rollback 成功時のみ `WriteIgnoreRegistry` 登録解除) を追記

### 本体実装の変更

なし。`update_columns.rs` / `plan_update_columns` / `config.rs` のロジックは触らない。

## 仕様ドキュメント更新

- `docs/spec-board/config-spec.md` の `update_columns` 仕様を更新済み（実装計画 §3.2 / §7 に沿った追補）

## システム図

rename トランザクションの失敗パスにおける write_ignore cleanup の状態遷移:

```mermaid
flowchart TD
    Start([update_columns_impl]) --> PreRead[PRE_READ: originals 全件 read]
    PreRead -->|失敗| ReadErr[Err RenameReadFailed]
    PreRead -->|成功| WIReg{watcher_installed?}
    WIReg -->|yes| Register[WriteIgnoreRegistry.register_bulk]
    WIReg -->|no| WriteSeq
    Register --> WriteSeq[WRITE_SEQUENTIAL: 順次 write_existing]
    WriteSeq -->|全件成功| Commit[COMMIT: config.json / tasks_cache / GUIDE.md]
    WriteSeq -->|途中失敗| Rollback[rollback_md written, originals]
    Rollback -->|rollback 失敗| RbErr[Err RenameRollbackFailed<br>write_ignore 残留]
    Rollback -->|rollback 成功| Cleanup[CLEANUP_WRITE_IGNORE: unregister]
    Cleanup --> WriteErr[Err RenameWriteFailed<br>registry 空]
    Commit --> Ok([Ok])

    style Cleanup fill:#e6ffe6,stroke:#080
    style WriteErr fill:#e6ffe6,stroke:#080
    style RbErr fill:#ffe6e6,stroke:#a00
```

追加テスト `fault_rewrite_fails_with_watcher_installed_clears_write_ignore_registry` は緑のパス (rollback 成功 → cleanup → `RenameWriteFailed`) を validate する。

## 関連Issue

- Closes #97
- 参考: PR #226 (主要実装)

## テスト

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` 通過
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` 通過 (warning ゼロ)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` 通過 (spec-board: 669 / spec-board-fs: 126)
- [x] 追加テスト単独実行 PASS: `cargo test -p spec-board fault_rewrite_fails_with_watcher_installed_clears_write_ignore_registry`
- [x] CI all green (fmt/clippy/coverage + lint/typecheck/test + post coverage comment)
- [x] Codex AI レビュー: **問題なし**

## レビューポイント

- **テストの位置づけ**: 既存実装 `cleanup_registered_write_ignores` の動作を固定する **characterization / regression test**。追加時点から Green が期待値であり、将来 cleanup を欠落させた場合に Red にして気付ける構造にした
- **rollback 失敗時の write_ignore 残留の docs 化**: `rollback_md(...)?` の `?` early return により `RenameRollbackFailed` 経路では write_ignore が解除されない現状仕様を docs 化（実装変更は本 PR スコープ外、必要に応じて別 Issue 化候補と明記）
- **GUIDE.md best-effort の方針**: GUIDE.md は AI エージェント向け補助ファイルであり主処理の成否を左右しないため、書き込み失敗時に `Result` を返さず WARN + stderr fallback で観測可能性のみ確保する設計を docs 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)