### PR TITLE
✨ [New Feature]: #124 [FE] DetailPanel status/priority に楽観更新を導入

### DIFF
--- a/src/__tests__/App.detailOptimistic.test.tsx
+++ b/src/__tests__/App.detailOptimistic.test.tsx
@@ -1,0 +1,244 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { App } from "@/App";
+import {
+  getColumns as getColumnsInvoke,
+  type OpenProjectPayload,
+  openDirectoryDialog,
+  openProject as openProjectInvoke,
+  TauriError,
+  updateTask as updateTaskInvoke,
+} from "@/lib/tauri";
+import { Task } from "@/types/task";
+import { Result } from "@/utils/result";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    openDirectoryDialog: vi.fn(),
+    openProject: vi.fn(),
+    getColumns: vi.fn(),
+    createTask: vi.fn(),
+    updateTask: vi.fn(),
+    deleteTask: vi.fn(),
+    updateColumns: vi.fn(),
+    updateCardOrder: vi.fn(),
+  };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+const openDirectoryDialogMock = vi.mocked(openDirectoryDialog);
+const openProjectMock = vi.mocked(openProjectInvoke);
+const getColumnsMock = vi.mocked(getColumnsInvoke);
+const updateTaskMock = vi.mocked(updateTaskInvoke);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+let hadIsReactActEnvironment = false;
+
+beforeAll(() => {
+  hadIsReactActEnvironment =
+    "IS_REACT_ACT_ENVIRONMENT" in reactActEnvironmentGlobal;
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+  const keysToDelete = hadIsReactActEnvironment
+    ? []
+    : (["IS_REACT_ACT_ENVIRONMENT"] as const);
+  for (const key of keysToDelete) {
+    Reflect.deleteProperty(reactActEnvironmentGlobal, key);
+  }
+});
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeEach(() => {
+  openDirectoryDialogMock.mockReset();
+  openProjectMock.mockReset();
+  getColumnsMock.mockReset();
+  getColumnsMock.mockResolvedValue({
+    ok: true,
+    value: {
+      columns: [
+        { name: "Todo", order: 0 },
+        { name: "Doing", order: 1 },
+        { name: "Done", order: 2 },
+      ],
+      doneColumn: "Done",
+    },
+  });
+  updateTaskMock.mockReset();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+const taskA: Task = Task.fromPayload({
+  id: "a",
+  title: "A タスク",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/a.md",
+});
+
+const payload: OpenProjectPayload = {
+  tasks: [taskA],
+  columns: ["Todo", "Doing", "Done"],
+};
+
+/**
+ * App を mount する。
+ */
+const mountApp = (): void => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<App />);
+  });
+};
+
+/**
+ * 「開く」ボタンを押下して project を読み込ませる。
+ */
+const openSuccessfully = async (): Promise<void> => {
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  openProjectMock.mockResolvedValueOnce(Result.ok(payload));
+  const buttons = container?.querySelectorAll("header button") ?? [];
+  const openBtn = Array.from(buttons).find((b) => b.textContent === "開く") as
+    | HTMLButtonElement
+    | undefined;
+  await act(async () => {
+    openBtn?.click();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+/**
+ * TaskCard を click して DetailPanel を開く。
+ */
+const openDetailPanel = (): void => {
+  const card = container?.querySelector<HTMLElement>(
+    "[data-testid='task-card']",
+  );
+  act(() => {
+    card?.click();
+  });
+};
+
+/**
+ * data-testid から HTMLSelectElement を取得する。
+ *
+ * @param testId data-testid 値
+ * @returns 該当要素
+ */
+const getSelect = (testId: string): HTMLSelectElement =>
+  document.querySelector(`[data-testid="${testId}"]`) as HTMLSelectElement;
+
+/**
+ * select 要素に change イベントを発火し、queue 内 microtask を 1 度だけ flush する。
+ * 楽観 dispatch は `enqueueProjectCommand` の microtask で走るため、ここで await が必要。
+ *
+ * @param select 対象 select
+ * @param value 設定する value
+ */
+const changeSelectValue = async (
+  select: HTMLSelectElement,
+  value: string,
+): Promise<void> => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLSelectElement.prototype,
+    "value",
+  )?.set;
+  await act(async () => {
+    setter?.call(select, value);
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    // 楽観 dispatch (queue の microtask) を 1 度だけ流す
+    await Promise.resolve();
+  });
+};
+
+test("StatusSelect 操作 → updateTask resolve 前に DetailPanel の StatusSelect 表示が新値（楽観反映）", async () => {
+  mountApp();
+  await openSuccessfully();
+  openDetailPanel();
+  expect(getSelect("status-select").value).toBe("Todo");
+
+  type UpdateTaskResult = Awaited<ReturnType<typeof updateTaskMock>>;
+  let resolveUpdate: (value: UpdateTaskResult) => void = () => {};
+  updateTaskMock.mockReturnValueOnce(
+    new Promise<UpdateTaskResult>((resolve) => {
+      resolveUpdate = resolve;
+    }),
+  );
+
+  await changeSelectValue(getSelect("status-select"), "Doing");
+  // IPC resolve 前に楽観反映で Select 表示が Doing になっている
+  expect(getSelect("status-select").value).toBe("Doing");
+
+  await act(async () => {
+    resolveUpdate(Result.ok({ ...taskA, status: "Doing" }));
+    await Promise.resolve();
+  });
+  // 確定後も Doing のまま
+  expect(getSelect("status-select").value).toBe("Doing");
+});
+
+test("IPC 失敗時 → DetailPanel Select 表示が元値に戻り、エラートーストが出る", async () => {
+  mountApp();
+  await openSuccessfully();
+  openDetailPanel();
+  expect(getSelect("status-select").value).toBe("Todo");
+
+  updateTaskMock.mockResolvedValueOnce(
+    Result.err(new TauriError("IO_ERROR", "io fail")),
+  );
+
+  await changeSelectValue(getSelect("status-select"), "Doing");
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  // rollback で Select 表示が Todo に戻る
+  expect(getSelect("status-select").value).toBe("Todo");
+  // エラートーストが出る
+  const errorToast = document.querySelector('[data-testid="toast-error"]');
+  expect(errorToast).not.toBeNull();
+});

--- a/src/features/board/hooks/useProject/__tests__/useProject.interaction.test.tsx
+++ b/src/features/board/hooks/useProject/__tests__/useProject.interaction.test.tsx
@@ -565,19 +565,58 @@ test("updateTask (loaded) 成功 → Result.ok(task) + 該当差し替え", asyn
   ).toBe("renamed");
 });
 
-test("updateTask (loaded) 失敗 → Result.err、state 不変", async () => {
+test("updateTask (loaded) 失敗 → Result.err、楽観 → rollback で state が snapshot に戻る", async () => {
   const probe = renderHook();
   await openLoaded(probe);
   const err = new TauriError("IO_ERROR", "io");
   updateTaskMock.mockResolvedValueOnce(Result.err(err));
   let result!: Awaited<ReturnType<UseProjectResult["updateTask"]>>;
   await act(async () => {
-    result = await probe.latest.updateTask({ filePath: "tasks/a.md" });
+    result = await probe.latest.updateTask({
+      filePath: "tasks/a.md",
+      status: "Doing",
+    });
   });
   expect(result.ok).toBe(false);
+  // 楽観反映後に rollback されて元の taskA に戻る
   expect(
     (probe.latest.state as { data: { tasks: Task[] } }).data.tasks,
   ).toEqual([taskA]);
+});
+
+test("updateTask 楽観対象キーなし ({ filePath, parent } のみ) → 楽観 dispatch skip、IPC 成功時に BE 値で確定 dispatch", async () => {
+  const probe = renderHook();
+  await openLoaded(probe);
+  // BE が parent 付与済み task を返す想定
+  const updated: Task = {
+    ...taskA,
+    hierarchy: { ...taskA.hierarchy, parentFilePath: "tasks/parent.md" },
+  };
+  let stateDuringIpc: Task | null = null;
+  updateTaskMock.mockImplementationOnce(async () => {
+    // IPC await 中の state スナップショット: 楽観 dispatch が skip されているので
+    // hierarchy.parentFilePath はまだ更新されていない（taskA のまま）
+    const data = (probe.latest.state as { data: { tasks: Task[] } }).data;
+    stateDuringIpc = data.tasks[0];
+    return Result.ok(updated);
+  });
+  let result!: Awaited<ReturnType<UseProjectResult["updateTask"]>>;
+  await act(async () => {
+    result = await probe.latest.updateTask({
+      filePath: "tasks/a.md",
+      parent: "tasks/parent.md",
+    });
+  });
+  expect(result).toEqual({ ok: true, value: updated });
+  // IPC 中の state は楽観反映されていない（parent は元のまま）
+  expect(
+    (stateDuringIpc as Task | null)?.hierarchy.parentFilePath,
+  ).toBeUndefined();
+  // 確定 dispatch で BE 値が反映される
+  expect(
+    (probe.latest.state as { data: { tasks: Task[] } }).data.tasks[0].hierarchy
+      .parentFilePath,
+  ).toBe("tasks/parent.md");
 });
 
 test("updateTask (idle) → invalid-state を即返す、invoke 未呼び出し", async () => {

--- a/src/features/board/hooks/useProject/actions/__tests__/tasks.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/tasks.behavior.test.ts
@@ -1,0 +1,525 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { TauriError, updateTask as updateTaskInvoke } from "@/lib/tauri";
+import { Task, type TaskPayload } from "@/types/task";
+import { Result } from "@/utils/result";
+import {
+  createProjectVersion,
+  invalidateProject,
+  type ProjectCommandQueue,
+} from "../../concurrency";
+import type { ProjectAction, ProjectData, ProjectState } from "../../reducer";
+import { reducer } from "../../reducer";
+import { updateTaskAction } from "../tasks";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    updateTask: vi.fn(),
+  };
+});
+
+const updateTaskMock = vi.mocked(updateTaskInvoke);
+
+/**
+ * Task payload を最小限の overrides で生成するテストヘルパ。
+ * @param overrides 上書きする TaskPayload フィールド
+ * @returns 楽観テストで扱う Task
+ */
+const makeTask = (overrides: Partial<TaskPayload>): Task =>
+  Task.fromPayload({
+    id: overrides.filePath ?? "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+/**
+ * 単一 task と Todo / Done カラムから ProjectData を組み立てるヘルパ。
+ */
+const makeData = (tasks: readonly Task[]): ProjectData => ({
+  tasks: tasks.map((t) => t),
+  columns: [
+    { name: "Todo", order: 0 },
+    { name: "Done", order: 1 },
+  ],
+});
+
+type Harness = {
+  state: { current: ProjectState };
+  actions: ProjectAction[];
+  deps: Parameters<typeof updateTaskAction>[0];
+};
+
+/**
+ * loaded 状態の updateTaskAction 実行に必要な harness を組み立てる。
+ * @param data 初期 ProjectData
+ * @returns harness
+ */
+const setupLoaded = (data: ProjectData): Harness => {
+  const state = {
+    current: { kind: "loaded", path: "/p", data } as ProjectState,
+  };
+  const actions: ProjectAction[] = [];
+  const queue: ProjectCommandQueue = { current: Promise.resolve() };
+  const version = createProjectVersion();
+  return {
+    state,
+    actions,
+    deps: {
+      projectVersion: version,
+      projectCommandQueue: queue,
+      getState: () => state.current,
+      dispatchSync: (action) => {
+        actions.push(action);
+        state.current = reducer(state.current, action);
+      },
+    },
+  };
+};
+
+const setupIdle = (): Harness => {
+  const state = { current: { kind: "idle" } as ProjectState };
+  const actions: ProjectAction[] = [];
+  const queue: ProjectCommandQueue = { current: Promise.resolve() };
+  const version = createProjectVersion();
+  return {
+    state,
+    actions,
+    deps: {
+      projectVersion: version,
+      projectCommandQueue: queue,
+      getState: () => state.current,
+      dispatchSync: (action) => {
+        actions.push(action);
+        state.current = reducer(state.current, action);
+      },
+    },
+  };
+};
+
+beforeEach(() => {
+  updateTaskMock.mockReset();
+});
+
+// === 正常系: 楽観 dispatch ===
+
+test("status 変更で楽観 dispatch が IPC await 前に発火する", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo" });
+  const harness = setupLoaded(makeData([taskA]));
+
+  let optimisticSeen: Task | null = null;
+  updateTaskMock.mockImplementation(async () => {
+    const data = (harness.state.current as { data: ProjectData }).data;
+    optimisticSeen =
+      data.tasks.find((t) => t.filePath === "tasks/a.md") ?? null;
+    return Result.ok({ ...taskA, status: "Doing" });
+  });
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+
+  expect(optimisticSeen).not.toBeNull();
+  expect((optimisticSeen as unknown as Task).status).toBe("Doing");
+});
+
+test("成功時、楽観 dispatch + 確定 dispatch の 2 回 dispatch される", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo" });
+  const confirmed = makeTask({
+    filePath: "tasks/a.md",
+    status: "Doing",
+    title: "from-be",
+  });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(Result.ok(confirmed));
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect(taskUpdates).toHaveLength(2);
+  expect((taskUpdates[0] as { task: Task }).task.status).toBe("Doing");
+  expect((taskUpdates[0] as { task: Task }).task.title).toBe("t");
+  expect((taskUpdates[1] as { task: Task }).task).toBe(confirmed);
+  const finalTasks = (harness.state.current as { data: ProjectData }).data
+    .tasks;
+  expect(finalTasks[0].title).toBe("from-be");
+});
+
+// === 正常系: priority バリエーション ===
+
+test("priority undefined → value への変更が楽観反映される", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(
+    Result.ok({ ...taskA, priority: "High" as const }),
+  );
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    priority: "High",
+  });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect((taskUpdates[0] as { task: Task }).task.priority).toBe("High");
+});
+
+test("priority: undefined を明示的に渡しても楽観 dispatch から除外される", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", priority: "High" });
+  const harness = setupLoaded(makeData([taskA]));
+  // BE は priority クリアをサポートしないため High のまま返ってくる想定
+  updateTaskMock.mockResolvedValue(Result.ok(taskA));
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    priority: undefined,
+    status: "Doing",
+  });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  // 楽観 dispatch では priority は変更されない（High のまま）。status のみ Doing 反映。
+  expect((taskUpdates[0] as { task: Task }).task.priority).toBe("High");
+  expect((taskUpdates[0] as { task: Task }).task.status).toBe("Doing");
+});
+
+test("priority 以外のフィールドも undefined 明示は楽観対象から除外される (status / title / labels / body)", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo", title: "orig" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(Result.ok(taskA));
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: undefined,
+    title: undefined,
+    labels: undefined,
+    body: undefined,
+  });
+
+  // 全フィールドが undefined → 楽観 dispatch は skip され、確定 dispatch (BE 戻り) のみ
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect(taskUpdates).toHaveLength(1);
+  expect((taskUpdates[0] as { task: Task }).task).toBe(taskA);
+});
+
+// === 正常系: 共有経路（title / labels） ===
+
+test("title 変更も同じ楽観経路で動く", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", title: "old" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(Result.ok({ ...taskA, title: "new" }));
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    title: "new",
+  });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect(taskUpdates).toHaveLength(2);
+  expect((taskUpdates[0] as { task: Task }).task.title).toBe("new");
+});
+
+test("labels 変更も楽観反映される", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", labels: ["a"] });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(
+    Result.ok({ ...taskA, labels: ["a", "b"] }),
+  );
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    labels: ["a", "b"],
+  });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect((taskUpdates[0] as { task: Task }).task.labels).toEqual(["a", "b"]);
+});
+
+// === 境界値 ===
+
+test("currentTask が見つからない場合 invalid-state Err、dispatch なし", async () => {
+  const harness = setupLoaded(makeData([makeTask({ filePath: "tasks/a.md" })]));
+
+  const result = await updateTaskAction(harness.deps, {
+    filePath: "tasks/missing.md",
+    status: "Doing",
+  });
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: { kind: string } }).error.kind).toBe(
+    "invalid-state",
+  );
+  expect(harness.actions).toHaveLength(0);
+  expect(updateTaskMock).not.toHaveBeenCalled();
+});
+
+test("canAcceptDataCommand=false (idle) で invalid-state Err、dispatch なし", async () => {
+  const harness = setupIdle();
+
+  const result = await updateTaskAction(harness.deps, {
+    filePath: "tasks/x.md",
+    status: "Doing",
+  });
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: { kind: string } }).error.kind).toBe(
+    "invalid-state",
+  );
+  expect(harness.actions).toHaveLength(0);
+  expect(updateTaskMock).not.toHaveBeenCalled();
+});
+
+test("params が filePath のみ（楽観対象キーなし）→ 楽観 dispatch skip、IPC 成功時に確定 dispatch のみ", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(Result.ok(taskA));
+
+  await updateTaskAction(harness.deps, { filePath: "tasks/a.md" });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect(taskUpdates).toHaveLength(1);
+  expect((taskUpdates[0] as { task: Task }).task).toBe(taskA);
+});
+
+test("params が { filePath, parent } のみ → 楽観 dispatch skip、確定 dispatch のみ", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(Result.ok(taskA));
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    parent: "tasks/parent.md",
+  });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect(taskUpdates).toHaveLength(1);
+  expect((taskUpdates[0] as { task: Task }).task).toBe(taskA);
+});
+
+test("params.parent と status を同時に渡しても、楽観 task の hierarchy.parentFilePath は元のまま（parent は楽観対象外）", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", parent: "tasks/old.md" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(Result.ok(taskA));
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+    parent: "tasks/new.md",
+  });
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect((taskUpdates[0] as { task: Task }).task.status).toBe("Doing");
+  expect(
+    (taskUpdates[0] as { task: Task }).task.hierarchy.parentFilePath,
+  ).toBe("tasks/old.md");
+});
+
+// === 異常系: rollback ===
+
+test("IPC 失敗時、楽観 → rollback の 2 段 dispatch、更新キーが snapshot 値に戻る", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(
+    Result.err(new TauriError("IO_ERROR", "io")),
+  );
+
+  const result = await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+
+  expect(result.ok).toBe(false);
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect(taskUpdates).toHaveLength(2);
+  expect((taskUpdates[0] as { task: Task }).task.status).toBe("Doing");
+  expect((taskUpdates[1] as { task: Task }).task.status).toBe("Todo");
+  const finalTasks = (harness.state.current as { data: ProjectData }).data
+    .tasks;
+  expect(finalTasks[0].status).toBe("Todo");
+});
+
+test("IPC 失敗時 rollback で ProjectError.tauri を返す", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md" });
+  const harness = setupLoaded(makeData([taskA]));
+  const err = new TauriError("IO_ERROR", "io");
+  updateTaskMock.mockResolvedValue(Result.err(err));
+
+  const result = await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: { kind: string; error?: TauriError } }).error).toEqual(
+    {
+      kind: "tauri",
+      error: err,
+    },
+  );
+});
+
+// === エッジ: concurrent 保護 (キー単位) ===
+
+test("rollback 時、外部 listener が同じキー (status) を別値に上書き済みなら rollback を skip し外部値を保護", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockImplementation(async () => {
+    // IPC 中に外部 listener が status を Done に上書きしたシナリオ
+    harness.deps.dispatchSync({
+      type: "task-updated",
+      originalFilePath: "tasks/a.md",
+      task: { ...taskA, status: "Done" },
+    });
+    return Result.err(new TauriError("IO_ERROR", "io"));
+  });
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+
+  // 楽観 (status: Doing) → 外部 (status: Done) → rollback skip
+  const finalTasks = (harness.state.current as { data: ProjectData }).data
+    .tasks;
+  expect(finalTasks[0].status).toBe("Done");
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  // dispatch: 楽観 + 外部 listener の 2 件。rollback は skip。
+  expect(taskUpdates).toHaveLength(2);
+});
+
+test("rollback 時、外部 listener が別キー (title) だけ更新済みなら、更新キー (status) は snapshot に戻し外部キーは保護", async () => {
+  const taskA = makeTask({
+    filePath: "tasks/a.md",
+    status: "Todo",
+    title: "orig-title",
+  });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockImplementation(async () => {
+    harness.deps.dispatchSync({
+      type: "task-updated",
+      originalFilePath: "tasks/a.md",
+      task: { ...taskA, status: "Doing", title: "external-title" },
+    });
+    return Result.err(new TauriError("IO_ERROR", "io"));
+  });
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+
+  const finalTasks = (harness.state.current as { data: ProjectData }).data
+    .tasks;
+  // status は snapshot (Todo) に戻り、title は外部値 (external-title) を保護
+  expect(finalTasks[0].status).toBe("Todo");
+  expect(finalTasks[0].title).toBe("external-title");
+});
+
+test("rollback 時、labels 配列が外部更新で変わっていれば labels は skip", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", labels: ["a"] });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockImplementation(async () => {
+    harness.deps.dispatchSync({
+      type: "task-updated",
+      originalFilePath: "tasks/a.md",
+      task: { ...taskA, labels: ["external"] },
+    });
+    return Result.err(new TauriError("IO_ERROR", "io"));
+  });
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    labels: ["a", "b"],
+  });
+
+  const finalTasks = (harness.state.current as { data: ProjectData }).data
+    .tasks;
+  // 外部 listener が labels を ["external"] に書き換えたため rollback skip
+  expect(finalTasks[0].labels).toEqual(["external"]);
+});
+
+// === エッジ: projectVersion 切替 ===
+
+test("IPC await 中に projectVersion 切替 → rollback skip + invalid-state Err", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockImplementation(async () => {
+    invalidateProject(harness.deps.projectVersion);
+    return Result.err(new TauriError("IO_ERROR", "io"));
+  });
+
+  const result = await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+
+  expect(result.ok).toBe(false);
+  expect((result as { error: { kind: string } }).error.kind).toBe(
+    "invalid-state",
+  );
+  // 楽観 dispatch のみで rollback dispatch は流れない
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  expect(taskUpdates).toHaveLength(1);
+});
+
+// === エッジ: idempotency (二重 dispatch) ===
+
+test("BE 確定 dispatch + 外部 listener 由来の dispatch が二重に流れても最終 state は idempotent", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo" });
+  const confirmed = makeTask({ filePath: "tasks/a.md", status: "Doing" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockResolvedValue(Result.ok(confirmed));
+
+  await updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+  // 外部 listener 由来の同等 dispatch
+  harness.deps.dispatchSync({
+    type: "task-updated",
+    originalFilePath: "tasks/a.md",
+    task: confirmed,
+  });
+
+  const finalTasks = (harness.state.current as { data: ProjectData }).data
+    .tasks;
+  expect(finalTasks[0].status).toBe("Doing");
+});
+
+// === エッジ: 連続変更 ===
+
+test("ToDo → Doing → Done の連続 invoke が queue で順次処理される", async () => {
+  const taskA = makeTask({ filePath: "tasks/a.md", status: "Todo" });
+  const harness = setupLoaded(makeData([taskA]));
+  updateTaskMock.mockImplementation(async (params) =>
+    Result.ok({ ...taskA, status: params.status ?? taskA.status }),
+  );
+
+  const first = updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Doing",
+  });
+  const second = updateTaskAction(harness.deps, {
+    filePath: "tasks/a.md",
+    status: "Done",
+  });
+  await Promise.all([first, second]);
+
+  const taskUpdates = harness.actions.filter((a) => a.type === "task-updated");
+  // 1 回目 楽観 + 1 回目 確定 + 2 回目 楽観 + 2 回目 確定 = 4 件
+  expect(taskUpdates).toHaveLength(4);
+  expect((taskUpdates[0] as { task: Task }).task.status).toBe("Doing");
+  expect((taskUpdates[1] as { task: Task }).task.status).toBe("Doing");
+  expect((taskUpdates[2] as { task: Task }).task.status).toBe("Done");
+  expect((taskUpdates[3] as { task: Task }).task.status).toBe("Done");
+});

--- a/src/features/board/hooks/useProject/actions/tasks.ts
+++ b/src/features/board/hooks/useProject/actions/tasks.ts
@@ -122,26 +122,66 @@ const pickOptimisticKeys = (
   params: UpdateTaskParams,
 ): readonly OptimisticField[] =>
   OPTIMISTIC_FIELDS.filter((key) => {
-    if (!hasOwn(params, key)) {return false;}
-    if (params[key] === undefined) {return false;}
+    if (!hasOwn(params, key)) {
+      return false;
+    }
+    if (params[key] === undefined) {
+      return false;
+    }
     return true;
   });
 
 /**
+ * params の指定キー 1 つを task に楽観反映する pure helper。
+ * `pickOptimisticKeys` が `undefined` 除外済みである前提のもとで type narrowing する。
+ *
+ * @param task 反映対象の Task
+ * @param params 更新パラメータ
+ * @param key 反映するキー
+ * @returns key を params の値で上書きした新 Task
+ */
+const applyOptimisticField = (
+  task: Task,
+  params: UpdateTaskParams,
+  key: OptimisticField,
+): Task => {
+  switch (key) {
+    case "title":
+      return params.title !== undefined
+        ? { ...task, title: params.title }
+        : task;
+    case "status":
+      return params.status !== undefined
+        ? { ...task, status: params.status }
+        : task;
+    case "priority":
+      return params.priority !== undefined
+        ? { ...task, priority: params.priority }
+        : task;
+    case "labels":
+      return params.labels !== undefined
+        ? { ...task, labels: params.labels }
+        : task;
+    case "body":
+      return params.body !== undefined
+        ? { ...task, body: params.body }
+        : task;
+  }
+};
+
+/**
  * snapshot に対し、抽出済みの楽観対象キーだけを params の値で上書きした Task を作る。
+ *
+ * @param current ベースとなる現在 Task（snapshot）
+ * @param params 更新パラメータ
+ * @param keys 反映するキー集合（`pickOptimisticKeys` で抽出済み）
+ * @returns 楽観反映後の Task
  */
 const buildOptimisticTask = (
   current: Task,
   params: UpdateTaskParams,
   keys: readonly OptimisticField[],
-): Task => {
-  const overrides: Partial<Task> = {};
-  for (const key of keys) {
-    // biome-ignore lint/suspicious/noExplicitAny: Task / UpdateTaskParams の key 単位 copy
-    (overrides as any)[key] = (params as any)[key];
-  }
-  return { ...current, ...overrides };
-};
+): Task => keys.reduce((task, key) => applyOptimisticField(task, params, key), current);
 
 /** filePath で現在の Task を visibleData から引き当てる。 */
 const findCurrentTask = (
@@ -165,14 +205,49 @@ const isKeyStillOptimistic = (
   optimistic: Task,
   key: OptimisticField,
 ): boolean => {
-  if (key === "labels") {return arrayShallowEq(current.labels, optimistic.labels);}
+  if (key === "labels") {
+    return arrayShallowEq(current.labels, optimistic.labels);
+  }
   return current[key] === optimistic[key];
+};
+
+/**
+ * 指定キー 1 つを snapshot 値で task に戻す pure helper。
+ *
+ * @param task ベースとなる現在 Task
+ * @param snapshot 反映する snapshot Task
+ * @param key 戻すキー
+ * @returns key を snapshot の値に戻した新 Task
+ */
+const applySnapshotField = (
+  task: Task,
+  snapshot: Task,
+  key: OptimisticField,
+): Task => {
+  switch (key) {
+    case "title":
+      return { ...task, title: snapshot.title };
+    case "status":
+      return { ...task, status: snapshot.status };
+    case "priority":
+      return { ...task, priority: snapshot.priority };
+    case "labels":
+      return { ...task, labels: snapshot.labels };
+    case "body":
+      return { ...task, body: snapshot.body };
+  }
 };
 
 /**
  * 失敗 rollback dispatch 用に、current ベースで「楽観値そのままのキーだけ snapshot 値に戻した」
  * task を組み立てる。外部 listener が触った他キーは current のまま保護する。
  * 全キーが既に外部更新済みなら undefined を返し、rollback dispatch を完全 skip する。
+ *
+ * @param current rollback 直前の最新 Task
+ * @param optimistic 楽観 dispatch で流した Task
+ * @param snapshot 楽観前の snapshot Task
+ * @param keys 楽観対象キー集合
+ * @returns rollback 用 Task。全キー既に外部更新済みなら undefined
  */
 const buildRollbackTask = (
   current: Task,
@@ -180,16 +255,16 @@ const buildRollbackTask = (
   snapshot: Task,
   keys: readonly OptimisticField[],
 ): Task | undefined => {
-  const overrides: Partial<Task> = {};
-  let anyRestored = false;
-  for (const key of keys) {
-    if (isKeyStillOptimistic(current, optimistic, key)) {
-      // biome-ignore lint/suspicious/noExplicitAny: Task の key 単位 copy
-      (overrides as any)[key] = (snapshot as any)[key];
-      anyRestored = true;
-    }
+  const restoreKeys = keys.filter((key) =>
+    isKeyStillOptimistic(current, optimistic, key),
+  );
+  if (restoreKeys.length === 0) {
+    return undefined;
   }
-  return anyRestored ? { ...current, ...overrides } : undefined;
+  return restoreKeys.reduce(
+    (task, key) => applySnapshotField(task, snapshot, key),
+    current,
+  );
 };
 
 /**

--- a/src/features/board/hooks/useProject/actions/tasks.ts
+++ b/src/features/board/hooks/useProject/actions/tasks.ts
@@ -83,7 +83,121 @@ export const createTaskAction = (
 };
 
 /**
- * 現在の active project の task を更新し、成功時に reducer へ反映する。
+ * UpdateTaskParams のうち、Task に flat に写像できる楽観更新対象キー。
+ *
+ * - `parent` は除外: Task 側で hierarchy.parentFilePath にネストされ、親側
+ *   hierarchy.childFilePaths にも波及するため、楽観構築コストが見合わない
+ *   （BE 確定 dispatch まで反映を待つ）。
+ * - `filePath` は lookup key で本体ではないため除外。
+ */
+const OPTIMISTIC_FIELDS = [
+  "title",
+  "status",
+  "priority",
+  "labels",
+  "body",
+] as const;
+type OptimisticField = (typeof OPTIMISTIC_FIELDS)[number];
+
+/**
+ * `Object.prototype.hasOwnProperty.call` の薄いラッパ。
+ * `Object.hasOwn` は ES2022 で tsconfig の `lib: ES2020` だと型エラーになるため避ける。
+ *
+ * @param obj 検査対象のオブジェクト
+ * @param key 自身のプロパティかを判定するキー名
+ * @returns obj 自身がキーを保有していれば true
+ */
+const hasOwn = (obj: object, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
+/**
+ * params に実際に含まれている楽観更新対象キーだけを抽出する。
+ *
+ * BE `UpdateTaskArgs` の各フィールドは `Option<T>` で `None = 不変` のため、
+ * 明示的に `undefined` を渡しても BE 側は反応しない。楽観 dispatch だけが
+ * `undefined` を Task に混入させると確定 dispatch で元値に戻り flicker するため、
+ * 全フィールドで `undefined` を楽観対象から除外する。
+ */
+const pickOptimisticKeys = (
+  params: UpdateTaskParams,
+): readonly OptimisticField[] =>
+  OPTIMISTIC_FIELDS.filter((key) => {
+    if (!hasOwn(params, key)) {return false;}
+    if (params[key] === undefined) {return false;}
+    return true;
+  });
+
+/**
+ * snapshot に対し、抽出済みの楽観対象キーだけを params の値で上書きした Task を作る。
+ */
+const buildOptimisticTask = (
+  current: Task,
+  params: UpdateTaskParams,
+  keys: readonly OptimisticField[],
+): Task => {
+  const overrides: Partial<Task> = {};
+  for (const key of keys) {
+    // biome-ignore lint/suspicious/noExplicitAny: Task / UpdateTaskParams の key 単位 copy
+    (overrides as any)[key] = (params as any)[key];
+  }
+  return { ...current, ...overrides };
+};
+
+/** filePath で現在の Task を visibleData から引き当てる。 */
+const findCurrentTask = (
+  state: ProjectStateT,
+  filePath: string,
+): Task | undefined =>
+  ProjectSessionState.visibleData(state)?.tasks.find(
+    (task) => task.filePath === filePath,
+  );
+
+/** 配列の浅い等値（同 reference または順序付き値一致）。labels 比較用。 */
+const arrayShallowEq = (
+  a: readonly string[],
+  b: readonly string[],
+): boolean =>
+  a === b || (a.length === b.length && a.every((v, i) => v === b[i]));
+
+/** 1 キー単位で「現在値 === 楽観値」かを判定する。 */
+const isKeyStillOptimistic = (
+  current: Task,
+  optimistic: Task,
+  key: OptimisticField,
+): boolean => {
+  if (key === "labels") {return arrayShallowEq(current.labels, optimistic.labels);}
+  return current[key] === optimistic[key];
+};
+
+/**
+ * 失敗 rollback dispatch 用に、current ベースで「楽観値そのままのキーだけ snapshot 値に戻した」
+ * task を組み立てる。外部 listener が触った他キーは current のまま保護する。
+ * 全キーが既に外部更新済みなら undefined を返し、rollback dispatch を完全 skip する。
+ */
+const buildRollbackTask = (
+  current: Task,
+  optimistic: Task,
+  snapshot: Task,
+  keys: readonly OptimisticField[],
+): Task | undefined => {
+  const overrides: Partial<Task> = {};
+  let anyRestored = false;
+  for (const key of keys) {
+    if (isKeyStillOptimistic(current, optimistic, key)) {
+      // biome-ignore lint/suspicious/noExplicitAny: Task の key 単位 copy
+      (overrides as any)[key] = (snapshot as any)[key];
+      anyRestored = true;
+    }
+  }
+  return anyRestored ? { ...current, ...overrides } : undefined;
+};
+
+/**
+ * 現在の active project の task を更新し、楽観 dispatch → IPC → 確定/rollback dispatch
+ * 構造で reducer に反映する。
+ *
+ * 楽観反映の対象は `OPTIMISTIC_FIELDS`（title / status / priority / labels / body）のみ。
+ * `parent` は hierarchy ネストのため BE 確定まで触らない。
  *
  * @param deps task action に必要な queue / version / state / dispatch 依存
  * @param params update_task に渡す更新パラメータ
@@ -104,16 +218,62 @@ export const updateTaskAction = (
       !ProjectSessionState.canAcceptDataCommand(deps.getState()) ||
       !isProjectCurrent(deps.projectVersion, version)
     ) {
-      return Result.err(ProjectError.invalidState("プロジェクトが切り替わりました"));
+      return Result.err(
+        ProjectError.invalidState("プロジェクトが切り替わりました"),
+      );
+    }
+
+    const snapshot = findCurrentTask(deps.getState(), params.filePath);
+    if (snapshot === undefined) {
+      return Result.err(
+        ProjectError.invalidState("更新対象のタスクが見つかりません"),
+      );
+    }
+    const optimisticKeys = pickOptimisticKeys(params);
+    const optimisticTask = buildOptimisticTask(
+      snapshot,
+      params,
+      optimisticKeys,
+    );
+
+    if (optimisticKeys.length > 0) {
+      deps.dispatchSync({
+        type: "task-updated",
+        originalFilePath: params.filePath,
+        task: optimisticTask,
+      });
     }
 
     const result = await updateTaskInvoke(params);
+
+    if (!isProjectCurrent(deps.projectVersion, version)) {
+      return Result.err(
+        ProjectError.invalidState("プロジェクトが切り替わりました"),
+      );
+    }
+
     if (!result.ok) {
+      if (optimisticKeys.length > 0) {
+        const current = findCurrentTask(deps.getState(), params.filePath);
+        if (current !== undefined) {
+          const rollbackTask = buildRollbackTask(
+            current,
+            optimisticTask,
+            snapshot,
+            optimisticKeys,
+          );
+          if (rollbackTask !== undefined) {
+            deps.dispatchSync({
+              type: "task-updated",
+              originalFilePath: params.filePath,
+              task: rollbackTask,
+            });
+          }
+        }
+      }
       return Result.err(ProjectError.tauri(result.error));
     }
-    if (!isProjectCurrent(deps.projectVersion, version)) {
-      return Result.err(ProjectError.invalidState("プロジェクトが切り替わりました"));
-    }
+
     deps.dispatchSync({
       type: "task-updated",
       originalFilePath: params.filePath,

--- a/src/features/detail/components/DetailPanel/__tests__/DetailPanel.controlled.test.tsx
+++ b/src/features/detail/components/DetailPanel/__tests__/DetailPanel.controlled.test.tsx
@@ -1,0 +1,193 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import { DetailPanel } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+/** テスト用カラム一覧 */
+const testColumns = [
+  { name: "Todo", order: 0 },
+  { name: "Doing", order: 1 },
+  { name: "Done", order: 2 },
+];
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+/**
+ * テスト用タスクを生成する。
+ * @param overrides 上書きするフィールド
+ * @returns テスト用タスク
+ */
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テストタスク",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+/**
+ * DetailPanel をレンダリングする。
+ * @param props 渡す props
+ * @returns rerender ヘルパ
+ */
+const render = (props: Parameters<typeof DetailPanel>[0]) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(DetailPanel, props));
+  });
+  return {
+    rerender: (next: Parameters<typeof DetailPanel>[0]) => {
+      act(() => {
+        root?.render(createElement(DetailPanel, next));
+      });
+    },
+  };
+};
+
+/**
+ * data-testid から HTMLSelectElement を取得する。
+ * @param testId data-testid 値
+ * @returns 該当 select 要素
+ */
+const getSelect = (testId: string): HTMLSelectElement =>
+  document.querySelector(`[data-testid="${testId}"]`) as HTMLSelectElement;
+
+/**
+ * select 要素に change イベントを発火する。
+ * @param select 対象 select 要素
+ * @param value 設定する value
+ */
+const changeSelectValue = (select: HTMLSelectElement, value: string): void => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLSelectElement.prototype,
+    "value",
+  )?.set;
+  act(() => {
+    setter?.call(select, value);
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+};
+
+test("初期 task.status が StatusSelect の選択値に反映される", () => {
+  render({
+    task: createTask({ status: "Doing" }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate: vi.fn(),
+    onDelete: vi.fn(),
+  });
+  expect(getSelect("status-select").value).toBe("Doing");
+});
+
+test("task.status が rerender で差し替わると StatusSelect 表示が追従する", () => {
+  const onTaskUpdate = vi.fn();
+  const onClose = vi.fn();
+  const onDelete = vi.fn();
+  const { rerender } = render({
+    task: createTask({ status: "Doing" }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete,
+  });
+  expect(getSelect("status-select").value).toBe("Doing");
+  rerender({
+    task: createTask({ status: "Done" }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete,
+  });
+  expect(getSelect("status-select").value).toBe("Done");
+});
+
+test("task.priority undefined ↔ value の rerender で PrioritySelect 表示が追従する", () => {
+  const onTaskUpdate = vi.fn();
+  const onClose = vi.fn();
+  const onDelete = vi.fn();
+  const { rerender } = render({
+    task: createTask({ priority: undefined }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete,
+  });
+  expect(getSelect("priority-select").value).toBe("");
+  rerender({
+    task: createTask({ priority: "High" }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete,
+  });
+  expect(getSelect("priority-select").value).toBe("High");
+  rerender({
+    task: createTask({ priority: undefined }),
+    columns: testColumns,
+    onClose,
+    onTaskUpdate,
+    onDelete,
+  });
+  expect(getSelect("priority-select").value).toBe("");
+});
+
+test("StatusSelect 操作で onTaskUpdate(task.id, { status }) が partial 形で呼ばれる", () => {
+  const onTaskUpdate = vi.fn();
+  render({
+    task: createTask({ id: "task-1", status: "Todo" }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  changeSelectValue(getSelect("status-select"), "Doing");
+  expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+  expect(onTaskUpdate).toHaveBeenCalledWith("task-1", { status: "Doing" });
+});
+
+test("PrioritySelect 操作で onTaskUpdate(task.id, { priority }) が partial 形で呼ばれる", () => {
+  const onTaskUpdate = vi.fn();
+  render({
+    task: createTask({ id: "task-1", priority: undefined }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  changeSelectValue(getSelect("priority-select"), "High");
+  expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+  expect(onTaskUpdate).toHaveBeenCalledWith("task-1", { priority: "High" });
+});
+
+test("PrioritySelect で「なし」を選ぶと onTaskUpdate(task.id, { priority: undefined }) が呼ばれる", () => {
+  const onTaskUpdate = vi.fn();
+  render({
+    task: createTask({ id: "task-1", priority: "High" }),
+    columns: testColumns,
+    onClose: vi.fn(),
+    onTaskUpdate,
+    onDelete: vi.fn(),
+  });
+  changeSelectValue(getSelect("priority-select"), "");
+  expect(onTaskUpdate).toHaveBeenCalledTimes(1);
+  expect(onTaskUpdate).toHaveBeenCalledWith("task-1", { priority: undefined });
+});


### PR DESCRIPTION
## 概要

DetailPanel の `StatusSelect` / `PrioritySelect` 変更時に発生していた「IPC await 完了まで Select 表示が古い値で固まる」UX 問題を解消するため、`updateTaskAction` を `moveTaskAction` と同じ「楽観 dispatch → IPC → 確定 / rollback dispatch」構造に書き換える。

## 変更の種類

- ✨ New Feature（楽観更新パターンの導入）
- 🧪 Tests（action 層 20 件、controlled 6 件、smoke 2 件、統合 1 件追加）

## 追加した内容

- **`src/features/board/hooks/useProject/actions/__tests__/tasks.behavior.test.ts`**: action 層の楽観 / 確定 / rollback / concurrent / idempotency 振る舞いを 20 件で検証
- **`src/features/detail/components/DetailPanel/__tests__/DetailPanel.controlled.test.tsx`**: controlled props 追従 6 件（task.status / task.priority の rerender 追従、Select 操作 partial callback）
- **`src/__tests__/App.detailOptimistic.test.tsx`**: App + 実 useProject の経路結合 smoke 2 件（楽観反映 / 失敗時 rollback + エラートースト）
- `updateTaskAction` 内 helper 6 本: `pickOptimisticKeys` / `buildOptimisticTask` / `findCurrentTask` / `arrayShallowEq` / `isKeyStillOptimistic` / `buildRollbackTask`

## 変更した内容

- **`src/features/board/hooks/useProject/actions/tasks.ts`**: `updateTaskAction` を以下の構造に書き換え
  - 楽観対象キー集合: `["title", "status", "priority", "labels", "body"]`（Task に flat に存在するキーのみ）
  - `parent` は `Task.hierarchy.parentFilePath` ネスト + 親側 `childFilePaths` 波及があるため楽観対象外（BE 確定 dispatch まで反映を待つ）
  - 全フィールドで `params[key] === undefined` を楽観対象から除外（BE 仕様: `Option<T> = None = 不変` で何送っても反応しないため flicker 防止）
  - IPC 失敗時 rollback は**キー単位で**「現在値 === 楽観値」を検査し、楽観値そのままのキーだけ snapshot 値に戻す。外部 listener が触った他キーは current のまま保護
  - `labels` 比較は配列の浅い等値（同 reference または順序付き値一致）
  - `projectVersion` 切替時は rollback を skip し `invalid-state` Err
- **`src/features/board/hooks/useProject/__tests__/useProject.interaction.test.tsx`**: updateTask 失敗ケースを `{ filePath, status: "Doing" }` に変更し楽観 → rollback 統合経路を直接検証。新規ケース「`{ filePath, parent }` のみ → 楽観 dispatch skip」を追加

## 仕様ドキュメント更新

不要（純粋な内部実装変更）。`updateTask` の公開 API（`useProject.updateTask` の引数・戻り値）は不変。BE 契約 (`update_task` Tauri command) も不変。

## システム図

```mermaid
flowchart TD
    SelectChange[DetailPanel: StatusSelect / PrioritySelect 変更] --> HandleUpdate[App.tsx#handleTaskUpdate]
    HandleUpdate --> UpdateTask[useProject.updateTask]
    UpdateTask --> Action[updateTaskAction]

    Action --> Preflight{preflight<br/>canAcceptDataCommand}
    Preflight -->|NG| ReturnInvalid[Return invalid-state Err]
    Preflight -->|OK| Enqueue[enqueueProjectCommand]

    Enqueue --> Snapshot[snapshot = findCurrentTask]
    Snapshot --> SnapshotCheck{snapshot<br/>存在?}
    SnapshotCheck -->|NG| ReturnInvalid
    SnapshotCheck -->|OK| Keys[optimisticKeys = pickOptimisticKeys]

    Keys --> Build[optimisticTask =<br/>buildOptimisticTask]
    Build --> Opt[OPTIMISTIC dispatch<br/>task-updated<br/>NEW]
    Opt --> IPC[await updateTaskInvoke]

    IPC --> VerCheck{projectVersion<br/>一致?}
    VerCheck -->|NG| ReturnInvalid
    VerCheck -->|OK| ResultCheck{result.ok?}

    ResultCheck -->|YES| Confirm[CONFIRM dispatch<br/>task-updated BE 値]
    Confirm --> ReturnOk[Return Result.ok value]

    ResultCheck -->|NO| Current[current = findCurrentTask]
    Current --> RollbackBuild[rollbackTask =<br/>buildRollbackTask<br/>キー単位で snapshot に戻す<br/>NEW]
    RollbackBuild --> RollbackCheck{rollbackTask<br/>あり?}
    RollbackCheck -->|YES| Rb[ROLLBACK dispatch<br/>task-updated<br/>NEW]
    Rb --> ReturnErr[Return ProjectError.tauri]
    RollbackCheck -->|NO| ReturnErr

    style Opt fill:#fff4d6
    style Confirm fill:#d6ffd6
    style Rb fill:#ffd6d6
    style RollbackBuild fill:#fff4d6
```

## 関連Issue

Closes #124

## テスト

| カテゴリ | コマンド | 結果 |
|:-|:-|:-|
| 単体テスト全件 | `pnpm test:run` | **868 件 / 100 ファイル すべて pass** |
| ビルド | `pnpm build` | 成功 (tsc + vite) |
| Lint | `pnpm exec oxlint` / `pnpm exec biome check` | 0 warnings / 0 errors |

### 新規テストの内訳

- `tasks.behavior.test.ts` 20 件: 楽観 dispatch / 2 段 dispatch / priority undefined 除外 / 全フィールド undefined 除外 / title・labels 経路 / currentTask 不在 / preflight 不成立 / `{ filePath, parent }` only / `params.parent` 渡し / IPC 失敗 rollback / 同キー外部上書き / 別キー外部上書き / labels 配列比較 / projectVersion 切替 / 二重 dispatch idempotency / 連続変更 queue 順次処理
- `DetailPanel.controlled.test.tsx` 6 件: 初期表示 / status rerender 追従 / priority undefined ↔ value rerender / Select 操作 partial callback (status / priority / なし)
- `App.detailOptimistic.test.tsx` 2 件: StatusSelect 操作で IPC resolve 前に楽観反映 / IPC 失敗で元値復帰 + エラートースト

### AI コードレビュー（Codex）

- review-001: 2 件指摘
  - Should Fix: `priority` 以外も `undefined` を除外すべき → 修正
  - Nice to Have: 既存失敗テストを楽観対象キー付きに → 修正
- review-002: **問題なし**

### 手動検証（残）

デスクトップ実機（`pnpm tauri dev`）での確認はレビュー時にお願いします:
- [ ] StatusSelect / PrioritySelect 即時反映
- [ ] 疑似障害テスト（BE エラー化）で Select 表示元値復帰 + エラートースト
- [ ] title / labels 編集が従来どおり動作（共有経路リグレッション）
- [ ] 高速連続変更で最終値固定（queue 順次処理）
- [ ] status 変更後にプロジェクト切替→戻りで state 健全

## レビューポイント

1. **楽観対象キーの設計**: `parent` を楽観対象から外した判断（hierarchy ネスト + 親側 childFilePaths への波及があるため楽観構築コストが見合わない）。`priority: undefined` を含む全 undefined 明示を除外（BE の `Option<T> = None = 不変` 仕様に合わせ flicker 防止）。
2. **rollback のキー単位戦略**: 外部 listener が触った他キーを保護するため `{ ...current, /* 戻すキーだけ */ }` で組み立てる。`buildRollbackTask` が `undefined` を返した場合は rollback dispatch 自体を skip。
3. **PrioritySelect「value → なし」の挙動**: 本 Issue 対象外。BE が priority クリアを未サポートのため楽観 dispatch も行わず、確定 dispatch で元値（High 等）に戻る既知挙動。BE 契約拡張は別 Issue で対応予定。
4. **`useProject.updateTask` シグネチャ不変**: callbacks 引数は追加していない（hearing-notes 論点 C → C2 採用）。呼び出し側 (App.tsx#handleTaskUpdate) も変更なし。
5. **`.gitignore` の `tasks*` グロブ問題**: 新規 `tasks.behavior.test.ts` がマッチして tracked 外になったため `git add -f` で強制追加した。プロジェクト全体の課題として `.gitignore` のパターンを `/tasks/` などに絞ることを推奨（本 PR では変更せず）。