### PR TITLE
✨ [New Feature]: #146 [FE] 書き込み失敗トーストを invokeWrapped に一元化

### DIFF
--- a/docs/spec-board/board-view-spec.md
+++ b/docs/spec-board/board-view-spec.md
@@ -99,8 +99,17 @@ stateDiagram-v2
 |:------------|:---------|:---------|:----------------|
 | ディレクトリ読み込み失敗 | 指定ディレクトリが存在しない、またはアクセス権限がない | トースト通知 | 別のディレクトリを選択 |
 | mdファイルパースエラー | フロントマターの形式が不正 | トースト通知 + 該当カードにエラーアイコン表示 | mdファイルを手動修正 |
-| ファイル書き込み失敗 | ディスク容量不足、権限エラー | トースト通知 | ファイルシステムの状態を確認 |
+| ファイル書き込み失敗 | ディスク容量不足、権限エラー | トースト通知（書き込み系コマンドは下記の一元化対象） | ファイルシステムの状態を確認 |
 | リンク切れ (プロジェクトロード時) | 開いたプロジェクトに `parent` / `links` / `children` / `reverseLinks` のいずれかが解決できないタスクが N >= 1 件含まれる | プロジェクトロード時 (state.kind が `"loaded"` に遷移したとき) に warning Toast「リンク切れが N 件あります」を 1 回表示。同一 `loadedPath` 内では再発火しない（別 project に切替後、N >= 1 なら再度 1 回発火する） | 詳細パネルで該当 path を確認し、リンクを削除するか参照先ファイルを作成。詳細は [task-card-spec.md](./task-card-spec.md) の「エラー表示」セクション参照 |
+
+### 書き込み失敗トーストの一元化
+
+書き込み（ミューテーション）系コマンドの失敗トーストは、各ハンドラではなく IPC ラッパ層（`invokeWrapped`）に集約して発火する。これにより失敗通知の source of truth を一本化し、握り潰し・通知の不統一・二重通知を防ぐ。
+
+- **共通トースト対象（allowlist）**: `create_task` / `update_task` / `delete_task` / `add_link` / `remove_link` / `update_columns` の失敗。`invokeWrapped` が「&lt;操作&gt;に失敗しました: &lt;詳細&gt;」を 1 件発火する。操作ラベルはコマンド単位で決まる（例: `update_columns` 由来はカラムの追加 / 改名 / 削除 / 並び替えのいずれでも「カラムの更新に失敗しました」に統一される）。`HAS_CHILDREN` 詳細は「子タスクが存在するため削除できません」に翻訳する。
+- **App 側の重複抑止**: App 各ハンドラは、失敗が allowlist 由来（= `invokeWrapped` が通知済み）のときだけ自前の失敗トーストを抑止する。判定は起点コマンド名を保持する `TauriError.command` に基づく。
+- **サイレント化させないもの（App 側が従来どおり通知）**: allowlist 外の tauri 失敗（`open_project` / 同一カラム `update_card_order` / `update_columns` 前段の `get_columns` refresh 失敗）と非 tauri 失敗（`invalid-state` / カラム domain validation）。
+- **成功トースト・partial-move 専用文・LiveRegion アナウンス**は本一元化の影響を受けず従来どおり表示する。`update_card_order` は意図的に allowlist 外とし、partial-move 区別を保つ。
 
 ## アクセシビリティ
 
@@ -140,7 +149,7 @@ stateDiagram-v2
 
 - ESC キー押下: ブラウザが `dragend` を発火し、自動で IDLE 状態へ復帰
 - Drag 直後の synthetic click: `dragGuardRef` で次の macrotask まで `onClick` を抑止し、誤って詳細パネルが開かないようにする
-- IPC 失敗（generic）: `update_task` 失敗 / 同一カラム内の `update_card_order` 失敗時は「タスクの移動に失敗しました: &lt;原因&gt;」トーストを表示。dragState は finally で必ず null に戻す
+- IPC 失敗（generic）: カラム間移動の `update_task` 失敗時は書き込み失敗通知の一元化により「タスクの更新に失敗しました: &lt;原因&gt;」トーストを表示する（`update_task` は共通トースト対象コマンドのため `invokeWrapped` 層が発火し、App 側の汎用「タスクの移動に失敗しました」は二重通知回避のため抑止される）。同一カラム内の `update_card_order` 失敗は共通トースト対象外のため、従来どおり App 側が「タスクの移動に失敗しました: &lt;原因&gt;」を表示する。dragState は finally で必ず null に戻す
 - IPC 部分失敗（partial-move）: カラム間移動で `update_task` 成功 + `update_card_order` 失敗のときは、カラム移動だけは完了しているため「カラムの移動は完了しましたが、並び順の保存に失敗しました。手動で並び替えてください。」と区別して表示する
 - stale state: queue 実行時に対象タスクが見つからない / `fromColumn` と `status` が乖離 / `toColumn` が消滅した場合は `invalid-state` で抜ける
 
@@ -151,7 +160,7 @@ stateDiagram-v2
 | イベント | LiveRegion アナウンス | エラー toast |
 |:--|:--|:--|
 | カラム間移動成功 | 「『タイトル』を『toColumn』に移動しました」 | なし |
-| カラム間移動失敗（`updateTask` reject、フル rollback 後） | 「『タイトル』を『toColumn』に移動しました」→「『タイトル』の移動を取り消しました」 | 「タスクの移動に失敗しました: ...」 |
+| カラム間移動失敗（`updateTask` reject、フル rollback 後） | 「『タイトル』を『toColumn』に移動しました」→「『タイトル』の移動を取り消しました」 | 「タスクの更新に失敗しました: ...」（`update_task` 共通トーストを `invokeWrapped` 層が発火。App 汎用「移動に失敗」は抑止） |
 | partial-move（status 確定 + cardOrder のみ補正） | 「『タイトル』を『toColumn』に移動しました」のみ（status は永続化済みのため取消アナウンスは流さない） | partial-move 用エラー toast |
 | 同一カラム並び替え（成功 / 失敗いずれも） | なし（`onOptimisticApplied` はカラム間 status 変更時のみ呼ぶ契約） | 失敗時のみ「タスクの移動に失敗しました: ...」 |
 | 楽観 dispatch 前 invalid-state（preflight 失敗: target 消失 / status 乖離 / toColumn 消失 / 開始前 version 切替） | なし（楽観 dispatch も `onOptimisticApplied` も発火しない） | `invalid-state` メッセージ |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,16 +8,19 @@ import {
 import { selectTaskOutcome } from "@/domains/task-selection";
 import { useToasts } from "@/hooks/useToasts";
 import type { OrphanStrategy } from "@/lib/tauri";
+import { registerToastSink } from "@/lib/tauri/toastSink";
 import {
   Board,
   EmptyState,
   HeaderBar,
   type MoveTaskParams,
   PROJECT_SWITCHED_MESSAGE,
+  type ProjectError,
   type ProjectState,
   projectErrorMessage,
   type ReorderColumnsEvent,
   useProject,
+  wasNotifiedByInvokeWrapped,
 } from "./features/board";
 import { DetailPanel } from "./features/detail";
 import {
@@ -95,10 +98,34 @@ export const App = () => {
     removeLink,
   } = useProject({
     onError: (err) => {
+      // invokeWrapped が既に通知済み（allowlist 由来 tauri）なら二重通知を避ける。
+      // allowlist 外 tauri（open_project / get_columns refresh / update_card_order 同一カラム）
+      // と非 tauri（invalid-state / validation）は invokeWrapped が出さないのでここで通知する。
+      if (wasNotifiedByInvokeWrapped(err)) {
+        return;
+      }
       showToast(projectErrorMessage(err), "error");
     },
   });
   const { submit: submitCreateTask } = useTaskCreate({ createTask });
+
+  // invokeWrapped 層の失敗トーストを App の showToast へ橋渡しする。
+  // React 19 strict-mode の二重マウント / showToast 再生成に追従するため依存配列に
+  // showToast を入れ、register が返す cleanup で必ず解除する。cleanup は「自分が登録した
+  // sink のときだけ」解除するため、再マウント順序の入れ替わりで新しい sink を誤って消さない。
+  useEffect(() => registerToastSink(showToast), [showToast]);
+
+  // 書き込み失敗の error トーストを出す共通ガード。allowlist 由来失敗は invokeWrapped が
+  // 既に通知済みのため抑止し、allowlist 外 tauri / 非 tauri 失敗だけ App 側で出す
+  // （サイレント化防止）。成功トースト・partial-move 専用文・announce・throw は各ハンドラ側に残す。
+  const showErrorUnlessNotified = useCallback(
+    (error: ProjectError, message: string): void => {
+      if (!wasNotifiedByInvokeWrapped(error)) {
+        showToast(message, "error");
+      }
+    },
+    [showToast],
+  );
 
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   // 削除楽観 dispatch 中に tasks から消えた target を一時保持する snapshot。
@@ -252,15 +279,15 @@ export const App = () => {
       // filePath は lookup key なので spread 順序を後置にして上書き防止
       const result = await updateTask({ ...updates, filePath });
       if (!result.ok) {
-        showToast(
+        showErrorUnlessNotified(
+          result.error,
           `タスクの更新に失敗しました: ${projectErrorMessage(result.error)}`,
-          "error",
         );
         return;
       }
       showToast("タスクを更新しました", "success");
     },
-    [tasks, updateTask, showToast],
+    [tasks, updateTask, showToast, showErrorUnlessNotified],
   );
 
   const handleAddTask = useCallback((columnName: string) => {
@@ -294,7 +321,10 @@ export const App = () => {
       });
       if (!result.ok) {
         const message = projectErrorMessage(result.error);
-        showToast(`カラムの追加に失敗しました: ${message}`, "error");
+        showErrorUnlessNotified(
+          result.error,
+          `カラムの追加に失敗しました: ${message}`,
+        );
         // AddColumnButton が editor を維持できるよう reject し直す
         throw new Error(message);
       }
@@ -308,7 +338,7 @@ export const App = () => {
       }
       showToast("カラムを追加しました", "success");
     },
-    [columns, updateColumns, showToast],
+    [columns, updateColumns, showToast, showErrorUnlessNotified],
   );
 
   const handleRenameColumn = useCallback(
@@ -340,7 +370,10 @@ export const App = () => {
       });
       if (!result.ok) {
         const message = projectErrorMessage(result.error);
-        showToast(`カラム名の変更に失敗しました: ${message}`, "error");
+        showErrorUnlessNotified(
+          result.error,
+          `カラム名の変更に失敗しました: ${message}`,
+        );
         // ColumnHeader が edit mode を維持できるよう reject し直す
         throw new Error(message);
       }
@@ -354,7 +387,7 @@ export const App = () => {
       }
       showToast("カラム名を変更しました", "success");
     },
-    [columns, updateColumns, showToast],
+    [columns, updateColumns, showToast, showErrorUnlessNotified],
   );
 
   const handleDeleteColumn = useCallback(
@@ -428,7 +461,10 @@ export const App = () => {
       });
       if (!result.ok) {
         const message = projectErrorMessage(result.error);
-        showToast(`カラムの削除に失敗しました: ${message}`, "error");
+        showErrorUnlessNotified(
+          result.error,
+          `カラムの削除に失敗しました: ${message}`,
+        );
         // Column の ConfirmDialog が維持できるよう reject し直す
         throw new Error(message);
       }
@@ -442,7 +478,7 @@ export const App = () => {
       }
       showToast("カラムを削除しました", "success");
     },
-    [columns, tasks, updateColumns, showToast],
+    [columns, tasks, updateColumns, showToast, showErrorUnlessNotified],
   );
 
   const handleCloseCreateModal = useCallback(() => {
@@ -477,12 +513,15 @@ export const App = () => {
       if (!result.ok) {
         // モーダルを閉じない: TaskCreateModal は onSubmit reject で開いたままになる
         const message = projectErrorMessage(result.error);
-        showToast(`タスクの作成に失敗しました: ${message}`, "error");
+        showErrorUnlessNotified(
+          result.error,
+          `タスクの作成に失敗しました: ${message}`,
+        );
         throw new Error(message);
       }
       showToast("タスクを作成しました", "success");
     },
-    [submitCreateTask, showToast],
+    [submitCreateTask, showToast, showErrorUnlessNotified],
   );
 
   const handleTaskDrop = useCallback(
@@ -520,11 +559,16 @@ export const App = () => {
           showToast(result.error.message, "error");
           return;
         }
-        const message = projectErrorMessage(result.error);
-        showToast(`タスクの移動に失敗しました: ${message}`, "error");
+        // cross-column の update_task 失敗（allowlist 由来）は invokeWrapped が通知済み → 抑止。
+        // 同一カラム並び替えの update_card_order 失敗（allowlist 外 tauri）はサイレント化を
+        // 避けるため従来どおり generic を出す。
+        showErrorUnlessNotified(
+          result.error,
+          `タスクの移動に失敗しました: ${projectErrorMessage(result.error)}`,
+        );
       }
     },
-    [tasks, moveTask, announce, showToast],
+    [tasks, moveTask, announce, showToast, showErrorUnlessNotified],
   );
 
   const handleColumnReorder = useCallback(
@@ -567,12 +611,14 @@ export const App = () => {
       ) {
         return;
       }
-      showToast(
+      // update_columns 失敗（reorderColumnsAction は updateColumns 経由）は invokeWrapped が
+      // 通知済み → 抑止。invalid-state 等の非 tauri はサイレント化を避けるため残す。
+      showErrorUnlessNotified(
+        result.error,
         `カラムの並び替えに失敗しました: ${projectErrorMessage(result.error)}`,
-        "error",
       );
     },
-    [reorderColumns, announce, showToast],
+    [reorderColumns, announce, showErrorUnlessNotified],
   );
 
   const handleAddLink = useCallback(
@@ -597,7 +643,12 @@ export const App = () => {
           return result;
         }
         const message = projectErrorMessage(result.error);
-        showToast(`リンクの追加に失敗しました: ${message}`, "error");
+        // add_link 失敗は invokeWrapped が通知済み → 抑止。非 tauri は残す。
+        // announce（取消）は通知有無に関わらず常に残す。
+        showErrorUnlessNotified(
+          result.error,
+          `リンクの追加に失敗しました: ${message}`,
+        );
         announce(
           `「${sourceTitle}」への「${targetTitle}」のリンク追加を取り消しました`,
         );
@@ -607,7 +658,7 @@ export const App = () => {
       announce(`「${sourceTitle}」に「${targetTitle}」をリンクしました`);
       return result;
     },
-    [tasks, addLink, announce, showToast],
+    [tasks, addLink, announce, showErrorUnlessNotified],
   );
 
   const handleRemoveLink = useCallback(
@@ -630,7 +681,12 @@ export const App = () => {
           return result;
         }
         const message = projectErrorMessage(result.error);
-        showToast(`リンクの削除に失敗しました: ${message}`, "error");
+        // remove_link 失敗は invokeWrapped が通知済み → 抑止。非 tauri は残す。
+        // announce（取消）は通知有無に関わらず常に残す。
+        showErrorUnlessNotified(
+          result.error,
+          `リンクの削除に失敗しました: ${message}`,
+        );
         announce(
           `「${sourceTitle}」から「${targetTitle}」へのリンク削除を取り消しました`,
         );
@@ -642,7 +698,7 @@ export const App = () => {
       );
       return result;
     },
-    [tasks, removeLink, announce, showToast],
+    [tasks, removeLink, announce, showErrorUnlessNotified],
   );
 
   const handleTaskDelete = useCallback(
@@ -676,7 +732,12 @@ export const App = () => {
         }
 
         const message = projectErrorMessage(result.error);
-        showToast(`タスクの削除に失敗しました: ${message}`, "error");
+        // delete_task 失敗は invokeWrapped が通知済み → 抑止。非 tauri は残す。
+        // announce（取消）と throw は通知有無に関わらず常に残す。
+        showErrorUnlessNotified(
+          result.error,
+          `タスクの削除に失敗しました: ${message}`,
+        );
         announce(`「${title}」の削除を取り消しました`);
         throw new Error(message);
       }
@@ -686,7 +747,7 @@ export const App = () => {
       showToast("タスクを削除しました", "success");
       announce(`「${title}」を削除しました`);
     },
-    [tasks, deleteTask, showToast, announce],
+    [tasks, deleteTask, showToast, announce, showErrorUnlessNotified],
   );
 
   /**

--- a/src/__tests__/App.mutationFailureToast.test.tsx
+++ b/src/__tests__/App.mutationFailureToast.test.tsx
@@ -1,0 +1,425 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { App } from "@/App";
+import { DRAG_MIME_TYPE } from "@/features/board/components/Board/dragState";
+import { unregisterToastSink } from "@/lib/tauri/toastSink";
+import { createDragEvent } from "@/test-fixtures/createDragEvent";
+import type { TaskPayload } from "@/types/task";
+
+// (b) 実発火版 / (c) 撤去回帰版 / 非サイレント系の統合テスト。
+// root barrel `@/lib/tauri` は丸ごとモックせず、`@tauri-apps/api/core` の invoke だけを
+// 制御することで invokeWrapped → sink → ToastContainer の実発火経路を通す。
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+
+const invokeMock = vi.mocked(invoke);
+const openDialogMock = vi.mocked(openDialog);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+let hadIsReactActEnvironment = false;
+
+beforeAll(() => {
+  hadIsReactActEnvironment =
+    "IS_REACT_ACT_ENVIRONMENT" in reactActEnvironmentGlobal;
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+  const keysToDelete = hadIsReactActEnvironment
+    ? []
+    : (["IS_REACT_ACT_ENVIRONMENT"] as const);
+  for (const key of keysToDelete) {
+    Reflect.deleteProperty(reactActEnvironmentGlobal, key);
+  }
+});
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+const seedFilePath = "tasks/a.md";
+
+const seedTaskPayload: TaskPayload = {
+  id: "a",
+  title: "A タスク",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "元の本文",
+  filePath: seedFilePath,
+  extras: {},
+  warnings: [],
+};
+
+const seedTaskPayloadB: TaskPayload = {
+  id: "b",
+  title: "B タスク",
+  status: "Todo",
+  labels: [],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "本文B",
+  filePath: "tasks/b.md",
+  extras: {},
+  warnings: [],
+};
+
+const openProjectRawPayload = {
+  tasks: [seedTaskPayload],
+  columns: ["Todo", "Doing", "Done"],
+};
+
+// 同一カラム並び替えを発火させるため Todo に 2 件並べた payload。
+const twoTaskRawPayload = {
+  tasks: [seedTaskPayload, seedTaskPayloadB],
+  columns: ["Todo", "Doing", "Done"],
+};
+
+const getColumnsRawPayload = {
+  columns: [
+    { name: "Todo", order: 0 },
+    { name: "Doing", order: 1 },
+    { name: "Done", order: 2 },
+  ],
+  doneColumn: "Done",
+};
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  openDialogMock.mockReset();
+});
+
+// モジュールスコープ sink がテスト間でリークしないよう必ず解除する。
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+  unregisterToastSink();
+});
+
+const mountApp = (): void => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<App />);
+  });
+};
+
+const clickHeaderOpenButton = async (): Promise<void> => {
+  const buttons = container?.querySelectorAll("header button") ?? [];
+  const openBtn = Array.from(buttons).find((b) => b.textContent === "開く") as
+    | HTMLButtonElement
+    | undefined;
+  await act(async () => {
+    openBtn?.click();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const openDetailPanel = (): void => {
+  const card = container?.querySelector<HTMLElement>(
+    "[data-testid='task-card']",
+  );
+  act(() => {
+    card?.click();
+  });
+};
+
+/**
+ * TaskCard を指定カラム section へ drop する。
+ * 別カラムなら status 変更（update_task）、同一カラムなら並び替え（update_card_order）が走る。
+ * @param columnLabel drop 先カラム名（section の aria-label）
+ */
+const dropFirstCardTo = async (columnLabel: string): Promise<void> => {
+  const card = container?.querySelector<HTMLElement>(
+    "[data-testid='task-card']",
+  );
+  const section = container?.querySelector<HTMLElement>(
+    `section[aria-label='${columnLabel}']`,
+  );
+  await act(async () => {
+    card?.dispatchEvent(createDragEvent("dragstart"));
+  });
+  const drop = createDragEvent("drop");
+  drop.dataTransfer.setData(DRAG_MIME_TYPE, seedFilePath);
+  await act(async () => {
+    section?.dispatchEvent(drop);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+/**
+ * 先頭カラムのヘッダを末尾カラム section へ drop する（カラム並び替え → update_columns）。
+ * @param toColumnLabel drop 先カラム名（section の aria-label）
+ */
+const dropFirstColumnTo = async (toColumnLabel: string): Promise<void> => {
+  const headers = container?.querySelectorAll<HTMLElement>(
+    "[data-testid='column-header']",
+  );
+  const headerFirst = headers?.[0];
+  const section = container?.querySelector<HTMLElement>(
+    `section[aria-label='${toColumnLabel}']`,
+  );
+  const startEvent = createDragEvent("dragstart");
+  await act(async () => {
+    headerFirst?.dispatchEvent(startEvent);
+  });
+  const drop = createDragEvent("drop", {
+    dataTransfer: startEvent.dataTransfer,
+  });
+  await act(async () => {
+    section?.dispatchEvent(drop);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+/**
+ * MarkdownBody の display をクリックして textarea を開き、値を流して Cmd+Enter で確定する。
+ * これにより handleTaskUpdate → updateTask（update_task）が走る。
+ * @param value 確定後の body 値
+ */
+const editBodyViaUI = async (value: string): Promise<void> => {
+  const display = container?.querySelector<HTMLElement>(
+    '[data-testid="markdown-body"]',
+  );
+  await act(async () => {
+    display?.click();
+  });
+  const textarea = container?.querySelector<HTMLTextAreaElement>(
+    '[data-testid="markdown-body-textarea"]',
+  );
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  await act(async () => {
+    setter?.call(textarea, value);
+    textarea?.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await act(async () => {
+    textarea?.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await Promise.resolve();
+  });
+};
+
+const errorToasts = (): Element[] =>
+  Array.from(container?.querySelectorAll('[data-testid="toast-error"]') ?? []);
+
+const successToast = (): Element | null =>
+  container?.querySelector('[data-testid="toast-success"]') ?? null;
+
+type Responder = () => Promise<unknown>;
+
+const resolveUndefined: Responder = () => Promise.resolve(undefined);
+
+// open_project / get_columns を成功させる基底応答に overrides を重ねた invoke 実装を作る。
+// 分岐を使わず cmd → responder の写像で routing する（テストの条件分岐禁止ルール準拠）。
+const makeInvoke =
+  (overrides: Record<string, Responder>) =>
+  (cmd: string): Promise<unknown> => {
+    const responders: Record<string, Responder> = {
+      open_project: () => Promise.resolve(openProjectRawPayload),
+      get_columns: () => Promise.resolve(getColumnsRawPayload),
+      ...overrides,
+    };
+    return (responders[cmd] ?? resolveUndefined)();
+  };
+
+test("(b)(c) update_task 失敗で error トーストが 1 件だけ実発火する（実経路 + 二重なし）", async () => {
+  openDialogMock.mockResolvedValueOnce("/p");
+  invokeMock.mockImplementation(
+    makeInvoke({
+      update_task: () => Promise.reject(new Error("書き込みに失敗しました")),
+    }),
+  );
+
+  mountApp();
+  await clickHeaderOpenButton();
+  openDetailPanel();
+  await editBodyViaUI("新しい本文");
+
+  await vi.waitFor(() => {
+    expect(errorToasts().length).toBe(1);
+  });
+  expect(errorToasts()[0].textContent).toContain(
+    "タスクの更新に失敗しました: 書き込みに失敗しました",
+  );
+});
+
+test("update_task 成功時は success トーストが出て error トーストは出ない", async () => {
+  openDialogMock.mockResolvedValueOnce("/p");
+  invokeMock.mockImplementation(
+    makeInvoke({
+      update_task: () =>
+        Promise.resolve({ ...seedTaskPayload, body: "新しい本文" }),
+    }),
+  );
+
+  mountApp();
+  await clickHeaderOpenButton();
+  openDetailPanel();
+  await editBodyViaUI("新しい本文");
+
+  await vi.waitFor(() => {
+    expect(successToast()).not.toBeNull();
+  });
+  expect(successToast()?.textContent).toContain("タスクを更新しました");
+  expect(errorToasts().length).toBe(0);
+});
+
+test("非サイレント: open_project 失敗（allowlist 外 tauri）は onError 経由で App が通知する", async () => {
+  openDialogMock.mockResolvedValueOnce("/p");
+  invokeMock.mockImplementation(
+    makeInvoke({
+      open_project: () =>
+        Promise.reject(new Error("ディレクトリにアクセスできません")),
+    }),
+  );
+
+  mountApp();
+  await clickHeaderOpenButton();
+
+  await vi.waitFor(() => {
+    expect(errorToasts().length).toBe(1);
+  });
+  // invokeWrapped は allowlist 外なので発火しない → App の onError が 1 件だけ出す。
+  expect(errorToasts()[0].textContent).toContain(
+    "ディレクトリにアクセスできません",
+  );
+});
+
+test("cross-column 移動の update_task 失敗は invokeWrapped 通知のみ（計 1 件・重複なし）", async () => {
+  openDialogMock.mockResolvedValueOnce("/p");
+  invokeMock.mockImplementation(
+    makeInvoke({
+      update_task: () => Promise.reject(new Error("書き込みに失敗しました")),
+    }),
+  );
+
+  mountApp();
+  await clickHeaderOpenButton();
+  // Todo → Done のカラム間移動。status 更新は update_task（allowlist）。
+  await dropFirstCardTo("Done");
+
+  await vi.waitFor(() => {
+    expect(errorToasts().length).toBe(1);
+  });
+  // invokeWrapped が「タスクの更新に失敗しました」を出し、App generic「移動に失敗」は抑止。
+  expect(errorToasts()[0].textContent).toContain("タスクの更新に失敗しました");
+});
+
+test("非サイレント: 同一カラム並び替えの update_card_order 失敗は generic を 1 件出す", async () => {
+  openDialogMock.mockResolvedValueOnce("/p");
+  invokeMock.mockImplementation(
+    makeInvoke({
+      open_project: () => Promise.resolve(twoTaskRawPayload),
+      update_card_order: () => Promise.reject(new Error("並び順保存に失敗")),
+    }),
+  );
+
+  mountApp();
+  await clickHeaderOpenButton();
+  // Todo に 2 件並んだ状態で先頭カードを末尾へ並び替え。update_card_order（allowlist 外）失敗。
+  await dropFirstCardTo("Todo");
+
+  await vi.waitFor(() => {
+    expect(errorToasts().length).toBe(1);
+  });
+  // invokeWrapped は発火しない → App の generic「タスクの移動に失敗しました」が残る。
+  expect(errorToasts()[0].textContent).toContain("タスクの移動に失敗しました");
+});
+
+test("partial-move（status 成功・並び順保存失敗）は専用文のみ・generic も重複も出さない", async () => {
+  openDialogMock.mockResolvedValueOnce("/p");
+  invokeMock.mockImplementation(
+    makeInvoke({
+      // status 更新は成功し、その後の並び順保存（update_card_order）だけ失敗する。
+      update_task: () =>
+        Promise.resolve({ ...seedTaskPayload, status: "Done" }),
+      update_card_order: () => Promise.reject(new Error("並び順保存に失敗")),
+    }),
+  );
+
+  mountApp();
+  await clickHeaderOpenButton();
+  await dropFirstCardTo("Done");
+
+  await vi.waitFor(() => {
+    expect(errorToasts().length).toBe(1);
+  });
+  // partial-move 専用文が出る。汎用「タスクの移動に失敗しました」や invokeWrapped 重複は出ない。
+  expect(errorToasts()[0].textContent).toContain("並び順の保存に失敗しました");
+  expect(errorToasts()[0].textContent).not.toContain(
+    "タスクの移動に失敗しました",
+  );
+});
+
+test("カラム並び替えの update_columns 失敗は invokeWrapped 通知のみ（計 1 件・重複なし）", async () => {
+  openDialogMock.mockResolvedValueOnce("/p");
+  invokeMock.mockImplementation(
+    makeInvoke({
+      update_columns: () => Promise.reject(new Error("書き込みに失敗しました")),
+    }),
+  );
+
+  mountApp();
+  await clickHeaderOpenButton();
+  // 先頭カラム（Todo）を Done へ並び替え。reorderColumnsAction → updateColumns（update_columns）。
+  await dropFirstColumnTo("Done");
+
+  await vi.waitFor(() => {
+    expect(errorToasts().length).toBe(1);
+  });
+  // invokeWrapped が「カラムの更新に失敗しました」を出し、App generic「並び替えに失敗」は抑止。
+  expect(errorToasts()[0].textContent).toContain("カラムの更新に失敗しました");
+});

--- a/src/features/board/hooks/useProject/index.ts
+++ b/src/features/board/hooks/useProject/index.ts
@@ -49,6 +49,7 @@ import type {
 
 export { PROJECT_SWITCHED_MESSAGE } from "./actions/updateColumns";
 export { ProjectError } from "./errors";
+export { wasNotifiedByInvokeWrapped } from "./notifiedByInvokeWrapped";
 export { projectErrorMessage } from "./projectErrorMessage";
 export type { ProjectData, ProjectState } from "./reducer";
 export type {

--- a/src/features/board/hooks/useProject/notifiedByInvokeWrapped/__tests__/notifiedByInvokeWrapped.behavior.test.ts
+++ b/src/features/board/hooks/useProject/notifiedByInvokeWrapped/__tests__/notifiedByInvokeWrapped.behavior.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import { TauriError } from "@/lib/tauri/tauriError";
+import { ProjectError } from "../../errors";
+import { wasNotifiedByInvokeWrapped } from "..";
+
+const tauriErrWithCommand = (command?: string): ProjectError =>
+  ProjectError.tauri(new TauriError("IO_ERROR", "失敗", undefined, command));
+
+test("allowlist 由来 tauri（command=update_task）は true", () => {
+  expect(wasNotifiedByInvokeWrapped(tauriErrWithCommand("update_task"))).toBe(
+    true,
+  );
+});
+
+test.for([
+  "update_card_order",
+  "get_columns",
+  "open_project",
+] as const)("allowlist 外 tauri（command=%s）は false", (command) => {
+  expect(wasNotifiedByInvokeWrapped(tauriErrWithCommand(command))).toBe(false);
+});
+
+test("command 未設定の tauri は false", () => {
+  expect(wasNotifiedByInvokeWrapped(tauriErrWithCommand(undefined))).toBe(
+    false,
+  );
+});
+
+test("invalid-state（非 tauri）は false", () => {
+  expect(wasNotifiedByInvokeWrapped(ProjectError.invalidState())).toBe(false);
+});
+
+test("partial-move（非 tauri）は false", () => {
+  const underlying = new TauriError("IO_ERROR", "並び順保存に失敗");
+  expect(wasNotifiedByInvokeWrapped(ProjectError.partialMove(underlying))).toBe(
+    false,
+  );
+});

--- a/src/features/board/hooks/useProject/notifiedByInvokeWrapped/index.ts
+++ b/src/features/board/hooks/useProject/notifiedByInvokeWrapped/index.ts
@@ -1,0 +1,19 @@
+import { isMutationCommand } from "@/lib/tauri/mutationFailureMessage";
+import type { ProjectError } from "../errors";
+
+/**
+ * この ProjectError が invokeWrapped 層で既にトースト通知済みかを判定する。
+ * tauri 由来かつ起点コマンドが書き込み allowlist のときだけ true。
+ *
+ * App 側はこれが true の失敗だけ自前の showToast を抑止し、二重通知を防ぐ。
+ * allowlist 外 tauri（update_card_order / get_columns refresh / open_project 等）や
+ * 非 tauri（invalid-state / partial-move）は false となり、App が従来どおり通知する
+ * （サイレント化の防止）。
+ *
+ * @param err 判定対象の ProjectError
+ * @returns invokeWrapped が通知済みなら true（App 側は出さない）
+ */
+export const wasNotifiedByInvokeWrapped = (err: ProjectError): boolean =>
+  err.kind === "tauri" &&
+  err.error.command !== undefined &&
+  isMutationCommand(err.error.command);

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -21,4 +21,5 @@ export {
   ProjectError,
   projectErrorMessage,
   useProject,
+  wasNotifiedByInvokeWrapped,
 } from "./hooks/useProject";

--- a/src/lib/tauri/invokeWrapped/__tests__/invokeWrapped.behavior.test.ts
+++ b/src/lib/tauri/invokeWrapped/__tests__/invokeWrapped.behavior.test.ts
@@ -1,0 +1,89 @@
+import { invoke } from "@tauri-apps/api/core";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
+import { TauriError } from "@/lib/tauri/tauriError";
+import { registerToastSink, unregisterToastSink } from "@/lib/tauri/toastSink";
+import type { Result as ResultT } from "@/utils/result";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+const invokeMock = vi.mocked(invoke);
+const sink = vi.fn();
+
+// Result.err を分岐なしで取り出す（テストの条件分岐禁止ルール準拠）。
+const expectErr = <T, E>(result: ResultT<T, E>): E => {
+  expect(result.ok).toBe(false);
+  return (result as { ok: false; error: E }).error;
+};
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  sink.mockReset();
+  // モジュールスコープ sink を毎テスト実登録する。
+  registerToastSink(sink);
+});
+
+// グローバル sink state が後続テストへリークしないよう必ず解除する。
+afterEach(unregisterToastSink);
+
+test("mutation reject 時に sink が操作別文言と error 種別で 1 回呼ばれる", async () => {
+  invokeMock.mockRejectedValueOnce(new Error("書き込みに失敗しました"));
+  const res = await invokeWrapped("create_task");
+  expect(sink).toHaveBeenCalledTimes(1);
+  expect(sink).toHaveBeenCalledWith(
+    "タスクの作成に失敗しました: 書き込みに失敗しました",
+    "error",
+  );
+  expect(res.ok).toBe(false);
+});
+
+test("reject でも throw せず Result.err(TauriError) を返す（既存契約）", async () => {
+  invokeMock.mockRejectedValueOnce(new Error("boom"));
+  const error = expectErr(await invokeWrapped("update_task"));
+  expect(error).toBeInstanceOf(TauriError);
+});
+
+test("reject 時 error に起点コマンド名が刻まれる", async () => {
+  invokeMock.mockRejectedValueOnce(new Error("boom"));
+  const error = expectErr(await invokeWrapped<unknown>("create_task"));
+  expect(error.command).toBe("create_task");
+});
+
+test("成功時は sink が呼ばれず Result.ok(value) を返す", async () => {
+  invokeMock.mockResolvedValueOnce({ id: "x" });
+  const res = await invokeWrapped("create_task");
+  expect(sink).not.toHaveBeenCalled();
+  expect(res).toEqual({ ok: true, value: { id: "x" } });
+});
+
+test.for([
+  "get_tasks",
+  "get_columns",
+  "open_project",
+] as const)("読み取り系 '%s' の reject では sink が発火しない", async (cmd) => {
+  invokeMock.mockRejectedValueOnce(new Error("read boom"));
+  const res = await invokeWrapped(cmd);
+  expect(sink).not.toHaveBeenCalled();
+  expect(res.ok).toBe(false);
+});
+
+test("update_card_order の reject では sink が発火しない（allowlist 外）", async () => {
+  invokeMock.mockRejectedValueOnce(new Error("order boom"));
+  const res = await invokeWrapped("update_card_order");
+  expect(sink).not.toHaveBeenCalled();
+  expect(res.ok).toBe(false);
+});
+
+test("連続失敗では都度発火する（重複抑止しない＝既存仕様）", async () => {
+  invokeMock.mockRejectedValue(new Error("書き込みに失敗しました"));
+  await invokeWrapped("update_task");
+  await invokeWrapped("update_task");
+  expect(sink).toHaveBeenCalledTimes(2);
+});
+
+test("sink 未登録でも mutation reject は例外なく Result.err を返す（no-op）", async () => {
+  unregisterToastSink();
+  invokeMock.mockRejectedValueOnce(new Error("boom"));
+  const res = await invokeWrapped("delete_task");
+  expect(res.ok).toBe(false);
+});

--- a/src/lib/tauri/invokeWrapped/index.ts
+++ b/src/lib/tauri/invokeWrapped/index.ts
@@ -1,10 +1,19 @@
 import { type InvokeArgs, invoke } from "@tauri-apps/api/core";
+import {
+  buildMutationFailureMessage,
+  isMutationCommand,
+} from "@/lib/tauri/mutationFailureMessage";
+import { getToastSink } from "@/lib/tauri/toastSink";
 import { Result, type Result as ResultT } from "@/utils/result";
 import { TauriError } from "../tauriError";
 
 /**
- * `invoke` を呼び、reject 値は `TauriError.from(e)` に正規化して `Result.err` に詰め直す。
+ * `invoke` を呼び、reject 値は `TauriError.from(e, cmd)` に正規化して `Result.err` に詰め直す。
  * 全 invoke ラッパでエラー正規化を一箇所に集約するための内部ヘルパ。
+ *
+ * 失敗時、書き込み系（allowlist）コマンドのみ登録済み sink へ失敗トーストを発火する。
+ * 読み取り系 / update_card_order は allowlist 外なので発火しない。sink 未登録時は no-op
+ * （App マウント前など）で従来挙動を維持する。`Result.err` を返す契約は不変。
  *
  * `args` を省略した場合は `invoke(cmd, undefined)` 相当として呼ぶ（Tauri 側で無視される）。
  *
@@ -20,6 +29,16 @@ export const invokeWrapped = async <T>(
     const value = await invoke<T>(cmd, args);
     return Result.ok(value);
   } catch (e) {
-    return Result.err(TauriError.from(e));
+    // 起点コマンドを error に刻む。App 側の重複抑止判定で使う。
+    const error = TauriError.from(e, cmd);
+    // 書き込み系コマンドの失敗だけを共通トースト化する。
+    if (isMutationCommand(cmd)) {
+      const sink = getToastSink();
+      // 未登録時は no-op（従来挙動を維持＝安全側のデフォルト）。
+      if (sink !== null) {
+        sink(buildMutationFailureMessage(cmd, error), "error");
+      }
+    }
+    return Result.err(error);
   }
 };

--- a/src/lib/tauri/mutationFailureMessage/__tests__/mutationFailureMessage.behavior.test.ts
+++ b/src/lib/tauri/mutationFailureMessage/__tests__/mutationFailureMessage.behavior.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import {
+  buildMutationFailureMessage,
+  isMutationCommand,
+} from "@/lib/tauri/mutationFailureMessage";
+import { TauriError } from "@/lib/tauri/tauriError";
+
+test.for([
+  "create_task",
+  "update_task",
+  "delete_task",
+  "add_link",
+  "remove_link",
+  "update_columns",
+] as const)("allowlist の書き込み cmd '%s' で isMutationCommand が true", (cmd) => {
+  expect(isMutationCommand(cmd)).toBe(true);
+});
+
+test.for([
+  "get_tasks",
+  "get_columns",
+  "open_project",
+  "update_card_order",
+] as const)("allowlist 外の cmd '%s' で isMutationCommand が false", (cmd) => {
+  expect(isMutationCommand(cmd)).toBe(false);
+});
+
+test.for([
+  "toString",
+  "constructor",
+  "hasOwnProperty",
+  "__proto__",
+] as const)("Object.prototype 継承プロパティ '%s' は isMutationCommand が false", (cmd) => {
+  expect(isMutationCommand(cmd)).toBe(false);
+});
+
+test("buildMutationFailureMessage は操作別固定文 + TauriError 詳細を組む", () => {
+  const error = new TauriError("IO_ERROR", "書き込み失敗");
+  expect(buildMutationFailureMessage("create_task", error)).toBe(
+    "タスクの作成に失敗しました: 書き込み失敗",
+  );
+});
+
+test("HAS_CHILDREN は専用文へ翻訳される", () => {
+  const error = new TauriError("HAS_CHILDREN", "task has children");
+  expect(buildMutationFailureMessage("delete_task", error)).toBe(
+    "タスクの削除に失敗しました: 子タスクが存在するため削除できません",
+  );
+});

--- a/src/lib/tauri/mutationFailureMessage/index.ts
+++ b/src/lib/tauri/mutationFailureMessage/index.ts
@@ -1,0 +1,66 @@
+import type { TauriError } from "@/lib/tauri/tauriError";
+
+const HAS_CHILDREN_MESSAGE = "子タスクが存在するため削除できません";
+
+/**
+ * 書き込み（ミューテーション）コマンド名 → 日本語操作ラベルの写像。
+ * このテーブルに載っている cmd のみ失敗トースト対象（= allowlist）。
+ * update_card_order は partial-move 専用文を useProject 側に残すため除外。
+ * get_tasks / get_columns / open_project は読み取り系のため除外。
+ *
+ * `as const satisfies` でリテラルキーを保ちつつ値型を検証する。
+ * （`Readonly<Record<string,string>>` 注釈だと keyof が string に潰れる）
+ */
+const MUTATION_COMMAND_LABELS = {
+  create_task: "タスクの作成",
+  update_task: "タスクの更新",
+  delete_task: "タスクの削除",
+  add_link: "リンクの追加",
+  remove_link: "リンクの削除",
+  update_columns: "カラムの更新",
+} as const satisfies Record<string, string>;
+
+/** 書き込み allowlist に含まれるコマンド名の union 型（テーブルのキーが source of truth）。 */
+export type MutationCommand = keyof typeof MUTATION_COMMAND_LABELS;
+
+/**
+ * allowlist 判定用に own キーだけを 1 度だけ収めた Set。
+ * 呼び出し毎の配列確保を避け、`Object.prototype` 継承キー（`toString` 等）も誤許可しない。
+ */
+const MUTATION_COMMAND_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(MUTATION_COMMAND_LABELS),
+);
+
+/**
+ * cmd が書き込み allowlist に含まれるかを判定するユーザー定義型ガード。
+ * true の分岐内では cmd が MutationCommand に narrowing される。
+ * @param cmd Tauri コマンド名 (snake_case)
+ * @returns allowlist に含まれれば true（型は `cmd is MutationCommand`）
+ */
+export const isMutationCommand = (cmd: string): cmd is MutationCommand =>
+  MUTATION_COMMAND_KEYS.has(cmd);
+
+/**
+ * TauriError から表示用 detail を取り出す。HAS_CHILDREN のみ専用文へ翻訳。
+ * @param error 正規化済み TauriError
+ * @returns toast に併記する詳細文字列
+ */
+const detailOf = (error: TauriError): string => {
+  if (error.code === "HAS_CHILDREN") {
+    return HAS_CHILDREN_MESSAGE;
+  }
+  return error.message;
+};
+
+/**
+ * 書き込み失敗時のトースト文言「<操作>に失敗しました: <detail>」を組み立てる。
+ * cmd は MutationCommand に絞り込み済みのため、ラベル参照は全域でフォールバック不要。
+ * @param cmd 書き込み allowlist コマンド名（型ガードで narrowing 済み）
+ * @param error 正規化済み TauriError
+ * @returns トースト本文
+ */
+export const buildMutationFailureMessage = (
+  cmd: MutationCommand,
+  error: TauriError,
+): string =>
+  `${MUTATION_COMMAND_LABELS[cmd]}に失敗しました: ${detailOf(error)}`;

--- a/src/lib/tauri/tauriError/__tests__/tauriError.behavior.test.ts
+++ b/src/lib/tauri/tauriError/__tests__/tauriError.behavior.test.ts
@@ -109,3 +109,17 @@ test("TauriError は Error / TauriError として instanceof で識別できる"
   expect(e).toBeInstanceOf(Error);
   expect(e).toBeInstanceOf(TauriError);
 });
+
+test("from(raw, command) は起点コマンド名を command に保持する", () => {
+  const e = TauriError.from(new Error("書き込みに失敗しました"), "create_task");
+  expect(e.command).toBe("create_task");
+});
+
+test("from(raw) で command を省略すると command は undefined（後方互換）", () => {
+  const raw = new Error("書き込みに失敗しました");
+  const e = TauriError.from(raw);
+  expect(e.command).toBeUndefined();
+  expect(e.message).toBe("書き込みに失敗しました");
+  expect(e.code).toBe("IO_ERROR");
+  expect(e.cause).toBe(raw);
+});

--- a/src/lib/tauri/tauriError/index.ts
+++ b/src/lib/tauri/tauriError/index.ts
@@ -65,17 +65,26 @@ export class TauriError extends Error {
   readonly code: TauriErrorCode;
   /** 元の reject 値（dev tools 参照用） */
   readonly cause?: unknown;
+  /** この error を生んだ Tauri コマンド名（invokeWrapped が付与）。allowlist 判定に使う。 */
+  readonly command?: string;
 
   /**
    * @param code エラー分類コード
    * @param message 人間可読メッセージ
    * @param cause 元の reject 値（任意）
+   * @param command 起点となった Tauri コマンド名（任意）
    */
-  constructor(code: TauriErrorCode, message: string, cause?: unknown) {
+  constructor(
+    code: TauriErrorCode,
+    message: string,
+    cause?: unknown,
+    command?: string,
+  ) {
     super(message);
     this.name = "TauriError";
     this.code = code;
     this.cause = cause;
+    this.command = command;
   }
 
   /**
@@ -88,12 +97,13 @@ export class TauriError extends Error {
    * code 判定は本 Issue では最小限の文字列パターンマッチのみ（マッチ不能は UNKNOWN）。
    *
    * @param raw invoke が reject した任意の値
-   * @returns 正規化済み TauriError（cause === raw）
+   * @param command 起点となった Tauri コマンド名（任意）。invokeWrapped から渡される
+   * @returns 正規化済み TauriError（cause === raw, command を保持）
    */
-  static from(raw: unknown): TauriError {
+  static from(raw: unknown, command?: string): TauriError {
     const extracted = extractMessage(raw);
     const message = extracted ?? FALLBACK_MESSAGE;
     const code = extracted === null ? "UNKNOWN" : classifyCode(extracted);
-    return new TauriError(code, message, raw);
+    return new TauriError(code, message, raw, command);
   }
 }

--- a/src/lib/tauri/toastSink/__tests__/toastSink.behavior.test.ts
+++ b/src/lib/tauri/toastSink/__tests__/toastSink.behavior.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  getToastSink,
+  registerToastSink,
+  unregisterToastSink,
+} from "@/lib/tauri/toastSink";
+
+// モジュールスコープ sink のグローバル state が後続テストへリークしないよう、
+// 各テスト後に必ず解除する。
+afterEach(unregisterToastSink);
+
+test("未登録時は getToastSink() が null を返す", () => {
+  expect(getToastSink()).toBeNull();
+});
+
+test("registerToastSink(fn) 後に getToastSink() が登録した fn を返す", () => {
+  const fn = vi.fn();
+  registerToastSink(fn);
+  expect(getToastSink()).toBe(fn);
+});
+
+test("unregisterToastSink() 後は getToastSink() が null に戻る", () => {
+  registerToastSink(vi.fn());
+  unregisterToastSink();
+  expect(getToastSink()).toBeNull();
+});
+
+test("再登録すると後から登録した sink で上書きされる", () => {
+  const a = vi.fn();
+  const b = vi.fn();
+  registerToastSink(a);
+  registerToastSink(b);
+  expect(getToastSink()).toBe(b);
+});
+
+test("register の戻り cleanup は自分が登録した sink のときだけ解除する", () => {
+  const a = vi.fn();
+  const b = vi.fn();
+  const cleanupA = registerToastSink(a);
+  registerToastSink(b);
+  // a の cleanup を呼んでも、現役は b なので b は消えない。
+  cleanupA();
+  expect(getToastSink()).toBe(b);
+});
+
+test("register の戻り cleanup は自分が現役なら sink を null に戻す", () => {
+  const a = vi.fn();
+  const cleanupA = registerToastSink(a);
+  cleanupA();
+  expect(getToastSink()).toBeNull();
+});

--- a/src/lib/tauri/toastSink/index.ts
+++ b/src/lib/tauri/toastSink/index.ts
@@ -1,0 +1,39 @@
+import type { ToastType } from "@/types/toast";
+
+/** トースト発火関数の型（useToasts.showToast と同形）。 */
+export type ToastSink = (message: string, type: ToastType) => void;
+
+let sink: ToastSink | null = null;
+
+/**
+ * トースト sink を登録し、その登録を取り消す cleanup 関数を返す。
+ * App の useEffect から `return registerToastSink(showToast)` の形で使う想定。
+ *
+ * 返す cleanup は「自分が登録した sink のときだけ」解除する。これにより、
+ * 別の登録によって sink が差し替わった後に古い cleanup が呼ばれても、
+ * 新しい sink を誤って消さない（複数 root / テスト並行実行での stale cleanup 対策）。
+ *
+ * @param fn 登録する sink
+ * @returns この登録だけを解除する cleanup 関数
+ */
+export const registerToastSink = (fn: ToastSink): (() => void) => {
+  sink = fn;
+  return () => {
+    if (sink === fn) {
+      sink = null;
+    }
+  };
+};
+
+/**
+ * 登録済み sink を無条件で解除する（主にテストの afterEach 用）。
+ */
+export const unregisterToastSink = (): void => {
+  sink = null;
+};
+
+/**
+ * 現在登録されている sink を返す。未登録なら null。
+ * @returns 登録済み sink、または null
+ */
+export const getToastSink = (): ToastSink | null => sink;


### PR DESCRIPTION
## 概要

Tauri バックエンドの書き込み（ミューテーション）系コマンドが失敗したとき、その失敗を `invokeWrapped` 層に集約捕捉し、操作別の日本語固定文＋`TauriError` 詳細を一律トーストで通知する。失敗通知の source of truth を一本化し、握り潰し・通知の不統一・二重通知を防ぐ。App 側は invokeWrapped が通知しない失敗だけを残し、サイレント化を防ぐ。

## 変更の種類

- ✨ 新機能
- 📝 ドキュメント更新（画面挙動の変更に伴う spec 追従）

## 追加した内容

- `src/lib/tauri/toastSink/` — React 非依存のモジュールスコープ sink（register/unregister/get、cleanup は自分の sink だけ解除）
- `src/lib/tauri/mutationFailureMessage/` — 書き込み allowlist テーブル（single source of truth）＋型ガード `isMutationCommand` ＋ `buildMutationFailureMessage`
- `src/features/board/hooks/useProject/notifiedByInvokeWrapped/` — `wasNotifiedByInvokeWrapped`（重複抑止判定の純関数）
- `src/__tests__/App.mutationFailureToast.test.tsx` — invoke だけモックする実発火 App 統合テスト
- 各モジュールの behavior テスト

## 変更した内容

- `TauriError` に optional な `command` を付与（`from(raw, command?)`、command 省略は後方互換）
- `invokeWrapped` の catch で起点コマンドを刻み、allowlist 失敗のみ sink へ 1 件発火（`Result.err` 契約は不変）
- `App.tsx` に sink 登録 effect を追加し、各 mutation ハンドラの失敗 `showToast` を共通ヘルパ `showErrorUnlessNotified` に集約（allowlist 由来のみ抑止）
- **画面挙動の変更**: カラム操作失敗が「カラムの更新に失敗しました」に統一、カラム間移動の `update_task` 失敗が「タスクの更新に失敗しました」表示に変更

## 仕様ドキュメント更新

`docs/spec-board/board-view-spec.md` を更新（**必須・実施済み**）。エラー表示セクションに「書き込み失敗トーストの一元化」（allowlist / 重複抑止 / 非サイレント対象）を追記し、D&D の generic 失敗文言と a11y アナウンス表のメッセージを実装に追従させた。

## システム図

```mermaid
flowchart TD
    invoke["Tauri invoke(cmd, args)"] -->|reject| catch["invokeWrapped catch"]
    catch --> tag["TauriError.from(e, cmd)<br/>起点 command を刻む [NEW]"]
    tag --> allow{"isMutationCommand(cmd)?<br/>allowlist 判定 [NEW]"}
    allow -->|No: read系 / update_card_order| ret["Result.err(error)<br/>(sink 不発火)"]
    allow -->|Yes| sink{"getToastSink() !== null?"}
    sink -->|未登録| ret
    sink -->|登録済| fire["sink(buildMutationFailureMessage) [NEW]"]
    fire --> toast["ToastContainer: error 1 件"]
    fire --> ret

    ret --> handler["App ハンドラ"]
    handler --> guard{"wasNotifiedByInvokeWrapped? [NEW]"}
    guard -->|true: allowlist 由来| skip["App 側 showToast 抑止<br/>(二重通知回避)"]
    guard -->|false: allowlist 外 / 非 tauri| show["App が従来どおり通知<br/>(サイレント化防止)"]

    style tag fill:#e8f5e9
    style allow fill:#e8f5e9
    style fire fill:#e8f5e9
    style guard fill:#e8f5e9
```

## 関連Issue

Closes #146

## テスト

- `pnpm test:run` — **165 files / 1301 tests passed**（既存 Optimistic / brokenLinkToast にリグレッションなし）
- `pnpm build`（tsc -b + vite build）成功
- oxlint 0 errors / Biome 変更ファイル clean
- AI レビュー（codex）: 初回指摘（`cmd in テーブル` が prototype 継承キーを誤許可）→ own-key の `Set.has` へ修正＋回帰テスト追加 → 再レビューで問題なし
- ⚠️ 実機 Tauri での手動検証は本環境では未実施。同等シナリオ（mutation 失敗 1 件 / open_project 通知 / partial-move 専用文 / 成功 / 非サイレント系）は `App.mutationFailureToast.test.tsx` の自動統合テストでカバー

## レビューポイント

- **設計の核**: allowlist 由来の失敗だけ App 側通知を抑止し、それ以外（allowlist 外 tauri＝`open_project` / 同一カラム `update_card_order` / `get_columns` refresh、非 tauri＝`invalid-state` / validation）は従来どおり通知してサイレント化を防ぐ点
- **純粋性 vs 到達手段**: `invokeWrapped` を React 非依存のまま保つためのモジュールスコープ sink ＋ `registerToastSink` の自分限定 cleanup（複数 root / strict-mode 二重マウント対策）
- **意図的除外**: `update_card_order` を allowlist 外とし partial-move 専用文を維持している点