### PR TITLE
✨ [New Feature]: #144 DetailPanel 循環警告バナー + scan 経路 warning 化

### DIFF
--- a/docs/spec-board/task-format-spec.md
+++ b/docs/spec-board/task-format-spec.md
@@ -79,7 +79,9 @@ links:
 - 省略時はルートレベルのタスクとして扱う
 - 多階層のネストが可能（親→子→孫→...）。ただしネストの深さは最大20階層まで（超過時はパースエラー）
 - 指定されたファイルが存在しない場合、警告を表示しフィールドは保持
-- 循環参照（A→B→A）が検出された場合、パースエラーとして通知
+- 循環参照（A→B→A）の扱い:
+  - **scan 経路（プロジェクト読み込み）**: scan を継続し、ループに含まれる全 task に `parentCycle` warning を付与しつつ `parent` を `None` に置き換える。ファイル本体の YAML `parent:` キーは変更しない（ユーザーが手で修正できるよう原文を残す）
+  - **create / update 経路**: 従来通り `CycleOrTooDeep` パースエラーとして拒否
 
 #### links
 
@@ -138,7 +140,7 @@ flowchart TD
 | PL-005 | priority 正規化 | `high` → `High`、`MEDIUM` → `Medium` のように先頭大文字に正規化 |
 | PL-006 | labels 正規化 | 文字列が渡された場合は単一要素の配列に変換。重複を除去 |
 | PL-007 | parent 解決 | `parent` フィールドのパスを解決し、親タスクの存在を検証。存在しない場合は `parentNotFound` warning を記録し、Task 自体は読み込み成功として扱う |
-| PL-008 | parent 循環参照検出 | 親子関係のツリーを辿り、循環参照がないか検証。循環検出時、または parent 参照（edge）を21回以上辿る場合は `CycleOrTooDeep` パースエラー。20 edge までは許容する |
+| PL-008 | parent 循環参照検出 | 親子関係のツリーを辿り、循環参照と深さ超過を検証する。**scan 経路（プロジェクト読み込み）**: 循環検出時は scan を継続し、ループに含まれる全 task に `parentCycle` warning を付与しつつ `parent` を `None` に置き換える。21 edge 以上の深さは `CycleOrTooDeep` パースエラー（深さ超過が循環検出より先行）。**create/update 経路**: 循環は引き続き `CycleOrTooDeep` パースエラーとして拒否する |
 | PL-009 | links 正規化 | 文字列が渡された場合は単一要素の配列に変換。重複を除去。存在しないパスは警告付きで保持 |
 | PL-010 | links 逆引きインデックス | 全タスク読み込み後、links の逆引きインデックスを構築。双方向リンクの表示に使用 |
 | PL-011 | 子タスク収集 | 全タスク読み込み後、各タスクの `parent` を元に子タスク一覧を構築 |
@@ -157,6 +159,7 @@ flowchart TD
 - `parent` が文字列だが読み込み済み Task の `file_path` に存在しない場合は、値を保持したまま `parentNotFound` warning を付与する
 - `parent` の存在検証では比較時のみ `\` と `./` を軽量正規化する。先頭 `/` または Windows drive prefix 付きの値は相対パス仕様外として `parentNotFound` warning を付与する
 - 自己参照 `parent` は存在する Task として扱い、循環検出は PL-008 で扱う
+- scan 時に親チェーンが循環している場合、ループに含まれる全 task に `parentCycle` warning を付与し、各 task の `parent` を `None` に置き換える。ファイル本体の YAML `parent:` キーは変更しない（ユーザーが手で修正できるよう原文を残す）
 - `extras` の非文字列 key は除外し、`nonStringExtraKeyIgnored` warning を付与する
 - `extras` の JSON 非互換 value は除外し、`extraValueNotJsonCompatible` warning を付与する
 
@@ -165,6 +168,7 @@ flowchart TD
 | code | field | 条件 | 挙動 |
 |:--|:--|:--|:--|
 | `parentNotFound` | `parent` | `parent` が文字列だが、読み込み済み Task の `file_path` に存在しない | `parent` 値は保持し、Task の `warnings` に追加する |
+| `parentCycle` | `parent` | scan 時に親チェーンが循環している（自己参照含む）と検出された | ループに含まれる全 task の `warnings` に追加し、各 task の `parent` を `None` に置き換える（ファイル本体の YAML は無変更） |
 
 ## シリアライズ仕様
 

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -200,7 +200,7 @@ pub(crate) fn open_project_impl<W: WatcherFactory>(
     let tasks = collect_tasks(root, &md_paths, &default_status);
 
     let tasks = TaskIndex::new(tasks)
-        .build_children()
+        .build_children_with_warnings()
         .map_err(map_hierarchy_error)?
         .build_reverse_links()
         .into_tasks();

--- a/src-tauri/src/project/open_tests.rs
+++ b/src-tauri/src/project/open_tests.rs
@@ -425,10 +425,10 @@ fn config_load_failure_when_spec_board_path_is_a_file_returns_io_category() {
 }
 
 #[test]
-fn parent_cycle_returns_scan_failed_with_io_marker() {
+fn parent_cycle_returns_scan_success_with_warnings() {
     let state = Arc::new(AppState::new());
     let dir = tempdir();
-    // a -> b -> a の循環
+    // a -> b -> a の循環。scan は成功し、A・B 両方に parentCycle warning が付く。
     write_md(
         dir.path(),
         "tasks/a.md",
@@ -441,19 +441,25 @@ fn parent_cycle_returns_scan_failed_with_io_marker() {
     );
     let raw = dir.path().to_str().expect("utf-8").to_string();
 
-    let err = open_with_noop(Arc::clone(&state), &raw).expect_err("cycle should fail");
+    let payload = open_with_noop(Arc::clone(&state), &raw).expect("cycle should not error");
 
-    match err {
-        OpenProjectError::ScanFailed { ref message } => {
-            // wrapper Display "io scan failed: ..." 側で \bio\b を満たすため、
-            // message 内に "io" を二重に埋め込まない契約。最終 Display には
-            // 必ず "io" が含まれることを担保する。
-            assert!(!message.starts_with("io"), "message: {message}");
-            let display = err.to_string();
-            assert!(display.starts_with("io scan failed:"));
-            assert!(display.contains("io"));
-        }
-        other => panic!("expected ScanFailed, got {other:?}"),
+    let ids: Vec<&str> = payload.tasks.iter().map(|t| t.id.as_str()).collect();
+    assert_eq!(ids, vec!["tasks/a.md", "tasks/b.md"]);
+
+    for task in &payload.tasks {
+        assert!(
+            task.warnings.iter().any(|w| {
+                w.code == crate::task::warning::TaskWarningCode::ParentCycle
+                    && w.field.as_deref() == Some("parent")
+            }),
+            "{} should have parentCycle warning",
+            task.file_path.as_str()
+        );
+        assert!(
+            task.parent.is_none(),
+            "{} parent should be cleared by cycle warning",
+            task.file_path.as_str()
+        );
     }
 }
 

--- a/src-tauri/src/task/add_link/command.rs
+++ b/src-tauri/src/task/add_link/command.rs
@@ -15,6 +15,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::task_index::{
     find_task_by_normalized, find_task_mut_by_normalized, AddLinkOutcome, Task, TaskIndex,
 };
+use crate::task::warning::TaskWarningCode;
 
 /// `add_link` Tauri command 薄層。
 #[tauri::command]
@@ -139,21 +140,33 @@ fn commit_cache(
                 });
             }
 
-            // 派生フィールド (children / reverse_links / warnings) と parent を
-            // 保持しつつ parse 由来フィールドのみ上書きする。`task_from_parsed` は
-            // children / reverse_links を空で返し、`ParentNotFound` のような
-            // downstream の派生 warning も再生成しない。add_link は parent /
-            // title / status / labels / extras を一切変更せず links のみ追加するため、
-            // warnings と parent は既存値をそのまま保持すれば正しい状態が維持される。
-            // 特に scan で `parent=None` 化された循環 task に link 追加した際、
-            // disk 由来の生 parent が復活して cycle 状態が崩れるのを防ぐ。
+            // 派生フィールド (children / reverse_links / warnings) を保持しつつ
+            // parse 由来フィールドのみ上書きする。`task_from_parsed` は children /
+            // reverse_links を空で返し、`ParentNotFound` のような downstream の
+            // 派生 warning も再生成しない。add_link は parent / title / status /
+            // labels / extras を一切変更せず links のみ追加するため、warnings は
+            // 既存値をそのまま保持すれば正しい状態が維持される。
+            //
+            // parent は通常は `updated_task` 側（disk と一致した値）を採用するが、
+            // 既存 cache が ParentCycle warning を持つ場合に限り cache 側の
+            // `parent=None` を維持する。これは scan で循環判定されたノードの
+            // cycle 状態を link 追加程度の操作で崩さないため。ファイル本体が
+            // 外部編集で変わった場合は watcher 再 scan で再判定される。
             let source_entry = cache
                 .get_mut(&source_key)
                 .expect("source presence verified above");
+            let was_cycle_member = source_entry.warnings.iter().any(|w| {
+                w.code == TaskWarningCode::ParentCycle
+                    && w.field.as_deref() == Some("parent")
+            });
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);
-            let preserved_parent = source_entry.parent.take();
+            let preserved_parent = if was_cycle_member {
+                source_entry.parent.take()
+            } else {
+                updated.parent.clone()
+            };
             *source_entry = Task {
                 children: preserved_children,
                 reverse_links: preserved_reverse,

--- a/src-tauri/src/task/add_link/command.rs
+++ b/src-tauri/src/task/add_link/command.rs
@@ -156,8 +156,7 @@ fn commit_cache(
                 .get_mut(&source_key)
                 .expect("source presence verified above");
             let was_cycle_member = source_entry.warnings.iter().any(|w| {
-                w.code == TaskWarningCode::ParentCycle
-                    && w.field.as_deref() == Some("parent")
+                w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent")
             });
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);

--- a/src-tauri/src/task/add_link/command.rs
+++ b/src-tauri/src/task/add_link/command.rs
@@ -139,22 +139,26 @@ fn commit_cache(
                 });
             }
 
-            // 派生フィールド (children / reverse_links / warnings) を保持しつつ
-            // parse 由来フィールドのみ上書きする。`task_from_parsed` は children /
-            // reverse_links を空で返し、`ParentNotFound` のような downstream の
-            // 派生 warning も再生成しない。add_link は parent / title / status /
-            // labels / extras を一切変更せず links のみ追加するため、warnings は
-            // 既存値をそのまま保持すれば正しい状態が維持される。
+            // 派生フィールド (children / reverse_links / warnings) と parent を
+            // 保持しつつ parse 由来フィールドのみ上書きする。`task_from_parsed` は
+            // children / reverse_links を空で返し、`ParentNotFound` のような
+            // downstream の派生 warning も再生成しない。add_link は parent /
+            // title / status / labels / extras を一切変更せず links のみ追加するため、
+            // warnings と parent は既存値をそのまま保持すれば正しい状態が維持される。
+            // 特に scan で `parent=None` 化された循環 task に link 追加した際、
+            // disk 由来の生 parent が復活して cycle 状態が崩れるのを防ぐ。
             let source_entry = cache
                 .get_mut(&source_key)
                 .expect("source presence verified above");
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);
+            let preserved_parent = source_entry.parent.take();
             *source_entry = Task {
                 children: preserved_children,
                 reverse_links: preserved_reverse,
                 warnings: preserved_warnings,
+                parent: preserved_parent,
                 ..updated.clone()
             };
             let returned_task = source_entry.clone();

--- a/src-tauri/src/task/add_link/command.rs
+++ b/src-tauri/src/task/add_link/command.rs
@@ -15,7 +15,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::task_index::{
     find_task_by_normalized, find_task_mut_by_normalized, AddLinkOutcome, Task, TaskIndex,
 };
-use crate::task::warning::TaskWarningCode;
+use crate::task::warning::has_parent_cycle_warning;
 
 /// `add_link` Tauri command 薄層。
 #[tauri::command]
@@ -155,9 +155,7 @@ fn commit_cache(
             let source_entry = cache
                 .get_mut(&source_key)
                 .expect("source presence verified above");
-            let was_cycle_member = source_entry.warnings.iter().any(|w| {
-                w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent")
-            });
+            let was_cycle_member = has_parent_cycle_warning(&source_entry.warnings);
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);

--- a/src-tauri/src/task/add_link/command_tests.rs
+++ b/src-tauri/src/task/add_link/command_tests.rs
@@ -225,3 +225,43 @@ fn add_link_registers_write_ignore_then_writes() {
         "write_ignore must hold exactly one entry for the source path"
     );
 }
+
+/// scan で cycle member とマークされた source task に add_link しても、
+/// cache 上の `parent=None` と `parentCycle` warning が崩れないこと。
+#[test]
+fn add_link_on_cycle_source_preserves_parent_none_and_cycle_warning() {
+    use crate::task::warning::TaskWarningCode;
+
+    let dir = tempdir();
+    let root = dir.path();
+    // A -> B -> A の循環。さらに link 先となる無関係 task C を用意。
+    seed_md(
+        root,
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\n",
+    );
+    seed_md(
+        root,
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n",
+    );
+    seed_md(root, "tasks/c.md", "---\ntitle: C\nstatus: Todo\n---\n");
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), root);
+
+    let returned = add_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/c.md"))
+        .expect("add_link should succeed");
+
+    assert!(
+        returned.parent.is_none(),
+        "cycle source must keep parent=None"
+    );
+    assert!(
+        returned
+            .warnings
+            .iter()
+            .any(|w| w.code == TaskWarningCode::ParentCycle),
+        "cycle source must keep parentCycle warning"
+    );
+}

--- a/src-tauri/src/task/remove_link/command.rs
+++ b/src-tauri/src/task/remove_link/command.rs
@@ -13,6 +13,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::remove_link::args::RemoveLinkArgs;
 use crate::task::remove_link::error::{RemoveLinkCommandError, RemoveLinkError};
 use crate::task::task_index::{find_task_mut_by_normalized, RemoveLinkOutcome, Task, TaskIndex};
+use crate::task::warning::TaskWarningCode;
 
 /// `remove_link` Tauri command 薄層。
 #[tauri::command]
@@ -133,20 +134,31 @@ fn commit_cache(
                 });
             }
 
-            // 派生フィールド (children / reverse_links / warnings) と parent を
-            // 保持しつつ parse 由来フィールドのみ上書きする。remove_link は
-            // parent / title / status / labels / extras を一切変更せず links を
-            // 縮めるだけのため、warnings と parent は既存値の保持で正しい状態が
-            // 維持される。特に scan で `parent=None` 化された循環 task に対する
-            // link 削除で、disk 由来の生 parent が復活して cycle 状態が崩れるのを
-            // 防ぐ。
+            // 派生フィールド (children / reverse_links / warnings) を保持しつつ
+            // parse 由来フィールドのみ上書きする。remove_link は parent / title /
+            // status / labels / extras を一切変更せず links を縮めるだけのため、
+            // warnings は既存値の保持で正しい状態が維持される。
+            //
+            // parent は通常は `updated_task` 側（disk と一致した値）を採用するが、
+            // 既存 cache が ParentCycle warning を持つ場合に限り cache 側の
+            // `parent=None` を維持する。これは scan で循環判定されたノードの
+            // cycle 状態を link 削除程度の操作で崩さないため。ファイル本体が
+            // 外部編集で変わった場合は watcher 再 scan で再判定される。
             let source_entry = cache
                 .get_mut(&source_key)
                 .expect("source presence verified above");
+            let was_cycle_member = source_entry.warnings.iter().any(|w| {
+                w.code == TaskWarningCode::ParentCycle
+                    && w.field.as_deref() == Some("parent")
+            });
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);
-            let preserved_parent = source_entry.parent.take();
+            let preserved_parent = if was_cycle_member {
+                source_entry.parent.take()
+            } else {
+                updated.parent.clone()
+            };
             *source_entry = Task {
                 children: preserved_children,
                 reverse_links: preserved_reverse,

--- a/src-tauri/src/task/remove_link/command.rs
+++ b/src-tauri/src/task/remove_link/command.rs
@@ -148,8 +148,7 @@ fn commit_cache(
                 .get_mut(&source_key)
                 .expect("source presence verified above");
             let was_cycle_member = source_entry.warnings.iter().any(|w| {
-                w.code == TaskWarningCode::ParentCycle
-                    && w.field.as_deref() == Some("parent")
+                w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent")
             });
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);

--- a/src-tauri/src/task/remove_link/command.rs
+++ b/src-tauri/src/task/remove_link/command.rs
@@ -13,7 +13,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::remove_link::args::RemoveLinkArgs;
 use crate::task::remove_link::error::{RemoveLinkCommandError, RemoveLinkError};
 use crate::task::task_index::{find_task_mut_by_normalized, RemoveLinkOutcome, Task, TaskIndex};
-use crate::task::warning::TaskWarningCode;
+use crate::task::warning::has_parent_cycle_warning;
 
 /// `remove_link` Tauri command 薄層。
 #[tauri::command]
@@ -147,9 +147,7 @@ fn commit_cache(
             let source_entry = cache
                 .get_mut(&source_key)
                 .expect("source presence verified above");
-            let was_cycle_member = source_entry.warnings.iter().any(|w| {
-                w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent")
-            });
+            let was_cycle_member = has_parent_cycle_warning(&source_entry.warnings);
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);

--- a/src-tauri/src/task/remove_link/command.rs
+++ b/src-tauri/src/task/remove_link/command.rs
@@ -133,20 +133,25 @@ fn commit_cache(
                 });
             }
 
-            // 派生フィールド (children / reverse_links / warnings) を保持しつつ
-            // parse 由来フィールドのみ上書きする。remove_link は parent / title /
-            // status / labels / extras を一切変更せず links を縮めるだけのため、
-            // warnings は既存値の保持で正しい状態が維持される。
+            // 派生フィールド (children / reverse_links / warnings) と parent を
+            // 保持しつつ parse 由来フィールドのみ上書きする。remove_link は
+            // parent / title / status / labels / extras を一切変更せず links を
+            // 縮めるだけのため、warnings と parent は既存値の保持で正しい状態が
+            // 維持される。特に scan で `parent=None` 化された循環 task に対する
+            // link 削除で、disk 由来の生 parent が復活して cycle 状態が崩れるのを
+            // 防ぐ。
             let source_entry = cache
                 .get_mut(&source_key)
                 .expect("source presence verified above");
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);
+            let preserved_parent = source_entry.parent.take();
             *source_entry = Task {
                 children: preserved_children,
                 reverse_links: preserved_reverse,
                 warnings: preserved_warnings,
+                parent: preserved_parent,
                 ..updated.clone()
             };
 

--- a/src-tauri/src/task/remove_link/command_tests.rs
+++ b/src-tauri/src/task/remove_link/command_tests.rs
@@ -333,3 +333,41 @@ fn registers_write_ignore_for_write_path() {
         "write_ignore must hold exactly one entry for the source path"
     );
 }
+
+#[test]
+fn remove_link_on_cycle_source_preserves_parent_none_and_cycle_warning() {
+    use crate::task::warning::TaskWarningCode;
+
+    let dir = tempdir();
+    let root = dir.path();
+    // A -> B -> A の循環。A には事前に C への link が貼られている。
+    seed_md(
+        root,
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\nlinks:\n  - tasks/c.md\n---\n",
+    );
+    seed_md(
+        root,
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n",
+    );
+    seed_md(root, "tasks/c.md", "---\ntitle: C\nstatus: Todo\n---\n");
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), root);
+
+    let returned = remove_link_impl(&state, &FsTaskIo, args_for("tasks/a.md", "tasks/c.md"))
+        .expect("remove_link should succeed");
+
+    assert!(
+        returned.parent.is_none(),
+        "cycle source must keep parent=None"
+    );
+    assert!(
+        returned
+            .warnings
+            .iter()
+            .any(|w| w.code == TaskWarningCode::ParentCycle),
+        "cycle source must keep parentCycle warning"
+    );
+}

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -20,9 +20,9 @@ use crate::task::frontmatter::{self, Parsed, Priority};
 use crate::task::label::Label;
 use crate::task::parse::{task_from_parsed, TaskParseContext, TaskParseError};
 use crate::task::path_lookup::{
-    normalize_link_path_for_lookup, normalize_parent_path_for_lookup,
-    normalize_relative_path_for_input, normalize_task_path_for_lookup, parent_lookup_index,
-    task_path_index,
+    append_child_to_parent, clear_children, normalize_link_path_for_lookup,
+    normalize_parent_path_for_lookup, normalize_relative_path_for_input,
+    normalize_task_path_for_lookup, parent_lookup_index, task_lookup_index, task_path_index,
 };
 use crate::task::remove_link::error::RemoveLinkError;
 use crate::task::reverse_links::build_reverse_links;
@@ -139,6 +139,79 @@ impl TaskIndex {
         Ok(Self {
             tasks: build_children(self.tasks)?,
         })
+    }
+
+    /// scan 経路用。親チェーンに循環が含まれる場合は Err を返さず、ループ内の
+    /// 全 task に `parentCycle` warning を付けて `parent = None` に置き換える
+    /// ことで scan 全体を継続させる。親チェーンの深さが `MAX_PARENT_DEPTH` を
+    /// 超える (TooDeep) 場合のみ既存どおり `Err` を返す。
+    ///
+    /// 既存 `build_children` と同様、最初に `validate_parent_existence` を
+    /// 実行して `ParentNotFound` warning を従来通り付与する。children 構築は
+    /// 循環ノードを `parent = None` 化した後に行うため、cycle member は
+    /// children 逆引きから自然に除外される。
+    pub fn build_children_with_warnings(mut self) -> Result<Self, TaskParseError> {
+        self.tasks = validate_parent_existence(self.tasks);
+
+        let parent_lookup = parent_lookup_index(&self.tasks);
+
+        // 各起点ごとに walk するための (normalized_path, origin_path) ペアを
+        // 事前に収集する。origin は TooDeep 時の `file_path` に使う。
+        let starts: Vec<(String, String)> = self
+            .tasks
+            .iter()
+            .map(|task| {
+                (
+                    normalize_task_path_for_lookup(task.file_path.as_str()),
+                    task.file_path.as_str().to_string(),
+                )
+            })
+            .collect();
+
+        let mut cycle_members: HashSet<String> = HashSet::new();
+        for (start_norm, start_origin) in starts {
+            match walk_parent_chain_collecting_cycle(&start_norm, &start_origin, &parent_lookup) {
+                ParentChainOutcome::Ok => {}
+                ParentChainOutcome::Cycle { members } => {
+                    for member in members {
+                        cycle_members.insert(member);
+                    }
+                }
+                ParentChainOutcome::TooDeep { file_path } => {
+                    return Err(TaskParseError::CycleOrTooDeep {
+                        reason: ParentHierarchyErrorReason::TooDeep,
+                        file_path,
+                    });
+                }
+            }
+        }
+
+        self.mark_cycle_members(&cycle_members);
+        Ok(self.build_children_links_only())
+    }
+
+    fn mark_cycle_members(&mut self, normalized_paths: &HashSet<String>) {
+        for task in &mut self.tasks {
+            let task_norm = normalize_task_path_for_lookup(task.file_path.as_str());
+            if !normalized_paths.contains(&task_norm) {
+                continue;
+            }
+            push_parent_cycle_warning(task);
+            task.parent = None;
+        }
+    }
+
+    /// children を逆引きで構築するが、parent chain の hierarchy 検証は行わない。
+    /// `build_children_with_warnings` が cycle member を `parent = None` 化した
+    /// 後に呼び、cycle が children 逆引きで再構築されないことを呼び出し側で保証する。
+    fn build_children_links_only(self) -> Self {
+        let mut tasks = self.tasks;
+        clear_children(&mut tasks);
+        let parent_index = task_lookup_index(&tasks);
+        for child_index in 0..tasks.len() {
+            append_child_to_parent(child_index, &mut tasks, &parent_index);
+        }
+        Self { tasks }
     }
 
     /// 各 Task の `links` を逆引きして `reverse_links` を構築する。
@@ -1121,6 +1194,78 @@ fn append_parent_not_found_warning(task: &mut Task, task_paths: &HashSet<String>
     }
 
     push_parent_not_found(task);
+}
+
+/// `build_children_with_warnings` での parent chain 走査結果。
+///
+/// `Cycle.members` は循環ループに含まれる task の正規化済み path 集合。
+/// tail 部分（cycle に到達するまでの経路）は含まない。
+enum ParentChainOutcome {
+    Ok,
+    Cycle { members: Vec<String> },
+    TooDeep { file_path: String },
+}
+
+/// 起点 task から parent chain を walk し、循環または TooDeep を検出する。
+///
+/// traversal stack (`Vec<String>`) と position (`HashMap<String, usize>`) で
+/// 経路上の正規化済み path を保持し、再出現した path の index 以降のみを cycle
+/// member として返す。これにより tail 付き循環 (`D → A → B → A`) でも tail (`D`)
+/// を巻き込まずに循環本体だけを抽出できる。
+///
+/// 深さ判定の順序は既存 `validate_parent_chain` と一致させる:
+/// 1) current の cycle 判定（stack/position 挿入時）
+/// 2) parent lookup
+/// 3) parent が None なら Ok 終端
+/// 4) `depth += 1`
+/// 5) `depth > MAX_PARENT_DEPTH` なら TooDeep
+/// 6) current = parent
+fn walk_parent_chain_collecting_cycle(
+    start_norm: &str,
+    start_origin: &str,
+    parent_lookup: &HashMap<String, Option<String>>,
+) -> ParentChainOutcome {
+    let mut stack: Vec<String> = Vec::new();
+    let mut position: HashMap<String, usize> = HashMap::new();
+    let mut current = start_norm.to_string();
+    let mut depth: usize = 0;
+
+    loop {
+        if let Some(&idx) = position.get(&current) {
+            let members = stack[idx..].to_vec();
+            return ParentChainOutcome::Cycle { members };
+        }
+        position.insert(current.clone(), stack.len());
+        stack.push(current.clone());
+
+        let Some(Some(parent)) = parent_lookup.get(&current) else {
+            return ParentChainOutcome::Ok;
+        };
+
+        depth += 1;
+        if depth > MAX_PARENT_DEPTH {
+            return ParentChainOutcome::TooDeep {
+                file_path: start_origin.to_string(),
+            };
+        }
+
+        current = parent.clone();
+    }
+}
+
+fn push_parent_cycle_warning(task: &mut Task) {
+    let already_exists = task.warnings.iter().any(|warning| {
+        warning.code == TaskWarningCode::ParentCycle && warning.field.as_deref() == Some("parent")
+    });
+    if already_exists {
+        return;
+    }
+
+    task.warnings.push(TaskWarning {
+        code: TaskWarningCode::ParentCycle,
+        field: Some("parent".to_string()),
+        message: "parent chain forms a cycle".to_string(),
+    });
 }
 
 fn push_parent_not_found(task: &mut Task) {

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -31,7 +31,7 @@ use crate::task::task_file_name::{TaskFileName, TaskFileNameError};
 use crate::task::task_file_path::TaskFilePath;
 use crate::task::task_title::TaskTitle;
 use crate::task::update::error::UpdateTaskError;
-use crate::task::warning::{TaskWarning, TaskWarningCode};
+use crate::task::warning::{ensure_parent_cycle_warning, TaskWarning, TaskWarningCode};
 
 const MAX_PARENT_DEPTH: usize = 20;
 
@@ -196,7 +196,7 @@ impl TaskIndex {
             if !normalized_paths.contains(&task_norm) {
                 continue;
             }
-            push_parent_cycle_warning(task);
+            ensure_parent_cycle_warning(&mut task.warnings);
             task.parent = None;
         }
     }
@@ -1251,21 +1251,6 @@ fn walk_parent_chain_collecting_cycle(
 
         current = parent.clone();
     }
-}
-
-fn push_parent_cycle_warning(task: &mut Task) {
-    let already_exists = task.warnings.iter().any(|warning| {
-        warning.code == TaskWarningCode::ParentCycle && warning.field.as_deref() == Some("parent")
-    });
-    if already_exists {
-        return;
-    }
-
-    task.warnings.push(TaskWarning {
-        code: TaskWarningCode::ParentCycle,
-        field: Some("parent".to_string()),
-        message: "parent chain forms a cycle".to_string(),
-    });
 }
 
 fn push_parent_not_found(task: &mut Task) {

--- a/src-tauri/src/task/task_index_parent_chain_tests.rs
+++ b/src-tauri/src/task/task_index_parent_chain_tests.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use super::{
     resolve_parent_for_new_task, validate_chain_from_parent, validate_parent_existence,
-    validate_parent_hierarchy, ParentHierarchyErrorReason, Task,
+    validate_parent_hierarchy, ParentHierarchyErrorReason, Task, TaskIndex,
 };
 use crate::task::parse::{task_from_markdown, TaskParseContext, TaskParseError};
 use crate::task::warning::{TaskWarning, TaskWarningCode};
@@ -351,6 +351,279 @@ fn validate_chain_from_parent_edge_20_returns_too_deep() {
     assert_eq!(
         validate_chain_from_parent(0, &tasks),
         Err(ParentHierarchyErrorReason::TooDeep),
+    );
+}
+
+fn task_by_path<'a>(tasks: &'a [Task], path: &str) -> &'a Task {
+    tasks
+        .iter()
+        .find(|t| t.file_path.as_str() == path)
+        .unwrap_or_else(|| panic!("expected task at `{path}` in {:?}", tasks))
+}
+
+fn has_parent_cycle_warning(task: &Task) -> bool {
+    task.warnings.iter().any(|warning| {
+        warning.code == TaskWarningCode::ParentCycle && warning.field.as_deref() == Some("parent")
+    })
+}
+
+#[test]
+fn build_children_with_warnings_keeps_parent_when_no_cycle() {
+    let tasks = vec![
+        task_without_parent("tasks/parent.md"),
+        task_with_parent("tasks/child.md", "tasks/parent.md"),
+    ];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("no cycle, no too-deep");
+    let tasks = index.into_tasks();
+
+    let child = task_by_path(&tasks, "tasks/child.md");
+    assert_eq!(child.parent, Some("tasks/parent.md".into()));
+    assert!(!has_parent_cycle_warning(child));
+    let parent = task_by_path(&tasks, "tasks/parent.md");
+    assert!(!has_parent_cycle_warning(parent));
+    // children も build される
+    assert_eq!(
+        parent.children,
+        vec!["tasks/child.md".to_string()],
+        "non-cycle parent should still gain its child"
+    );
+}
+
+#[test]
+fn build_children_with_warnings_keeps_parent_not_found_warning() {
+    let tasks = vec![task_with_parent("tasks/child.md", "tasks/missing.md")];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("missing parent should not error");
+    let tasks = index.into_tasks();
+
+    let child = task_by_path(&tasks, "tasks/child.md");
+    assert!(child.warnings.iter().any(|warning| {
+        warning.code == TaskWarningCode::ParentNotFound
+            && warning.field.as_deref() == Some("parent")
+    }));
+    // parent_not_found のままで parent は保持されている
+    assert_eq!(child.parent, Some("tasks/missing.md".into()));
+    assert!(!has_parent_cycle_warning(child));
+}
+
+#[test]
+fn build_children_with_warnings_marks_self_loop_as_cycle() {
+    let tasks = vec![task_with_parent("tasks/a.md", "tasks/a.md")];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("self loop should warn, not error");
+    let tasks = index.into_tasks();
+
+    let a = task_by_path(&tasks, "tasks/a.md");
+    assert!(has_parent_cycle_warning(a), "self loop must add warning");
+    assert_eq!(a.parent, None, "self loop must clear parent");
+    assert!(
+        a.children.is_empty(),
+        "self loop should not become its own child"
+    );
+}
+
+#[test]
+fn build_children_with_warnings_marks_two_node_cycle() {
+    let tasks = vec![
+        task_with_parent("tasks/a.md", "tasks/b.md"),
+        task_with_parent("tasks/b.md", "tasks/a.md"),
+    ];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("two-node cycle should warn, not error");
+    let tasks = index.into_tasks();
+
+    let a = task_by_path(&tasks, "tasks/a.md");
+    let b = task_by_path(&tasks, "tasks/b.md");
+    assert!(has_parent_cycle_warning(a));
+    assert!(has_parent_cycle_warning(b));
+    assert_eq!(a.parent, None);
+    assert_eq!(b.parent, None);
+    assert!(a.children.is_empty());
+    assert!(b.children.is_empty());
+}
+
+#[test]
+fn build_children_with_warnings_marks_three_node_cycle() {
+    let tasks = vec![
+        task_with_parent("tasks/a.md", "tasks/b.md"),
+        task_with_parent("tasks/b.md", "tasks/c.md"),
+        task_with_parent("tasks/c.md", "tasks/a.md"),
+    ];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("three-node cycle should warn, not error");
+    let tasks = index.into_tasks();
+
+    for path in ["tasks/a.md", "tasks/b.md", "tasks/c.md"] {
+        let task = task_by_path(&tasks, path);
+        assert!(
+            has_parent_cycle_warning(task),
+            "{path} should have parentCycle warning"
+        );
+        assert_eq!(task.parent, None, "{path} should have parent cleared");
+    }
+}
+
+#[test]
+fn build_children_with_warnings_excludes_tail_from_cycle() {
+    // D は A→B→A の cycle に到達する tail。D 自身は cycle の一部ではない。
+    let tasks = vec![
+        task_with_parent("tasks/d.md", "tasks/a.md"),
+        task_with_parent("tasks/a.md", "tasks/b.md"),
+        task_with_parent("tasks/b.md", "tasks/a.md"),
+    ];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("tail cycle should warn, not error");
+    let tasks = index.into_tasks();
+
+    let a = task_by_path(&tasks, "tasks/a.md");
+    let b = task_by_path(&tasks, "tasks/b.md");
+    let d = task_by_path(&tasks, "tasks/d.md");
+    assert!(has_parent_cycle_warning(a));
+    assert!(has_parent_cycle_warning(b));
+    assert!(
+        !has_parent_cycle_warning(d),
+        "D is only a tail and must not be flagged"
+    );
+    assert_eq!(
+        d.parent,
+        Some("tasks/a.md".into()),
+        "D's parent must be kept"
+    );
+}
+
+#[test]
+fn build_children_with_warnings_detects_separator_variation_cycle() {
+    let tasks = vec![
+        task_with_parent("tasks/a.md", ".\\tasks\\b.md"),
+        task_with_parent("tasks/b.md", "./tasks/a.md"),
+    ];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("separator variation cycle should warn, not error");
+    let tasks = index.into_tasks();
+
+    assert!(has_parent_cycle_warning(task_by_path(&tasks, "tasks/a.md")));
+    assert!(has_parent_cycle_warning(task_by_path(&tasks, "tasks/b.md")));
+}
+
+#[test]
+fn build_children_with_warnings_keeps_existing_warning_when_adding_cycle() {
+    // 循環 task に既存 warning (invalidTitleUsedFileName) を併存させたケース。
+    // タイトル `123` は数値として yaml にパースされて invalidTitleUsedFileName warning を生む。
+    let raw_a = "---\ntitle: 123\nstatus: Todo\nparent: tasks/b.md\n---\n";
+    let raw_b = "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n";
+    let tasks = vec![
+        task_from(raw_a, "tasks/a.md"),
+        task_from(raw_b, "tasks/b.md"),
+    ];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("warning + cycle");
+    let tasks = index.into_tasks();
+
+    let a = task_by_path(&tasks, "tasks/a.md");
+    assert!(
+        a.warnings
+            .iter()
+            .any(|w| w.code == TaskWarningCode::InvalidTitleUsedFileName),
+        "pre-existing warning must be preserved"
+    );
+    assert!(has_parent_cycle_warning(a));
+}
+
+#[test]
+fn build_children_with_warnings_does_not_duplicate_cycle_warning() {
+    let mut task_a = task_with_parent("tasks/a.md", "tasks/b.md");
+    task_a.warnings.push(TaskWarning {
+        code: TaskWarningCode::ParentCycle,
+        field: Some("parent".into()),
+        message: "parent chain forms a cycle".to_string(),
+    });
+    let tasks = vec![task_a, task_with_parent("tasks/b.md", "tasks/a.md")];
+
+    let index = TaskIndex::new(tasks)
+        .build_children_with_warnings()
+        .expect("duplicate cycle warning should not error");
+    let tasks = index.into_tasks();
+
+    let a = task_by_path(&tasks, "tasks/a.md");
+    let cycle_count = a
+        .warnings
+        .iter()
+        .filter(|w| w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent"))
+        .count();
+    assert_eq!(cycle_count, 1, "parentCycle warning must not be duplicated");
+}
+
+#[test]
+fn build_children_with_warnings_returns_too_deep_for_depth_over_max() {
+    let result = TaskIndex::new(parent_chain_with_edge_count(21)).build_children_with_warnings();
+
+    assert!(matches!(
+        result,
+        Err(TaskParseError::CycleOrTooDeep {
+            file_path,
+            reason: ParentHierarchyErrorReason::TooDeep,
+        }) if file_path == "tasks/0.md"
+    ));
+}
+
+#[test]
+fn build_children_with_warnings_accepts_max_depth() {
+    let index = TaskIndex::new(parent_chain_with_edge_count(20))
+        .build_children_with_warnings()
+        .expect("depth=20 must be accepted");
+    let tasks = index.into_tasks();
+
+    // 全 task が parent 維持・cycle warning なし
+    for task in &tasks {
+        assert!(
+            !has_parent_cycle_warning(task),
+            "{} should not be cyclic",
+            task.file_path.as_str()
+        );
+    }
+}
+
+#[test]
+fn build_children_with_warnings_prefers_too_deep_over_cycle() {
+    // 深さ上限 (>20) を超えるノード列の最後で root へループバックさせる。
+    // walk 中で depth > MAX_PARENT_DEPTH に先にヒットして TooDeep が返るべき。
+    let mut tasks = Vec::new();
+    for index in 0..22 {
+        tasks.push(task_with_parent(
+            &format!("tasks/{index}.md"),
+            &format!("tasks/{}.md", index + 1),
+        ));
+    }
+    // 最後の task を 0 へループバック
+    tasks.push(task_with_parent("tasks/22.md", "tasks/0.md"));
+
+    let result = TaskIndex::new(tasks).build_children_with_warnings();
+    assert!(
+        matches!(
+            result,
+            Err(TaskParseError::CycleOrTooDeep {
+                reason: ParentHierarchyErrorReason::TooDeep,
+                ..
+            })
+        ),
+        "TooDeep must precede cycle detection when depth limit is reached first: {result:?}"
     );
 }
 

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -13,6 +13,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::task_index::{Task, TaskIndex, UpdateTaskOutcome};
 use crate::task::update::args::UpdateTaskArgs;
 use crate::task::update::error::{UpdateTaskCommandError, UpdateTaskError};
+use crate::task::warning::{TaskWarning, TaskWarningCode};
 
 /// `update_task` Tauri command 薄層。
 #[tauri::command]
@@ -119,14 +120,47 @@ fn commit_cache(
                 }
                 Ok(cache.get(&cache_key).cloned())
             } else {
-                cache.insert(cache_key.clone(), outcome.updated_task.clone());
-                Ok(Some(outcome.updated_task.clone()))
+                // 非 parent 更新では、scan で cycle member とマークされた状態
+                // (parent=None + parentCycle warning) を新しい cache 値でも
+                // 維持する。`outcome.updated_task` は disk の生の `parent:` を
+                // 復活させているため、明示的に override しないとバナーが消える。
+                let was_cycle_member = cache
+                    .get(&cache_key)
+                    .map(|prev| {
+                        prev.warnings.iter().any(|w| {
+                            w.code == TaskWarningCode::ParentCycle
+                                && w.field.as_deref() == Some("parent")
+                        })
+                    })
+                    .unwrap_or(false);
+                let mut next = outcome.updated_task.clone();
+                if was_cycle_member {
+                    next.parent = None;
+                    ensure_parent_cycle_warning(&mut next.warnings);
+                }
+                cache.insert(cache_key.clone(), next.clone());
+                Ok(Some(next))
             }
         })?;
 
     returned?.ok_or(UpdateTaskCommandError::Validation(
         UpdateTaskError::FileNotFound(cache_key),
     ))
+}
+
+/// `warnings` に既に `ParentCycle` (field=`parent`) があれば何もせず、無ければ追加する。
+fn ensure_parent_cycle_warning(warnings: &mut Vec<TaskWarning>) {
+    let already = warnings
+        .iter()
+        .any(|w| w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent"));
+    if already {
+        return;
+    }
+    warnings.push(TaskWarning {
+        code: TaskWarningCode::ParentCycle,
+        field: Some("parent".to_string()),
+        message: "parent chain forms a cycle".to_string(),
+    });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -13,7 +13,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::task_index::{Task, TaskIndex, UpdateTaskOutcome};
 use crate::task::update::args::UpdateTaskArgs;
 use crate::task::update::error::{UpdateTaskCommandError, UpdateTaskError};
-use crate::task::warning::{ensure_parent_cycle_warning, TaskWarningCode};
+use crate::task::warning::{ensure_parent_cycle_warning, has_parent_cycle_warning};
 
 /// `update_task` Tauri command 薄層。
 #[tauri::command]
@@ -126,12 +126,7 @@ fn commit_cache(
                 // 復活させているため、明示的に override しないとバナーが消える。
                 let was_cycle_member = cache
                     .get(&cache_key)
-                    .map(|prev| {
-                        prev.warnings.iter().any(|w| {
-                            w.code == TaskWarningCode::ParentCycle
-                                && w.field.as_deref() == Some("parent")
-                        })
-                    })
+                    .map(|prev| has_parent_cycle_warning(&prev.warnings))
                     .unwrap_or(false);
                 let mut next = outcome.updated_task.clone();
                 if was_cycle_member {

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -13,7 +13,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::task_index::{Task, TaskIndex, UpdateTaskOutcome};
 use crate::task::update::args::UpdateTaskArgs;
 use crate::task::update::error::{UpdateTaskCommandError, UpdateTaskError};
-use crate::task::warning::{TaskWarning, TaskWarningCode};
+use crate::task::warning::{ensure_parent_cycle_warning, TaskWarningCode};
 
 /// `update_task` Tauri command 薄層。
 #[tauri::command]
@@ -146,21 +146,6 @@ fn commit_cache(
     returned?.ok_or(UpdateTaskCommandError::Validation(
         UpdateTaskError::FileNotFound(cache_key),
     ))
-}
-
-/// `warnings` に既に `ParentCycle` (field=`parent`) があれば何もせず、無ければ追加する。
-fn ensure_parent_cycle_warning(warnings: &mut Vec<TaskWarning>) {
-    let already = warnings
-        .iter()
-        .any(|w| w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent"));
-    if already {
-        return;
-    }
-    warnings.push(TaskWarning {
-        code: TaskWarningCode::ParentCycle,
-        field: Some("parent".to_string()),
-        message: "parent chain forms a cycle".to_string(),
-    });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task/update/command_tests.rs
+++ b/src-tauri/src/task/update/command_tests.rs
@@ -681,3 +681,86 @@ fn update_task_registers_write_ignore_and_consumes_on_modified_and_renamed_event
     );
     assert!(state.write_ignore().is_empty().unwrap());
 }
+
+/// scan 経路で循環判定された task のタイトルを更新しても、
+/// 次の cache snapshot で parentCycle warning と parent=None が保持されること。
+#[test]
+fn update_title_on_cycle_task_preserves_parent_cycle_warning() {
+    let dir = tempdir();
+    let root = dir.path();
+    seed_md(
+        root,
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\n",
+    );
+    seed_md(
+        root,
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), root);
+
+    let before = state.tasks_snapshot().unwrap();
+    let before_a = before.iter().find(|t| t.file_path == "tasks/a.md").unwrap();
+    assert!(before_a.parent.is_none());
+    assert!(before_a
+        .warnings
+        .iter()
+        .any(|w| w.code == TaskWarningCode::ParentCycle));
+
+    let mut args = args_for("tasks/a.md");
+    args.title = Some("Renamed".into());
+
+    let updated = update_task_impl(&state, &FsTaskIo, args).expect("update title ok");
+    assert_eq!(updated.title.as_str(), "Renamed");
+    assert!(
+        updated.parent.is_none(),
+        "parent should remain None on cycle task after non-parent update"
+    );
+    assert!(
+        updated
+            .warnings
+            .iter()
+            .any(|w| w.code == TaskWarningCode::ParentCycle),
+        "parentCycle warning must be preserved after non-parent update"
+    );
+
+    let after = state.tasks_snapshot().unwrap();
+    let after_b = after.iter().find(|t| t.file_path == "tasks/b.md").unwrap();
+    assert!(after_b.parent.is_none());
+    assert!(after_b
+        .warnings
+        .iter()
+        .any(|w| w.code == TaskWarningCode::ParentCycle));
+}
+
+#[test]
+fn update_body_on_cycle_task_preserves_parent_cycle_warning() {
+    let dir = tempdir();
+    let root = dir.path();
+    seed_md(
+        root,
+        "tasks/a.md",
+        "---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\nold body\n",
+    );
+    seed_md(
+        root,
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n",
+    );
+
+    let state = Arc::new(AppState::new());
+    open_with_noop(Arc::clone(&state), root);
+
+    let mut args = args_for("tasks/a.md");
+    args.body = Some("new body".into());
+
+    let updated = update_task_impl(&state, &FsTaskIo, args).expect("update body ok");
+    assert!(updated.parent.is_none());
+    assert!(updated
+        .warnings
+        .iter()
+        .any(|w| w.code == TaskWarningCode::ParentCycle));
+}

--- a/src-tauri/src/task/warning.rs
+++ b/src-tauri/src/task/warning.rs
@@ -27,15 +27,21 @@ pub struct TaskWarning {
     pub message: String,
 }
 
+/// `warnings` 配列に `ParentCycle` (field=`parent`) が含まれているかを判定する
+/// 共通 helper。`watcher_event` / `update` / `add_link` / `remove_link` の
+/// 各経路で同じ判定が必要になるため、ここに集約することで条件のズレを防ぐ。
+pub fn has_parent_cycle_warning(warnings: &[TaskWarning]) -> bool {
+    warnings.iter().any(|warning| {
+        warning.code == TaskWarningCode::ParentCycle && warning.field.as_deref() == Some("parent")
+    })
+}
+
 /// `warnings` 配列に `ParentCycle` (field=`parent`) が既存なら何もせず、
 /// 無ければ追加する共通 helper。message / field の文言を 1 箇所に集約することで
 /// scan 経路 (`task_index::mark_cycle_members`) と update 経路
 /// (`task::update::command::commit_cache`) の間で表記揺れが起きないようにする。
 pub fn ensure_parent_cycle_warning(warnings: &mut Vec<TaskWarning>) {
-    let already_exists = warnings.iter().any(|warning| {
-        warning.code == TaskWarningCode::ParentCycle && warning.field.as_deref() == Some("parent")
-    });
-    if already_exists {
+    if has_parent_cycle_warning(warnings) {
         return;
     }
 

--- a/src-tauri/src/task/warning.rs
+++ b/src-tauri/src/task/warning.rs
@@ -27,6 +27,25 @@ pub struct TaskWarning {
     pub message: String,
 }
 
+/// `warnings` 配列に `ParentCycle` (field=`parent`) が既存なら何もせず、
+/// 無ければ追加する共通 helper。message / field の文言を 1 箇所に集約することで
+/// scan 経路 (`task_index::mark_cycle_members`) と update 経路
+/// (`task::update::command::commit_cache`) の間で表記揺れが起きないようにする。
+pub fn ensure_parent_cycle_warning(warnings: &mut Vec<TaskWarning>) {
+    let already_exists = warnings.iter().any(|warning| {
+        warning.code == TaskWarningCode::ParentCycle && warning.field.as_deref() == Some("parent")
+    });
+    if already_exists {
+        return;
+    }
+
+    warnings.push(TaskWarning {
+        code: TaskWarningCode::ParentCycle,
+        field: Some("parent".to_string()),
+        message: "parent chain forms a cycle".to_string(),
+    });
+}
+
 #[cfg(test)]
 #[path = "warning_tests.rs"]
 mod warning_tests;

--- a/src-tauri/src/task/warning.rs
+++ b/src-tauri/src/task/warning.rs
@@ -16,6 +16,7 @@ pub enum TaskWarningCode {
     ParentNotFound,
     NonStringExtraKeyIgnored,
     ExtraValueNotJsonCompatible,
+    ParentCycle,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,3 +26,7 @@ pub struct TaskWarning {
     pub field: Option<String>,
     pub message: String,
 }
+
+#[cfg(test)]
+#[path = "warning_tests.rs"]
+mod warning_tests;

--- a/src-tauri/src/task/warning_tests.rs
+++ b/src-tauri/src/task/warning_tests.rs
@@ -1,4 +1,39 @@
-use super::{TaskWarning, TaskWarningCode};
+use super::{has_parent_cycle_warning, TaskWarning, TaskWarningCode};
+
+#[test]
+fn has_parent_cycle_warning_returns_true_when_code_and_field_match() {
+    let warnings = vec![TaskWarning {
+        code: TaskWarningCode::ParentCycle,
+        field: Some("parent".to_string()),
+        message: "parent chain forms a cycle".to_string(),
+    }];
+    assert!(has_parent_cycle_warning(&warnings));
+}
+
+#[test]
+fn has_parent_cycle_warning_returns_false_when_field_mismatches() {
+    let warnings = vec![TaskWarning {
+        code: TaskWarningCode::ParentCycle,
+        field: Some("links".to_string()),
+        message: "x".to_string(),
+    }];
+    assert!(!has_parent_cycle_warning(&warnings));
+}
+
+#[test]
+fn has_parent_cycle_warning_returns_false_for_other_codes() {
+    let warnings = vec![TaskWarning {
+        code: TaskWarningCode::ParentNotFound,
+        field: Some("parent".to_string()),
+        message: "x".to_string(),
+    }];
+    assert!(!has_parent_cycle_warning(&warnings));
+}
+
+#[test]
+fn has_parent_cycle_warning_returns_false_for_empty_slice() {
+    assert!(!has_parent_cycle_warning(&[]));
+}
 
 #[test]
 fn parent_cycle_code_serializes_to_camel_case_string() {

--- a/src-tauri/src/task/warning_tests.rs
+++ b/src-tauri/src/task/warning_tests.rs
@@ -1,0 +1,27 @@
+use super::{TaskWarning, TaskWarningCode};
+
+#[test]
+fn parent_cycle_code_serializes_to_camel_case_string() {
+    let serialized = serde_json::to_string(&TaskWarningCode::ParentCycle).expect("serialize code");
+    assert_eq!(serialized, "\"parentCycle\"");
+}
+
+#[test]
+fn parent_cycle_code_round_trips_through_serde() {
+    let json = "\"parentCycle\"";
+    let deserialized: TaskWarningCode = serde_json::from_str(json).expect("deserialize code");
+    assert_eq!(deserialized, TaskWarningCode::ParentCycle);
+}
+
+#[test]
+fn parent_cycle_warning_serializes_with_camel_case_field_names() {
+    let warning = TaskWarning {
+        code: TaskWarningCode::ParentCycle,
+        field: Some("parent".to_string()),
+        message: "parent chain forms a cycle".to_string(),
+    };
+    let serialized = serde_json::to_value(&warning).expect("serialize warning");
+    assert_eq!(serialized["code"], "parentCycle");
+    assert_eq!(serialized["field"], "parent");
+    assert_eq!(serialized["message"], "parent chain forms a cycle");
+}

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 
 use crate::task::parse::{normalized_task_file_path, task_from_markdown, TaskParseContext};
 use crate::task::task_file_path::TaskFilePath;
+use crate::task::warning::{ensure_parent_cycle_warning, TaskWarningCode};
 use spec_board_fs::task::file_scanner::task_md_relative_path;
 use spec_board_fs::watcher::core::FsEvent;
 
@@ -179,16 +180,32 @@ fn handle_upsert(
         }
     };
     let cache_key = PathBuf::from(task.file_path.as_str());
-    let event_name = ctx.state.with_tasks_cache_mut(|cache| {
+    let (event_name, emitted_task) = ctx.state.with_tasks_cache_mut(|cache| {
         let event = match mode {
             UpsertMode::Auto if cache.contains_key(&cache_key) => "task-updated",
             UpsertMode::Auto => "task-created",
             UpsertMode::ForceCreated => "task-created",
         };
-        cache.insert(cache_key, task.clone());
-        event
+        // 直前まで cycle member として正規化されていた task は、disk 由来の raw
+        // `parent:` で warning とバナーを失わせないよう、parent=None と
+        // parentCycle warning を引き継ぐ。新規 cycle の検出はフル再 scan に委ねる。
+        let was_cycle_member = cache
+            .get(&cache_key)
+            .map(|prev| {
+                prev.warnings.iter().any(|w| {
+                    w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent")
+                })
+            })
+            .unwrap_or(false);
+        let mut next = task;
+        if was_cycle_member {
+            next.parent = None;
+            ensure_parent_cycle_warning(&mut next.warnings);
+        }
+        cache.insert(cache_key, next.clone());
+        (event, next)
     })?;
-    (ctx.emit)(event_name, json!({ "task": task }));
+    (ctx.emit)(event_name, json!({ "task": emitted_task }));
     Ok(())
 }
 

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -188,7 +188,10 @@ fn handle_upsert(
         };
         // 直前まで cycle member として正規化されていた task は、disk 由来の raw
         // `parent:` で warning とバナーを失わせないよう、parent=None と
-        // parentCycle warning を引き継ぐ。新規 cycle の検出はフル再 scan に委ねる。
+        // parentCycle warning を引き継ぐ。
+        // ただし新しい parsed task の parent が None の場合は、ユーザーが外部編集で
+        // 親参照を消して循環を解消したとみなし、preserve せず disk の状態をそのまま
+        // 反映する。新規 cycle の検出はフル再 scan に委ねる。
         let was_cycle_member = cache
             .get(&cache_key)
             .map(|prev| {
@@ -198,7 +201,7 @@ fn handle_upsert(
             })
             .unwrap_or(false);
         let mut next = task;
-        if was_cycle_member {
+        if was_cycle_member && next.parent.is_some() {
             next.parent = None;
             ensure_parent_cycle_warning(&mut next.warnings);
         }

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -19,7 +19,7 @@ use serde_json::json;
 
 use crate::task::parse::{normalized_task_file_path, task_from_markdown, TaskParseContext};
 use crate::task::task_file_path::TaskFilePath;
-use crate::task::warning::{ensure_parent_cycle_warning, TaskWarningCode};
+use crate::task::warning::{ensure_parent_cycle_warning, has_parent_cycle_warning};
 use spec_board_fs::task::file_scanner::task_md_relative_path;
 use spec_board_fs::watcher::core::FsEvent;
 
@@ -194,11 +194,7 @@ fn handle_upsert(
         // 反映する。新規 cycle の検出はフル再 scan に委ねる。
         let was_cycle_member = cache
             .get(&cache_key)
-            .map(|prev| {
-                prev.warnings.iter().any(|w| {
-                    w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent")
-                })
-            })
+            .map(|prev| has_parent_cycle_warning(&prev.warnings))
             .unwrap_or(false);
         let mut next = task;
         if was_cycle_member && next.parent.is_some() {

--- a/src-tauri/src/watcher_event/tests.rs
+++ b/src-tauri/src/watcher_event/tests.rs
@@ -765,3 +765,68 @@ fn modify_event_for_non_cycle_task_does_not_inject_parent_cycle_warning() {
         "非 cycle task に parentCycle warning が混入してはならない"
     );
 }
+
+#[test]
+fn modify_event_drops_parent_cycle_warning_when_disk_parent_is_removed() {
+    use crate::task::parse::{task_from_markdown, TaskParseContext};
+    use crate::task::warning::{ensure_parent_cycle_warning, TaskWarningCode};
+
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+
+    // 元々 A.md は parent: tasks/b.md で B.md と循環していた。
+    let a_initial = "---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\n\nbody\n";
+    let abs_a = write_md(dir.path(), "tasks/a.md", a_initial);
+    write_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n\nbody\n",
+    );
+
+    let parse_ctx = TaskParseContext {
+        file_path: PathBuf::from("tasks/a.md"),
+        default_status: "Todo".into(),
+    };
+    let mut seeded = task_from_markdown(a_initial.as_bytes(), &parse_ctx).expect("parse seed");
+    seeded.parent = None;
+    ensure_parent_cycle_warning(&mut seeded.warnings);
+    state
+        .with_tasks_cache_mut(|cache| {
+            cache.insert(PathBuf::from("tasks/a.md"), seeded);
+        })
+        .expect("seed cache");
+
+    // ユーザーが外部編集で A.md から parent を除去して循環を解消した。
+    let a_resolved = "---\ntitle: A\nstatus: Todo\n---\n\nresolved body\n";
+    write_md(dir.path(), "tasks/a.md", a_resolved);
+
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Modified(abs_a), &ctx).expect("modify ok");
+
+    let snapshot = state.tasks_snapshot().expect("readable");
+    let a = snapshot
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .expect("A in cache");
+
+    assert!(
+        a.parent.is_none(),
+        "disk 側で parent を消した結果がそのまま反映される"
+    );
+    assert!(
+        !a.warnings
+            .iter()
+            .any(|w| w.code == TaskWarningCode::ParentCycle),
+        "disk 側で parent が消えた以上、parentCycle warning は維持しない"
+    );
+
+    let emitted = &entries(&log)[0].1["task"];
+    assert!(
+        emitted.get("parent").is_none_or(|v| v.is_null()),
+        "emit payload も parent=None を反映する"
+    );
+}
+
+fn entries(log: &EmitLog) -> Vec<(String, Value)> {
+    log.lock().unwrap().clone()
+}

--- a/src-tauri/src/watcher_event/tests.rs
+++ b/src-tauri/src/watcher_event/tests.rs
@@ -803,6 +803,10 @@ fn modify_event_drops_parent_cycle_warning_when_disk_parent_is_removed() {
     let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
     handle_event(&FsEvent::Modified(abs_a), &ctx).expect("modify ok");
 
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len(), "one emit expected");
+    assert_eq!("task-updated", entries[0].0);
+
     let snapshot = state.tasks_snapshot().expect("readable");
     let a = snapshot
         .iter()
@@ -820,13 +824,9 @@ fn modify_event_drops_parent_cycle_warning_when_disk_parent_is_removed() {
         "disk 側で parent が消えた以上、parentCycle warning は維持しない"
     );
 
-    let emitted = &entries(&log)[0].1["task"];
+    let emitted = &entries[0].1["task"];
     assert!(
         emitted.get("parent").is_none_or(|v| v.is_null()),
         "emit payload も parent=None を反映する"
     );
-}
-
-fn entries(log: &EmitLog) -> Vec<(String, Value)> {
-    log.lock().unwrap().clone()
 }

--- a/src-tauri/src/watcher_event/tests.rs
+++ b/src-tauri/src/watcher_event/tests.rs
@@ -673,3 +673,95 @@ fn adapter_thread_with_panicking_emit_does_not_crash_test_thread() {
     let panicked = join.join().expect("thread should not abort the process");
     assert!(panicked, "emit panic should be caught by catch_unwind");
 }
+
+#[test]
+fn modify_event_preserves_parent_cycle_warning_and_parent_none() {
+    use crate::task::parse::{task_from_markdown, TaskParseContext};
+    use crate::task::warning::{ensure_parent_cycle_warning, TaskWarningCode};
+
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+
+    // disk 上は A.md / B.md が相互参照する循環構成。
+    let a_body = "---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\n\nbody\n";
+    let abs_a = write_md(dir.path(), "tasks/a.md", a_body);
+    write_md(
+        dir.path(),
+        "tasks/b.md",
+        "---\ntitle: B\nstatus: Todo\nparent: tasks/a.md\n---\n\nbody\n",
+    );
+
+    // scan 経路（build_children_with_warnings）通過後の状態を cache に直接セット:
+    // A は cycle member として parent=None + parentCycle warning を持つ。
+    let parse_ctx = TaskParseContext {
+        file_path: PathBuf::from("tasks/a.md"),
+        default_status: "Todo".into(),
+    };
+    let mut seeded = task_from_markdown(a_body.as_bytes(), &parse_ctx).expect("parse seed");
+    seeded.parent = None;
+    ensure_parent_cycle_warning(&mut seeded.warnings);
+    state
+        .with_tasks_cache_mut(|cache| {
+            cache.insert(PathBuf::from("tasks/a.md"), seeded);
+        })
+        .expect("seed cache");
+
+    // 外部編集で A.md の本文を更新したものとする（parent は disk 上もそのまま）。
+    let updated_body = "---\ntitle: A\nstatus: Todo\nparent: tasks/b.md\n---\n\nupdated body\n";
+    write_md(dir.path(), "tasks/a.md", updated_body);
+
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Modified(abs_a), &ctx).expect("modify ok");
+
+    let entries = drain_log(&log);
+    assert_eq!(1, entries.len(), "one emit expected");
+    assert_eq!("task-updated", entries[0].0);
+
+    let snapshot = state.tasks_snapshot().expect("readable");
+    let a = snapshot
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .expect("A in cache");
+
+    assert!(
+        a.parent.is_none(),
+        "cycle member の parent は None のまま保持される（disk の raw parent で復活させない）"
+    );
+    assert!(
+        a.warnings.iter().any(|w| w.code == TaskWarningCode::ParentCycle
+            && w.field.as_deref() == Some("parent")),
+        "cycle member の parentCycle warning は preserve される"
+    );
+
+    let emitted = &entries[0].1["task"];
+    assert!(
+        emitted.get("parent").map_or(true, |v| v.is_null()),
+        "emit payload も parent=None を反映する"
+    );
+}
+
+#[test]
+fn modify_event_for_non_cycle_task_does_not_inject_parent_cycle_warning() {
+    let dir = TempDir::new().expect("tempdir");
+    let state = Arc::new(AppState::new());
+
+    let abs = write_md(dir.path(), "tasks/a.md", &task_md("A"));
+    let (ctx, log) = build_ctx(dir.path().to_path_buf(), Arc::clone(&state));
+    handle_event(&FsEvent::Created(abs.clone()), &ctx).expect("seed create");
+    drain_log(&log);
+
+    write_md(dir.path(), "tasks/a.md", &task_md("A2"));
+    handle_event(&FsEvent::Modified(abs), &ctx).expect("modify ok");
+
+    let snapshot = state.tasks_snapshot().expect("readable");
+    let a = snapshot
+        .iter()
+        .find(|t| t.file_path.as_str() == "tasks/a.md")
+        .expect("A in cache");
+    assert!(
+        !a.warnings
+            .iter()
+            .any(|w| w.code == crate::task::warning::TaskWarningCode::ParentCycle),
+        "非 cycle task に parentCycle warning が混入してはならない"
+    );
+}

--- a/src-tauri/src/watcher_event/tests.rs
+++ b/src-tauri/src/watcher_event/tests.rs
@@ -735,7 +735,7 @@ fn modify_event_preserves_parent_cycle_warning_and_parent_none() {
 
     let emitted = &entries[0].1["task"];
     assert!(
-        emitted.get("parent").map_or(true, |v| v.is_null()),
+        emitted.get("parent").is_none_or(|v| v.is_null()),
         "emit payload も parent=None を反映する"
     );
 }

--- a/src/features/detail/components/CycleWarningBanner/__tests__/CycleWarningBanner.rendering.test.tsx
+++ b/src/features/detail/components/CycleWarningBanner/__tests__/CycleWarningBanner.rendering.test.tsx
@@ -1,0 +1,95 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test } from "vitest";
+import { Task, type TaskPayload, type TaskWarning } from "@/types/task";
+import { CycleWarningBanner } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+/**
+ * テスト用の Task を生成するファクトリ。
+ * @param warnings - 注入する warnings 配列
+ * @returns Task
+ */
+const makeTask = (warnings: TaskWarning[]): Task => {
+  const payload: TaskPayload = {
+    id: "task-1",
+    title: "サンプル",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/sample.md",
+    extras: {},
+    warnings,
+  };
+  return Task.fromPayload(payload);
+};
+
+/**
+ * CycleWarningBanner をレンダリングするヘルパー。
+ * @param task - 注入する Task
+ */
+const render = (task: Task) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(CycleWarningBanner, { task }));
+  });
+};
+
+const cycleWarning: TaskWarning = {
+  code: "parentCycle",
+  field: "parent",
+  message: "parent chain forms a cycle",
+};
+
+const parentNotFoundWarning: TaskWarning = {
+  code: "parentNotFound",
+  field: "parent",
+  message: "parent task was not found",
+};
+
+test("parentCycle warning を持つとき role=alert 要素が描画される", () => {
+  render(makeTask([cycleWarning]));
+  const banner = container?.querySelector('[role="alert"]');
+  expect(banner).not.toBeNull();
+  expect(banner?.getAttribute("data-testid")).toBe("cycle-warning-banner");
+});
+
+test("バナーのメッセージに『親タスクが循環しています』が含まれる", () => {
+  render(makeTask([cycleWarning]));
+  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  expect(banner?.textContent).toContain("親タスクが循環しています");
+});
+
+test("warnings が空のとき何もレンダーされない", () => {
+  render(makeTask([]));
+  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  expect(banner).toBeNull();
+});
+
+test("parentNotFound のみのとき、バナーは表示されない", () => {
+  render(makeTask([parentNotFoundWarning]));
+  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  expect(banner).toBeNull();
+});
+
+test("parentCycle と parentNotFound が併存していてもバナーが表示される", () => {
+  render(makeTask([cycleWarning, parentNotFoundWarning]));
+  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  expect(banner).not.toBeNull();
+});

--- a/src/features/detail/components/CycleWarningBanner/__tests__/CycleWarningBanner.rendering.test.tsx
+++ b/src/features/detail/components/CycleWarningBanner/__tests__/CycleWarningBanner.rendering.test.tsx
@@ -72,24 +72,32 @@ test("parentCycle warning を持つとき role=alert 要素が描画される", 
 
 test("バナーのメッセージに『親タスクが循環しています』が含まれる", () => {
   render(makeTask([cycleWarning]));
-  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  const banner = container?.querySelector(
+    '[data-testid="cycle-warning-banner"]',
+  );
   expect(banner?.textContent).toContain("親タスクが循環しています");
 });
 
 test("warnings が空のとき何もレンダーされない", () => {
   render(makeTask([]));
-  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  const banner = container?.querySelector(
+    '[data-testid="cycle-warning-banner"]',
+  );
   expect(banner).toBeNull();
 });
 
 test("parentNotFound のみのとき、バナーは表示されない", () => {
   render(makeTask([parentNotFoundWarning]));
-  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  const banner = container?.querySelector(
+    '[data-testid="cycle-warning-banner"]',
+  );
   expect(banner).toBeNull();
 });
 
 test("parentCycle と parentNotFound が併存していてもバナーが表示される", () => {
   render(makeTask([cycleWarning, parentNotFoundWarning]));
-  const banner = container?.querySelector('[data-testid="cycle-warning-banner"]');
+  const banner = container?.querySelector(
+    '[data-testid="cycle-warning-banner"]',
+  );
   expect(banner).not.toBeNull();
 });

--- a/src/features/detail/components/CycleWarningBanner/index.stories.tsx
+++ b/src/features/detail/components/CycleWarningBanner/index.stories.tsx
@@ -1,0 +1,67 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Task, type TaskPayload } from "@/types/task";
+import { CycleWarningBanner } from ".";
+
+const basePayload: TaskPayload = {
+  id: "task-1",
+  title: "サンプル",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/sample.md",
+  extras: {},
+  warnings: [],
+};
+
+const meta: Meta<typeof CycleWarningBanner> = {
+  title: "features/detail/CycleWarningBanner",
+  component: CycleWarningBanner,
+};
+export default meta;
+
+type Story = StoryObj<typeof CycleWarningBanner>;
+
+export const Default: Story = {
+  args: {
+    task: Task.fromPayload({
+      ...basePayload,
+      warnings: [
+        {
+          code: "parentCycle",
+          field: "parent",
+          message: "parent chain forms a cycle",
+        },
+      ],
+    }),
+  },
+};
+
+export const NoWarning: Story = {
+  args: {
+    task: Task.fromPayload(basePayload),
+  },
+};
+
+export const MultipleWarnings: Story = {
+  args: {
+    task: Task.fromPayload({
+      ...basePayload,
+      warnings: [
+        {
+          code: "parentCycle",
+          field: "parent",
+          message: "parent chain forms a cycle",
+        },
+        {
+          code: "parentNotFound",
+          field: "parent",
+          message: "parent task was not found",
+        },
+      ],
+    }),
+  },
+};

--- a/src/features/detail/components/CycleWarningBanner/index.tsx
+++ b/src/features/detail/components/CycleWarningBanner/index.tsx
@@ -1,0 +1,35 @@
+import type { Task } from "@/types/task";
+
+/** CycleWarningBanner の Props */
+export type CycleWarningBannerProps = {
+  /** 表示対象タスク */
+  task: Task;
+};
+
+/**
+ * DetailPanel ヘッダー直下に表示する循環警告バナー。
+ * `task.warnings` に `parentCycle` を含むときのみ描画し、ユーザーに
+ * 親タスクの循環を通知する。dismiss 不可で `role="alert"` を持つ。
+ *
+ * @param props - {@link CycleWarningBannerProps}
+ * @returns 循環警告バナー要素、または `null`
+ */
+export const CycleWarningBanner = (props: CycleWarningBannerProps) => {
+  const { task } = props;
+  const hasCycle = task.warnings.some((w) => w.code === "parentCycle");
+  if (!hasCycle) {
+    return null;
+  }
+  return (
+    <div
+      role="alert"
+      data-testid="cycle-warning-banner"
+      className="flex items-start gap-2 rounded-md border border-yellow-300 bg-yellow-50 px-3 py-2 text-sm text-yellow-800"
+    >
+      <span aria-hidden="true">⚠</span>
+      <span>
+        親タスクが循環しています。<code>parent:</code> を見直してください。
+      </span>
+    </div>
+  );
+};

--- a/src/features/detail/components/DetailPanel/__tests__/DetailPanel.cycleWarning.test.tsx
+++ b/src/features/detail/components/DetailPanel/__tests__/DetailPanel.cycleWarning.test.tsx
@@ -1,0 +1,100 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { Task, type TaskPayload, type TaskWarning } from "@/types/task";
+import { DetailPanel } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+const testColumns = [
+  { name: "Todo", order: 0 },
+  { name: "In Progress", order: 1 },
+  { name: "Done", order: 2 },
+];
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+/**
+ * テスト用タスクを生成する
+ * @param warnings - 注入する warnings 配列
+ * @returns テスト用タスク
+ */
+function createTaskWithWarnings(warnings: TaskWarning[]): Task {
+  const payload: TaskPayload = {
+    id: "task-1",
+    title: "テストタスク",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "本文",
+    filePath: "tasks/test.md",
+    extras: {},
+    warnings,
+  };
+  return Task.fromPayload(payload);
+}
+
+/**
+ * DetailPanel をレンダリングするヘルパー
+ * @param task - 渡すタスク
+ */
+function render(task: Task) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      createElement(DetailPanel, {
+        task,
+        columns: testColumns,
+        onClose: vi.fn(),
+        onTaskUpdate: vi.fn(),
+        onDelete: vi.fn(),
+      }),
+    );
+  });
+}
+
+const cycleWarning: TaskWarning = {
+  code: "parentCycle",
+  field: "parent",
+  message: "parent chain forms a cycle",
+};
+
+test("parentCycle warning を持つタスクの DetailPanel に role=alert バナーが表示される", () => {
+  render(createTaskWithWarnings([cycleWarning]));
+  const banner = document.querySelector(
+    '[data-testid="cycle-warning-banner"][role="alert"]',
+  );
+  expect(banner).not.toBeNull();
+});
+
+test("warning が無いタスクでは循環バナーが表示されない", () => {
+  render(createTaskWithWarnings([]));
+  const banner = document.querySelector('[data-testid="cycle-warning-banner"]');
+  expect(banner).toBeNull();
+});
+
+test("循環バナーはタスクタイトル入力より DOM 上で前に出る", () => {
+  render(createTaskWithWarnings([cycleWarning]));
+  const banner = document.querySelector(
+    '[data-testid="cycle-warning-banner"]',
+  );
+  const titleInput = document.querySelector(
+    '[aria-label="タスクタイトル"]',
+  );
+  expect(banner).not.toBeNull();
+  expect(titleInput).not.toBeNull();
+  const relation = banner?.compareDocumentPosition(titleInput as Node) ?? 0;
+  expect(relation & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+});

--- a/src/features/detail/components/DetailPanel/__tests__/DetailPanel.cycleWarning.test.tsx
+++ b/src/features/detail/components/DetailPanel/__tests__/DetailPanel.cycleWarning.test.tsx
@@ -87,12 +87,8 @@ test("warning が無いタスクでは循環バナーが表示されない", () 
 
 test("循環バナーはタスクタイトル入力より DOM 上で前に出る", () => {
   render(createTaskWithWarnings([cycleWarning]));
-  const banner = document.querySelector(
-    '[data-testid="cycle-warning-banner"]',
-  );
-  const titleInput = document.querySelector(
-    '[aria-label="タスクタイトル"]',
-  );
+  const banner = document.querySelector('[data-testid="cycle-warning-banner"]');
+  const titleInput = document.querySelector('[aria-label="タスクタイトル"]');
   expect(banner).not.toBeNull();
   expect(titleInput).not.toBeNull();
   const relation = banner?.compareDocumentPosition(titleInput as Node) ?? 0;

--- a/src/features/detail/components/DetailPanel/index.tsx
+++ b/src/features/detail/components/DetailPanel/index.tsx
@@ -12,6 +12,7 @@ import type { Column } from "@/types/column";
 import type { Task } from "@/types/task";
 import type { Result } from "@/utils/result";
 import { Result as ResultDomain } from "@/utils/result";
+import { CycleWarningBanner } from "../CycleWarningBanner";
 import { LabelEditor } from "../LabelEditor";
 import { LinksSection } from "../LinksSection";
 import { MarkdownBody } from "../MarkdownBody";
@@ -198,6 +199,7 @@ export const DetailPanel = ({
       >
         <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
           <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <CycleWarningBanner task={task} />
             {parentTask && onSelectTask && (
               <ParentLink parentTask={parentTask} onSelect={onSelectTask} />
             )}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -23,7 +23,8 @@ export type TaskWarningCode =
   | "invalidParentIgnored"
   | "parentNotFound"
   | "nonStringExtraKeyIgnored"
-  | "extraValueNotJsonCompatible";
+  | "extraValueNotJsonCompatible"
+  | "parentCycle";
 
 /** Task 生成時に継続可能な問題として返る warning。 */
 export type TaskWarning = {


### PR DESCRIPTION
## 概要

- BE: scan 経路 (`open_project`) の親チェーン循環検出を Err から warning 化へ切替。`TaskIndex::build_children_with_warnings` を新設し、循環ループに含まれる全 task に `parentCycle` warning + `parent=None` を付与して scan 全体を継続させる。create / update / add_link / remove_link の各経路では従来通り Err を返し、cycle 状態 (parent=None + parentCycle warning) も cache 上で保持する。
- FE: `TaskWarningCode` に `"parentCycle"` を追加し、`CycleWarningBanner` (role="alert") を新設して `DetailPanel` ヘッダー直下に常時表示。`task.warnings` に `parentCycle` が含まれるときのみ render し、dismiss 不可。
- 仕様: `docs/spec-board/task-format-spec.md` の PL-008 と `#### parent` セクションを scan / create / update 経路別に書き分け、warning code 表に `parentCycle` を追加。

## 変更の種類

- ✨ 新機能

## 追加した内容

- BE: `TaskWarningCode::ParentCycle` バリアント + serde round-trip テスト (`src-tauri/src/task/warning_tests.rs`)
- BE: `TaskIndex::build_children_with_warnings` aggregate method + 関連 helper (`walk_parent_chain_collecting_cycle` / `mark_cycle_members` / `push_parent_cycle_warning` / `build_children_links_only`)
- BE: `task_index_parent_chain_tests.rs` に `build_children_with_warnings_*` テスト 12 件追加
- BE: `update/command.rs` の `ensure_parent_cycle_warning` helper + 非 parent 更新で cycle 状態を維持するロジック
- BE: 各経路の cycle 状態保持テスト (update title / update body / add_link / remove_link)
- FE: `CycleWarningBanner` コンポーネント + 5 テスト + Storybook 3 ストーリー
- FE: `DetailPanel.cycleWarning.test.tsx` 統合テスト 3 件

## 変更した内容

- BE: `project/open.rs` の `open_project_impl` を `.build_children()` → `.build_children_with_warnings()` に切替
- BE: `open_tests.rs` の既存 `parent_cycle_returns_scan_failed_with_io_marker` を `parent_cycle_returns_scan_success_with_warnings` に書き換え（scan 成功 + warnings 検証）
- BE: `task::add_link/command.rs` と `task::remove_link/command.rs` の `commit_cache` で `parent` も preserve するように修正（scan で `parent=None` 化された循環 task に link 操作しても cycle 状態が崩れない）
- BE: `update/command.rs` の非 parent 更新分岐で、既存 cache が cycle member の場合 `parent=None` + `parentCycle` warning を維持する
- FE: `DetailPanel` ヘッダー領域に `<CycleWarningBanner task={task} />` を `<ParentLink>` の上に挿入
- FE: `TaskWarningCode` 末尾に `"parentCycle"` を追加（既存 8 variant 全保持）

## 仕様ドキュメント更新

- `docs/spec-board/task-format-spec.md`
  - `PL-008` を scan 経路 warning 化 + create/update 経路 Err 維持に書き換え
  - `#### parent` セクションも scan / create / update の経路別に書き分け
  - Task 変換時 warning code 表に `parentCycle` (field: `parent`、message: `parent chain forms a cycle`) を追加

## システム図

```mermaid
flowchart TD
    A[open_project スタート] --> B[scan .md files]
    B --> C[TaskIndex::new]
    C --> D["TaskIndex::build_children_with_warnings<br/>[NEW] scan 経路専用 aggregate method"]
    D --> E{各 task の<br/>parent chain を walk}
    E -->|正常| F[OK]
    E -->|循環検出| G["[NEW] mark_cycle_members:<br/>ループ全 task に parentCycle warning<br/>+ parent = None"]
    E -->|深さ 21 以上| H[Err: CycleOrTooDeep TooDeep]
    F --> I[build_children_links_only]
    G --> I
    I --> J[build_reverse_links]
    J --> K[AppState commit]
    K --> L["IPC: TaskPayload[]<br/>warnings 含む"]
    L --> M["FE: DetailPanel"]
    M --> N{warnings に<br/>parentCycle あり?}
    N -->|あり| O["[NEW] CycleWarningBanner<br/>role=alert 常時表示"]
    N -->|なし| P[バナー非表示]

    style D fill:#fef3c7,stroke:#f59e0b
    style G fill:#fef3c7,stroke:#f59e0b
    style O fill:#fef3c7,stroke:#f59e0b
```

## 関連Issue

Closes #144

## テスト

### 自動テスト

- BE: `cargo test --lib` → **691 passed**（既存 cycle Err テストも維持しつつ、新規 `build_children_with_warnings_*` 12 件を追加）
- FE: `pnpm test:run` → **1177 passed**（147 ファイル）
- ビルド: `pnpm build` → OK（TypeScript ビルド + Vite ビルド）
- 静的解析: `cargo clippy -- -D warnings` / `cargo fmt --check` → OK

### AI レビュー（Codex CLI）

- review-001: `docs/spec-board/task-format-spec.md:82` の `#### parent` 表記が `PL-008` と矛盾していると指摘 → 経路別に書き分けるように修正
- review-002: **問題なし**

### 手動検証 (TODO: マージ前にユーザー側で確認)

- [ ] `tasks/` 配下に A.md (`parent: tasks/b.md`) / B.md (`parent: tasks/a.md`) を作成 → `pnpm tauri dev` で起動
- [ ] Board に A・B が表示され scan 失敗しないこと
- [ ] A をクリック → DetailPanel ヘッダー直下に「親タスクが循環しています…」バナーが ⚠ 付きで表示されること
- [ ] B でも同様にバナーが表示されること
- [ ] 循環外の task ではバナーが表示されないこと
- [ ] A.md の `parent:` を削除して保存 → 数秒後（watcher 再 scan）に A・B のバナーが自動で消えること
- [ ] スクリーンリーダーで `role="alert"` がアナウンスされること

## レビューポイント

- **循環検出アルゴリズム** (`task_index.rs:walk_parent_chain_collecting_cycle`): traversal stack `Vec<String>` + position `HashMap<String, usize>` で実装。再出現した path の `position[path]` 以降を cycle member として返すので、tail 付き循環 `D→A→B→A` でも `D` を巻き込まず `A`・`B` のみが warning 対象になる。
- **TooDeep と Cycle の優先順位**: walk のループは既存 `validate_parent_chain` と完全に同じ判定順 (cycle 判定 → parent lookup → 終端判定 → depth++ → 上限判定 → 進む) を採用し、深さ境界の挙動が保たれる。21 ノード超の cycle (`D0→...→D21→D1`) は cycle 検出より TooDeep が先行する（テスト `build_children_with_warnings_prefers_too_deep_over_cycle` で確認）。
- **scan 経路と create/update 経路の分離**: 既存 `build_children` (free function) / `validate_parent_hierarchy` は変更せず create / update 経路が引き続き利用する。scan 経路のみ新 method を経由するため、既存 `task_index_plan_update_tests.rs` の `ParentCycleOrTooDeep` 系テストはそのまま維持。
- **cycle 状態の永続化**: `update_task` の非 parent 更新、`add_link`、`remove_link` で `parent=None` と `parentCycle` warning が cache 上で消えないよう、各 command で明示的に保持する処理を追加した。各 command に 1 件以上の cycle 維持テストを追加済み。
- **規約準拠**: aggregate method 中心の 2 段構成 (`TaskIndex::build_children_with_warnings` + `open_project_impl`) で実装、free function 3 段分離はしていない。コードコメントに spec ID (`PL-XXX`) を含まず、`if (cond) return;` の inline return も無し。

## チェックリスト

- [x] セルフレビューを実施した
- [x] pnpm test:run が通る
- [x] pnpm build が通る
- [x] cargo test / cargo clippy / cargo fmt --check が通る
- [x] 仕様変更があるため `docs/spec-board/task-format-spec.md` を更新した
- [x] feature 間の依存は `index.ts` の公開 API 経由
- [x] 関連 Issue を PR にリンクした (Closes #144)
- [ ] UI 変更があるため Tauri アプリで実機動作確認（マージ前にユーザー側で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)