### PR TITLE
🧪 [Tests]: #123 [FE] DetailPanel タイトル inline 編集の統合テストを追加

### DIFF
--- a/src/__tests__/App.interaction.test.tsx
+++ b/src/__tests__/App.interaction.test.tsx
@@ -485,6 +485,43 @@ test("DetailPanel の status 変更 → updateTask invoke が呼ばれ + 成功 
   expect(container?.textContent).toContain("タスクを更新しました");
 });
 
+test("DetailPanel タイトル inline 編集 Enter → updateTask invoke が { filePath, title } で呼ばれ + 成功 toast", async () => {
+  mountApp();
+  await openSuccessfully();
+  await openDetailPanelForFirstTask();
+
+  const updatedTitle = "新しいタイトル";
+  const updated: Task = { ...taskA, title: updatedTitle };
+  updateTaskMock.mockResolvedValueOnce(Result.ok(updated));
+
+  const titleDisplay = querySelectorRequired<HTMLInputElement>(
+    '[data-testid="editable-text-display"]',
+  );
+  await act(async () => {
+    titleDisplay.click();
+  });
+  const titleInput = querySelectorRequired<HTMLInputElement>(
+    '[data-testid="editable-text-input"]',
+  );
+  await act(async () => {
+    setInputValue(titleInput, updatedTitle);
+  });
+  await act(async () => {
+    titleInput.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  expect(updateTaskMock).toHaveBeenCalledTimes(1);
+  expect(updateTaskMock).toHaveBeenCalledWith(
+    expect.objectContaining({ filePath: "tasks/a.md", title: updatedTitle }),
+  );
+  expect(container?.textContent).toContain("タスクを更新しました");
+});
+
 test("DetailPanel の status 変更失敗時 → updateTask invoke + エラー toast 表示", async () => {
   mountApp();
   await openSuccessfully();

--- a/src/features/detail/components/DetailPanel/__tests__/DetailPanel.titleEdit.test.tsx
+++ b/src/features/detail/components/DetailPanel/__tests__/DetailPanel.titleEdit.test.tsx
@@ -1,0 +1,257 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import { DetailPanel } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+/** テスト用カラム一覧 */
+const testColumns = [
+  { name: "Todo", order: 0 },
+  { name: "In Progress", order: 1 },
+  { name: "Done", order: 2 },
+];
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+/**
+ * テスト用タスクを生成する
+ * @param overrides - 上書きするフィールド
+ * @returns テスト用タスク
+ */
+function createTask(overrides: Partial<TaskPayload> = {}): Task {
+  return Task.fromPayload({
+    id: "task-1",
+    title: "テストタスク",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+}
+
+/**
+ * DetailPanel をレンダリングするヘルパー
+ * @param props - DetailPanel に渡す props
+ * @returns rerender ヘルパーを含むオブジェクト
+ */
+function render(props: Parameters<typeof DetailPanel>[0]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(DetailPanel, props));
+  });
+  const rerender = (next: Parameters<typeof DetailPanel>[0]) => {
+    act(() => {
+      root?.render(createElement(DetailPanel, next));
+    });
+  };
+  return { rerender };
+}
+
+/**
+ * editable-text-display 要素をクリックして Edit モードに遷移させる
+ * @returns Edit モードの input 要素
+ */
+function enterEditMode(): HTMLInputElement {
+  const display = document.querySelector(
+    '[data-testid="editable-text-display"]',
+  ) as HTMLInputElement;
+  act(() => {
+    display.click();
+  });
+  return document.querySelector(
+    '[data-testid="editable-text-input"]',
+  ) as HTMLInputElement;
+}
+
+/**
+ * controlled input に値を流し込み input イベントを発火する
+ * @param input - 対象 input 要素
+ * @param value - 設定する値
+ */
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  act(() => {
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/**
+ * input に keydown を dispatch する
+ * @param input - 対象 input 要素
+ * @param key - dispatch するキー名
+ */
+function pressKey(input: HTMLInputElement, key: string): void {
+  act(() => {
+    input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+/**
+ * editable-text-display が表示されるまで待つ
+ */
+async function waitForDisplay(): Promise<void> {
+  await vi.waitFor(() => {
+    expect(
+      document.querySelector('[data-testid="editable-text-display"]'),
+    ).toBeTruthy();
+  });
+}
+
+test("タイトル表示をクリックすると Edit モードに切り替わる", async () => {
+  const onTaskUpdate = vi.fn();
+  render({
+    task: createTask({ title: "元タイトル" }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  await waitForDisplay();
+  enterEditMode();
+  expect(
+    document.querySelector('[data-testid="editable-text-input"]'),
+  ).toBeTruthy();
+  expect(onTaskUpdate).not.toHaveBeenCalled();
+});
+
+test("Enter で確定すると onTaskUpdate(task.id, { title }) が呼ばれる", async () => {
+  const onTaskUpdate = vi.fn();
+  render({
+    task: createTask({ id: "task-1", title: "元タイトル" }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  await waitForDisplay();
+  const input = enterEditMode();
+  setInputValue(input, "新タイトル");
+  pressKey(input, "Enter");
+  expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+  expect(onTaskUpdate).toHaveBeenCalledWith("task-1", { title: "新タイトル" });
+});
+
+test("Esc でキャンセルすると onTaskUpdate は呼ばれず表示が元に戻り、パネルも閉じない", async () => {
+  // 編集中 Esc は EditableText 側で stopPropagation されているため
+  // DetailPanel#useEscToClose 経由の onClose は発火しない契約を併せて検証する。
+  const onTaskUpdate = vi.fn();
+  const onClose = vi.fn();
+  render({
+    task: createTask({ title: "元タイトル" }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  await waitForDisplay();
+  const input = enterEditMode();
+  setInputValue(input, "捨てる文字列");
+  pressKey(input, "Escape");
+  expect(onTaskUpdate).not.toHaveBeenCalled();
+  expect(onClose).not.toHaveBeenCalled();
+  const display = document.querySelector(
+    '[data-testid="editable-text-display"]',
+  ) as HTMLInputElement;
+  expect(display.value).toBe("元タイトル");
+});
+
+test("空文字確定では onTaskUpdate が呼ばれない", async () => {
+  const onTaskUpdate = vi.fn();
+  render({
+    task: createTask({ title: "元タイトル" }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  await waitForDisplay();
+  const input = enterEditMode();
+  setInputValue(input, "   ");
+  pressKey(input, "Enter");
+  expect(onTaskUpdate).not.toHaveBeenCalled();
+});
+
+test("Enter 確定後に再度 Edit → Enter すると onTaskUpdate が 2 回呼ばれる（rerender で親 props 更新を伴う）", async () => {
+  // 「確定後の最新タイトルから再編集できる」ことを保証するため、
+  // 1 回目確定後に親 props (task.title) を更新する rerender ヘルパーで再描画してから 2 回目編集に入る。
+  // rerender なしだと表示値が元タイトルに戻ったままになり、controlled コンポーネントとしての
+  // 再編集挙動を検証できない（DetailPanel の `value={task.title || task.filePath}` 仕様より）。
+  const onTaskUpdate = vi.fn();
+  const onClose = vi.fn();
+  const onDelete = vi.fn();
+  const { rerender } = render({
+    task: createTask({ id: "task-1", title: "元タイトル" }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete,
+  });
+  await waitForDisplay();
+  const firstInput = enterEditMode();
+  setInputValue(firstInput, "1 回目タイトル");
+  pressKey(firstInput, "Enter");
+  // 親が onTaskUpdate を受けて task.title を更新した想定で rerender
+  rerender({
+    task: createTask({ id: "task-1", title: "1 回目タイトル" }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete,
+  });
+  const secondInput = enterEditMode();
+  setInputValue(secondInput, "2 回目タイトル");
+  pressKey(secondInput, "Enter");
+  expect(onTaskUpdate).toHaveBeenCalledTimes(2);
+  expect(onTaskUpdate).toHaveBeenNthCalledWith(1, "task-1", {
+    title: "1 回目タイトル",
+  });
+  expect(onTaskUpdate).toHaveBeenNthCalledWith(2, "task-1", {
+    title: "2 回目タイトル",
+  });
+});
+
+test("task.title が空で filePath fallback 表示でも編集確定で onTaskUpdate(id, { title }) が呼ばれる", async () => {
+  const onTaskUpdate = vi.fn();
+  render({
+    task: createTask({
+      id: "task-1",
+      title: "",
+      filePath: "tasks/fallback.md",
+    }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  await vi.waitFor(() => {
+    const display = document.querySelector(
+      '[data-testid="editable-text-display"]',
+    ) as HTMLInputElement | null;
+    expect(display?.value).toBe("tasks/fallback.md");
+  });
+  const input = enterEditMode();
+  setInputValue(input, "新タイトル");
+  pressKey(input, "Enter");
+  expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+  expect(onTaskUpdate).toHaveBeenCalledWith("task-1", { title: "新タイトル" });
+});


### PR DESCRIPTION
## 概要

Issue #123「[FE] detail-edit - タイトル: インライン編集 → updateTask」の Acceptance Criteria を、**DetailPanel 統合観点のテスト追加のみ**で明文化します。実装コードには変更を加えません。

既存実装 4 層（`EditableText` → `DetailPanel#handleTitleConfirm` → `App#handleTaskUpdate` → `updateTask` wrapper）は既に AC を満たしているため、性質上「characterization test 寄りの TDD」となります。

## 実装変更なし

以下のファイルに差分はありません:

- `src/components/EditableText/`
- `src/features/detail/components/DetailPanel/index.tsx`
- `src/App.tsx`
- `src/lib/tauri/taskCommands/updateTask/`

## 追加テスト一覧

### `src/features/detail/components/DetailPanel/__tests__/DetailPanel.titleEdit.test.tsx`（新規 6 ケース）

| # | テスト | 観点 |
|---|---|---|
| 1 | タイトル表示をクリックすると Edit モードに切り替わる | クリック遷移 |
| 2 | Enter で確定すると `onTaskUpdate(task.id, { title })` が呼ばれる | AC コア |
| 3 | Esc でキャンセルすると `onTaskUpdate` 非呼出 / 表示元戻し / `onClose` 非呼出 | AC コア |
| 4 | 空文字確定では `onTaskUpdate` が呼ばれない | trim ガード |
| 5 | Enter 確定後 rerender → 再 Edit → Enter で `onTaskUpdate` 2 回 | 連続編集 |
| 6 | `task.title` 空で `filePath` fallback 表示中でも編集確定で `onTaskUpdate` | fallback |

### `src/__tests__/App.interaction.test.tsx`（+1 ケース）

- DetailPanel タイトル inline 編集 Enter → `updateTask({ filePath, title })` 呼出 + 成功 toast

既存「DetailPanel の status 変更」テストの雛形を流用し、status → title に差し替えた end-to-end カバレッジ。

## チェックリスト

- [x] `pnpm test:run` 全 839 件 Pass
- [x] `pnpm exec biome check` 対象 2 ファイル Clean
- [x] `pnpm lint`（oxlint）Clean
- [x] `pnpm typecheck` 型エラーなし
- [x] 実装ファイル（EditableText / DetailPanel#index.tsx / App.tsx / updateTask wrapper）に差分ゼロ
- [x] Codex CLI レビュー: 問題なし

## Test plan

- [x] 新規 6 テストが Green
- [x] 追加 App 統合テストが Green
- [x] 既存テストへのリグレッションなし

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)