### PR TITLE
🔧 [Config]: release で .app も添付し draft をやめる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,13 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           BUNDLE_DIR="src-tauri/target/universal-apple-darwin/release/bundle"
-          # 既存の release が無ければ draft で作成（既にあれば作成失敗を握りつぶす）
+          # .app はディレクトリなので、そのままでは release 添付できない。
+          # ditto で zip に固めてからアップロードする (.app の symlink 等を保持)
+          APP_PATH="$(ls -d "$BUNDLE_DIR"/macos/*.app | head -n1)"
+          APP_NAME="$(basename "$APP_PATH" .app)"
+          APP_ZIP="$BUNDLE_DIR/macos/${APP_NAME}_${TAG#v}_universal.app.zip"
+          ditto -c -k --keepParent "$APP_PATH" "$APP_ZIP"
+          # 既存の release が無ければ公開状態で作成（既にあれば作成失敗を握りつぶす）
           gh release view "$TAG" >/dev/null 2>&1 \
-            || gh release create "$TAG" --draft --title "spec-board $TAG" --generate-notes
-          gh release upload "$TAG" "$BUNDLE_DIR"/dmg/*.dmg --clobber
+            || gh release create "$TAG" --title "spec-board $TAG" --generate-notes
+          gh release upload "$TAG" "$BUNDLE_DIR"/dmg/*.dmg "$APP_ZIP" --clobber


### PR DESCRIPTION
## 概要

release ワークフローで macOS の `.app` も Release に添付し、リリースを draft ではなく公開状態で作成するよう修正する。

## 変更の種類

- 🔧 設定変更（CI / GitHub Actions）

## 変更した内容

- `.github/workflows/release.yml` の「Attach artifacts to release」ステップ
  - **`.app` を添付**: `.app` はディレクトリのため `gh release upload` で直接添付できない。`ditto -c -k --keepParent` で zip 化（symlink 等を保持）し、`spec-board_<version>_universal.app.zip` として `.dmg` と一緒にアップロードする
  - **draft をやめる**: `gh release create` の `--draft` を削除し、タグ push 時に公開状態の Release を作成する

## 仕様ドキュメント更新

- 不要（CI ワークフローの調整であり、公開 API・データ形式・画面挙動・設定項目の変更なし）

## 背景

`v0.1.0` の初回リリースで以下を確認:
- 添付物が `spec-board_0.1.0_universal.dmg` のみで `.app` が無い
- ワークフローのソースに `--draft` が残っており、将来のリリースが draft になる

## テスト

- ワークフロー YAML の変更のみ。実発火は `v*` タグ push 時のため本 PR 上では未実行。
- マージ後、既存 `v0.1.0` のワークフロー再実行、または新規タグで `.app.zip` 添付・公開状態を確認予定。

## レビューポイント

- `.app` の zip 化に macOS ネイティブの `ditto` を使用（`.app` の symlink / リソースを正しく保持するため `zip` より推奨）。
- 既存の公開済み `v0.1.0` リリースに遡って `.app` を足すかどうかは別途運用判断（本 PR はワークフローの修正のみ）。