### PR TITLE
✨ [New Feature]: #121 [FE] task-create 優先度なし omit + サブIssue 経路で parent 自動セット

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { type LiveAnnouncement, LiveRegion } from "@/components/LiveRegion";
 import { ToastContainer } from "@/components/ToastContainer";
 import { useToasts } from "@/hooks/useToasts";
@@ -112,6 +112,12 @@ export const App = () => {
   const [createModalParent, setCreateModalParent] = useState<
     string | undefined
   >(undefined);
+  // サブIssue 追加経路で親が自動セットされたことを示す state。
+  // 値が入っているとき parentCandidates は親 1 件に絞られ、UI 上 read-only になる。
+  // 親が tasks から消えても本 state は残るため、ParentTaskSelect の filePath fallback が起動する。
+  const [subIssueParentPath, setSubIssueParentPath] = useState<
+    string | undefined
+  >(undefined);
   const [announcement, setAnnouncement] = useState<LiveAnnouncement | null>(
     null,
   );
@@ -137,14 +143,25 @@ export const App = () => {
     setSelectedTaskId(null);
     setCreateModalStatus(null);
     setCreateModalParent(undefined);
+    setSubIssueParentPath(undefined);
   } else if (state.kind !== "loaded" && createModalStatus !== null) {
     setCreateModalStatus(null);
     setCreateModalParent(undefined);
+    setSubIssueParentPath(undefined);
   }
 
   const tasks = tasksOf(state);
   const columns = columnsOf(state);
   const doneColumn = doneColumnOf(state);
+  // サブIssue モード中は親候補を 1 件に絞り、ユーザに「親が自動セットされた」ことを示す。
+  // tasks から親が消えると filter 結果が [] になり、ParentTaskSelect の filePath fallback が起動する。
+  const parentCandidates = useMemo(() => {
+    if (subIssueParentPath === undefined) {
+      return tasks;
+    }
+    return tasks.filter((t) => t.filePath === subIssueParentPath);
+  }, [tasks, subIssueParentPath]);
+  const parentReadOnly = subIssueParentPath !== undefined;
   // path 末尾セグメントを project 名として表示する。OS の path separator は
   // / / \ どちらにも対応する (Windows / POSIX 双方)。
   const displayedPath = state.kind === "loaded" ? state.path : null;
@@ -190,6 +207,7 @@ export const App = () => {
   const handleAddTask = useCallback((columnName: string) => {
     setCreateModalStatus(columnName);
     setCreateModalParent(undefined);
+    setSubIssueParentPath(undefined);
   }, []);
 
   const handleAddColumn = useCallback(
@@ -371,6 +389,7 @@ export const App = () => {
   const handleCloseCreateModal = useCallback(() => {
     setCreateModalStatus(null);
     setCreateModalParent(undefined);
+    setSubIssueParentPath(undefined);
   }, []);
 
   const defaultCreateStatus =
@@ -388,6 +407,7 @@ export const App = () => {
       }
       setCreateModalStatus(defaultCreateStatus);
       setCreateModalParent(parentFilePath);
+      setSubIssueParentPath(parentFilePath);
     },
     [defaultCreateStatus, showToast],
   );
@@ -584,9 +604,10 @@ export const App = () => {
         <TaskCreateModal
           columns={columns}
           initialStatus={createModalStatus}
-          parentCandidates={tasks}
+          parentCandidates={parentCandidates}
           existingTasks={tasks}
           initialParent={createModalParent}
+          parentReadOnly={parentReadOnly}
           onSubmit={handleCreateTask}
           onClose={handleCloseCreateModal}
         />

--- a/src/__tests__/App.createModalProps.test.tsx
+++ b/src/__tests__/App.createModalProps.test.tsx
@@ -1,0 +1,319 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+const taskCreateModalSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/task-form", async () => {
+  const actual = await vi.importActual<typeof import("@/features/task-form")>(
+    "@/features/task-form",
+  );
+  return {
+    ...actual,
+    TaskCreateModal: (props: { onClose: () => void }) => {
+      taskCreateModalSpy(props);
+      return (
+        <button
+          type="button"
+          data-testid="mock-task-create-modal-close"
+          onClick={props.onClose}
+        >
+          close
+        </button>
+      );
+    },
+  };
+});
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    openDirectoryDialog: vi.fn(),
+    openProject: vi.fn(),
+    getColumns: vi.fn(),
+    createTask: vi.fn(),
+    updateTask: vi.fn(),
+    deleteTask: vi.fn(),
+    updateColumns: vi.fn(),
+    updateCardOrder: vi.fn(),
+  };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+import { App } from "@/App";
+import {
+  createTask as createTaskInvoke,
+  deleteTask as deleteTaskInvoke,
+  getColumns as getColumnsInvoke,
+  openDirectoryDialog,
+  openProject as openProjectInvoke,
+} from "@/lib/tauri";
+import { Task } from "@/types/task";
+import { Result } from "@/utils/result";
+
+const openDirectoryDialogMock = vi.mocked(openDirectoryDialog);
+const openProjectMock = vi.mocked(openProjectInvoke);
+const getColumnsMock = vi.mocked(getColumnsInvoke);
+const createTaskMock = vi.mocked(createTaskInvoke);
+const deleteTaskMock = vi.mocked(deleteTaskInvoke);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+let hadIsReactActEnvironment = false;
+
+beforeAll(() => {
+  hadIsReactActEnvironment =
+    "IS_REACT_ACT_ENVIRONMENT" in reactActEnvironmentGlobal;
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+  const keysToDelete = hadIsReactActEnvironment
+    ? []
+    : (["IS_REACT_ACT_ENVIRONMENT"] as const);
+  for (const key of keysToDelete) {
+    Reflect.deleteProperty(reactActEnvironmentGlobal, key);
+  }
+});
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+const parentTask = Task.fromPayload({
+  id: "parent",
+  title: "親タスク",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/parent.md",
+});
+const otherTask = Task.fromPayload({
+  id: "other",
+  title: "他タスク",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/other.md",
+});
+
+const fixtureTasks = [parentTask, otherTask];
+
+beforeEach(() => {
+  taskCreateModalSpy.mockClear();
+  openDirectoryDialogMock.mockReset();
+  openProjectMock.mockReset();
+  getColumnsMock.mockReset();
+  createTaskMock.mockReset();
+  deleteTaskMock.mockReset();
+  getColumnsMock.mockResolvedValue(
+    Result.ok({
+      columns: [
+        { name: "Todo", order: 0 },
+        { name: "Done", order: 1 },
+      ],
+      doneColumn: "Done",
+    }),
+  );
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+const mountApp = () => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<App />);
+  });
+};
+
+const openProjectWithTasks = async () => {
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  openProjectMock.mockResolvedValueOnce(
+    Result.ok({
+      tasks: fixtureTasks,
+      columns: ["Todo", "Done"],
+    }),
+  );
+  const buttons = container?.querySelectorAll("header button") ?? [];
+  const openBtn = Array.from(buttons).find((b) => b.textContent === "開く") as
+    | HTMLButtonElement
+    | undefined;
+  await act(async () => {
+    openBtn?.click();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const clickParentTaskCard = async () => {
+  const cards = container?.querySelectorAll('[role="button"]') ?? [];
+  const target = Array.from(cards).find((c) =>
+    c.textContent?.includes("親タスク"),
+  ) as HTMLElement | undefined;
+  await act(async () => {
+    target?.click();
+  });
+};
+
+const clickSubIssueAddButton = async () => {
+  const btn = container?.querySelector(
+    '[data-testid="sub-issue-add-button"]',
+  ) as HTMLButtonElement | null;
+  await act(async () => {
+    btn?.click();
+  });
+};
+
+const clickColumnAddButton = async (columnName: string) => {
+  const btn = container?.querySelector(
+    `button[aria-label="${columnName}に追加"]`,
+  ) as HTMLButtonElement | null;
+  await act(async () => {
+    btn?.click();
+  });
+};
+
+const lastModalProps = (): Record<string, unknown> => {
+  const calls = taskCreateModalSpy.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1][0] as Record<string, unknown>;
+};
+
+test("経路1: handleAddSubIssue → parentCandidates は親 1 件、parentReadOnly=true", async () => {
+  mountApp();
+  await openProjectWithTasks();
+  await clickParentTaskCard();
+  await clickSubIssueAddButton();
+
+  const props = lastModalProps();
+  const candidates = props.parentCandidates as Task[];
+  expect(candidates).toHaveLength(1);
+  expect(candidates[0]?.filePath).toBe("tasks/parent.md");
+  expect(props.parentReadOnly).toBe(true);
+  expect(props.initialParent).toBe("tasks/parent.md");
+});
+
+test("経路2: handleAddTask（通常作成）→ parentCandidates は tasks 全件、parentReadOnly=false", async () => {
+  mountApp();
+  await openProjectWithTasks();
+  await clickColumnAddButton("Todo");
+
+  const props = lastModalProps();
+  const candidates = props.parentCandidates as Task[];
+  expect(candidates.map((t) => t.filePath)).toEqual([
+    "tasks/parent.md",
+    "tasks/other.md",
+  ]);
+  expect(props.parentReadOnly).toBe(false);
+  expect(props.initialParent).toBeUndefined();
+});
+
+test("経路3a: subIssue → close で modal が unmount される（close 経路の発火確認）", async () => {
+  mountApp();
+  await openProjectWithTasks();
+
+  await clickParentTaskCard();
+  await clickSubIssueAddButton();
+  expect(lastModalProps().parentReadOnly).toBe(true);
+  const callsBeforeClose = taskCreateModalSpy.mock.calls.length;
+
+  // mock TaskCreateModal の閉じるボタンで handleCloseCreateModal を発火させる。
+  // close 後は createModalStatus=null のため modal は再 render されず、spy も追加で呼ばれない。
+  const closeBtn = container?.querySelector(
+    '[data-testid="mock-task-create-modal-close"]',
+  ) as HTMLButtonElement | null;
+  await act(async () => {
+    closeBtn?.click();
+  });
+
+  expect(
+    container?.querySelector('[data-testid="mock-task-create-modal-close"]'),
+  ).toBeNull();
+  expect(taskCreateModalSpy.mock.calls.length).toBe(callsBeforeClose);
+});
+
+test("経路3b: subIssue → 直接 handleAddTask（通常作成）で parentReadOnly=false（stale leak 検出）", async () => {
+  mountApp();
+  await openProjectWithTasks();
+
+  await clickParentTaskCard();
+  await clickSubIssueAddButton();
+  expect(lastModalProps().parentReadOnly).toBe(true);
+
+  // close を挟まずに通常作成へ切り替える経路。handleAddTask 側の setSubIssueParentPath(undefined) 漏れを検出する。
+  // close 側は経路3aで modal unmount までを確認し、reset 漏れはこの経路では検出対象にしない。
+  await clickColumnAddButton("Todo");
+
+  const props = lastModalProps();
+  expect(props.parentReadOnly).toBe(false);
+  const candidates = props.parentCandidates as Task[];
+  expect(candidates.map((t) => t.filePath)).toEqual([
+    "tasks/parent.md",
+    "tasks/other.md",
+  ]);
+});
+
+test("経路4: subIssue モード中に親タスクが tasks から消えると parentCandidates=[]", async () => {
+  mountApp();
+  await openProjectWithTasks();
+  await clickParentTaskCard();
+  await clickSubIssueAddButton();
+  expect((lastModalProps().parentCandidates as Task[]).length).toBe(1);
+
+  // DetailPanel の削除ボタン → ConfirmDialog → 確定 で親タスクを tasks から消す
+  deleteTaskMock.mockResolvedValueOnce(Result.ok(undefined));
+  const deleteBtn = container?.querySelector(
+    '[data-testid="detail-delete-button"]',
+  ) as HTMLButtonElement | null;
+  await act(async () => {
+    deleteBtn?.click();
+  });
+  const confirmBtn = container?.querySelector(
+    '[data-testid="confirm-confirm-button"]',
+  ) as HTMLButtonElement | null;
+  await act(async () => {
+    confirmBtn?.click();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  const props = lastModalProps();
+  expect((props.parentCandidates as Task[]).length).toBe(0);
+  expect(props.parentReadOnly).toBe(true);
+  expect(props.initialParent).toBe("tasks/parent.md");
+});

--- a/src/features/task-form/components/ParentTaskSelect/__tests__/ParentTaskSelect.readOnly.test.tsx
+++ b/src/features/task-form/components/ParentTaskSelect/__tests__/ParentTaskSelect.readOnly.test.tsx
@@ -1,0 +1,104 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import { ParentTaskSelect } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+/**
+ * テスト用タスクを生成する
+ * @param overrides - 上書きするフィールド
+ * @returns テスト用タスク
+ */
+function makeTask(overrides: Partial<TaskPayload> = {}): Task {
+  return Task.fromPayload({
+    id: "t-1",
+    title: "親候補",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/candidate.md",
+    ...overrides,
+  });
+}
+
+/**
+ * ParentTaskSelect をレンダリングするヘルパー
+ * @param props - ParentTaskSelect に渡す props
+ */
+function render(props: Parameters<typeof ParentTaskSelect>[0]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(ParentTaskSelect, props));
+  });
+}
+
+test("readOnly=true で selected あり → × ボタンが描画されない", () => {
+  const task = makeTask({
+    id: "t-1",
+    title: "親",
+    filePath: "tasks/parent.md",
+  });
+  render({
+    tasks: [task],
+    value: "tasks/parent.md",
+    onChange: vi.fn(),
+    readOnly: true,
+  });
+  expect(
+    document.querySelector('[data-testid="parent-task-selected"]'),
+  ).toBeTruthy();
+  expect(
+    document.querySelector('[data-testid="parent-task-clear"]'),
+  ).toBeNull();
+});
+
+test("readOnly=true && value が tasks 不在 → filePath fallback + × 非描画", () => {
+  render({
+    tasks: [],
+    value: "tasks/missing.md",
+    onChange: vi.fn(),
+    readOnly: true,
+  });
+  const selected = document.querySelector(
+    '[data-testid="parent-task-selected"]',
+  );
+  expect(selected).toBeTruthy();
+  expect(selected?.textContent).toBe("tasks/missing.md");
+  expect(
+    document.querySelector('[data-testid="parent-task-clear"]'),
+  ).toBeNull();
+});
+
+test("readOnly=false && value が tasks 不在 → filePath fallback + × 描画", () => {
+  render({
+    tasks: [],
+    value: "tasks/missing.md",
+    onChange: vi.fn(),
+    readOnly: false,
+  });
+  const selected = document.querySelector(
+    '[data-testid="parent-task-selected"]',
+  );
+  expect(selected).toBeTruthy();
+  expect(selected?.textContent).toBe("tasks/missing.md");
+  expect(
+    document.querySelector('[data-testid="parent-task-clear"]'),
+  ).toBeTruthy();
+});

--- a/src/features/task-form/components/ParentTaskSelect/__tests__/ParentTaskSelect.readOnly.test.tsx
+++ b/src/features/task-form/components/ParentTaskSelect/__tests__/ParentTaskSelect.readOnly.test.tsx
@@ -86,6 +86,26 @@ test("readOnly=true && value が tasks 不在 → filePath fallback + × 非描�
   ).toBeNull();
 });
 
+test("readOnly=true && value=undefined → 検索 input を描画せず未設定 placeholder のみ表示", () => {
+  render({
+    tasks: [
+      makeTask({ id: "t-1", title: "候補", filePath: "tasks/candidate.md" }),
+    ],
+    value: undefined,
+    onChange: vi.fn(),
+    readOnly: true,
+  });
+  expect(
+    document.querySelector('[data-testid="parent-task-input"]'),
+  ).toBeNull();
+  expect(document.querySelector('[data-testid="parent-task-list"]')).toBeNull();
+  const placeholder = document.querySelector(
+    '[data-testid="parent-task-readonly-empty"]',
+  );
+  expect(placeholder).toBeTruthy();
+  expect(placeholder?.textContent).toContain("未設定");
+});
+
 test("readOnly=false && value が tasks 不在 → filePath fallback + × 描画", () => {
   render({
     tasks: [],

--- a/src/features/task-form/components/ParentTaskSelect/index.tsx
+++ b/src/features/task-form/components/ParentTaskSelect/index.tsx
@@ -13,6 +13,13 @@ type ParentTaskSelectProps = {
   onChange: (filePath: string | undefined) => void;
   /** 無効化（送信中など） */
   disabled?: boolean;
+  /**
+   * 親フィールドを変更不可にする。
+   * true のとき × ボタンを描画しない。検索 input への影響はなく、
+   * value !== undefined が前提のためそもそも検索 input フェーズには入らない想定。
+   * disabled と直交し、両方 true でも独立に効く。
+   */
+  readOnly?: boolean;
 };
 
 /**
@@ -27,6 +34,7 @@ export const ParentTaskSelect = ({
   value,
   onChange,
   disabled = false,
+  readOnly = false,
 }: ParentTaskSelectProps) => {
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -69,29 +77,38 @@ export const ParentTaskSelect = ({
     setQuery("");
   };
 
+  const selectedLabel = selected ? selected.title || selected.filePath : value;
+  const showSelectedLike = selectedLabel !== undefined;
+
   return (
     <div data-testid="parent-task-select">
       <div className="mb-1 block text-xs font-medium text-gray-700">
-        {selected ? "親タスク" : <label htmlFor={inputId}>親タスク</label>}
+        {showSelectedLike ? (
+          "親タスク"
+        ) : (
+          <label htmlFor={inputId}>親タスク</label>
+        )}
       </div>
-      {selected ? (
+      {showSelectedLike ? (
         <div className="flex items-center gap-2 rounded border border-gray-300 bg-gray-50 px-2 py-1 text-sm">
           <span
             className="min-w-0 flex-1 truncate text-gray-800"
             data-testid="parent-task-selected"
           >
-            {selected.title || selected.filePath}
+            {selectedLabel}
           </span>
-          <button
-            type="button"
-            aria-label="親タスクを解除"
-            className="rounded text-gray-400 hover:text-gray-700 disabled:opacity-50"
-            disabled={disabled}
-            onClick={handleClear}
-            data-testid="parent-task-clear"
-          >
-            ×
-          </button>
+          {!readOnly && (
+            <button
+              type="button"
+              aria-label="親タスクを解除"
+              className="rounded text-gray-400 hover:text-gray-700 disabled:opacity-50"
+              disabled={disabled}
+              onClick={handleClear}
+              data-testid="parent-task-clear"
+            >
+              ×
+            </button>
+          )}
         </div>
       ) : (
         <div className="relative">

--- a/src/features/task-form/components/ParentTaskSelect/index.tsx
+++ b/src/features/task-form/components/ParentTaskSelect/index.tsx
@@ -15,8 +15,9 @@ type ParentTaskSelectProps = {
   disabled?: boolean;
   /**
    * 親フィールドを変更不可にする。
-   * true のとき × ボタンを描画しない。検索 input への影響はなく、
-   * value !== undefined が前提のためそもそも検索 input フェーズには入らない想定。
+   * true のとき × ボタンを描画しない。さらに `value === undefined` の場合も
+   * 検索 input は描画されず、未設定 placeholder のみ表示する（props 単体で
+   * 「変更不可」契約を自己完結させる）。
    * disabled と直交し、両方 true でも独立に効く。
    */
   readOnly?: boolean;
@@ -79,11 +80,12 @@ export const ParentTaskSelect = ({
 
   const selectedLabel = selected ? selected.title || selected.filePath : value;
   const showSelectedLike = selectedLabel !== undefined;
+  const showReadOnlyEmpty = !showSelectedLike && readOnly;
 
   return (
     <div data-testid="parent-task-select">
       <div className="mb-1 block text-xs font-medium text-gray-700">
-        {showSelectedLike ? (
+        {showSelectedLike || showReadOnlyEmpty ? (
           "親タスク"
         ) : (
           <label htmlFor={inputId}>親タスク</label>
@@ -109,6 +111,13 @@ export const ParentTaskSelect = ({
               ×
             </button>
           )}
+        </div>
+      ) : showReadOnlyEmpty ? (
+        <div
+          className="rounded border border-gray-300 bg-gray-50 px-2 py-1 text-sm text-gray-500"
+          data-testid="parent-task-readonly-empty"
+        >
+          （未設定）
         </div>
       ) : (
         <div className="relative">

--- a/src/features/task-form/components/TaskCreateModal/index.tsx
+++ b/src/features/task-form/components/TaskCreateModal/index.tsx
@@ -13,6 +13,11 @@ type TaskCreateModalProps = {
   parentCandidates?: Task[];
   /** 親タスクの初期値（サブIssue 追加時の自動設定用） */
   initialParent?: string;
+  /**
+   * 親フィールドのみを変更不可にするフラグ。
+   * サブIssue 追加経路で自動セットされた親を保護するために使う。TaskForm に pass-through する。
+   */
+  parentReadOnly?: boolean;
   /** 重複判定に使う既存タスク一覧。未指定なら DUPLICATE 判定なし。 */
   existingTasks?: readonly Task[];
   /**
@@ -37,6 +42,7 @@ export const TaskCreateModal = ({
   initialStatus,
   parentCandidates,
   initialParent,
+  parentReadOnly,
   existingTasks,
   onSubmit,
   onClose,
@@ -114,6 +120,7 @@ export const TaskCreateModal = ({
           initialStatus={initialStatus}
           parentCandidates={parentCandidates}
           initialParent={initialParent}
+          parentReadOnly={parentReadOnly}
           existingTasks={existingTasks}
           isSubmitting={isSubmitting}
           onSubmit={handleSubmit}

--- a/src/features/task-form/components/TaskForm/TaskFormParent/__tests__/TaskFormParent.interaction.test.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormParent/__tests__/TaskFormParent.interaction.test.tsx
@@ -81,3 +81,17 @@ test("受け取った props が ParentTaskSelect にそのまま渡る", () => {
   expect(passedProps.onChange).toBe(onChange);
   expect(passedProps.disabled).toBe(true);
 });
+
+test("readOnly props を ParentTaskSelect に pass-through する", () => {
+  render({
+    tasks: mockTasks,
+    value: "tasks/p-1.md",
+    onChange: vi.fn(),
+    disabled: false,
+    readOnly: true,
+  });
+  const lastCall =
+    parentTaskSelectSpy.mock.calls[parentTaskSelectSpy.mock.calls.length - 1];
+  const passedProps = lastCall[0] as { readOnly?: boolean };
+  expect(passedProps.readOnly).toBe(true);
+});

--- a/src/features/task-form/components/TaskForm/TaskFormParent/index.tsx
+++ b/src/features/task-form/components/TaskForm/TaskFormParent/index.tsx
@@ -13,6 +13,8 @@ type TaskFormParentProps = {
   onChange: (value: string | undefined) => void;
   /** 無効化 */
   disabled: boolean;
+  /** 親フィールドを変更不可にする。ParentTaskSelect に pass-through する。 */
+  readOnly?: boolean;
 };
 
 /**
@@ -27,6 +29,7 @@ export const TaskFormParent = ({
   value,
   onChange,
   disabled,
+  readOnly,
 }: TaskFormParentProps) => {
   return (
     <ParentTaskSelect
@@ -34,6 +37,7 @@ export const TaskFormParent = ({
       value={value}
       onChange={onChange}
       disabled={disabled}
+      readOnly={readOnly}
     />
   );
 };

--- a/src/features/task-form/components/TaskForm/index.tsx
+++ b/src/features/task-form/components/TaskForm/index.tsx
@@ -24,6 +24,12 @@ type TaskFormProps = {
   parentCandidates?: Task[];
   /** 親タスクの初期値（サブIssue 追加時の自動設定用） */
   initialParent?: string;
+  /**
+   * 親フィールドのみを変更不可にするフラグ。
+   * サブIssue 追加経路で親が自動セットされた状態を保護するために使う。
+   * parentCandidates が undefined のときは無視される。
+   */
+  parentReadOnly?: boolean;
   /** 重複判定に使う既存タスク一覧。未指定なら DUPLICATE 判定なし。 */
   existingTasks?: readonly Task[];
   /** 送信中かどうか（true の間は送信ボタンと入力欄が無効化される） */
@@ -53,6 +59,7 @@ export const TaskForm = ({
   initialStatus,
   parentCandidates,
   initialParent,
+  parentReadOnly,
   existingTasks,
   isSubmitting = false,
   submitLabel = "作成",
@@ -119,6 +126,7 @@ export const TaskForm = ({
           value={fields.state.values.parent}
           onChange={(value) => fields.dispatch({ type: "parent", value })}
           disabled={isSubmitting}
+          readOnly={parentReadOnly}
         />
       )}
       <TaskFormBody

--- a/src/features/task-form/hooks/useTaskCreate/__tests__/useTaskCreate.behavior.test.tsx
+++ b/src/features/task-form/hooks/useTaskCreate/__tests__/useTaskCreate.behavior.test.tsx
@@ -225,7 +225,7 @@ test("T7: injected createTask が reject すると submit も reject し、isSub
   expect(probe.latest.isSubmitting).toBe(false);
 });
 
-test("T3: TaskFormValues が CreateTaskParams にそのまま pass-through される", async () => {
+test("T3: priority / parent が undefined のとき CreateTaskParams から key 自体を含めない", async () => {
   const createTask = vi.fn().mockResolvedValue(Result.ok(taskFixture));
   const probe = renderHook({ createTask });
   const values: TaskFormValues = {
@@ -238,12 +238,39 @@ test("T3: TaskFormValues が CreateTaskParams にそのまま pass-through さ�
     await probe.latest.submit(values);
   });
   expect(createTask).toHaveBeenCalledTimes(1);
+  const params = createTask.mock.calls[0][0] as Record<string, unknown>;
+  expect(params).toEqual({
+    title: "T",
+    status: "TODO",
+    labels: [],
+    body: "",
+  });
+  expect(params).not.toHaveProperty("priority");
+  expect(params).not.toHaveProperty("parent");
+  expect(Object.prototype.hasOwnProperty.call(params, "priority")).toBe(false);
+  expect(Object.prototype.hasOwnProperty.call(params, "parent")).toBe(false);
+});
+
+test("T3b: priority / parent が値を持つときは CreateTaskParams に含まれる", async () => {
+  const createTask = vi.fn().mockResolvedValue(Result.ok(taskFixture));
+  const probe = renderHook({ createTask });
+  const values: TaskFormValues = {
+    title: "T",
+    status: "TODO",
+    priority: "High",
+    labels: ["bug"],
+    parent: "tasks/parent.md",
+    body: "body",
+  };
+  await act(async () => {
+    await probe.latest.submit(values);
+  });
   expect(createTask).toHaveBeenCalledWith({
     title: "T",
     status: "TODO",
-    priority: undefined,
-    labels: [],
-    parent: undefined,
-    body: "",
+    priority: "High",
+    labels: ["bug"],
+    parent: "tasks/parent.md",
+    body: "body",
   });
 });

--- a/src/features/task-form/hooks/useTaskCreate/index.ts
+++ b/src/features/task-form/hooks/useTaskCreate/index.ts
@@ -32,17 +32,18 @@ export type UseTaskCreateResult = {
 };
 
 /**
- * TaskFormValues を BE 仕様の CreateTaskParams にそのまま pass-through する。
+ * TaskFormValues を BE 仕様の CreateTaskParams に変換する。
+ * priority / parent は undefined のとき key 自体を含めず、BE 側で None として扱わせる。
  * @param values フォーム値
  * @returns BE invoke 用のパラメータ
  */
 const toCreateTaskParams = (values: TaskFormValues): CreateTaskParams => ({
   title: values.title,
   status: values.status,
-  priority: values.priority,
   labels: values.labels,
-  parent: values.parent,
   body: values.body,
+  ...(values.priority !== undefined && { priority: values.priority }),
+  ...(values.parent !== undefined && { parent: values.parent }),
 });
 
 /**


### PR DESCRIPTION
## 概要

タスク作成フォームについて以下 2 点を実装する。

1. 優先度「なし」選択時に `priority` を `create_task` 引数の **key ごと omit** する（仕様: `task-format-spec.md:68`）
2. サブIssue 追加経路で **親フィールドを read-only 化**し、自動セットされた親をユーザーに明示する（× ボタン非表示 + 親消失時の filePath fallback）

## 変更の種類

- ✨ 新機能

## 追加した内容

- `ParentTaskSelect` の `readOnly?: boolean` props + filePath fallback ブランチ
- `TaskFormParent` / `TaskForm` / `TaskCreateModal` の `readOnly` / `parentReadOnly` props（D14: 上位は `parentReadOnly`、`TaskFormParent` 以下は `readOnly`）
- `App.tsx` の `subIssueParentPath: string | undefined` state + `useMemo` で `parentCandidates` / `parentReadOnly` を導出
- テスト 4 ファイル（追加 / 更新合計 +13 ケース）
  - `useTaskCreate.behavior.test.tsx` T3 を破壊的更新 + T3b 追加（`hasOwnProperty` で key 不在を厳密検証）
  - `ParentTaskSelect.readOnly.test.tsx` 新規（× 非描画 / filePath fallback 3 ケース）
  - `TaskFormParent.interaction.test.tsx` に `readOnly` pass-through ケース追加
  - `App.createModalProps.test.tsx` 新規（subIssue / 通常 / close+unmount / 直接通常切替 / 親消失 fallback の 5 経路）

## 変更した内容

- `useTaskCreate.toCreateTaskParams` を条件付き spread に変更し、`priority` / `parent` が undefined のとき key 自体を含めない
- `App.tsx` の `handleAddSubIssue` で `setSubIssueParentPath(parentFilePath)` を呼ぶ
- `handleAddTask` / `handleCloseCreateModal` / プロジェクト切替 (render-phase reset) で `setSubIssueParentPath(undefined)` を追加（D10 — stale leak 防止）
- `TaskCreateModal` 呼び出しに `parentCandidates` (derived) / `parentReadOnly` (derived) を渡す

## 削除した内容

なし

## 仕様ドキュメント更新

**不要**: `docs/spec-board/task-card-spec.md:108, 123` / `task-format-spec.md:68` に既に該当文言があり、本変更を spec として既にカバー済み。

## システム図

サブIssue 追加経路の state 配線と props 伝搬:

\`\`\`mermaid
flowchart TD
  detail[\"DetailPanel<br/>+サブIssue追加\"]
  app_state[\"App.tsx state<br/>subIssueParentPath: string | undefined [NEW]\"]
  derive[\"useMemo<br/>parentCandidates = tasks.filter(t =&gt; t.filePath === subIssueParentPath)<br/>parentReadOnly = subIssueParentPath !== undefined [NEW]\"]
  modal[\"TaskCreateModal<br/>parentReadOnly props [NEW]\"]
  form[\"TaskForm<br/>parentReadOnly props [NEW]\"]
  parent_field[\"TaskFormParent<br/>readOnly props [NEW]\"]
  select[\"ParentTaskSelect<br/>readOnly + filePath fallback [NEW]\"]
  invoke[\"create_task invoke<br/>priority/parent を undefined のとき omit [NEW]\"]

  detail -- handleAddSubIssue(fp) --> app_state
  app_state --> derive
  derive --> modal
  modal --> form
  form --> parent_field
  parent_field --> select
  form -- submit --> invoke

  style app_state fill:#e1f5ff,stroke:#0366d6
  style derive fill:#e1f5ff,stroke:#0366d6
  style modal fill:#e1f5ff,stroke:#0366d6
  style form fill:#e1f5ff,stroke:#0366d6
  style parent_field fill:#e1f5ff,stroke:#0366d6
  style select fill:#e1f5ff,stroke:#0366d6
  style invoke fill:#e1f5ff,stroke:#0366d6
\`\`\`

実装計画詳細: [.plugin-workspace/.specs/008-task-create-priority-none-and-parent-auto/implementation-plan.md](.plugin-workspace/.specs/008-task-create-priority-none-and-parent-auto/implementation-plan.md)

## 関連Issue

Refs #121

## テスト

- ✅ \`pnpm test:run\`: **104 files / 901 tests passed**（+13 ケース追加）
- ✅ \`pnpm build\`: 緑（tsc + Vite）
- ✅ \`pnpm lint\` (oxlint): 0 warnings / 0 errors
- ✅ Codex CLI コードレビュー: 「問題なし」（4 回ループ、感度検証として `handleAddTask` reset を一時削除して経路3b が期待通り FAIL することを確認）
- ⚠️ 手動確認（Tauri 実機）: 本 PR では未実施。マージ前にレビュアー側で手動シナリオ実施を推奨（[implementation-plan.md Section 8-2](.plugin-workspace/.specs/008-task-create-priority-none-and-parent-auto/implementation-plan.md) 参照）

## レビューポイント

- **D1 / D16**: `priority` key omit は `toCreateTaskParams` の単一ポイントで実施。テストは `expect.not.objectContaining({ priority: expect.anything() })` を避け、`Object.prototype.hasOwnProperty.call` で厳密に key 不在を検証（`expect.anything()` は `undefined` にマッチしないため）
- **D3 / D14**: subIssue モード判別の discriminator props は追加せず、App.tsx の props 値（`parentCandidates` 候補数 / `parentReadOnly`）で振る舞いを決める。`TaskForm` 以上では `parentReadOnly` 名にし、フィールドが parent 限定であることを明示
- **D4**: `subIssueParentPath` は `string | undefined` のみ保持し、`parentCandidates` は `useMemo` で `tasks` から毎レンダ導出。Task スナップショットを state に持たないことで、親が tasks から消えたとき filePath fallback が起動する
- **D10**: `subIssueParentPath` の reset は 3 経路すべてで明示的に実施（`handleAddTask` / `handleCloseCreateModal` / render-phase project switch 分岐）。`useEffect` での reset は使わない（既存 App.tsx:125-132 コメント参照、stale state race 回避）
- **D15**: `App.createModalProps.test.tsx` で 5 経路（subIssue / 通常 / close+unmount / 直接通常切替 / 親消失 fallback）を統合テストでカバー。`handleAddTask` の reset を一時削除すると経路3b が FAIL することを感度検証済み

## チェックリスト

- [x] セルフレビュー実施
- [x] pnpm test:run 緑
- [x] pnpm build 緑
- [x] Biome / oxlint 0 warnings
- [ ] Tauri 実機での手動確認（未実施、マージ前推奨）
- [x] 仕様変更は spec に既存記述あり（更新不要）
- [x] feature 間依存は `index.ts` 公開 API 経由
- [x] 関連 Issue を本文で参照
- [x] 破壊的変更なし