### PR TITLE
🧪 [Tests]: #136 [FE] 同一カラム dnd-order updateCardOrder payload 検証テスト追加

### DIFF
--- a/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts
@@ -265,6 +265,38 @@ test("同一カラム並び替え: 楽観 → 確定で card-order-updated が 2
   ]);
 });
 
+test("同一カラム並び替え: 楽観 dispatch payload の filePaths が buildMovedFilePaths 結果と一致", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Todo"],
+      ["tasks/c.md", "Todo"],
+    ]),
+  );
+  updateCardOrderMock.mockResolvedValue(Result.ok(undefined));
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Todo",
+    toIndex: 2,
+  });
+
+  const expectedPaths = ["tasks/b.md", "tasks/a.md", "tasks/c.md"];
+  expect(harness.actions).toEqual([
+    {
+      type: "card-order-updated",
+      columnName: "Todo",
+      filePaths: expectedPaths,
+    },
+    {
+      type: "card-order-updated",
+      columnName: "Todo",
+      filePaths: expectedPaths,
+    },
+  ]);
+});
+
 test("カラム内並び替え後の ProjectData.tasks 表示順が filePaths と一致", async () => {
   const harness = setupLoaded(
     makeData([
@@ -342,6 +374,41 @@ test("同一カラム並び替え: updateCardOrder 失敗 → 楽観 dispatch �
   expect(
     next.data.tasks.filter((t) => t.status === "Todo").map((t) => t.filePath),
   ).toEqual(["tasks/a.md", "tasks/b.md", "tasks/c.md"]);
+});
+
+test("同一カラム並び替え失敗時: rollback dispatch の filePaths が toColumnOrderBefore に正確に戻る", async () => {
+  const harness = setupLoaded(
+    makeData([
+      ["tasks/a.md", "Todo"],
+      ["tasks/b.md", "Todo"],
+      ["tasks/c.md", "Todo"],
+    ]),
+  );
+  updateCardOrderMock.mockResolvedValue(
+    Result.err(new TauriError("IO_ERROR", "io fail")),
+  );
+
+  await moveTaskAction(harness.deps, {
+    taskFilePath: "tasks/a.md",
+    fromColumn: "Todo",
+    toColumn: "Todo",
+    toIndex: 2,
+  });
+
+  const optimisticPaths = ["tasks/b.md", "tasks/a.md", "tasks/c.md"];
+  const rollbackPaths = ["tasks/a.md", "tasks/b.md", "tasks/c.md"];
+  expect(harness.actions).toEqual([
+    {
+      type: "card-order-updated",
+      columnName: "Todo",
+      filePaths: optimisticPaths,
+    },
+    {
+      type: "card-order-updated",
+      columnName: "Todo",
+      filePaths: rollbackPaths,
+    },
+  ]);
 });
 
 test("updateTask が Result.err なら ProjectError.tauri を返し updateCardOrder は呼ばれない / カラムは原状", async () => {


### PR DESCRIPTION
## 概要

GitHub Issue #136 「[FE] dnd-order - 同一カラム内ドロップ判定 + updateCardOrder 呼び出し」の 3 タスク（判定 / 呼び出し / 引数テスト）は **既存実装で完全に充足済み** であることを確認したため、本 PR ではプロダクトコードを一切変更せず、**テスト精度向上の最小差分**として `moveTask.behavior.test.ts` に 2 件の payload 検証テストを追加する。

## 変更の種類

- 🧪 Tests（テスト追加）

## 追加した内容

`src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts` に下記 2 件を追加（+67 行）:

1. **同一カラム並び替え: 楽観 dispatch payload の filePaths が buildMovedFilePaths 結果と一致**
   - 楽観 dispatch (1 回目) の `filePaths` payload が並び替え後の順序と一致することを `toEqual` で完全比較
2. **同一カラム並び替え失敗時: rollback dispatch の filePaths が toColumnOrderBefore に正確に戻る**
   - rollback dispatch (2 回目) の `filePaths` payload が原状の順序と一致することを `toEqual` で完全比較

## 変更した内容

なし（既存テスト・プロダクトコードへの変更ゼロ）。

## 削除した内容

なし。

## 既存実装で satisfies されている Issue #136 の 3 タスク

| Issue タスク | 実装箇所 |
|---|---|
| `sourceColumn === targetColumn` 判定 | `src/features/board/hooks/useProject/actions/moveTask.ts:493` (`params.fromColumn !== params.toColumn ? crossColumn : sameColumn`) |
| `updateCardOrder(columnName, filePaths)` 呼び出し | `moveTask.ts:438-441` (`MoveExecution.sameColumn` 内) |
| 引数テスト | `moveTask.behavior.test.ts:239-266` (`toHaveBeenCalledWith({ columnName, filePaths })`) |

## 仕様ドキュメント更新

**不要**（純粋なテスト追加であり、コード挙動・公開 API・データ形式に差分が一切ないため、`docs/spec-board/` の更新は不要）。

## システム図

```mermaid
flowchart TD
    A[moveTaskAction<br/>fromColumn === toColumn] --> B[MoveSnapshot.from]
    B --> C[buildMovedFilePaths]
    C --> D{isSameOrder?}
    D -- Yes --> E[Result.ok no-op]
    D -- No --> F[dispatchSync<br/>card-order-updated #1<br/>filePaths = optimistic]
    F --> G[updateCardOrder IPC]
    G --> H{Result?}
    H -- ok --> I[dispatchSync<br/>card-order-updated #2<br/>filePaths = optimistic]
    H -- err --> J[dispatchSync<br/>card-order-updated #2<br/>filePaths = toColumnOrderBefore]
    style F fill:#fff4c2,stroke:#d4a017
    style J fill:#fff4c2,stroke:#d4a017
    F -. "追加観点 1<br/>payload を toEqual 検証" .- F
    J -. "追加観点 2<br/>rollback payload を toEqual 検証" .- J
```

黄色ハイライト部分が今回新規に payload 内容まで検証する dispatch。

## 関連Issue

Refs #136

> 本 PR は Issue #136 の 3 タスクが既存実装で satisfies されていることの確認 + テスト精度向上であり、Issue クローズ条件を満たすが、最終クローズ判断はレビュアーに委ねる。

## テスト

- ✅ `pnpm test:run src/features/board/hooks/useProject/actions/__tests__/moveTask.behavior.test.ts` — **26 件 pass**（既存 24 + 追加 2）
- ✅ `pnpm test:run`（全体）— **115 files / 993 tests pass**
- ✅ `pnpm build`（`tsc -b && vite build`）成功
- ✅ Biome / oxlint 警告 0
- ✅ Codex AI レビュー — **問題なし**

## レビューポイント

- **スコープ外の明示**: 本 PR はテスト追加のみで、以下は意図的に手を付けていない:
  - `filePaths` の `readonly string[]` 化リファクタ
  - `MoveSnapshot.isSameOrder` の単体テスト切り出し
  - 同一カラム経路の `versionGuard` 切替テスト
  - `Board` / `Column` コンポーネントの drop handler 改修
  - バックエンド (Rust `update_card_order` command)
- **アサート方針**: `actions.map((a) => a.type)` 列のみ検証していた既存テストに対し、新規 2 件は `harness.actions` 配列丸ごと `toEqual` で `type` / `columnName` / `filePaths` 全 3 フィールドを完全比較する設計。`expect.objectContaining` は使わず固い比較で意図を明確化している。
- **テスト重複**: 既存 L239-266 / L314-345 の type 列検証テストとは観点が異なる（type vs payload 中身）ため、両方残す設計判断を採用。

## チェックリスト

- [x] セルフレビューを実施した
- [x] `pnpm test:run` が通る
- [x] `pnpm build` が通る
- [x] cargo は対象外（Rust 変更なし）
- [x] Biome / oxlint の警告を解消した
- [x] UI 変更なし
- [x] 仕様ドキュメント更新は不要（理由を本文に明記）
- [x] feature 間依存は変更していない
- [x] 関連 Issue を本文にリンクした
- [x] 破壊的変更なし