### PR TITLE
✨ [New Feature]: #120 [FE] タスク作成時のタイトル 4 種バリデーション

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -585,6 +585,7 @@ export const App = () => {
           columns={columns}
           initialStatus={createModalStatus}
           parentCandidates={tasks}
+          existingTasks={tasks}
           initialParent={createModalParent}
           onSubmit={handleCreateTask}
           onClose={handleCloseCreateModal}

--- a/src/domains/KebabCase/__tests__/KebabCase.behavior.test.ts
+++ b/src/domains/KebabCase/__tests__/KebabCase.behavior.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+import { KebabCase } from "..";
+
+test("ASCII 基本ケース", () => {
+  const cases: Array<[string, string, string]> = [
+    ["Fix Login Bug", "fix-login-bug", "general ascii"],
+    ["FOO", "foo", "uppercase only"],
+    ["foo--bar", "foo-bar", "consecutive hyphens collapse"],
+    ["  Fix login!! bug  ", "fix-login-bug", "trim and collapse symbols"],
+    ["Hello_World.md", "hello-world-md", "underscore and dot are separators"],
+  ];
+  for (const [input, expected, label] of cases) {
+    expect(KebabCase.from(input), label).toBe(expected);
+  }
+});
+
+test("非 ASCII / mixed ケース", () => {
+  const cases: Array<[string, string, string]> = [
+    ["タスク 1", "タスク-1", "mixed: cjk + ascii"],
+    ["Fix バグ", "fix-バグ", "mixed: ascii first + cjk"],
+    ["日本語 title", "日本語-title", "mixed: cjk + ascii word"],
+    ["バグ修正", "バグ修正", "all non-ascii passthrough"],
+  ];
+  for (const [input, expected, label] of cases) {
+    expect(KebabCase.from(input), label).toBe(expected);
+  }
+});
+
+test("空 / 記号のみ", () => {
+  const cases: Array<[string, string, string]> = [
+    ["", "", "empty input"],
+    ["!!!", "", "all symbols collapse to empty"],
+  ];
+  for (const [input, expected, label] of cases) {
+    expect(KebabCase.from(input), label).toBe(expected);
+  }
+});

--- a/src/domains/KebabCase/index.ts
+++ b/src/domains/KebabCase/index.ts
@@ -1,0 +1,60 @@
+declare const kebabCaseBrand: unique symbol;
+
+/**
+ * タスクタイトルから生成された kebab-case ファイル名 base 文字列。
+ * `KebabCase.from` 経由でのみ生成される branded string。
+ */
+export type KebabCase = string & { readonly [kebabCaseBrand]: true };
+
+/** KebabCase の companion API。 */
+export const KebabCase = {
+  /**
+   * 任意の文字列を kebab-case のファイル名 base 文字列に変換する。
+   * BE 側 `to_kebab_case` と挙動を一致させる。
+   *  - 入力に ASCII が 1 文字も含まれなければ入力そのままを返す（日本語のみは保持）
+   *  - ASCII を含む場合: 英大文字 → 小文字、英数字以外の ASCII は区切り、非 ASCII はそのまま
+   *  - 区切りの連続は 1 個に集約、先頭末尾の `-` を除去
+   *  - 空入力 / 記号のみの入力は空文字を返す（フォールバック名なし）
+   *
+   * @param raw 任意の入力文字列
+   * @returns kebab-case 化した branded 文字列
+   */
+  from: (raw: string): KebabCase => {
+    const hasAscii = [...raw].some((c) => c.charCodeAt(0) < 128);
+    if (!hasAscii) {
+      return raw as KebabCase;
+    }
+    let out = "";
+    let lastWasSeparator = true;
+    for (const ch of raw) {
+      const code = ch.charCodeAt(0);
+      if (code >= 128) {
+        out += ch;
+        lastWasSeparator = false;
+        continue;
+      }
+      const isDigit = code >= 0x30 && code <= 0x39;
+      const isLower = code >= 0x61 && code <= 0x7a;
+      const isUpper = code >= 0x41 && code <= 0x5a;
+      if (isDigit || isLower) {
+        out += ch;
+        lastWasSeparator = false;
+        continue;
+      }
+      if (isUpper) {
+        out += String.fromCharCode(code + 32);
+        lastWasSeparator = false;
+        continue;
+      }
+      if (lastWasSeparator) {
+        continue;
+      }
+      out += "-";
+      lastWasSeparator = true;
+    }
+    if (out.endsWith("-")) {
+      out = out.slice(0, -1);
+    }
+    return out as KebabCase;
+  },
+} as const;

--- a/src/features/task-form/components/TaskCreateModal/index.tsx
+++ b/src/features/task-form/components/TaskCreateModal/index.tsx
@@ -13,6 +13,8 @@ type TaskCreateModalProps = {
   parentCandidates?: Task[];
   /** 親タスクの初期値（サブIssue 追加時の自動設定用） */
   initialParent?: string;
+  /** 重複判定に使う既存タスク一覧。未指定なら DUPLICATE 判定なし。 */
+  existingTasks?: readonly Task[];
   /**
    * 送信時のコールバック。reject した場合モーダルは閉じない。
    * 親側でトースト通知などのエラーハンドリングを行う想定。
@@ -35,6 +37,7 @@ export const TaskCreateModal = ({
   initialStatus,
   parentCandidates,
   initialParent,
+  existingTasks,
   onSubmit,
   onClose,
 }: TaskCreateModalProps) => {
@@ -111,6 +114,7 @@ export const TaskCreateModal = ({
           initialStatus={initialStatus}
           parentCandidates={parentCandidates}
           initialParent={initialParent}
+          existingTasks={existingTasks}
           isSubmitting={isSubmitting}
           onSubmit={handleSubmit}
           onCancel={onClose}

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/__tests__/TaskFormTitle.interaction.test.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/__tests__/TaskFormTitle.interaction.test.tsx
@@ -1,6 +1,7 @@
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
+import type { TitleValidationError } from "@/features/task-form/lib/fields/title";
 import { TaskFormTitle } from "..";
 
 let container: HTMLDivElement | null = null;
@@ -58,12 +59,12 @@ test("入力で onChange が呼ばれる", () => {
   expect(onChange).toHaveBeenCalledWith("abc");
 });
 
-test("error 指定で error メッセージと aria 属性が描画される", () => {
+test("error 指定で aria 属性が描画される", () => {
   render({
     value: "",
     onChange: vi.fn(),
     disabled: false,
-    error: "必須",
+    error: { code: "EMPTY" },
   });
   const input = container?.querySelector(
     "[data-testid='task-form-title']",
@@ -71,9 +72,48 @@ test("error 指定で error メッセージと aria 属性が描画される", (
   const errorEl = container?.querySelector(
     "[data-testid='task-form-title-error']",
   );
-  expect(errorEl?.textContent).toBe("必須");
+  expect(errorEl).toBeTruthy();
   expect(input.getAttribute("aria-invalid")).toBe("true");
   expect(input.getAttribute("aria-describedby")).toBe(errorEl?.id);
+});
+
+test("4 種エラーそれぞれで対応する日本語メッセージが描画される", () => {
+  const cases: Array<[TitleValidationError, string, string]> = [
+    [{ code: "EMPTY" }, "タイトルを入力してください", "EMPTY"],
+    [
+      { code: "DUPLICATE", fileName: "fix-login-bug.md" },
+      "同じ名前のタスクがすでに存在します",
+      "DUPLICATE",
+    ],
+    [
+      { code: "TOO_LONG", max: 200, actual: 201 },
+      "タイトルは200文字以内で入力してください",
+      "TOO_LONG",
+    ],
+    [
+      { code: "FORBIDDEN_CHAR", chars: ["<", ">"] },
+      "使用できない文字が含まれています: < >",
+      "FORBIDDEN_CHAR",
+    ],
+  ];
+  for (const [error, expected, label] of cases) {
+    render({
+      value: "",
+      onChange: vi.fn(),
+      disabled: false,
+      error,
+    });
+    const errorEl = container?.querySelector(
+      "[data-testid='task-form-title-error']",
+    );
+    expect(errorEl?.textContent, label).toBe(expected);
+    act(() => {
+      root?.unmount();
+    });
+    container?.remove();
+    container = null;
+    root = null;
+  }
 });
 
 test("label の htmlFor と input の id が一致する", () => {

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/__tests__/titleErrorMessage.behavior.test.ts
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/__tests__/titleErrorMessage.behavior.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import type { TitleValidationError } from "@/features/task-form/lib/fields/title";
+import { titleErrorMessage } from "../titleErrorMessage";
+
+test("titleErrorMessage: 4 種のエラーコードを日本語化", () => {
+  const cases: Array<[TitleValidationError, string, string]> = [
+    [{ code: "EMPTY" }, "タイトルを入力してください", "EMPTY"],
+    [
+      { code: "DUPLICATE", fileName: "fix-login-bug.md" },
+      "同じ名前のタスクがすでに存在します",
+      "DUPLICATE",
+    ],
+    [
+      { code: "TOO_LONG", max: 200, actual: 201 },
+      "タイトルは200文字以内で入力してください",
+      "TOO_LONG",
+    ],
+    [
+      { code: "FORBIDDEN_CHAR", chars: ["<", ">"] },
+      "使用できない文字が含まれています: < >",
+      "FORBIDDEN_CHAR (multi)",
+    ],
+    [
+      { code: "FORBIDDEN_CHAR", chars: ["<"] },
+      "使用できない文字が含まれています: <",
+      "FORBIDDEN_CHAR (single)",
+    ],
+  ];
+
+  for (const [error, expected, label] of cases) {
+    expect(titleErrorMessage(error), label).toBe(expected);
+  }
+});

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/index.stories.tsx
@@ -1,5 +1,6 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TITLE_MAX_LENGTH } from "@/features/task-form/lib/fields/title";
 import { TaskFormTitle } from ".";
 
 const meta: Meta<typeof TaskFormTitle> = {
@@ -30,8 +31,12 @@ export const WithDuplicateError: Story = {
 
 export const WithTooLongError: Story = {
   args: {
-    value: "a".repeat(201),
-    error: { code: "TOO_LONG", max: 200, actual: 201 },
+    value: "a".repeat(TITLE_MAX_LENGTH + 1),
+    error: {
+      code: "TOO_LONG",
+      max: TITLE_MAX_LENGTH,
+      actual: TITLE_MAX_LENGTH + 1,
+    },
   },
 };
 

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/index.stories.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/index.stories.tsx
@@ -17,6 +17,27 @@ type Story = StoryObj<typeof TaskFormTitle>;
 
 export const Default: Story = {};
 
-export const WithError: Story = {
-  args: { value: "", error: "タイトルを入力してください" },
+export const WithEmptyError: Story = {
+  args: { value: "", error: { code: "EMPTY" } },
+};
+
+export const WithDuplicateError: Story = {
+  args: {
+    value: "Fix login bug",
+    error: { code: "DUPLICATE", fileName: "fix-login-bug.md" },
+  },
+};
+
+export const WithTooLongError: Story = {
+  args: {
+    value: "a".repeat(201),
+    error: { code: "TOO_LONG", max: 200, actual: 201 },
+  },
+};
+
+export const WithForbiddenCharError: Story = {
+  args: {
+    value: "a<b>c",
+    error: { code: "FORBIDDEN_CHAR", chars: ["<", ">"] },
+  },
 };

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/index.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/index.tsx
@@ -1,4 +1,6 @@
 import { useId } from "react";
+import type { TitleValidationError } from "@/features/task-form/lib/fields/title";
+import { titleErrorMessage } from "./titleErrorMessage";
 
 type TaskFormTitleProps = {
   /** 現在値 */
@@ -8,8 +10,8 @@ type TaskFormTitleProps = {
    * @param value - 新しい値
    */
   onChange: (value: string) => void;
-  /** エラーメッセージ。undefined なら「エラーなし」 */
-  error?: string;
+  /** 構造化エラー。undefined なら「エラーなし」。表示直前に titleErrorMessage で日本語化する。 */
+  error?: TitleValidationError;
   /** 無効化 */
   disabled: boolean;
 };
@@ -55,7 +57,7 @@ export const TaskFormTitle = ({
           className="mt-1 text-xs text-red-600"
           data-testid="task-form-title-error"
         >
-          {error}
+          {titleErrorMessage(error)}
         </p>
       )}
     </div>

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/titleErrorMessage.ts
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/titleErrorMessage.ts
@@ -4,6 +4,7 @@ import type { TitleValidationError } from "@/features/task-form/lib/fields/title
  * タイトルバリデーションエラーを画面表示用の日本語メッセージに変換する。
  * @param error バリデーションエラー
  * @returns 表示用文字列
+ * @throws 未知の `error.code` が渡された場合。型ガードが破られた場合に黙ってフォールバックしないため。
  */
 export const titleErrorMessage = (error: TitleValidationError): string => {
   switch (error.code) {
@@ -17,7 +18,11 @@ export const titleErrorMessage = (error: TitleValidationError): string => {
       return `使用できない文字が含まれています: ${error.chars.join(" ")}`;
     default: {
       error satisfies never;
-      return "";
+      // 到達不能。型ガードが破られた場合（型と実値の乖離）に黙ってフォールバックせず
+      // 早期に検出できるよう例外を投げる。
+      throw new Error(
+        `titleErrorMessage: unknown TitleValidationError code: ${JSON.stringify(error)}`,
+      );
     }
   }
 };

--- a/src/features/task-form/components/TaskForm/TaskFormTitle/titleErrorMessage.ts
+++ b/src/features/task-form/components/TaskForm/TaskFormTitle/titleErrorMessage.ts
@@ -1,0 +1,23 @@
+import type { TitleValidationError } from "@/features/task-form/lib/fields/title";
+
+/**
+ * タイトルバリデーションエラーを画面表示用の日本語メッセージに変換する。
+ * @param error バリデーションエラー
+ * @returns 表示用文字列
+ */
+export const titleErrorMessage = (error: TitleValidationError): string => {
+  switch (error.code) {
+    case "EMPTY":
+      return "タイトルを入力してください";
+    case "DUPLICATE":
+      return "同じ名前のタスクがすでに存在します";
+    case "TOO_LONG":
+      return `タイトルは${error.max}文字以内で入力してください`;
+    case "FORBIDDEN_CHAR":
+      return `使用できない文字が含まれています: ${error.chars.join(" ")}`;
+    default: {
+      error satisfies never;
+      return "";
+    }
+  }
+};

--- a/src/features/task-form/components/TaskForm/index.tsx
+++ b/src/features/task-form/components/TaskForm/index.tsx
@@ -24,6 +24,8 @@ type TaskFormProps = {
   parentCandidates?: Task[];
   /** 親タスクの初期値（サブIssue 追加時の自動設定用） */
   initialParent?: string;
+  /** 重複判定に使う既存タスク一覧。未指定なら DUPLICATE 判定なし。 */
+  existingTasks?: readonly Task[];
   /** 送信中かどうか（true の間は送信ボタンと入力欄が無効化される） */
   isSubmitting?: boolean;
   /** 送信ボタンのラベル（デフォルト: "作成"） */
@@ -51,6 +53,7 @@ export const TaskForm = ({
   initialStatus,
   parentCandidates,
   initialParent,
+  existingTasks,
   isSubmitting = false,
   submitLabel = "作成",
   cancelLabel = "キャンセル",
@@ -64,6 +67,7 @@ export const TaskForm = ({
     initialParent,
     parentFieldVisible: parentCandidates !== undefined,
     isSubmitting,
+    existingTasks,
     onSubmit,
     finalizeLabels: labels.finalizeLabels,
   });

--- a/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
+++ b/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
@@ -7,6 +7,7 @@ import {
   useTaskFormFields,
 } from "@/features/task-form/hooks/useTaskFormFields";
 import type { TaskFormValues } from "@/features/task-form/types";
+import { Task } from "@/types/task";
 
 let container: HTMLDivElement | null = null;
 let root: ReturnType<typeof createRoot> | null = null;
@@ -69,6 +70,25 @@ const makeFormEvent = () =>
     preventDefault: vi.fn(),
   }) as unknown as React.FormEvent<HTMLFormElement>;
 
+/**
+ * テスト用の Task を生成するファクトリ。
+ * filePath 以外はデフォルト値で埋める。
+ * @param filePath Task の filePath
+ * @returns Task インスタンス
+ */
+const makeTask = (filePath: string): Task =>
+  Task.fromPayload({
+    id: filePath,
+    title: filePath,
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath,
+  });
+
 test("初期 state: values はデフォルト、errors は空、parent は visible=false で undefined", () => {
   const { get } = render(defaultArgs());
   expect(get().state.values).toEqual({
@@ -90,47 +110,38 @@ test("parentFieldVisible=true + initialParent が初期 state に反映される
   expect(get().state.values.parent).toBe("tasks/p-1.md");
 });
 
-test("dispatch title（空）: values.title と errors.title が同時更新される", () => {
+test("dispatch title: 入力時は errors.title をクリアするのみ（再 validate しない）", () => {
   const { get } = render(defaultArgs());
   act(() => {
     get().dispatch({ type: "title", value: "" });
   });
   expect(get().state.values.title).toBe("");
-  expect(get().state.errors.title).toBe("タイトルを入力してください");
+  expect(get().state.errors.title).toBeUndefined();
 });
 
-test("dispatch title（有効）: errors.title が undefined に戻る", () => {
+test("dispatch title: エラー表示中に値を変えると errors.title が undefined になる", () => {
   const { get } = render(defaultArgs());
   act(() => {
-    get().dispatch({ type: "title", value: "" });
+    get().handleSubmit(makeFormEvent());
   });
-  expect(get().state.errors.title).toBe("タイトルを入力してください");
+  expect(get().state.errors.title?.code).toBe("EMPTY");
   act(() => {
     get().dispatch({ type: "title", value: "abc" });
   });
   expect(get().state.errors.title).toBeUndefined();
 });
 
-test("dispatch validateAll: 現在の values を再検証して errors を更新する", () => {
-  const { get } = render(defaultArgs());
-  expect(get().state.errors.title).toBeUndefined();
-  act(() => {
-    get().dispatch({ type: "validateAll" });
-  });
-  expect(get().state.errors.title).toBe("タイトルを入力してください");
-});
-
-test("handleSubmit: 空タイトルでは onSubmit を呼ばず errors.title をセット", () => {
+test("handleSubmit: 空タイトルでは onSubmit を呼ばず errors.title.code = EMPTY", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
     get().handleSubmit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
-  expect(get().state.errors.title).toBe("タイトルを入力してください");
+  expect(get().state.errors.title?.code).toBe("EMPTY");
 });
 
-test("handleSubmit: 空白のみタイトルでも errors.title がセットされる", () => {
+test("handleSubmit: 空白のみタイトルでも EMPTY エラー", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -140,7 +151,114 @@ test("handleSubmit: 空白のみタイトルでも errors.title がセットさ�
     get().handleSubmit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
-  expect(get().state.errors.title).toBe("タイトルを入力してください");
+  expect(get().state.errors.title?.code).toBe("EMPTY");
+});
+
+test("handleSubmit: TOO_LONG（201 文字）", () => {
+  const onSubmit = vi.fn();
+  const { get } = render({ ...defaultArgs(), onSubmit });
+  act(() => {
+    get().dispatch({ type: "title", value: "a".repeat(201) });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(get().state.errors.title?.code).toBe("TOO_LONG");
+});
+
+test("handleSubmit: FORBIDDEN_CHAR", () => {
+  const onSubmit = vi.fn();
+  const { get } = render({ ...defaultArgs(), onSubmit });
+  act(() => {
+    get().dispatch({ type: "title", value: "a<b" });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(get().state.errors.title?.code).toBe("FORBIDDEN_CHAR");
+});
+
+test("handleSubmit DUPLICATE: parent なし → tasks/ 直下の既存タスクと一致", () => {
+  const onSubmit = vi.fn();
+  const { get } = render({
+    ...defaultArgs(),
+    onSubmit,
+    existingTasks: [makeTask("tasks/fix-login-bug.md")],
+  });
+  act(() => {
+    get().dispatch({ type: "title", value: "Fix Login Bug" });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(get().state.errors.title?.code).toBe("DUPLICATE");
+});
+
+test("handleSubmit DUPLICATE: parent あり → 親 dirname スコープで判定", () => {
+  const onSubmit = vi.fn();
+  const { get } = render({
+    ...defaultArgs(),
+    onSubmit,
+    parentFieldVisible: true,
+    initialParent: "tasks/parent/parent.md",
+    existingTasks: [makeTask("tasks/parent/fix-login-bug.md")],
+  });
+  act(() => {
+    get().dispatch({ type: "title", value: "Fix Login Bug" });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(get().state.errors.title?.code).toBe("DUPLICATE");
+});
+
+test("handleSubmit DUPLICATE スコープ外: parent なしで他 dirname にだけ同名 → 重複扱いしない", () => {
+  const onSubmit = vi.fn();
+  const { get } = render({
+    ...defaultArgs(),
+    onSubmit,
+    existingTasks: [makeTask("tasks/parent/fix-login-bug.md")],
+  });
+  act(() => {
+    get().dispatch({ type: "title", value: "Fix Login Bug" });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(onSubmit).toHaveBeenCalledTimes(1);
+  expect(get().state.errors.title).toBeUndefined();
+});
+
+test("handleSubmit DUPLICATE: Windows パス区切り (\\) でも検出される", () => {
+  const onSubmit = vi.fn();
+  const { get } = render({
+    ...defaultArgs(),
+    onSubmit,
+    existingTasks: [makeTask("tasks\\fix-login-bug.md")],
+  });
+  act(() => {
+    get().dispatch({ type: "title", value: "Fix Login Bug" });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(get().state.errors.title?.code).toBe("DUPLICATE");
+});
+
+test("入力中は重複判定しない（onChange で重複 title を入力しても errors.title は undefined）", () => {
+  const { get } = render({
+    ...defaultArgs(),
+    existingTasks: [makeTask("tasks/fix-login-bug.md")],
+  });
+  act(() => {
+    get().dispatch({ type: "title", value: "Fix Login Bug" });
+  });
+  expect(get().state.errors.title).toBeUndefined();
 });
 
 test("handleSubmit: isSubmitting=true では何もしない", () => {

--- a/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
+++ b/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
@@ -237,6 +237,25 @@ test("handleSubmit DUPLICATE スコープ外: parent なしで他 dirname にだ
   expect(get().state.errors.title).toBeUndefined();
 });
 
+test("handleSubmit DUPLICATE: parent が bare filename のときは tasks/ 直下と比較する", () => {
+  const onSubmit = vi.fn();
+  const { get } = render({
+    ...defaultArgs(),
+    onSubmit,
+    parentFieldVisible: true,
+    initialParent: "parent.md",
+    existingTasks: [makeTask("tasks/fix-login-bug.md")],
+  });
+  act(() => {
+    get().dispatch({ type: "title", value: "Fix Login Bug" });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(get().state.errors.title?.code).toBe("DUPLICATE");
+});
+
 test("handleSubmit DUPLICATE: Windows パス区切り (\\) でも検出される", () => {
   const onSubmit = vi.fn();
   const { get } = render({

--- a/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
+++ b/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
@@ -250,6 +250,64 @@ test("handleSubmit DUPLICATE: Windows パス区切り (\\) でも検出される
   expect(get().state.errors.title?.code).toBe("DUPLICATE");
 });
 
+test("handleSubmit: 直前の DUPLICATE エラーが残った状態でも、再 submit が Ok なら errors.title をクリアする", () => {
+  const onSubmit = vi.fn();
+  let tasks: readonly Task[] = [makeTask("tasks/fix-login-bug.md")];
+  const Wrapper = (
+    props: Omit<UseTaskFormFieldsArgs, "existingTasks"> & {
+      existingTasks: readonly Task[];
+      onResult: (r: UseTaskFormFieldsResult) => void;
+    },
+  ) => {
+    const { onResult, ...args } = props;
+    const result = useTaskFormFields(args);
+    useEffect(() => {
+      onResult(result);
+    });
+    return null;
+  };
+  let latest: UseTaskFormFieldsResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const renderWith = (current: readonly Task[]) => {
+    act(() => {
+      root?.render(
+        createElement(Wrapper, {
+          initialStatus: "Todo",
+          parentFieldVisible: false,
+          isSubmitting: false,
+          onSubmit,
+          finalizeLabels: () => [],
+          existingTasks: current,
+          onResult: (r) => {
+            latest = r;
+          },
+        }),
+      );
+    });
+  };
+  renderWith(tasks);
+  const get = () => latest as unknown as UseTaskFormFieldsResult;
+
+  act(() => {
+    get().dispatch({ type: "title", value: "Fix Login Bug" });
+  });
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(get().state.errors.title?.code).toBe("DUPLICATE");
+  expect(onSubmit).not.toHaveBeenCalled();
+
+  tasks = [];
+  renderWith(tasks);
+  act(() => {
+    get().handleSubmit(makeFormEvent());
+  });
+  expect(get().state.errors.title).toBeUndefined();
+  expect(onSubmit).toHaveBeenCalledTimes(1);
+});
+
 test("入力中は重複判定しない（onChange で重複 title を入力しても errors.title は undefined）", () => {
   const { get } = render({
     ...defaultArgs(),

--- a/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
+++ b/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
@@ -6,6 +6,7 @@ import {
   type UseTaskFormFieldsResult,
   useTaskFormFields,
 } from "@/features/task-form/hooks/useTaskFormFields";
+import { TITLE_MAX_LENGTH } from "@/features/task-form/lib/fields/title";
 import type { TaskFormValues } from "@/features/task-form/types";
 import { Task } from "@/types/task";
 
@@ -154,11 +155,14 @@ test("handleSubmit: 空白のみタイトルでも EMPTY エラー", () => {
   expect(get().state.errors.title?.code).toBe("EMPTY");
 });
 
-test("handleSubmit: TOO_LONG（201 文字）", () => {
+test("handleSubmit: TOO_LONG（TITLE_MAX_LENGTH + 1 文字）", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
-    get().dispatch({ type: "title", value: "a".repeat(201) });
+    get().dispatch({
+      type: "title",
+      value: "a".repeat(TITLE_MAX_LENGTH + 1),
+    });
   });
   act(() => {
     get().handleSubmit(makeFormEvent());

--- a/src/features/task-form/hooks/useTaskFormFields/index.ts
+++ b/src/features/task-form/hooks/useTaskFormFields/index.ts
@@ -226,6 +226,11 @@ export const useTaskFormFields = (
         dispatch({ type: "validateAll", error: result.error });
         return;
       }
+      // 前回 submit で残った DUPLICATE 等の古いエラー表示を消す。
+      // parent / existingTasks が変わって今回 Ok になったケースが該当する。
+      if (state.errors.title !== undefined) {
+        dispatch({ type: "validateAll", error: undefined });
+      }
       const labels = finalizeLabels();
       onSubmit({
         title: TitleField.normalize(state.values.title),
@@ -236,7 +241,14 @@ export const useTaskFormFields = (
         labels: [...labels],
       });
     },
-    [isSubmitting, onSubmit, finalizeLabels, existingTasks, state.values],
+    [
+      isSubmitting,
+      onSubmit,
+      finalizeLabels,
+      existingTasks,
+      state.values,
+      state.errors.title,
+    ],
   );
 
   return { state, dispatch, handleSubmit };

--- a/src/features/task-form/hooks/useTaskFormFields/index.ts
+++ b/src/features/task-form/hooks/useTaskFormFields/index.ts
@@ -2,8 +2,12 @@ import type { Dispatch, FormEvent } from "react";
 import { useCallback, useReducer } from "react";
 import { ParentField } from "@/features/task-form/lib/fields/parent";
 import { PriorityField } from "@/features/task-form/lib/fields/priority";
-import { TitleField } from "@/features/task-form/lib/fields/title";
+import {
+  TitleField,
+  type TitleValidationError,
+} from "@/features/task-form/lib/fields/title";
 import type { TaskFormValues } from "@/features/task-form/types";
+import type { Task } from "@/types/task";
 
 /** useTaskFormFields の引数 */
 export type UseTaskFormFieldsArgs = {
@@ -15,6 +19,11 @@ export type UseTaskFormFieldsArgs = {
   parentFieldVisible: boolean;
   /** 送信中か（true の間は submit が無視される） */
   isSubmitting: boolean;
+  /**
+   * 既存タスク一覧。submit 時の重複判定スコープ構築に使う。
+   * 未指定なら DUPLICATE 判定は走らない（空 Set 扱い）。
+   */
+  existingTasks?: readonly Task[];
   /**
    * バリデーション通過後に呼ばれる送信コールバック。
    * @param values - 正規化済みフォーム値
@@ -39,7 +48,7 @@ export type FieldValues = {
 
 /** 各 field のエラー（値が undefined ならエラーなし） */
 export type FieldErrors = {
-  title?: string;
+  title?: TitleValidationError;
 };
 
 /** useTaskFormFields の state */
@@ -55,7 +64,7 @@ export type FieldsAction =
   | { type: "priority"; value: PriorityField }
   | { type: "parent"; value: ParentField }
   | { type: "body"; value: string }
-  | { type: "validateAll" };
+  | { type: "validateAll"; error: TitleValidationError | undefined };
 
 /** useTaskFormFields の返却値 */
 export type UseTaskFormFieldsResult = {
@@ -71,8 +80,49 @@ export type UseTaskFormFieldsResult = {
 };
 
 /**
+ * BE 側 create_task が parent 未指定時に書き込む root dirname。
+ * BE が `tasks/` 直下に固定で書き込む実装であることを前提に成立させている。
+ * BE 側で root が動的になる変更が入った場合は、args に rootDir 相当を追加するか
+ * existingTasks から推定する設計に切り替える必要がある。
+ */
+const DEFAULT_TARGET_DIR = "tasks";
+
+/**
+ * パス文字列を Windows / POSIX 両対応で分解する。
+ * 空セグメントと "." を除去することで `./tasks/foo.md` や `tasks//foo.md` の表記揺れを吸収する。
+ * @param p パス文字列
+ * @returns 区切り文字でセグメント化した配列
+ */
+const pathSegments = (p: string): string[] =>
+  p.split(/[\\/]/).filter((s) => s !== "" && s !== ".");
+
+/**
+ * パス文字列の末尾セグメント（basename）を返す。
+ * @param p パス文字列
+ * @returns 末尾セグメント。セグメントが取れない場合は入力をそのまま返す
+ */
+const pathBasename = (p: string): string => {
+  const segments = pathSegments(p);
+  return segments[segments.length - 1] ?? p;
+};
+
+/**
+ * パス文字列のディレクトリ部分（dirname）を POSIX 区切りで返す。
+ * セグメントが 1 個以下なら空文字を返す。
+ * @param p パス文字列
+ * @returns dirname 文字列（POSIX 区切り）
+ */
+const pathDirname = (p: string): string => {
+  const segments = pathSegments(p);
+  if (segments.length <= 1) {
+    return "";
+  }
+  return segments.slice(0, -1).join("/");
+};
+
+/**
  * TaskForm の field 値・エラー遷移を計算する pure reducer。
- * バリデーション判断は TitleField.validate に委譲し、ここでは配線のみ。
+ * title 入力時はエラーをクリアするだけにし、再 validate は handleSubmit 側で行う。
  * @param state - 現在の state
  * @param action - アクション
  * @returns 新しい state
@@ -80,16 +130,15 @@ export type UseTaskFormFieldsResult = {
 const reducer = (state: FieldsState, action: FieldsAction): FieldsState => {
   switch (action.type) {
     case "title": {
-      const error = TitleField.validate(action.value);
       if (
         Object.is(state.values.title, action.value) &&
-        Object.is(state.errors.title, error)
+        state.errors.title === undefined
       ) {
         return state;
       }
       return {
         values: { ...state.values, title: action.value },
-        errors: { ...state.errors, title: error },
+        errors: { ...state.errors, title: undefined },
       };
     }
     case "status":
@@ -111,7 +160,7 @@ const reducer = (state: FieldsState, action: FieldsAction): FieldsState => {
     case "validateAll":
       return {
         ...state,
-        errors: { title: TitleField.validate(state.values.title) },
+        errors: { title: action.error },
       };
     default: {
       action satisfies never;
@@ -148,16 +197,33 @@ export const useTaskFormFields = (
     errors: {},
   }));
 
-  const { isSubmitting, onSubmit, finalizeLabels } = args;
+  const { isSubmitting, onSubmit, finalizeLabels, existingTasks } = args;
   const handleSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       if (isSubmitting) {
         return;
       }
-      const titleError = TitleField.validate(state.values.title);
-      if (titleError !== undefined) {
-        dispatch({ type: "validateAll" });
+      const parentFilePath = state.values.parent;
+      const targetDir =
+        parentFilePath !== undefined
+          ? pathDirname(parentFilePath)
+          : DEFAULT_TARGET_DIR;
+
+      const existingFileNames = new Set<string>();
+      if (existingTasks !== undefined) {
+        for (const t of existingTasks) {
+          if (pathDirname(t.filePath) === targetDir) {
+            existingFileNames.add(pathBasename(t.filePath));
+          }
+        }
+      }
+
+      const result = TitleField.validate(state.values.title, {
+        existingFileNames,
+      });
+      if (!result.ok) {
+        dispatch({ type: "validateAll", error: result.error });
         return;
       }
       const labels = finalizeLabels();
@@ -170,7 +236,7 @@ export const useTaskFormFields = (
         labels: [...labels],
       });
     },
-    [isSubmitting, onSubmit, finalizeLabels, state.values],
+    [isSubmitting, onSubmit, finalizeLabels, existingTasks, state.values],
   );
 
   return { state, dispatch, handleSubmit };

--- a/src/features/task-form/hooks/useTaskFormFields/index.ts
+++ b/src/features/task-form/hooks/useTaskFormFields/index.ts
@@ -209,10 +209,15 @@ export const useTaskFormFields = (
         return;
       }
       const parentFilePath = state.values.parent;
+      const parentDir =
+        parentFilePath !== undefined ? pathDirname(parentFilePath) : undefined;
+      // parent が "parent.md" のように dirname を含まない bare filename だと
+      // pathDirname が空文字を返すため、root 配下扱いで DEFAULT_TARGET_DIR に
+      // フォールバックして、tasks/ 直下の既存タスクと比較できるようにする。
       const targetDir =
-        parentFilePath !== undefined
-          ? pathDirname(parentFilePath)
-          : DEFAULT_TARGET_DIR;
+        parentDir === undefined || parentDir === ""
+          ? DEFAULT_TARGET_DIR
+          : parentDir;
 
       const existingFileNames = new Set<string>();
       if (existingTasks !== undefined) {

--- a/src/features/task-form/hooks/useTaskFormFields/index.ts
+++ b/src/features/task-form/hooks/useTaskFormFields/index.ts
@@ -186,16 +186,20 @@ const reducer = (state: FieldsState, action: FieldsAction): FieldsState => {
 export const useTaskFormFields = (
   args: UseTaskFormFieldsArgs,
 ): UseTaskFormFieldsResult => {
-  const [state, dispatch] = useReducer(reducer, args, (a) => ({
-    values: {
-      title: TitleField.initial(),
-      status: a.initialStatus,
-      priority: PriorityField.initial(),
-      parent: ParentField.initial(a.parentFieldVisible, a.initialParent),
-      body: "",
-    },
-    errors: {},
-  }));
+  const [state, dispatch] = useReducer(
+    reducer,
+    args,
+    (a): FieldsState => ({
+      values: {
+        title: TitleField.initial(),
+        status: a.initialStatus,
+        priority: PriorityField.initial(),
+        parent: ParentField.initial(a.parentFieldVisible, a.initialParent),
+        body: "",
+      },
+      errors: {},
+    }),
+  );
 
   const { isSubmitting, onSubmit, finalizeLabels, existingTasks } = args;
   const handleSubmit = useCallback(

--- a/src/features/task-form/hooks/useTaskFormFields/index.ts
+++ b/src/features/task-form/hooks/useTaskFormFields/index.ts
@@ -160,7 +160,7 @@ const reducer = (state: FieldsState, action: FieldsAction): FieldsState => {
     case "validateAll":
       return {
         ...state,
-        errors: { title: action.error },
+        errors: { ...state.errors, title: action.error },
       };
     default: {
       action satisfies never;

--- a/src/features/task-form/index.ts
+++ b/src/features/task-form/index.ts
@@ -4,4 +4,12 @@ export type {
   UseTaskCreateResult,
 } from "./hooks/useTaskCreate";
 export { useTaskCreate } from "./hooks/useTaskCreate";
+export type {
+  TitleValidationContext,
+  TitleValidationError,
+} from "./lib/fields/title";
+export {
+  FORBIDDEN_TITLE_CHARS,
+  TITLE_MAX_LENGTH,
+} from "./lib/fields/title";
 export type { TaskFormValues } from "./types";

--- a/src/features/task-form/lib/fields/title/__tests__/title.behavior.test.ts
+++ b/src/features/task-form/lib/fields/title/__tests__/title.behavior.test.ts
@@ -120,11 +120,7 @@ test("validate: 優先順位は EMPTY → FORBIDDEN_CHAR → TOO_LONG → DUPLIC
 
   const cases: Array<[string, TitleValidationError, string]> = [
     ["", { code: "EMPTY" }, "empty wins over everything"],
-    [
-      "   ",
-      { code: "EMPTY" },
-      "whitespace-only also EMPTY (priority over FORBIDDEN even if char present in source)",
-    ],
+    ["   ", { code: "EMPTY" }, "whitespace-only is EMPTY"],
     [
       longForbidden,
       { code: "FORBIDDEN_CHAR", chars: ["<"] },

--- a/src/features/task-form/lib/fields/title/__tests__/title.behavior.test.ts
+++ b/src/features/task-form/lib/fields/title/__tests__/title.behavior.test.ts
@@ -1,22 +1,135 @@
 import { expect, test } from "vitest";
-import { TitleField } from "..";
+import { Result } from "@/utils/result";
+import {
+  FORBIDDEN_TITLE_CHARS,
+  TITLE_MAX_LENGTH,
+  TitleField,
+  type TitleValidationError,
+} from "..";
+
+const emptyCtx = { existingFileNames: new Set<string>() };
 
 test("initial は空文字を返す", () => {
   expect(TitleField.initial()).toBe("");
 });
 
-test("validate: 空文字でエラー", () => {
-  expect(TitleField.validate("")).toBe("タイトルを入力してください");
-});
-
-test("validate: 空白のみでエラー（trim 判定）", () => {
-  expect(TitleField.validate("   ")).toBe("タイトルを入力してください");
-});
-
-test("validate: 非空文字で undefined", () => {
-  expect(TitleField.validate("abc")).toBeUndefined();
-});
-
 test("normalize: 前後空白を trim する", () => {
   expect(TitleField.normalize("  x  ")).toBe("x");
+});
+
+test("validate: 空文字は EMPTY", () => {
+  expect(TitleField.validate("", emptyCtx)).toEqual(
+    Result.err({ code: "EMPTY" }),
+  );
+});
+
+test("validate: 空白のみは EMPTY（trim 判定）", () => {
+  expect(TitleField.validate("   ", emptyCtx)).toEqual(
+    Result.err({ code: "EMPTY" }),
+  );
+});
+
+test("validate: 非空文字で Ok", () => {
+  expect(TitleField.validate("abc", emptyCtx)).toEqual(Result.ok(undefined));
+});
+
+test("validate: 禁止文字 1 個", () => {
+  expect(TitleField.validate("a<b", emptyCtx)).toEqual(
+    Result.err({ code: "FORBIDDEN_CHAR", chars: ["<"] }),
+  );
+});
+
+test("validate: 禁止文字 複数（FORBIDDEN_TITLE_CHARS 宣言順）", () => {
+  expect(TitleField.validate("a<b>c", emptyCtx)).toEqual(
+    Result.err({ code: "FORBIDDEN_CHAR", chars: ["<", ">"] }),
+  );
+});
+
+test("validate: 禁止文字 全種", () => {
+  const all = FORBIDDEN_TITLE_CHARS.join("");
+  const result = TitleField.validate(`x${all}`, emptyCtx);
+  expect(result).toEqual(
+    Result.err({
+      code: "FORBIDDEN_CHAR",
+      chars: [...FORBIDDEN_TITLE_CHARS],
+    }),
+  );
+});
+
+test("validate: TITLE_MAX_LENGTH ぴったりは Ok", () => {
+  const v = "a".repeat(TITLE_MAX_LENGTH);
+  expect(TitleField.validate(v, emptyCtx)).toEqual(Result.ok(undefined));
+});
+
+test("validate: TITLE_MAX_LENGTH 超過は TOO_LONG", () => {
+  const v = "a".repeat(TITLE_MAX_LENGTH + 1);
+  expect(TitleField.validate(v, emptyCtx)).toEqual(
+    Result.err({
+      code: "TOO_LONG",
+      max: TITLE_MAX_LENGTH,
+      actual: TITLE_MAX_LENGTH + 1,
+    }),
+  );
+});
+
+test("validate: DUPLICATE — kebab + .md が existingFileNames に含まれる", () => {
+  const ctx = {
+    existingFileNames: new Set<string>(["fix-login-bug.md"]),
+  };
+  expect(TitleField.validate("Fix Login Bug", ctx)).toEqual(
+    Result.err({ code: "DUPLICATE", fileName: "fix-login-bug.md" }),
+  );
+});
+
+test("validate: existingFileNames が空 Set のときは DUPLICATE 判定されない", () => {
+  expect(TitleField.validate("Fix Login Bug", emptyCtx)).toEqual(
+    Result.ok(undefined),
+  );
+});
+
+test("validate: DUPLICATE — スコープ外（別 fileName）は Ok", () => {
+  const ctx = {
+    existingFileNames: new Set<string>(["other-task.md"]),
+  };
+  expect(TitleField.validate("Fix Login Bug", ctx)).toEqual(
+    Result.ok(undefined),
+  );
+});
+
+test("validate: 優先順位は EMPTY → FORBIDDEN_CHAR → TOO_LONG → DUPLICATE", () => {
+  const longForbidden = `<${"a".repeat(TITLE_MAX_LENGTH + 1)}`;
+  const ctx = {
+    existingFileNames: new Set<string>([
+      `${"a".repeat(TITLE_MAX_LENGTH + 1)}.md`,
+    ]),
+  };
+
+  const cases: Array<[string, TitleValidationError, string]> = [
+    ["", { code: "EMPTY" }, "empty wins over everything"],
+    [
+      "   ",
+      { code: "EMPTY" },
+      "whitespace-only also EMPTY (priority over FORBIDDEN even if char present in source)",
+    ],
+    [
+      longForbidden,
+      { code: "FORBIDDEN_CHAR", chars: ["<"] },
+      "FORBIDDEN_CHAR wins over TOO_LONG",
+    ],
+    [
+      "a".repeat(TITLE_MAX_LENGTH + 1),
+      {
+        code: "TOO_LONG",
+        max: TITLE_MAX_LENGTH,
+        actual: TITLE_MAX_LENGTH + 1,
+      },
+      "TOO_LONG wins over DUPLICATE",
+    ],
+  ];
+
+  for (const [input, expected, label] of cases) {
+    expect(TitleField.validate(input, ctx), label).toEqual(
+      Result.err(expected),
+    );
+  }
 });

--- a/src/features/task-form/lib/fields/title/__tests__/title.behavior.test.ts
+++ b/src/features/task-form/lib/fields/title/__tests__/title.behavior.test.ts
@@ -29,6 +29,20 @@ test("validate: 空白のみは EMPTY（trim 判定）", () => {
   );
 });
 
+test("validate: kebab 後空文字になる入力（記号/アンダースコアのみ）は EMPTY", () => {
+  const cases: Array<[string, string]> = [
+    ["!!!", "ASCII 記号のみ"],
+    ["___", "アンダースコアのみ"],
+    [".", "ドットのみ"],
+    ["-_-", "ハイフン・アンダースコア混在"],
+  ];
+  for (const [input, label] of cases) {
+    expect(TitleField.validate(input, emptyCtx), label).toEqual(
+      Result.err({ code: "EMPTY" }),
+    );
+  }
+});
+
 test("validate: 非空文字で Ok", () => {
   expect(TitleField.validate("abc", emptyCtx)).toEqual(Result.ok(undefined));
 });

--- a/src/features/task-form/lib/fields/title/index.ts
+++ b/src/features/task-form/lib/fields/title/index.ts
@@ -85,7 +85,14 @@ export const TitleField = {
         actual: trimmed.length,
       });
     }
-    const fileName = `${KebabCase.from(trimmed)}.md`;
+    const kebabBase = KebabCase.from(trimmed);
+    if (kebabBase.length === 0) {
+      // 記号のみ・アンダースコアのみ等で kebab base が空になる入力は
+      // ファイル名 base が作れず、BE 側でも InvalidTitle となるため
+      // EMPTY 扱いで弾く。
+      return Result.err({ code: "EMPTY" });
+    }
+    const fileName = `${kebabBase}.md`;
     if (ctx.existingFileNames.has(fileName)) {
       return Result.err({ code: "DUPLICATE", fileName });
     }

--- a/src/features/task-form/lib/fields/title/index.ts
+++ b/src/features/task-form/lib/fields/title/index.ts
@@ -1,5 +1,44 @@
+import { KebabCase } from "@/domains/KebabCase";
+import { Result } from "@/utils/result";
+
 /** TitleField が保持する値の型（生の入力文字列） */
 export type TitleField = string;
+
+/** タイトルに許容する最大文字数（trim 後） */
+export const TITLE_MAX_LENGTH = 200;
+
+/**
+ * タイトルに使用を禁止する文字（OS ファイル名予約文字）。
+ * 配列の順序は FORBIDDEN_CHAR エラーの `chars` 列挙順にも使用する。
+ */
+export const FORBIDDEN_TITLE_CHARS = [
+  "<",
+  ">",
+  ":",
+  '"',
+  "/",
+  "\\",
+  "|",
+  "?",
+  "*",
+] as const;
+
+/** タイトルバリデーションのエラー判別共用体。 */
+export type TitleValidationError =
+  | { code: "EMPTY" }
+  | { code: "DUPLICATE"; fileName: string }
+  | { code: "TOO_LONG"; max: number; actual: number }
+  | { code: "FORBIDDEN_CHAR"; chars: string[] };
+
+/** バリデーションに渡すコンテキスト。 */
+export type TitleValidationContext = {
+  /**
+   * kebab(title) + ".md" の重複判定に使う既存ファイル名集合（basename ベース）。
+   * 呼び出し側で「作成先 dirname に同居する既存タスク」だけに絞り込んだ集合を渡す。
+   * 重複判定が不要な場合は空 Set を渡す。
+   */
+  existingFileNames: ReadonlySet<string>;
+};
 
 /**
  * タイトル field の companion object。
@@ -13,18 +52,43 @@ export const TitleField = {
   initial: (): TitleField => "",
 
   /**
-   * タイトルをバリデーションする。
-   * trim 後が空の場合にエラー文字列、妥当ならば undefined を返す。
-   * @param v - 現在の値
-   * @returns エラー文字列または undefined
-   */
-  validate: (v: TitleField): string | undefined =>
-    v.trim().length === 0 ? "タイトルを入力してください" : undefined,
-
-  /**
    * 送信用に値を正規化する（前後空白除去）。
    * @param v - 現在の値
    * @returns 正規化された値
    */
   normalize: (v: TitleField): string => v.trim(),
+
+  /**
+   * タイトルをバリデーションする。
+   * 優先順位は EMPTY → FORBIDDEN_CHAR → TOO_LONG → DUPLICATE。
+   * 最初にマッチしたエラーのみ返し、後続は評価しない。
+   * @param v 現在の値
+   * @param ctx 重複判定用コンテキスト（必須）
+   * @returns Result<void, TitleValidationError>
+   */
+  validate: (
+    v: TitleField,
+    ctx: TitleValidationContext,
+  ): Result<void, TitleValidationError> => {
+    const trimmed = v.trim();
+    if (trimmed.length === 0) {
+      return Result.err({ code: "EMPTY" });
+    }
+    const forbidden = FORBIDDEN_TITLE_CHARS.filter((c) => v.includes(c));
+    if (forbidden.length > 0) {
+      return Result.err({ code: "FORBIDDEN_CHAR", chars: [...forbidden] });
+    }
+    if (trimmed.length > TITLE_MAX_LENGTH) {
+      return Result.err({
+        code: "TOO_LONG",
+        max: TITLE_MAX_LENGTH,
+        actual: trimmed.length,
+      });
+    }
+    const fileName = `${KebabCase.from(trimmed)}.md`;
+    if (ctx.existingFileNames.has(fileName)) {
+      return Result.err({ code: "DUPLICATE", fileName });
+    }
+    return Result.ok(undefined);
+  },
 };


### PR DESCRIPTION
## 概要

タスク作成モーダル (`TaskCreateModal`) の submit 時に、FE 側で 4 種のタイトルバリデーション（EMPTY / FORBIDDEN_CHAR / TOO_LONG / DUPLICATE）を行い、`create_task` Tauri command 呼び出し前に不正入力を弾く。エラーは TaskFormTitle 直下にインラインで表示し、`aria-invalid` / `aria-describedby` も連動させる。

## 変更の種類

- ✨ 新機能（公開 API に validation 型を追加するが、既存呼び出しは互換維持）

## 追加した内容

- **`src/domains/KebabCase/`**: BE `src-tauri/crates/fs/src/task/kebab_case.rs` の `to_kebab_case` を branded 型 + companion API として TS 移植。BE テストテーブル全件（ASCII 5 / 非 ASCII 4 / 空・記号 2）を移植して挙動一致を担保。
- **`titleErrorMessage` helper** (`TaskFormTitle/titleErrorMessage.ts`): `TitleValidationError` → 日本語メッセージ変換の pure 関数。`error satisfies never` で網羅性チェック。
- **`TitleValidationError` 判別共用体**: `EMPTY` / `DUPLICATE` / `TOO_LONG` / `FORBIDDEN_CHAR` の構造化エラー。
- **`TITLE_MAX_LENGTH`** (= 200) / **`FORBIDDEN_TITLE_CHARS`** (OS 予約文字 9 種) 定数。
- **`TaskFormTitle` Storybook 4 種**: `WithEmptyError` / `WithDuplicateError` / `WithTooLongError` / `WithForbiddenCharError`。

## 変更した内容

- **`TitleField.validate`**: シグネチャを `(v) => string | undefined` から `(v, ctx) => Result<void, TitleValidationError>` に変更。優先順位は EMPTY → FORBIDDEN_CHAR → TOO_LONG → DUPLICATE。`ctx.existingFileNames` は型レベル必須（重複判定不要時は空 Set を明示的に渡す）。kebab base が空になる入力（`"!!!"` / `"___"` 等）は EMPTY に畳み込み、BE `TaskFileNameError::InvalidTitle` と整合する。
- **`useTaskFormFields`**:
  - `args.existingTasks?: readonly Task[]` を追加。
  - handleSubmit 内で BE の配置先と一致する **dirname スコープ**に絞った basename Set を構築（`parent` 未指定 → `tasks/` 直下、`parent` 指定 → 親 Task の dirname と同居）。
  - `pathBasename` / `pathDirname` helper は `split(/[\\/]/)` で **POSIX / Windows 区切り両対応**。
  - reducer `case "title"` は入力時にエラークリアのみ（再 validate しない）。
  - `validateAll` action に `error` payload を追加し、submit 時のエラーを reducer 外で計算して注入（reducer の純粋性維持）。
  - `FieldErrors.title` の型を `TitleValidationError | undefined` に変更。
- **`TaskForm` / `TaskCreateModal`**: `existingTasks?: readonly Task[]` prop を追加して `useTaskFormFields` まで透過。
- **`TaskFormTitle`**: `error` prop 型を `TitleValidationError | undefined` に変更し、表示直前に `titleErrorMessage` で日本語化。`aria-invalid` / `aria-describedby` 配線は既存維持。
- **`App.tsx`**: `<TaskCreateModal>` に `existingTasks={tasks}` を追加（`parentCandidates={tasks}` はそのまま残し意味分離）。
- **`src/features/task-form/index.ts`**: `TitleValidationError` / `TitleValidationContext` / `TITLE_MAX_LENGTH` / `FORBIDDEN_TITLE_CHARS` を re-export。

## 仕様ドキュメント更新

不要（純粋に FE バリデーション追加のため、`docs/spec-board/` 配下の公開仕様・データ形式・画面挙動・設定項目に変更なし）。

### DUPLICATE 判定の責務分担

BE と FE で役割を分担している。両者は競合せず補完関係にある:

- **BE (最終的整合性ガード)**: `unique_filename` が `{base}-1.md` / `{base}-2.md` ... と suffix を採番してファイル名衝突を回避する。`create_task` は常に成功させる方針で、データ整合性のラストガードを担う。
- **FE (UX 警告 + submit ブロック)**: `TitleField.validate` の DUPLICATE は他のエラー (EMPTY / FORBIDDEN_CHAR / TOO_LONG) と同じく **submit を弾く**。これは「`-1.md` のような suffix 付きファイルが意図せず生成される事故を防ぎ、ユーザーに同名タスクの存在を気づかせる」UX 上の挙動。

「UX 警告」という語は「BE の整合性ガードと違って、FE 側は UX のために存在する」というニュアンスで使っているが、その表現として **submit ブロック**を選んでいる（spec DoD §2 と一致）。確認ダイアログ等を挟まずシンプルに弾く方針。

## システム図

```mermaid
flowchart TD
  App[App.tsx<br/>tasks: Task NEW: existingTasks prop] --> Modal[TaskCreateModal NEW: existingTasks prop]
  Modal --> Form[TaskForm NEW: existingTasks prop]
  Form --> Hook["useTaskFormFields NEW: args.existingTasks, dirname スコープ解決"]

  Hook -->|submit 時| TargetDir{parent 指定?}
  TargetDir -->|未指定| Tasks["targetDir = tasks/"]
  TargetDir -->|指定| ParentDir["targetDir = pathDirname parentFilePath"]

  Tasks --> Filter[existingTasks を dirname で filter → basename Set]
  ParentDir --> Filter
  Filter --> Validate["TitleField.validate v, ctx existingFileNames"]

  Validate -->|Result.ok| OnSubmit[onSubmit values → create_task invoke]
  Validate -->|Result.err| Dispatch["dispatch validateAll error"]
  Dispatch --> Errors["state.errors.title NEW: TitleValidationError"]
  Errors --> Title["TaskFormTitle NEW: error prop 構造化"]
  Title --> Msg["titleErrorMessage NEW: error → 日本語"]

  style App fill:#e3f2fd
  style Hook fill:#fff3e0
  style Validate fill:#fff3e0
  style Filter fill:#fff3e0
  style Errors fill:#fff3e0
  style Title fill:#fff3e0
  style Msg fill:#fff3e0
```

## 関連Issue

Closes #120

## テスト

- `pnpm test:run`: **853 / 853 緑**（既存 835 + 新規 18）
- `pnpm build`: 成功
- `pnpm biome check src`: clean
- `pnpm oxlint src`: clean
- AI コードレビュー（codex）: 「問題なし」

新規テストカバレッジ:
- `KebabCase.behavior` 3 ケース（BE テストテーブル 11 件を網羅）
- `title.behavior` 15 ケース（4 エラー × 境界値 + 優先順位 + kebab 空入力 4 ケース）
- `titleErrorMessage.behavior` 1 ケース（5 パラメータ化）
- `useTaskFormFields.interaction` 17 ケース（4 エラーコード × 配線 + dirname スコープ + Windows パス + エラークリア UX）
- `TaskFormTitle.interaction` 既存 + 4 種エラー × メッセージ表示

⚠️ 手動 (Tauri アプリ) での目視確認は未実施。レビュー時に動作確認してください（4 エラー表示 / aria-invalid / エラークリア UX）。

## レビューポイント

1. **重複判定のスコープ設計** (`useTaskFormFields/index.ts`): BE の配置先（parent 未指定 → `tasks/` 直下、parent 指定 → 親 Task の dirname）と一致させ、別 dirname の同名は重複扱いしない方針。BE の root を `tasks/` リテラルで前提化している点（将来 BE 側で root が動的化する場合に追従が必要）。
2. **`DEFAULT_TARGET_DIR = "tasks"` のハードコード**: `useTaskFormFields/index.ts` 内に自然文コメント付きで定義。将来 BE 側で root を可変にする変更が入った場合は `args.rootDir` 追加 or `existingTasks` から推定する設計に切り替える必要あり。
3. **`pathBasename` / `pathDirname` helper の hook 内閉じ込め**: ドメイン中心パターンに従い別ファイル切り出しせず `useTaskFormFields` 内に閉じている（feedback `spec-board-aggregate-method` に準拠）。
4. **kebab BE 一致テスト**: BE `kebab_case_tests.rs` のテストテーブル全件を TS 版にそのまま移植。BE 実装変更時は両側で同じテストを更新するルールが必要。
5. **`ctx` の型レベル必須化**: `TitleField.validate(value, ctx)` の `ctx` を必須引数とし、重複判定不要時も空 Set を明示的に渡す設計。呼び出し漏れを型で防ぐ。
6. **コミット粒度**: Phase 単位の 6 コミット + バグ修正 1 コミット。Phase 2 (TitleField) → Phase 4 (useTaskFormFields) の間は API シグネチャ変更途中のため中間コミット単独では `tsc -b` が通らない可能性がある（PR 全体としては最終 commit で緑）。

## チェックリスト

- [x] セルフレビュー実施
- [x] pnpm test:run / pnpm build / biome / oxlint 全て緑
- [x] UI 変更があるが Tauri アプリでの動作確認は未実施（レビュー時に確認依頼）
- [x] 仕様変更なし（FE バリデーション追加のみ）
- [x] feature 間依存は `index.ts` 公開 API 経由
- [x] 関連 Issue #120 を本文で連携
- [x] 破壊的変更なし（公開 API は型追加のみ、既存呼び出しは互換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)