### PR TITLE
✨ [New Feature]: #100 [BE] update_card_order で不在ファイルパスを自動除外

### DIFF
--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -296,7 +296,7 @@ links:（任意）
 
 **振る舞い**:
 1. `columnName` が `columns[]` に存在しない場合は更新を拒否し、`config.json` を変更しない（エラー文字列: `カラムが見つかりません: {columnName}`）
-2. `filePaths` は FE が事前に正規化した結果をそのまま `cardOrder[columnName]` に保存する。バックエンド側では未存在ファイルパスの除外などのフィルタを行わない
+2. `filePaths` は FE が正規化済みの project-relative path であることを前提とし、BE 側では `canonicalize` や `project_root` 配下に収まっているかの containment 検証は行わない。各パスを `project_root.join(path)` で解決した結果に対し `std::fs::metadata` を呼び、`Err` が `ErrorKind::NotFound` の場合のみ除外する。`permission denied` 等の `NotFound` 以外の I/O エラーはユーザーのカード並びを誤って消さないために保守的にパスを保持する。クリーンアップ後の配列を `cardOrder[columnName]` に上書き保存する。順序は入力 `filePaths` を保持し、削除対象のみ抜く
 3. 既存キーがあれば**上書き**、無ければ**新規追加**として `cardOrder` に書き込む
 4. 書き込みは tmp → rename ベース（Unix では `rename(2)` の atomic 置換、Windows では既存ファイル上書き時に backup 経由の 2 段 rename にフォールバック）で行い、`config.json` 自体が中途半端な内容になる部分書き込みを防止する
 5. `.spec-board/` ディレクトリは watcher の拡張子フィルタで除外されるため、本書き込みによって FE への変更通知（emit）は走らない

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -35,6 +35,8 @@
 //! `ConfigIo` を `IO_ERROR` 系（内側メッセージ次第で `NOT_FOUND` /
 //! `PERMISSION_DENIED` に転ぶ）として扱う想定。
 
+use std::io::ErrorKind;
+use std::path::Path;
 use std::sync::Arc;
 
 use spec_board_fs::config::config_io::{write_config_json, ConfigIoError};
@@ -119,7 +121,8 @@ pub(crate) fn update_card_order_impl(
         return Err(UpdateCardOrderError::UnknownColumn { column_name });
     }
 
-    config.card_order.insert(column_name, file_paths);
+    let cleaned = cleanup_missing_paths(&project_root, file_paths);
+    config.card_order.insert(column_name, cleaned);
 
     let json = serde_json::to_string_pretty(&config)?;
     write_config_json(&project_root, &json)?;
@@ -133,6 +136,22 @@ pub(crate) fn update_card_order_impl(
     state.replace_config_if_project_matches(&project_root, config)?;
 
     Ok(())
+}
+
+/// `file_paths` のうち `project_root` 配下に実在しないエントリを除外して返す。
+///
+/// 各パスを `project_root.join(rel)` で解決し `std::fs::metadata` で判定する。
+/// `Err(NotFound)` のみ除外し、`permission denied` など他の I/O エラーは
+/// ユーザーのカード並びを誤って失わないために保守的に保持する。
+/// 入力順は保持する。
+fn cleanup_missing_paths(project_root: &Path, file_paths: Vec<String>) -> Vec<String> {
+    file_paths
+        .into_iter()
+        .filter(|rel| match std::fs::metadata(project_root.join(rel)) {
+            Ok(_) => true,
+            Err(e) => e.kind() != ErrorKind::NotFound,
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/config/update_card_order_tests.rs
+++ b/src-tauri/src/config/update_card_order_tests.rs
@@ -205,29 +205,6 @@ fn state_config_remains_unchanged_when_disk_write_fails() {
 }
 
 #[test]
-fn cleans_up_when_all_paths_exist() {
-    let dir = tempdir();
-    let state = Arc::new(AppState::new());
-    open_with_noop(&state, dir.path());
-
-    write_md(dir.path(), "tasks/a.md", "");
-    write_md(dir.path(), "tasks/b.md", "");
-
-    update_card_order_impl(
-        &state,
-        "Todo".to_string(),
-        vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()],
-    )
-    .expect("update should succeed");
-
-    let on_disk = read_config_json(dir.path());
-    assert_eq!(
-        on_disk.card_order.get("Todo"),
-        Some(&vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()])
-    );
-}
-
-#[test]
 fn cleans_up_to_empty_when_all_paths_missing() {
     let dir = tempdir();
     let state = Arc::new(AppState::new());
@@ -275,18 +252,6 @@ fn cleans_up_only_missing_paths_in_mixed_input() {
             "tasks/exists-2.md".to_string()
         ])
     );
-}
-
-#[test]
-fn cleans_up_empty_input_to_empty() {
-    let dir = tempdir();
-    let state = Arc::new(AppState::new());
-    open_with_noop(&state, dir.path());
-
-    update_card_order_impl(&state, "Todo".to_string(), vec![]).expect("empty input should succeed");
-
-    let on_disk = read_config_json(dir.path());
-    assert_eq!(on_disk.card_order.get("Todo"), Some(&Vec::<String>::new()));
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/config/update_card_order_tests.rs
+++ b/src-tauri/src/config/update_card_order_tests.rs
@@ -28,11 +28,22 @@ fn read_config_json(project_root: &Path) -> Config {
     serde_json::from_str(&raw).expect("config.json is valid")
 }
 
+fn write_md(root: &Path, rel: &str, content: &str) {
+    let abs = root.join(rel);
+    if let Some(parent) = abs.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(abs, content).unwrap();
+}
+
 #[test]
 fn overwrites_existing_card_order_entry() {
     let dir = tempdir();
     let state = Arc::new(AppState::new());
     open_with_noop(&state, dir.path());
+
+    write_md(dir.path(), "tasks/a.md", "");
+    write_md(dir.path(), "tasks/b.md", "");
 
     update_card_order_impl(
         &state,
@@ -98,6 +109,9 @@ fn last_call_wins_on_consecutive_invocations() {
     let state = Arc::new(AppState::new());
     open_with_noop(&state, dir.path());
 
+    write_md(dir.path(), "tasks/a.md", "");
+    write_md(dir.path(), "tasks/b.md", "");
+
     update_card_order_impl(
         &state,
         "Todo".to_string(),
@@ -126,6 +140,8 @@ fn inserts_new_entry_when_column_not_in_card_order() {
 
     let initial = state.config().unwrap().unwrap();
     assert!(!initial.card_order.contains_key("In Progress"));
+
+    write_md(dir.path(), "tasks/x.md", "");
 
     update_card_order_impl(
         &state,
@@ -186,4 +202,104 @@ fn state_config_remains_unchanged_when_disk_write_fails() {
     );
 
     assert_eq!(fs::read_to_string(&target).unwrap(), "keep");
+}
+
+#[test]
+fn cleans_up_when_all_paths_exist() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    write_md(dir.path(), "tasks/a.md", "");
+    write_md(dir.path(), "tasks/b.md", "");
+
+    update_card_order_impl(
+        &state,
+        "Todo".to_string(),
+        vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()],
+    )
+    .expect("update should succeed");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(
+        on_disk.card_order.get("Todo"),
+        Some(&vec!["tasks/a.md".to_string(), "tasks/b.md".to_string()])
+    );
+}
+
+#[test]
+fn cleans_up_to_empty_when_all_paths_missing() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    update_card_order_impl(
+        &state,
+        "Todo".to_string(),
+        vec![
+            "tasks/missing-1.md".to_string(),
+            "tasks/missing-2.md".to_string(),
+        ],
+    )
+    .expect("update should succeed");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(on_disk.card_order.get("Todo"), Some(&Vec::<String>::new()));
+}
+
+#[test]
+fn cleans_up_only_missing_paths_in_mixed_input() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    write_md(dir.path(), "tasks/exists-1.md", "");
+    write_md(dir.path(), "tasks/exists-2.md", "");
+
+    update_card_order_impl(
+        &state,
+        "Todo".to_string(),
+        vec![
+            "tasks/exists-1.md".to_string(),
+            "tasks/missing.md".to_string(),
+            "tasks/exists-2.md".to_string(),
+        ],
+    )
+    .expect("update should succeed");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(
+        on_disk.card_order.get("Todo"),
+        Some(&vec![
+            "tasks/exists-1.md".to_string(),
+            "tasks/exists-2.md".to_string()
+        ])
+    );
+}
+
+#[test]
+fn cleans_up_empty_input_to_empty() {
+    let dir = tempdir();
+    let state = Arc::new(AppState::new());
+    open_with_noop(&state, dir.path());
+
+    update_card_order_impl(&state, "Todo".to_string(), vec![]).expect("empty input should succeed");
+
+    let on_disk = read_config_json(dir.path());
+    assert_eq!(on_disk.card_order.get("Todo"), Some(&Vec::<String>::new()));
+}
+
+#[cfg(unix)]
+#[test]
+fn keeps_path_when_metadata_returns_non_notfound_error() {
+    let dir = tempdir();
+
+    // NUL バイトを含む相対パスは fs::metadata で ErrorKind::InvalidInput を返す
+    // （非 NotFound）。保守的に保持されることを確認する。
+    let nul_path = "tasks/with\0nul.md".to_string();
+    let input = vec![nul_path.clone()];
+
+    let result = super::cleanup_missing_paths(dir.path(), input);
+
+    assert_eq!(result, vec![nul_path]);
 }


### PR DESCRIPTION
## 概要

`update_card_order` Tauri command で `cardOrder[columnName]` を保存する際に、引数 `file_paths` のうち `project_root` 配下に実在しないタスクファイルパスを保存前に除外するクリーンアップを追加した。これにより FE が古いキャッシュを送ってきたり、ユーザーが手動で `.md` を削除した場合でも `config.json` に dangling reference が永続化されない。

## 変更の種類

- ✨ New Feature（BE）
- 📝 Doc（`config-spec.md` 整合化）

## 追加した内容

- `src-tauri/src/config/update_card_order.rs` に private free function `cleanup_missing_paths(&Path, Vec<String>) -> Vec<String>` を新設
  - 各パスを `project_root.join(rel)` で絶対化し `std::fs::metadata` を呼ぶ
  - `Ok(_)` / 非 `NotFound` エラー → 保持、`Err(NotFound)` → 除外
  - 入力順を `into_iter().filter().collect()` で保持
- `update_card_order_tests.rs` に新規 5 件のテストを追加（impl 経由 4 件 + Unix 限定 `super::cleanup_missing_paths` 純粋テスト 1 件）
- 既存テスト 3 件の fixture を実ファイル化（`write_md` helper 複製）

## 変更した内容

- `update_card_order_impl` の `has_column` 検証後・`card_order.insert` 直前で `cleanup_missing_paths` を挟む
- `docs/spec-board/config-spec.md` の `update_card_order` 振る舞い節を、`NotFound` のみ除外する新仕様に書き換え

## 仕様ドキュメント更新

- 更新: `docs/spec-board/config-spec.md`（`update_card_order` の振る舞い節 line 299 周辺を新文言に置換）
- `line 66` の cardOrder 自動除去記述と整合

## システム図

```mermaid
flowchart TD
    A[invoke 'update_card_order'<br/>columnName, filePaths] --> B[update_card_order_impl]
    B --> C[snapshot_project_and_config]
    C --> D{config.has_column?}
    D -- No --> E[Err UnknownColumn]
    D -- Yes --> F["cleanup_missing_paths<br/>(NEW)"]
    F --> G[card_order.insert column, cleaned]
    G --> H[serde_json::to_string_pretty]
    H --> I[write_config_json]
    I --> J[replace_config_if_project_matches]

    style F fill:#ffeb3b,stroke:#f57f17,stroke-width:2px
```

クリーンアップ判定（1 パスあたり）:

```mermaid
flowchart TD
    P[file_paths i] --> Q[abs = project_root.join path]
    Q --> R[fs::metadata abs]
    R -- Ok --> K1[keep]
    R -- Err NotFound --> K2[drop]
    R -- Err other --> K3[keep 保守的]

    style K2 fill:#ef9a9a
    style K3 fill:#fff59d
```

## 関連Issue

Refs #100

## テスト

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — 差分なし
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p spec-board --all-targets -- -D warnings` — warning 0
- `cargo test -p spec-board update_card_order` — 12 件すべて pass（既存 7 件 + 新規 5 件）
- `cargo test --manifest-path src-tauri/Cargo.toml` — 全 674 件 pass

## レビューポイント

- **保守的フィルタの妥当性**: `permission denied` 等の非 `NotFound` I/O エラーで保守的にパスを保持する判断について。ユーザーのカード並びを誤って失わないことを優先したが、ヒアリングで合意済み
- **helper 配置**: `cleanup_missing_paths` は `update_card_order.rs` 内の private free function とした。task ドメインの aggregate-centric 指針（feedback メモリ）は config ドメインには適用されないと判断（薄い I/O 検証 helper であり、aggregate invariant ではないため）
- **`#[cfg(unix)]` ガード**: 非 `NotFound` エラー時の保持を検証するテストは NUL バイトを使うため Unix 限定とした