### PR TITLE
✨ [New Feature]: #260 ラベルレジストリ (labels.yml) をフルスタック実装

### DIFF
--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -15,6 +15,7 @@ project-root/
 │   ├── config.json                          # プロジェクト設定（カラム・カード順序など）
 │   ├── config.json.bak                      # 古い version の config を読み込んだ際のマイグレーション前バックアップ（後述「マイグレーション」節）
 │   ├── config.json.bak.tmp.{pid}.{nanos}.{counter}  # backup 書き出し中の一時ファイル（rename で `.bak` に昇格／load 冒頭に閾値超過の orphan は cleanup）
+│   ├── labels.yml                           # ラベルマスタ定義（説明・グループ・色などのメタ情報。後述「labels.yml スキーマ」節）
 │   └── GUIDE.md                             # AIエージェント向けフォーマットガイド（自動生成）
 └── tasks/
     └── ...
@@ -73,6 +74,58 @@ project-root/
 
 - サブIssue進捗バーにおける「完了」の判定基準となるカラム
 - 未設定の場合は `columns` の最後のカラムをデフォルトとして使用
+
+## labels.yml スキーマ
+
+タスク frontmatter の `labels`（自由文字列の配列）に対し、説明・グループ・色などのメタ情報を一元管理する「ラベルマスタ定義ファイル」を `.spec-board/labels.yml` に置く。`config.json` とは別ファイルで管理し、トップレベルの `labels:` キー配下に定義の配列を並べる。
+
+```yaml
+# .spec-board/labels.yml
+labels:
+  - name: bug
+    description: バグ報告
+    group: type
+    color: "#D73A4A"        # 必ずクォートする（unquoted な #... は YAML コメント扱いになる）
+    updated: "2026-05-30T12:00:00Z"
+  - name: enhancement       # name のみ（他フィールドは任意・省略可）
+```
+
+### フィールド定義
+
+| フィールド | 型 | 必須 | デフォルト | 説明 |
+|:----------|:---|:-----|:----------|:-----|
+| labels | `LabelDefinition[]` | いいえ | `[]` | ラベル定義の配列。トップレベルキー欠落 / `null` / 空配列はいずれも空レジストリ（= 全ラベル暗黙扱い）に正規化される |
+| labels[].name | `string` | はい | - | ラベル識別子。完全一致・未正規化（trim / 大文字小文字統一なし）。空文字 `""` は不可 |
+| labels[].description | `string` | いいえ | なし | ラベルの説明文 |
+| labels[].group | `string` | いいえ | なし | UI 上のグルーピングに使うグループ名（グルーピングの表示は表示層の責務） |
+| labels[].color | `string` | いいえ | なし（既定色） | `#RRGGBB` 形式の色。不正形式は lenient に「色なし（既定色）」へ倒す（後述） |
+| labels[].updated | `string` | いいえ | なし | 最終更新日時。ISO 8601 を推奨するが形式は検証せず文字列のまま保持する |
+
+### 配置・読み込み
+
+- `.spec-board/labels.yml` に配置する。ファイル不在時は空レジストリ（`labels: []`）として扱い、プロジェクトは正常に開ける（後方互換）。
+- プロジェクトオープン時（`open_project`）に読み込み、`AppState` に保持する。取得は独立した `get_labels` コマンドで行う（`open_project` の payload には同梱しない）。
+- 空ファイル / コメントのみ / `---`（null ドキュメント）/ `labels:` キー欠落 / `labels: null` はいずれも空レジストリに正規化する。
+
+### color の lenient 解釈
+
+- `color` は `#RRGGBB`（`#` + 16 進 6 桁）のみ妥当とみなす。妥当な場合のみ色として保持する。
+- 不正形式（`"red"` / `"#GGG"` 等）・型不一致（数値 `123` / マッピング `{}`）・欠落・`null` はエラーにせず「色なし」へ倒す。payload では `color` を省略し、既定色の適用は FE 表示層の責務とする。
+- **`color` はクォート必須**: YAML では `#` 以降がコメント扱いになるため、`color: #1A2B3C`（クォートなし）は値が `null` と解釈され、silently 既定色へ倒れる。必ず `color: "#1A2B3C"` とクォートする。
+
+### name 一意性の検証
+
+- `name` はマスタ内で完全一致・一意。重複が見つかれば load 時に拒否し、`open_project` は `labels load failed (parse)` として失敗する。
+- `name` が空文字 `""` の定義も load 時に拒否する（`labels load failed (parse)`）。空白のみ `"   "` は trim しない方針のため許容する（未正規化）。
+- ここでの「一意性 / 空拒否」はマスタ定義 `labels.yml` 自身に対する制約であり、**frontmatter の未定義ラベル**（labels.yml に存在しないラベル名）は警告なく暗黙許容する点と区別する。
+
+### スキーマの前方互換
+
+- 未知のトップレベルキー / 定義内キーは無視する（`deny_unknown_fields` は付けない）。将来のフィールド追加に対する前方互換のため。
+- lenient なのは `color` のみ。`name` / `description` / `group` / `updated` は文字列型を strict に検証し、文字列以外（数値 `123` / bool / mapping / sequence 等）が来た場合は `labels load failed (parse)` として扱う（`description: "123"` のようにクォートすれば文字列として受理される）。
+- `get_labels` payload は labels.yml の定義順をそのまま保持する（並べ替えない）。`group` での UI グルーピングは表示層の責務。
+
+> **スコープ境界**: 本仕様は labels.yml のスキーマ確定・読み込み・`get_labels` コマンド・invoke ラッパまでを対象とする。実際のラベル色の UI 反映（既定色の具体値 / design token 定義）は別 Issue で扱う。
 
 ## 設定の初期化
 

--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -17,6 +17,7 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | `update_task` | 既存タスクのmdファイルを更新 |
 | `delete_task` | タスクのmdファイルを削除 |
 | `get_columns` | カラム設定を取得（[config-spec.md](./config-spec.md) 参照） |
+| `get_labels` | ラベルマスタ定義を取得（[config-spec.md](./config-spec.md) 「labels.yml スキーマ」参照） |
 | `update_columns` | カラム設定を更新（[config-spec.md](./config-spec.md) 参照） |
 | `update_card_order` | カラム内のカード並び順を更新（[config-spec.md](./config-spec.md) 参照） |
 | `add_link` | タスク間の関連リンクを追加 |
@@ -28,7 +29,9 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 
 **説明**: 指定ディレクトリをプロジェクトとして開き、配下のmdファイルをスキャンしてタスク一覧を返す。同時に `notify` ベースの実 watcher を起動し、`task-created` / `task-updated` / `task-deleted` を `tauri::AppHandle::emit` でフロントエンドに配信する adapter を `AppState` に設置する。
 
-> 本コマンド呼び出しでは GUIDE.md の best-effort 書き出し（`<project_root>/.spec-board/GUIDE.md`）と `AppState` の 5 フィールド（`project_path` / `config` / `tasks_cache` / `watcher_handle` / `write_ignore`）の更新を、(1) watcher 起動準備 → (2) 旧 watcher 停止 → (3) state commit → (4) adapter spawn の 4 段階で行う。watcher 起動が失敗した場合は AppState を一切変更せず `WatcherInitFailed` を返す（旧プロジェクトを表示したまま動作継続）。
+> 本コマンド呼び出しでは GUIDE.md の best-effort 書き出し（`<project_root>/.spec-board/GUIDE.md`）と `AppState` の 6 フィールド（`project_path` / `config` / `labels` / `tasks_cache` / `watcher_handle` / `write_ignore`）の更新を、(1) watcher 起動準備 → (2) 旧 watcher 停止 → (3) state commit → (4) adapter spawn の 4 段階で行う。watcher 起動が失敗した場合は AppState を一切変更せず `WatcherInitFailed` を返す（旧プロジェクトを表示したまま動作継続）。
+
+> `.spec-board/labels.yml`（ラベルマスタ）も config 読み込みと同じく open 時に読み込み、`AppState.labels` に commit する。不在時は空レジストリ（`labels: []`）で開け、後方互換を保つ。壊れた YAML / name 重複 / name 空文字は `labels load failed (parse)`、I/O 異常は `labels load failed (io)` として open に失敗する。取得は独立コマンド `get_labels` で行い、本コマンドの payload には同梱しない。
 
 **引数**:
 

--- a/docs/spec-board/task-format-spec.md
+++ b/docs/spec-board/task-format-spec.md
@@ -72,6 +72,7 @@ links:
 - 省略可能。省略時は空配列として扱う
 - 各ラベルは任意の文字列
 - 重複するラベルはパース時に除去
+- frontmatter の `labels` は自由文字列であり、ラベルマスタ `.spec-board/labels.yml`（[config-spec.md](./config-spec.md) 「labels.yml スキーマ」参照）に未定義のラベルも**警告なく暗黙許容**する。labels.yml の読み込みは frontmatter の `labels` に一切干渉せず非破壊である（マスタはあくまで説明・色などのメタ情報の付与に使う）
 
 #### parent
 

--- a/src-tauri/crates/fs/src/config/config_io.rs
+++ b/src-tauri/crates/fs/src/config/config_io.rs
@@ -32,8 +32,161 @@ use thiserror::Error;
 const SPEC_BOARD_DIR: &str = ".spec-board";
 const CONFIG_FILE_NAME: &str = "config.json";
 const GUIDE_MARKDOWN_FILE_NAME: &str = "GUIDE.md";
+/// `.spec-board/labels.yml`（ラベルマスタ定義）のファイル名。
+///
+/// 中身（YAML）のパース / シリアライズは本体クレート側の責務であり、本サブクレートは
+/// [`SpecBoardDir`] 経由で raw `String` の読み書きのみを担当する（境界規約）。
+pub const LABELS_FILE_NAME: &str = "labels.yml";
 static GUIDE_MARKDOWN_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CONFIG_JSON_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+static SPEC_BOARD_DIR_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// プロジェクトの `.spec-board/` ディレクトリを管理し、配下ファイルの
+/// **format 非依存**な raw `String` I/O を提供するリソース管理 struct。
+///
+/// `project_root` を保持するため、呼び出し側は project_root を毎回引数で引き回さない。
+/// 本 struct は **パースをしない**（YAML / JSON の解釈は本体クレート `spec-board` 側の
+/// store の責務）。`.spec-board/` という「リソース」を所有する境界として機能する。
+///
+/// # 提供する操作
+///
+/// - [`SpecBoardDir::file_path`]: `.spec-board/<file_name>` の絶対パス（存在有無は問わない）
+/// - [`SpecBoardDir::ensure`]: `.spec-board/` を冪等に作成
+/// - [`SpecBoardDir::read_file`]: 配下ファイルを raw `String` で読む（不在のみ `Ok(None)`）
+/// - [`SpecBoardDir::write_file`]: 配下ファイルへ tmp→rename の atomic write（symlink 拒否込み）
+pub struct SpecBoardDir {
+    project_root: PathBuf,
+}
+
+impl SpecBoardDir {
+    /// `project_root` を保持する [`SpecBoardDir`] を生成する。
+    pub fn new(project_root: impl Into<PathBuf>) -> Self {
+        Self {
+            project_root: project_root.into(),
+        }
+    }
+
+    /// `.spec-board/<file_name>` の絶対パス相当を返す（純粋計算、I/O なし）。
+    ///
+    /// `project_root` が相対パスなら戻り値も相対パスになる（`canonicalize` は行わない）。
+    pub fn file_path(&self, file_name: &str) -> PathBuf {
+        self.project_root.join(SPEC_BOARD_DIR).join(file_name)
+    }
+
+    /// `.spec-board/` を冪等に作成し、その `PathBuf` を返す。
+    ///
+    /// 詳細なエラー条件は [`ensure_spec_board_dir`] と同じ。
+    pub fn ensure(&self) -> Result<PathBuf, ConfigIoError> {
+        ensure_spec_board_dir(&self.project_root)
+    }
+
+    /// `.spec-board/<file_name>` の中身を `String` で読み込む。
+    ///
+    /// - 対象ファイルが存在しない場合のみ `Ok(None)` を返す（呼び出し側で Default 初期化に分岐）。
+    /// - 中身が不正フォーマットでも本層では検査せず、生の文字列として返す（パースは本体クレート）。
+    /// - `project_root` / `.spec-board/` の不在・非ディレクトリ、壊れた symlink（dangling）は
+    ///   `Err(ConfigIoError::Io)` を返す（「ファイル不在」と「環境異常」を呼び出し側で区別可能にするため）。
+    ///
+    /// # Errors
+    ///
+    /// - `project_root` / `.spec-board/` 不在 / アクセス不可 / 非ディレクトリ
+    /// - 対象ファイルがディレクトリ / 特殊ファイル / dangling symlink として存在する
+    /// - 権限不足等で `read_to_string` が失敗する
+    pub fn read_file(&self, file_name: &str) -> Result<Option<String>, ConfigIoError> {
+        Self::validate_file_name(file_name)?;
+        validate_dir(&self.project_root)?;
+        let spec_board_dir = self.project_root.join(SPEC_BOARD_DIR);
+        validate_dir(&spec_board_dir)?;
+
+        let path = self.file_path(file_name);
+
+        // dir entry の存在は `symlink_metadata` で先に確認する。`metadata` は symlink を
+        // 辿るため dangling symlink を `NotFound` として `Ok(None)` 扱いしてしまうが、
+        // これは「ファイル不在」ではなく環境異常として `Err(Io)` を返したい。
+        if let Err(e) = std::fs::symlink_metadata(&path) {
+            return if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(None)
+            } else {
+                Err(io_err(&path, e))
+            };
+        }
+
+        let meta = std::fs::metadata(&path).map_err(|e| io_err(&path, e))?;
+        if !meta.is_file() {
+            let kind = if meta.is_dir() {
+                std::io::ErrorKind::IsADirectory
+            } else {
+                std::io::ErrorKind::InvalidInput
+            };
+            return Err(io_err(&path, std::io::Error::from(kind)));
+        }
+
+        let content = std::fs::read_to_string(&path).map_err(|e| io_err(&path, e))?;
+        Ok(Some(content))
+    }
+
+    /// `.spec-board/<file_name>` へ `content` を書き込む。
+    ///
+    /// 書き込み前に [`SpecBoardDir::ensure`] で `.spec-board/` を作成し、fresh tmp file へ
+    /// 書いてから `rename` で置き換える。`.spec-board/` または対象ファイルが symlink の場合は、
+    /// project root 外のファイル上書きを防ぐため拒否する。
+    ///
+    /// # Errors
+    ///
+    /// - `project_root` が存在しない / 非ディレクトリ / アクセス不可
+    /// - `.spec-board/` または対象ファイルが symlink として存在する
+    /// - 権限不足等で `.spec-board/` 作成または書き込みが失敗する
+    pub fn write_file(&self, file_name: &str, content: &str) -> Result<PathBuf, ConfigIoError> {
+        Self::validate_file_name(file_name)?;
+        let spec_board_dir = self.ensure()?;
+        reject_existing_symlink(&spec_board_dir)?;
+        let target = self.file_path(file_name);
+        reject_existing_symlink(&target)?;
+
+        let tmp_path = unique_spec_board_tmp_path(&spec_board_dir, file_name);
+        write_file_via_tmp(&target, content, &tmp_path)?;
+
+        Ok(target)
+    }
+
+    /// `file_name` が `.spec-board/` 直下の単一ファイル名であることを検証する。
+    ///
+    /// パスセパレータ・`..`（親ディレクトリ）・絶対パス・空文字を拒否し、`.spec-board/`
+    /// 外への読み書き（path traversal）を防ぐ。現状の呼び出しは定数ファイル名のみだが、
+    /// `SpecBoardDir` は公開 API のため、将来ユーザー入力由来の名前が渡された場合の
+    /// 防御として正規化された単一コンポーネント（`Component::Normal` 1 個）だけを許可する。
+    fn validate_file_name(file_name: &str) -> Result<(), ConfigIoError> {
+        use std::path::Component;
+        let mut components = Path::new(file_name).components();
+        let is_single_normal = matches!(
+            (components.next(), components.next()),
+            (Some(Component::Normal(_)), None)
+        );
+        if !is_single_normal {
+            return Err(io_err(
+                Path::new(file_name),
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("invalid .spec-board file name: `{file_name}`"),
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// `.spec-board/<file_name>.tmp.{pid}.{nanos}.{counter}` 形式の unique tmp パスを生成する。
+///
+/// `file_name` をプレフィックスに含めることで、異なる対象ファイルの並行書き込みでも
+/// tmp パスが衝突しない。`counter` は process-local AtomicU64 で in-process 一意性を担保。
+fn unique_spec_board_tmp_path(spec_board_dir: &Path, file_name: &str) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let counter = SPEC_BOARD_DIR_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    spec_board_dir.join(format!("{file_name}.tmp.{pid}.{nanos}.{counter}"))
+}
 
 /// `config_io` モジュールのファイル I/O で発生し得るエラー。
 ///
@@ -164,41 +317,9 @@ pub fn ensure_spec_board_dir(project_root: &Path) -> Result<PathBuf, ConfigIoErr
 ///   存在する場合（`Ok(None)` には**しない**。dir entry は存在するため「設定ファイル
 ///   不在」ではなく環境異常として扱う）
 pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoError> {
-    validate_dir(project_root)?;
-    let spec_board_dir = project_root.join(SPEC_BOARD_DIR);
-    validate_dir(&spec_board_dir)?;
-
-    let config_path = config_path(project_root);
-
-    // dir entry の存在は `symlink_metadata` で先に確認する。`metadata` は
-    // symlink を辿るため、dangling symlink (リンク先が消えた状態) を
-    // `NotFound` として `Ok(None)` 扱いしてしまうが、これは「設定ファイル
-    // 不在」ではなく環境異常（壊れた symlink）として `Err(Io)` を返したい。
-    if let Err(e) = std::fs::symlink_metadata(&config_path) {
-        return if e.kind() == std::io::ErrorKind::NotFound {
-            Ok(None)
-        } else {
-            Err(io_err(&config_path, e))
-        };
-    }
-
-    // symlink_metadata が成功 = dir entry は存在する。ここで `metadata` が
-    // `NotFound` を返すのは dangling symlink のときのみ。
-    // 「壊れた symlink」を `Ok(None)` にしないため、`Err` として伝播する。
-    let meta = std::fs::metadata(&config_path).map_err(|e| io_err(&config_path, e))?;
-    if !meta.is_file() {
-        // ディレクトリの場合は `IsADirectory`、それ以外の非ファイル（特殊ファイル等）は
-        // `InvalidInput` を返す。呼び出し側が `ErrorKind` で分岐できるよう明示する。
-        let kind = if meta.is_dir() {
-            std::io::ErrorKind::IsADirectory
-        } else {
-            std::io::ErrorKind::InvalidInput
-        };
-        return Err(io_err(&config_path, std::io::Error::from(kind)));
-    }
-
-    let content = std::fs::read_to_string(&config_path).map_err(|e| io_err(&config_path, e))?;
-    Ok(Some(content))
+    // raw String の読み込みは format 非依存の `SpecBoardDir` に委譲する。
+    // `config.json` 固有の検査（version / schema）は本体クレート側の責務。
+    SpecBoardDir::new(project_root).read_file(CONFIG_FILE_NAME)
 }
 
 /// `<project_root>/.spec-board/GUIDE.md` へ Markdown 文字列を書き込む。

--- a/src-tauri/crates/fs/src/config/config_io.rs
+++ b/src-tauri/crates/fs/src/config/config_io.rs
@@ -68,8 +68,25 @@ impl SpecBoardDir {
 
     /// `.spec-board/<file_name>` の絶対パス相当を返す（純粋計算、I/O なし）。
     ///
-    /// `project_root` が相対パスなら戻り値も相対パスになる（`canonicalize` は行わない）。
-    pub fn file_path(&self, file_name: &str) -> PathBuf {
+    /// `read_file` / `write_file` と同じく `file_name` を検証し、パスセパレータ・`..`・
+    /// 絶対パス・空文字を拒否する。これにより公開 API として `.spec-board/` 外を指す
+    /// パスを生成できないようにする（path traversal 防止。`read_file`/`write_file` だけが
+    /// 検証する非対称を解消する）。`project_root` が相対パスなら戻り値も相対パスになる
+    /// （`canonicalize` は行わない）。
+    ///
+    /// # Errors
+    ///
+    /// - `file_name` が単一の通常コンポーネントでない（`..` / セパレータ / 絶対パス / 空）場合
+    pub fn file_path(&self, file_name: &str) -> Result<PathBuf, ConfigIoError> {
+        Self::validate_file_name(file_name)?;
+        Ok(self.join_unchecked(file_name))
+    }
+
+    /// `.spec-board/<file_name>` を検証せず join する内部ヘルパー。
+    ///
+    /// 呼び出し側で先に [`SpecBoardDir::validate_file_name`] 済みであることを前提とする
+    /// （`read_file` / `write_file` は冒頭で検証してからこれを使う）。
+    fn join_unchecked(&self, file_name: &str) -> PathBuf {
         self.project_root.join(SPEC_BOARD_DIR).join(file_name)
     }
 
@@ -98,7 +115,7 @@ impl SpecBoardDir {
         let spec_board_dir = self.project_root.join(SPEC_BOARD_DIR);
         validate_dir(&spec_board_dir)?;
 
-        let path = self.file_path(file_name);
+        let path = self.join_unchecked(file_name);
 
         // dir entry の存在は `symlink_metadata` で先に確認する。`metadata` は symlink を
         // 辿るため dangling symlink を `NotFound` として `Ok(None)` 扱いしてしまうが、
@@ -140,7 +157,7 @@ impl SpecBoardDir {
         Self::validate_file_name(file_name)?;
         let spec_board_dir = self.ensure()?;
         reject_existing_symlink(&spec_board_dir)?;
-        let target = self.file_path(file_name);
+        let target = self.join_unchecked(file_name);
         reject_existing_symlink(&target)?;
 
         let tmp_path = unique_spec_board_tmp_path(&spec_board_dir, file_name);

--- a/src-tauri/crates/fs/src/config/config_io_tests.rs
+++ b/src-tauri/crates/fs/src/config/config_io_tests.rs
@@ -417,3 +417,98 @@ fn read_config_json_returns_err_when_config_is_unreadable() {
         }
     }
 }
+
+// ───────── SpecBoardDir（format 非依存 raw I/O） ─────────
+
+#[test]
+fn labels_file_name_is_labels_yml() {
+    assert_eq!(LABELS_FILE_NAME, "labels.yml");
+}
+
+#[test]
+fn spec_board_dir_read_file_returns_content_when_present() {
+    let tmp = TempDir::new().unwrap();
+    let spec_board = tmp.path().join(".spec-board");
+    std::fs::create_dir(&spec_board).unwrap();
+    std::fs::write(spec_board.join(LABELS_FILE_NAME), "labels: []\n").unwrap();
+
+    let dir = SpecBoardDir::new(tmp.path());
+    let content = dir.read_file(LABELS_FILE_NAME).unwrap();
+    assert_eq!(content, Some("labels: []\n".to_string()));
+}
+
+#[test]
+fn spec_board_dir_read_file_returns_none_when_file_absent() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir(tmp.path().join(".spec-board")).unwrap();
+
+    let dir = SpecBoardDir::new(tmp.path());
+    let content = dir.read_file(LABELS_FILE_NAME).unwrap();
+    assert_eq!(content, None);
+}
+
+#[test]
+fn spec_board_dir_read_file_errs_when_spec_board_is_file() {
+    let tmp = TempDir::new().unwrap();
+    // `.spec-board` をディレクトリではなくファイルにする = 環境異常
+    std::fs::write(tmp.path().join(".spec-board"), b"not a dir").unwrap();
+
+    let dir = SpecBoardDir::new(tmp.path());
+    let err = dir.read_file(LABELS_FILE_NAME).unwrap_err();
+    let ConfigIoError::Io { .. } = err;
+}
+
+#[test]
+fn spec_board_dir_write_then_read_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let dir = SpecBoardDir::new(tmp.path());
+
+    let written = dir.write_file(LABELS_FILE_NAME, "labels:\n  - name: bug\n").unwrap();
+    assert_eq!(written, tmp.path().join(".spec-board").join(LABELS_FILE_NAME));
+
+    let content = dir.read_file(LABELS_FILE_NAME).unwrap();
+    assert_eq!(content, Some("labels:\n  - name: bug\n".to_string()));
+}
+
+#[test]
+fn spec_board_dir_write_creates_spec_board_dir_when_absent() {
+    let tmp = TempDir::new().unwrap();
+    let dir = SpecBoardDir::new(tmp.path());
+
+    dir.write_file(LABELS_FILE_NAME, "labels: []\n").unwrap();
+    assert!(tmp.path().join(".spec-board").is_dir());
+}
+
+#[cfg(unix)]
+#[test]
+fn spec_board_dir_write_rejects_symlink_leaf() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    let spec_board = tmp.path().join(".spec-board");
+    std::fs::create_dir(&spec_board).unwrap();
+    let outside = tmp.path().join("outside.yml");
+    std::fs::write(&outside, b"original").unwrap();
+    // labels.yml を project 外ファイルへの symlink にする
+    symlink(&outside, spec_board.join(LABELS_FILE_NAME)).unwrap();
+
+    let dir = SpecBoardDir::new(tmp.path());
+    let err = dir.write_file(LABELS_FILE_NAME, "overwritten").unwrap_err();
+    let ConfigIoError::Io { .. } = err;
+    // symlink 先のファイルが上書きされていないこと
+    assert_eq!(std::fs::read_to_string(&outside).unwrap(), "original");
+}
+
+#[test]
+fn spec_board_dir_rejects_path_traversal_file_names() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir(tmp.path().join(".spec-board")).unwrap();
+    let dir = SpecBoardDir::new(tmp.path());
+
+    for bad in ["../outside.yml", "../../etc/passwd", "sub/dir.yml", "/abs.yml", ""] {
+        let read_err = dir.read_file(bad).unwrap_err();
+        let ConfigIoError::Io { .. } = read_err;
+        let write_err = dir.write_file(bad, "x").unwrap_err();
+        let ConfigIoError::Io { .. } = write_err;
+    }
+}

--- a/src-tauri/crates/fs/src/config/config_io_tests.rs
+++ b/src-tauri/crates/fs/src/config/config_io_tests.rs
@@ -463,8 +463,13 @@ fn spec_board_dir_write_then_read_roundtrip() {
     let tmp = TempDir::new().unwrap();
     let dir = SpecBoardDir::new(tmp.path());
 
-    let written = dir.write_file(LABELS_FILE_NAME, "labels:\n  - name: bug\n").unwrap();
-    assert_eq!(written, tmp.path().join(".spec-board").join(LABELS_FILE_NAME));
+    let written = dir
+        .write_file(LABELS_FILE_NAME, "labels:\n  - name: bug\n")
+        .unwrap();
+    assert_eq!(
+        written,
+        tmp.path().join(".spec-board").join(LABELS_FILE_NAME)
+    );
 
     let content = dir.read_file(LABELS_FILE_NAME).unwrap();
     assert_eq!(content, Some("labels:\n  - name: bug\n".to_string()));
@@ -505,7 +510,13 @@ fn spec_board_dir_rejects_path_traversal_file_names() {
     std::fs::create_dir(tmp.path().join(".spec-board")).unwrap();
     let dir = SpecBoardDir::new(tmp.path());
 
-    for bad in ["../outside.yml", "../../etc/passwd", "sub/dir.yml", "/abs.yml", ""] {
+    for bad in [
+        "../outside.yml",
+        "../../etc/passwd",
+        "sub/dir.yml",
+        "/abs.yml",
+        "",
+    ] {
         let read_err = dir.read_file(bad).unwrap_err();
         let ConfigIoError::Io { .. } = read_err;
         let write_err = dir.write_file(bad, "x").unwrap_err();

--- a/src-tauri/crates/fs/src/config/config_io_tests.rs
+++ b/src-tauri/crates/fs/src/config/config_io_tests.rs
@@ -523,3 +523,19 @@ fn spec_board_dir_rejects_path_traversal_file_names() {
         let ConfigIoError::Io { .. } = write_err;
     }
 }
+
+#[test]
+fn spec_board_dir_file_path_validates_and_rejects_traversal() {
+    let tmp = TempDir::new().unwrap();
+    let dir = SpecBoardDir::new(tmp.path());
+
+    // 正常: 単一ファイル名は .spec-board/ 直下の絶対パス
+    let ok = dir.file_path(LABELS_FILE_NAME).unwrap();
+    assert_eq!(ok, tmp.path().join(".spec-board").join(LABELS_FILE_NAME));
+
+    // 異常: 親ディレクトリ / セパレータ / 絶対パス / 空は拒否
+    for bad in ["../outside.yml", "sub/dir.yml", "/abs.yml", ""] {
+        let err = dir.file_path(bad).unwrap_err();
+        let ConfigIoError::Io { .. } = err;
+    }
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1431,7 +1431,7 @@ impl LabelRegistryStore for YamlLabelRegistryStore {
         if content.trim().is_empty() {
             return Ok(LabelRegistry::default());
         }
-        let path = self.dir.file_path(LABELS_FILE_NAME);
+        let path = self.dir.file_path(LABELS_FILE_NAME)?;
         // Option で受けることで、コメントのみ / `---`（null ドキュメント）も None → Default に倒す。
         let registry = serde_yaml_ng::from_str::<Option<LabelRegistry>>(&content)
             .map_err(|source| LoadLabelsError::Parse { path, source })?

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -54,6 +54,7 @@
 
 pub mod column_name;
 pub mod get_columns;
+pub mod get_labels;
 pub mod update_card_order;
 pub mod update_columns;
 
@@ -66,7 +67,9 @@ use crate::config::column_name::ColumnName;
 use crate::config::update_columns::{ColumnRename, UpdateColumnsArgs, UpdateColumnsError};
 use crate::task::task_file_path::TaskFilePath;
 use crate::task::task_index::Task;
-use spec_board_fs::config::config_io::{self, write_guide_markdown, ConfigIoError};
+use spec_board_fs::config::config_io::{
+    self, write_guide_markdown, ConfigIoError, SpecBoardDir, LABELS_FILE_NAME,
+};
 use thiserror::Error;
 
 /// `cardOrder` の型エイリアス。キー = カラム名、値 = タスクファイルパスの並び順配列。
@@ -1176,5 +1179,277 @@ pub fn load_or_default(project_root: &Path) -> Result<Config, LoadConfigError> {
     Ok(config)
 }
 
+// ───────── ラベルマスタ（`.spec-board/labels.yml`） ─────────
+
+/// `labels.yml` 全体。トップレベルは `labels:` キー配下の定義配列。
+///
+/// 将来 `version` 等のメタを同階層に追加しやすい構造にしてある。`labels:` キー欠落 /
+/// `labels: null` / 空配列のいずれも空 `Vec`（= 全ラベル暗黙扱い）に正規化する。
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelRegistry {
+    /// ラベル定義の配列。lenient deserialize は Label 固有のロジックなので
+    /// module free function ではなく aggregate の関連関数に紐づける。
+    #[serde(default, deserialize_with = "LabelRegistry::deserialize_labels")]
+    pub labels: Vec<LabelDefinition>,
+}
+
+impl LabelRegistry {
+    /// `labels:` フィールドの lenient deserialize。`null`（YAML の `~` / キー単独）でも
+    /// 空 `Vec` に倒す（`#[serde(default)]` だけでは `labels: null` が Vec の deserialize で
+    /// 落ちるため）。Label 固有ロジックなので aggregate の関連関数として保持する。
+    fn deserialize_labels<'de, D>(de: D) -> Result<Vec<LabelDefinition>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let opt = Option::<Vec<LabelDefinition>>::deserialize(de)?;
+        Ok(opt.unwrap_or_default())
+    }
+
+    /// マスタ整合性を検証する。
+    ///
+    /// (1) `name` 空文字拒否（既存 `Label::try_from_str` 同方針、trim しない）、
+    /// (2) `name` の完全一致重複検出（未正規化・完全一致一意）。定義順は保持したまま
+    /// 検証のみ行う。ドメイン不変条件なので aggregate に同居させる。load / save 双方が
+    /// `#[from]` で自エラーへ持ち上げる。
+    fn validate(&self) -> Result<(), LabelValidationError> {
+        let mut seen: HashSet<&str> = HashSet::with_capacity(self.labels.len());
+        for label in &self.labels {
+            if label.name.is_empty() {
+                return Err(LabelValidationError::EmptyLabelName);
+            }
+            if !seen.insert(label.name.as_str()) {
+                return Err(LabelValidationError::DuplicateLabelName {
+                    name: label.name.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// 単一ラベルのマスタ定義。`name` のみ必須、他は任意。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LabelDefinition {
+    /// ラベル識別子（必須）。完全一致・未正規化（trim / case 正規化なし）。
+    /// 文字列以外（数値 / bool / mapping 等）は型不一致として deserialize で拒否する
+    /// （lenient なのは `color` のみという契約）。
+    #[serde(deserialize_with = "LabelDefinition::deserialize_string")]
+    pub name: String,
+    #[serde(
+        default,
+        deserialize_with = "LabelDefinition::deserialize_opt_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub description: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "LabelDefinition::deserialize_opt_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub group: Option<String>,
+    /// `#RRGGBB`。不正形式・型不一致（`123` / `{}` 等）は lenient に `None`（既定色）へ倒す。
+    #[serde(
+        default,
+        deserialize_with = "LabelColor::deserialize_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub color: Option<LabelColor>,
+    /// 最終更新日時（任意）。形式検証は行わず文字列のまま保持する。
+    #[serde(
+        default,
+        deserialize_with = "LabelDefinition::deserialize_opt_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub updated: Option<String>,
+}
+
+impl LabelDefinition {
+    /// 文字列フィールド（`name`）の strict deserialize。文字列以外は型不一致エラー。
+    /// `color` 以外は lenient フォールバックを設けない契約のため、数値 / bool / 構造などは
+    /// `LoadLabelsError::Parse` に倒す。Label 固有ロジックなので型に紐づける。
+    fn deserialize_string<'de, D>(de: D) -> Result<String, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match serde_yaml_ng::Value::deserialize(de)? {
+            serde_yaml_ng::Value::String(s) => Ok(s),
+            other => Err(serde::de::Error::custom(format!(
+                "label field must be a string, found {}",
+                yaml_value_type(&other)
+            ))),
+        }
+    }
+
+    /// 任意文字列フィールド（`description` / `group` / `updated`）の strict deserialize。
+    /// `null` のみ `None` を許し、文字列は `Some`、それ以外の型は型不一致エラーに倒す。
+    fn deserialize_opt_string<'de, D>(de: D) -> Result<Option<String>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match serde_yaml_ng::Value::deserialize(de)? {
+            serde_yaml_ng::Value::Null => Ok(None),
+            serde_yaml_ng::Value::String(s) => Ok(Some(s)),
+            other => Err(serde::de::Error::custom(format!(
+                "expected a string, found {}",
+                yaml_value_type(&other)
+            ))),
+        }
+    }
+}
+
+/// `serde_yaml_ng::Value` の種別名を返す（型不一致エラーメッセージ用）。
+fn yaml_value_type(value: &serde_yaml_ng::Value) -> &'static str {
+    match value {
+        serde_yaml_ng::Value::Null => "null",
+        serde_yaml_ng::Value::Bool(_) => "boolean",
+        serde_yaml_ng::Value::Number(_) => "number",
+        serde_yaml_ng::Value::String(_) => "string",
+        serde_yaml_ng::Value::Sequence(_) => "sequence",
+        serde_yaml_ng::Value::Mapping(_) => "mapping",
+        serde_yaml_ng::Value::Tagged(_) => "tagged value",
+    }
+}
+
+/// `#RRGGBB` 形式の色 VO。constructor で形式を強制する。
+///
+/// `Deserialize` は derive せず、フィールド側の関連関数 [`LabelColor::deserialize_opt`]
+/// 経由でのみ生成する（不正値を `None` に倒すため）。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LabelColor(String);
+
+impl LabelColor {
+    /// `#RRGGBB`（`#` + 16 進 6 桁）のみ受理する。それ以外は `None`。
+    pub fn from_hex(raw: &str) -> Option<Self> {
+        let is_valid = raw.len() == 7
+            && raw.starts_with('#')
+            && raw[1..].bytes().all(|b| b.is_ascii_hexdigit());
+        is_valid.then(|| Self(raw.to_string()))
+    }
+
+    /// 保持している `#RRGGBB` 文字列を返す。
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// `color` フィールドの lenient deserialize。`serde_yaml_ng::Value` で一旦受け、
+    /// 「文字列かつ `#RRGGBB` 妥当」のみ `Some(LabelColor)`、それ以外（不正文字列 /
+    /// 数値 / mapping / null）は `None` に倒す。**エラーにしない**。LabelColor 固有
+    /// ロジックなので関連関数として型に紐づける。
+    fn deserialize_opt<'de, D>(de: D) -> Result<Option<LabelColor>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_yaml_ng::Value::deserialize(de)?;
+        Ok(value.as_str().and_then(LabelColor::from_hex))
+    }
+}
+
+/// ラベルマスタの整合性違反。`LabelRegistry::validate` が返すドメインエラー。
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum LabelValidationError {
+    /// `name` が完全一致で重複している（未正規化・完全一致一意の契約違反）。
+    #[error("duplicate label name in labels.yml: `{name}`")]
+    DuplicateLabelName { name: String },
+    /// `name` が空文字（`""`）。識別子として無効。空白のみ（`"   "`）は trim しない方針のため許容する。
+    #[error("label name must not be empty in labels.yml")]
+    EmptyLabelName,
+}
+
+/// `labels.yml` の読み込みエラー。`labels load failed (io|parse)` 方針に揃える。
+#[derive(Debug, Error)]
+pub enum LoadLabelsError {
+    #[error(transparent)]
+    Io(#[from] ConfigIoError),
+    #[error("failed to parse labels.yml at `{path}`: {source}", path = path.display())]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml_ng::Error,
+    },
+    /// マスタ整合性違反（name 空 / 重複）。load / save 双方で共有する。
+    #[error(transparent)]
+    Validation(#[from] LabelValidationError),
+}
+
+/// `labels.yml` の書き込みエラー（save 経路）。
+#[derive(Debug, Error)]
+pub enum SaveLabelsError {
+    #[error(transparent)]
+    Io(#[from] ConfigIoError),
+    #[error("failed to serialize labels: {0}")]
+    Serialize(#[source] serde_yaml_ng::Error),
+    /// 不整合なマスタは保存させない（load と同じ不変条件を共有）。
+    #[error(transparent)]
+    Validation(#[from] LabelValidationError),
+}
+
+/// ラベルマスタの永続化を抽象化する trait（format / 配置に非依存）。
+///
+/// 呼び出し側（`open_project` 等）はこの trait にのみ依存し、保存形式（YAML）も
+/// 具象型名も意識しない。テスト時はモック実装を注入できる。
+pub trait LabelRegistryStore {
+    /// マスタを読み込む。不在 / 空相当は Default（空レジストリ）。
+    fn load(&self) -> Result<LabelRegistry, LoadLabelsError>;
+    /// マスタを保存する（編集機能向け。本 Issue では read 経路が主だが対称性のため定義）。
+    fn save(&self, registry: &LabelRegistry) -> Result<(), SaveLabelsError>;
+}
+
+/// 既定の [`LabelRegistryStore`] を生成するファクトリ。**これが唯一の入口**。
+///
+/// 呼び出し側は具象型を名指しせず、trait だけを受け取る。形式の差し替え（JSON 等）は
+/// ここの戻り値を変えるだけで完結する。
+pub fn label_registry_store(project_root: &Path) -> impl LabelRegistryStore {
+    YamlLabelRegistryStore::new(project_root)
+}
+
+/// `.spec-board/labels.yml`（YAML 形式）でラベルマスタを管理する具象 store。
+///
+/// 形式（YAML）と配置（labels.yml）の知識をここに閉じ込める。I/O は内包する
+/// [`SpecBoardDir`]（リソース管理 struct）へ委譲する。`pub(crate)`: モジュール外からは
+/// [`label_registry_store`] ファクトリ + trait 経由でのみ触る。
+pub(crate) struct YamlLabelRegistryStore {
+    dir: SpecBoardDir,
+}
+
+impl YamlLabelRegistryStore {
+    pub(crate) fn new(project_root: impl Into<PathBuf>) -> Self {
+        Self {
+            dir: SpecBoardDir::new(project_root),
+        }
+    }
+}
+
+impl LabelRegistryStore for YamlLabelRegistryStore {
+    fn load(&self) -> Result<LabelRegistry, LoadLabelsError> {
+        // raw String 取得は SpecBoardDir（format 非依存）、YAML パースは本 store（境界規約）。
+        let Some(content) = self.dir.read_file(LABELS_FILE_NAME)? else {
+            return Ok(LabelRegistry::default());
+        };
+        // 空白のみは Default（serde に渡すと unit/null で落ちるため先に弾く）。
+        if content.trim().is_empty() {
+            return Ok(LabelRegistry::default());
+        }
+        let path = self.dir.file_path(LABELS_FILE_NAME);
+        // Option で受けることで、コメントのみ / `---`（null ドキュメント）も None → Default に倒す。
+        let registry = serde_yaml_ng::from_str::<Option<LabelRegistry>>(&content)
+            .map_err(|source| LoadLabelsError::Parse { path, source })?
+            .unwrap_or_default();
+        registry.validate()?;
+        Ok(registry)
+    }
+
+    fn save(&self, registry: &LabelRegistry) -> Result<(), SaveLabelsError> {
+        registry.validate()?;
+        let content = serde_yaml_ng::to_string(registry).map_err(SaveLabelsError::Serialize)?;
+        self.dir.write_file(LABELS_FILE_NAME, &content)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod config_tests;
+
+#[cfg(test)]
+mod label_registry_tests;

--- a/src-tauri/src/config/get_labels.rs
+++ b/src-tauri/src/config/get_labels.rs
@@ -1,0 +1,80 @@
+//! `get_labels` Tauri command 本体。
+//!
+//! `AppState.labels` に commit 済みの `LabelRegistry` からラベル定義一覧を取得し、
+//! FE のラベル表示用 payload として返す読み取り専用 command。`get_columns` と同じ
+//! 3 段構成（payload 型 + `#[tauri::command]` 薄層 + `_impl`）を採用する。
+//!
+//! payload は labels.yml の定義順をそのまま保持する（並べ替えない）。labels.yml 不在
+//! （= 空レジストリ・暗黙ラベル）でも `Ok(空配列)` を返す。プロジェクト未オープン
+//! （`labels` が `None`）のときのみ `NoProjectOpen`。
+//!
+//! # エラー文字列の契約
+//!
+//! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`（`get_columns` と一致）
+//! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`（同上）
+
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::State;
+use thiserror::Error;
+
+use crate::config::LabelDefinition;
+use crate::state::{AppState, AppStateError};
+
+/// `get_labels` コマンドが FE へ返す payload。
+///
+/// 各定義は name / description / group / color / updated を含み、labels.yml の定義順を保持する。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetLabelsPayload {
+    pub labels: Vec<LabelDefinition>,
+}
+
+/// `get_labels` コマンドのエラー。
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GetLabelsError {
+    /// `AppState.labels` が `None`（プロジェクト未オープン）。
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+    /// `AppState` 内部 mutex (`labels`) が poison 状態。
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+}
+
+impl From<AppStateError> for GetLabelsError {
+    fn from(_: AppStateError) -> Self {
+        GetLabelsError::StateLockPoisoned
+    }
+}
+
+/// Tauri command 薄層。`get_labels_impl` を呼び、エラーを文字列化して返す。
+///
+/// # Errors
+///
+/// - プロジェクト未オープン時に `"プロジェクトが開かれていません"`
+/// - `labels` の `Mutex` が poison している場合に `"内部状態のロックが破損しました"`
+#[tauri::command]
+pub fn get_labels(state: State<'_, Arc<AppState>>) -> Result<GetLabelsPayload, String> {
+    get_labels_impl(state.inner()).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の本体関数。`AppState.labels` から payload を組む。
+///
+/// labels.yml 不在 = 空レジストリ（暗黙ラベル）でも `Ok(空配列)`。
+/// プロジェクト未オープン（labels が `None`）のみ `NoProjectOpen`。
+///
+/// # Errors
+///
+/// - `AppState.labels` が `None` の場合 `GetLabelsError::NoProjectOpen`
+/// - `labels` の `Mutex` が poison している場合 `GetLabelsError::StateLockPoisoned`
+pub(crate) fn get_labels_impl(state: &AppState) -> Result<GetLabelsPayload, GetLabelsError> {
+    let registry = state.labels()?.ok_or(GetLabelsError::NoProjectOpen)?;
+    Ok(GetLabelsPayload {
+        labels: registry.labels,
+    })
+}
+
+#[cfg(test)]
+#[path = "get_labels_tests.rs"]
+mod get_labels_tests;

--- a/src-tauri/src/config/get_labels_tests.rs
+++ b/src-tauri/src/config/get_labels_tests.rs
@@ -1,0 +1,102 @@
+//! `get_labels_impl` のユニットテスト。
+
+use super::{get_labels_impl, GetLabelsError, GetLabelsPayload};
+use crate::config::{LabelColor, LabelDefinition, LabelRegistry};
+use crate::state::{AppState, AppStateError};
+
+fn label(name: &str, color: Option<&str>) -> LabelDefinition {
+    LabelDefinition {
+        name: name.to_string(),
+        description: None,
+        group: None,
+        color: color.and_then(LabelColor::from_hex),
+        updated: None,
+    }
+}
+
+#[test]
+fn returns_err_when_no_project_open() {
+    let state = AppState::new();
+    let err = get_labels_impl(&state).expect_err("labels 未注入時は Err");
+    assert_eq!(err, GetLabelsError::NoProjectOpen);
+}
+
+#[test]
+fn returns_empty_payload_when_registry_is_empty() {
+    let state = AppState::new();
+    // labels.yml 不在 = 空レジストリでも Ok（暗黙ラベル）
+    state
+        .replace_labels(Some(LabelRegistry::default()))
+        .expect("writable");
+
+    let payload = get_labels_impl(&state).expect("正常系");
+    assert_eq!(payload, GetLabelsPayload { labels: vec![] });
+}
+
+#[test]
+fn returns_labels_preserving_definition_order() {
+    let state = AppState::new();
+    let registry = LabelRegistry {
+        labels: vec![
+            label("zebra", Some("#111111")),
+            label("apple", None),
+            label("mango", Some("#222222")),
+        ],
+    };
+    state
+        .replace_labels(Some(registry.clone()))
+        .expect("writable");
+
+    let payload = get_labels_impl(&state).expect("正常系");
+    assert_eq!(payload.labels, registry.labels);
+    let names: Vec<&str> = payload.labels.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(names, vec!["zebra", "apple", "mango"]);
+}
+
+#[test]
+fn returns_all_fields_in_payload() {
+    let state = AppState::new();
+    let registry = LabelRegistry {
+        labels: vec![LabelDefinition {
+            name: "bug".to_string(),
+            description: Some("バグ".to_string()),
+            group: Some("type".to_string()),
+            color: LabelColor::from_hex("#D73A4A"),
+            updated: Some("2026-05-30T00:00:00Z".to_string()),
+        }],
+    };
+    state.replace_labels(Some(registry)).expect("writable");
+
+    let payload = get_labels_impl(&state).expect("正常系");
+    let label = &payload.labels[0];
+    assert_eq!(label.name, "bug");
+    assert_eq!(label.description.as_deref(), Some("バグ"));
+    assert_eq!(label.group.as_deref(), Some("type"));
+    assert_eq!(
+        label.color.as_ref().map(LabelColor::as_str),
+        Some("#D73A4A")
+    );
+    assert_eq!(label.updated.as_deref(), Some("2026-05-30T00:00:00Z"));
+}
+
+#[test]
+fn state_lock_poisoned_display_matches_contract() {
+    assert_eq!(
+        GetLabelsError::StateLockPoisoned.to_string(),
+        "内部状態のロックが破損しました"
+    );
+}
+
+#[test]
+fn no_project_open_display_matches_contract() {
+    assert_eq!(
+        GetLabelsError::NoProjectOpen.to_string(),
+        "プロジェクトが開かれていません"
+    );
+}
+
+#[test]
+fn from_app_state_error_maps_to_state_lock_poisoned() {
+    let err: GetLabelsError = AppStateError::LockPoisoned.into();
+    assert_eq!(err, GetLabelsError::StateLockPoisoned);
+}

--- a/src-tauri/src/config/label_registry_tests.rs
+++ b/src-tauri/src/config/label_registry_tests.rs
@@ -1,0 +1,343 @@
+//! `LabelRegistry` / `LabelColor` / `LabelRegistryStore`（`YamlLabelRegistryStore`）の
+//! ユニットテスト。load / save / color lenient / validate / format 抽象（trait モック）を網羅する。
+
+use super::{
+    label_registry_store, LabelColor, LabelDefinition, LabelRegistry, LabelRegistryStore,
+    LabelValidationError, LoadLabelsError, SaveLabelsError,
+};
+use tempfile::TempDir;
+
+fn write_labels_yml(root: &std::path::Path, content: &str) {
+    let dir = root.join(".spec-board");
+    std::fs::create_dir_all(&dir).expect("create .spec-board");
+    std::fs::write(dir.join("labels.yml"), content).expect("write labels.yml");
+}
+
+// ───────── load: 正常系 ─────────
+
+#[test]
+fn load_parses_definitions_with_all_fields() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(
+        tmp.path(),
+        "labels:\n  - name: bug\n    description: バグ報告\n    group: type\n    color: \"#D73A4A\"\n    updated: \"2026-05-30T12:00:00Z\"\n",
+    );
+
+    let store = label_registry_store(tmp.path());
+    let registry = store.load().expect("load ok");
+
+    assert_eq!(registry.labels.len(), 1);
+    let label = &registry.labels[0];
+    assert_eq!(label.name, "bug");
+    assert_eq!(label.description.as_deref(), Some("バグ報告"));
+    assert_eq!(label.group.as_deref(), Some("type"));
+    assert_eq!(
+        label.color.as_ref().map(LabelColor::as_str),
+        Some("#D73A4A")
+    );
+    assert_eq!(label.updated.as_deref(), Some("2026-05-30T12:00:00Z"));
+}
+
+#[test]
+fn load_name_only_label_leaves_optional_fields_none() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(tmp.path(), "labels:\n  - name: enhancement\n");
+
+    let registry = label_registry_store(tmp.path()).load().expect("load ok");
+    assert_eq!(registry.labels.len(), 1);
+    let label = &registry.labels[0];
+    assert_eq!(label.name, "enhancement");
+    assert!(label.description.is_none());
+    assert!(label.group.is_none());
+    assert!(label.color.is_none());
+    assert!(label.updated.is_none());
+}
+
+#[test]
+fn load_preserves_definition_order() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(
+        tmp.path(),
+        "labels:\n  - name: zebra\n  - name: apple\n  - name: mango\n",
+    );
+
+    let registry = label_registry_store(tmp.path()).load().expect("load ok");
+    let names: Vec<&str> = registry.labels.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(names, vec!["zebra", "apple", "mango"]);
+}
+
+#[test]
+fn load_ignores_unknown_keys() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(
+        tmp.path(),
+        "version: 2\nlabels:\n  - name: bug\n    futureField: ignored\n",
+    );
+
+    let registry = label_registry_store(tmp.path()).load().expect("load ok");
+    assert_eq!(registry.labels.len(), 1);
+    assert_eq!(registry.labels[0].name, "bug");
+}
+
+// ───────── load: 空相当 → Default ─────────
+
+#[test]
+fn load_absent_file_returns_default() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".spec-board")).unwrap();
+
+    let registry = label_registry_store(tmp.path()).load().expect("load ok");
+    assert_eq!(registry, LabelRegistry::default());
+    assert!(registry.labels.is_empty());
+}
+
+#[test]
+fn load_empty_variants_normalize_to_default() {
+    let cases = [
+        ("", "完全に空"),
+        ("   \n  \n", "空白のみ"),
+        ("# just a comment\n", "コメントのみ"),
+        ("---\n", "null ドキュメント"),
+        ("labels:\n", "labels キーのみ（値なし）"),
+        ("labels: null\n", "labels: null"),
+        ("labels: []\n", "空配列"),
+    ];
+    for (content, desc) in cases {
+        let tmp = TempDir::new().unwrap();
+        write_labels_yml(tmp.path(), content);
+        let registry = label_registry_store(tmp.path())
+            .load()
+            .unwrap_or_else(|e| panic!("{desc}: load 失敗 {e}"));
+        assert!(registry.labels.is_empty(), "{desc}: 空 Vec を期待");
+    }
+}
+
+// ───────── color: lenient ─────────
+
+#[test]
+fn load_valid_quoted_color_is_some() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(
+        tmp.path(),
+        "labels:\n  - name: bug\n    color: \"#1A2B3C\"\n",
+    );
+    let registry = label_registry_store(tmp.path()).load().expect("load ok");
+    assert_eq!(
+        registry.labels[0].color.as_ref().map(LabelColor::as_str),
+        Some("#1A2B3C")
+    );
+}
+
+#[test]
+fn load_unquoted_color_is_treated_as_yaml_comment_and_becomes_none() {
+    let tmp = TempDir::new().unwrap();
+    // `color: #1A2B3C` は `#` 以降コメント扱い → 値 null → None
+    write_labels_yml(tmp.path(), "labels:\n  - name: bug\n    color: #1A2B3C\n");
+    let registry = label_registry_store(tmp.path()).load().expect("load ok");
+    assert!(registry.labels[0].color.is_none());
+}
+
+#[test]
+fn load_invalid_color_values_fall_back_to_none() {
+    let cases = [
+        "labels:\n  - name: a\n    color: \"red\"\n",
+        "labels:\n  - name: a\n    color: \"#GGGGGG\"\n",
+        "labels:\n  - name: a\n    color: \"#123\"\n",
+        "labels:\n  - name: a\n    color: 123\n",
+        "labels:\n  - name: a\n    color: {}\n",
+        "labels:\n  - name: a\n    color: null\n",
+    ];
+    for content in cases {
+        let tmp = TempDir::new().unwrap();
+        write_labels_yml(tmp.path(), content);
+        let registry = label_registry_store(tmp.path())
+            .load()
+            .unwrap_or_else(|e| panic!("color lenient であるべき: {content:?} -> {e}"));
+        assert!(
+            registry.labels[0].color.is_none(),
+            "不正 color は None: {content:?}"
+        );
+    }
+}
+
+#[test]
+fn label_color_from_hex_accepts_only_rrggbb() {
+    assert!(LabelColor::from_hex("#000000").is_some());
+    assert!(LabelColor::from_hex("#abcdef").is_some());
+    assert!(LabelColor::from_hex("#ABCDEF").is_some());
+    assert!(LabelColor::from_hex("000000").is_none());
+    assert!(LabelColor::from_hex("#12345").is_none());
+    assert!(LabelColor::from_hex("#1234567").is_none());
+    assert!(LabelColor::from_hex("#GGGGGG").is_none());
+    assert!(LabelColor::from_hex("").is_none());
+}
+
+// ───────── load: parse / validation エラー ─────────
+
+#[test]
+fn load_broken_yaml_returns_parse_error() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(tmp.path(), "labels:\n  - name: bug\n  invalid: : :\n");
+    let err = label_registry_store(tmp.path()).load().unwrap_err();
+    assert!(matches!(err, LoadLabelsError::Parse { .. }), "got {err:?}");
+}
+
+#[test]
+fn load_non_string_field_type_mismatch_is_parse_error() {
+    // color 以外（name / description / group / updated）の型不一致は Parse（lenient は color のみ）。
+    // 数値・bool・mapping いずれの非文字列も拒否する。
+    let cases = [
+        "labels:\n  - name: 123\n",
+        "labels:\n  - name: bug\n    description: 123\n",
+        "labels:\n  - name: bug\n    group: true\n",
+        "labels:\n  - name: bug\n    updated: 2026\n",
+        "labels:\n  - name: bug\n    description:\n      nested: true\n",
+    ];
+    for content in cases {
+        let tmp = TempDir::new().unwrap();
+        write_labels_yml(tmp.path(), content);
+        let err = label_registry_store(tmp.path()).load().unwrap_err();
+        assert!(
+            matches!(err, LoadLabelsError::Parse { .. }),
+            "型不一致は Parse: {content:?} -> {err:?}"
+        );
+    }
+}
+
+#[test]
+fn load_duplicate_name_is_validation_error() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(tmp.path(), "labels:\n  - name: bug\n  - name: bug\n");
+    let err = label_registry_store(tmp.path()).load().unwrap_err();
+    assert!(
+        matches!(
+            err,
+            LoadLabelsError::Validation(LabelValidationError::DuplicateLabelName { .. })
+        ),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn load_empty_name_is_validation_error() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(tmp.path(), "labels:\n  - name: \"\"\n");
+    let err = label_registry_store(tmp.path()).load().unwrap_err();
+    assert!(
+        matches!(
+            err,
+            LoadLabelsError::Validation(LabelValidationError::EmptyLabelName)
+        ),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn load_whitespace_only_name_is_allowed() {
+    let tmp = TempDir::new().unwrap();
+    write_labels_yml(tmp.path(), "labels:\n  - name: \"   \"\n");
+    let registry = label_registry_store(tmp.path())
+        .load()
+        .expect("空白のみ name は許容（未正規化）");
+    assert_eq!(registry.labels[0].name, "   ");
+}
+
+// ───────── save ─────────
+
+#[test]
+fn save_then_load_roundtrips_registry() {
+    let tmp = TempDir::new().unwrap();
+    let registry = LabelRegistry {
+        labels: vec![
+            LabelDefinition {
+                name: "bug".to_string(),
+                description: Some("バグ".to_string()),
+                group: Some("type".to_string()),
+                color: LabelColor::from_hex("#D73A4A"),
+                updated: Some("2026-05-30T00:00:00Z".to_string()),
+            },
+            LabelDefinition {
+                name: "enhancement".to_string(),
+                description: None,
+                group: None,
+                color: None,
+                updated: None,
+            },
+        ],
+    };
+
+    let store = label_registry_store(tmp.path());
+    store.save(&registry).expect("save ok");
+    let loaded = store.load().expect("load ok");
+    assert_eq!(loaded, registry);
+}
+
+#[test]
+fn save_rejects_inconsistent_registry() {
+    let tmp = TempDir::new().unwrap();
+    let registry = LabelRegistry {
+        labels: vec![
+            LabelDefinition {
+                name: "dup".to_string(),
+                description: None,
+                group: None,
+                color: None,
+                updated: None,
+            },
+            LabelDefinition {
+                name: "dup".to_string(),
+                description: None,
+                group: None,
+                color: None,
+                updated: None,
+            },
+        ],
+    };
+    let err = label_registry_store(tmp.path())
+        .save(&registry)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SaveLabelsError::Validation(LabelValidationError::DuplicateLabelName { .. })
+        ),
+        "got {err:?}"
+    );
+    // 検証で弾くため labels.yml は書き出されない
+    assert!(!tmp.path().join(".spec-board/labels.yml").exists());
+}
+
+// ───────── format 抽象（trait モック） ─────────
+
+/// 任意の `LabelRegistry` を返すモック store。YAML を介さず DI できることの検証用。
+struct MockStore {
+    registry: LabelRegistry,
+}
+
+impl LabelRegistryStore for MockStore {
+    fn load(&self) -> Result<LabelRegistry, LoadLabelsError> {
+        Ok(self.registry.clone())
+    }
+    fn save(&self, _registry: &LabelRegistry) -> Result<(), SaveLabelsError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn store_can_be_mocked_via_trait_object() {
+    let registry = LabelRegistry {
+        labels: vec![LabelDefinition {
+            name: "mocked".to_string(),
+            description: None,
+            group: None,
+            color: None,
+            updated: None,
+        }],
+    };
+    let store = MockStore {
+        registry: registry.clone(),
+    };
+    // &dyn LabelRegistryStore として trait 越しに使える（具象型を名指ししない）
+    let dyn_store: &dyn LabelRegistryStore = &store;
+    assert_eq!(dyn_store.load().expect("load ok"), registry);
+}

--- a/src-tauri/src/config/update_card_order_tests.rs
+++ b/src-tauri/src/config/update_card_order_tests.rs
@@ -19,7 +19,13 @@ fn tempdir() -> TempDir {
 fn open_with_noop(state: &Arc<AppState>, path: &Path) {
     let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
         .expect("non-empty path");
-    open_project_impl(state, &intent, &NoopWatcherFactory).expect("open should succeed");
+    open_project_impl(
+        state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &NoopWatcherFactory,
+    )
+    .expect("open should succeed");
 }
 
 fn read_config_json(project_root: &Path) -> Config {

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -809,7 +809,13 @@ fn write_initial_config(root: &Path, json: &str) {
 fn open_with_noop(state: Arc<AppState>, path: &Path) {
     let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
         .expect("non-empty path");
-    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+    open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &NoopWatcherFactory,
+    )
+    .expect("open should succeed");
 }
 
 fn read_config_json(root: &Path) -> Config {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ pub fn run() {
             task::add_link::add_link,
             task::remove_link::remove_link,
             config::get_columns::get_columns,
+            config::get_labels::get_labels,
             config::update_card_order::update_card_order,
             config::update_columns::update_columns
         ])

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -432,7 +432,7 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 /// 避けるためであり、commit 直前の probe は pre-flight 後 / commit 前に
 /// 他スレッドで poison が発生する稀なケースの取り逃しを減らすための念押し。
 ///
-/// 1. **pre-flight**: `project_path` / `config` / `tasks_cache` /
+/// 1. **pre-flight**: `project_path` / `config` / `labels` / `tasks_cache` /
 ///    `watcher_handle` / `write_ignore` の各 lock を順に probe し、
 ///    開始時点で既に poison していれば早期に `Err(StateLockPoisoned)` を返す。
 ///    この時点ではまだ何も書き換えていないため、`open_project_impl` の

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -39,6 +39,8 @@
 //! | `ScanFailed` | `io scan failed: ...` | `IO_ERROR` |
 //! | `ConfigLoadFailed` (`category="io"`) | `config load failed (io): ...` | `IO_ERROR` |
 //! | `ConfigLoadFailed` (`category="parse"`) | `config load failed (parse): ...` | `PARSE_ERROR` |
+//! | `LabelsLoadFailed` (`category="io"`) | `labels load failed (io): ...` | `IO_ERROR` |
+//! | `LabelsLoadFailed` (`category="parse"`) | `labels load failed (parse): ...` | `PARSE_ERROR` |
 //! | `NotADirectory` | `ディレクトリではありません: ...` | `UNKNOWN`（FE 側 PATTERNS 未対応） |
 //! | `StateLockPoisoned` | `内部状態のロックが破損しました` | `UNKNOWN`（FE 側 PATTERNS 未対応） |
 //!
@@ -70,7 +72,8 @@ use std::sync::Arc;
 
 use crate::config::column_name::ColumnName;
 use crate::config::{
-    load_or_default, write_guide_markdown_best_effort, Column, Config, LoadConfigError,
+    label_registry_store, load_or_default, write_guide_markdown_best_effort, Column, Config,
+    LabelRegistry, LabelRegistryStore, LoadConfigError, LoadLabelsError,
 };
 use crate::project::watcher_factory::{TauriWatcherFactory, WatcherFactory};
 use crate::project::OpenProjectIntent;
@@ -119,6 +122,15 @@ pub enum OpenProjectError {
     /// FE 正規表現 (`\bio\b` / `\bparse\b`) にマッチさせる。
     #[error("config load failed ({category}): {message}")]
     ConfigLoadFailed {
+        category: &'static str,
+        message: String,
+    },
+    /// `.spec-board/labels.yml` の読み込みに失敗した。
+    ///
+    /// `category` は `"io"` または `"parse"`。`config load failed` と同じ Display 契約に
+    /// 揃え、FE 正規表現（`\bio\b` / `\bparse\b`）にマッチさせる。
+    #[error("labels load failed ({category}): {message}")]
+    LabelsLoadFailed {
         category: &'static str,
         message: String,
     },
@@ -175,7 +187,10 @@ pub fn open_project(
 ) -> Result<OpenProjectPayload, String> {
     let intent = OpenProjectIntent::try_from(path).map_err(|e| e.to_string())?;
     let watcher = TauriWatcherFactory::new(app);
-    open_project_impl(state.inner(), &intent, &watcher).map_err(|e| e.to_string())
+    // ファクトリで既定の labels store（YAML 具象）を生成して注入する。
+    // effect 層は `&dyn LabelRegistryStore` のみに依存し、具象型も YAML 形式も知らない。
+    let labels_store = label_registry_store(intent.as_path());
+    open_project_impl(state.inner(), &intent, &labels_store, &watcher).map_err(|e| e.to_string())
 }
 
 /// `open_project` Tauri command の effect 層本体（テスト容易性のための一般化版）。
@@ -185,6 +200,7 @@ pub fn open_project(
 pub(crate) fn open_project_impl<W: WatcherFactory>(
     state: &Arc<AppState>,
     intent: &OpenProjectIntent,
+    labels_store: &dyn LabelRegistryStore,
     watcher: &W,
 ) -> Result<OpenProjectPayload, OpenProjectError> {
     let root = intent.as_path();
@@ -193,6 +209,8 @@ pub(crate) fn open_project_impl<W: WatcherFactory>(
     check_app_state_locks(state)?;
 
     let config = load_or_default(root).map_err(map_load_config_error)?;
+    // ラベルマスタも config と同様 commit 前に読み込む（load 失敗時は旧 state 非破壊）。
+    let labels = labels_store.load().map_err(map_load_labels_error)?;
 
     let md_paths = scan_md_files(root).map_err(|e| map_scan_error(e, raw_path))?;
 
@@ -212,12 +230,12 @@ pub(crate) fn open_project_impl<W: WatcherFactory>(
 
     write_guide_markdown_best_effort(root, &config);
 
-    commit_app_state_with_prepared(state, root, &config, &tasks, prepared, watcher)?;
+    commit_app_state_with_prepared(state, root, &config, &labels, &tasks, prepared, watcher)?;
 
     Ok(build_payload(tasks, &config))
 }
 
-/// AppState 4 mutex + WriteIgnoreRegistry の lock 健全性を一括 probe する。
+/// AppState 5 mutex + WriteIgnoreRegistry の lock 健全性を一括 probe する。
 ///
 /// scan / parse / GUIDE 副作用を実行する前に呼び出すことで、lock poison が
 /// 確定している場合に `.spec-board/GUIDE.md` の不要な書き出しや scan の無駄を
@@ -363,6 +381,21 @@ fn map_load_config_error(err: LoadConfigError) -> OpenProjectError {
     }
 }
 
+/// `LoadLabelsError` を `category` 付きの `LabelsLoadFailed` に分類する。
+///
+/// - `Io` → `category: "io"`
+/// - `Parse`（YAML 構文）/ `Validation`（name 空・重複のマスタ整合性違反）→ `category: "parse"`
+fn map_load_labels_error(err: LoadLabelsError) -> OpenProjectError {
+    let category = match &err {
+        LoadLabelsError::Io(_) => "io",
+        LoadLabelsError::Parse { .. } | LoadLabelsError::Validation(_) => "parse",
+    };
+    OpenProjectError::LabelsLoadFailed {
+        category,
+        message: err.to_string(),
+    }
+}
+
 /// `TaskParseError` を `ScanFailed` に詰め直す。
 ///
 /// `build_children` は `validate_parent_hierarchy` 経由で `CycleOrTooDeep` のみ
@@ -381,7 +414,7 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 ///
 /// # ロック健全性の早期検出（pre-flight の限界）
 ///
-/// 5 つの lock を独立して順次取得するため、**真の atomic な commit ではない**。
+/// 6 つの lock を独立して順次取得するため、**真の atomic な commit ではない**。
 /// commit 冒頭で実行する pre-flight は「commit 開始時点で既に poison している
 /// mutex を早期検出して副作用前に Err 復帰させる」ためのものであり、
 /// pre-flight 後 / 個別 setter 呼び出し中に他スレッドの panic 等で後続 lock が
@@ -406,18 +439,18 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 ///    「失敗時は旧プロジェクト state を保持する」契約が守られる。
 /// 2. **書き込み**: 副作用を以下の順で実行する。
 ///    - `take_watcher_handle().stop()`: 新 cache が書かれる前に旧 watcher を必ず停止
-///    - `replace_project_and_config`: `project_path` と `config` を**両 lock 同時保持下で
-///      atomic に swap**する（`update_card_order` 等の reader が「新 path + 旧 config」を
-///      観測して旧 config を新プロジェクトの `config.json` に書き出す cross-project
-///      corruption を防ぐ）
+///    - `replace_project_config_and_labels`: `project_path` / `config` / `labels` を
+///      **3 lock 同時保持下で atomic に swap**する（`update_card_order` 等の reader が
+///      「新 path + 旧 config」を観測して旧 config を新プロジェクトの `config.json` に
+///      書き出す cross-project corruption を防ぐ）
 ///    - `replace_tasks_cache`: tasks_cache を新値に置換
 ///    - `write_ignore().clear()`: 旧プロジェクトの登録パスを破棄
 ///    - `install_watcher_handle`: 新 watcher を install。旧 handle は既に上で
 ///      `stop()` 済みのため、ここでは新 handle を置くだけ
 ///
-/// `replace_project_and_config` は `project_path → config` の AppState lock 順序
-/// 契約に従って両 lock を順に取得・同時保持する。他の setter は単一フィールドのみを
-/// 操作するため、AppState の AB-BA 防止規約に抵触しない。
+/// `replace_project_config_and_labels` は `project_path → config → labels` の AppState
+/// lock 順序契約に従って 3 lock を順に取得・同時保持する。他の setter は単一フィールド
+/// のみを操作するため、AppState の AB-BA 防止規約に抵触しない。
 ///
 /// `tasks_cache` の key は `PathBuf::from(task.file_path)`（`task.file_path` は
 /// 既に root 相対の正規化済み文字列）。
@@ -434,6 +467,7 @@ pub(crate) fn commit_app_state_with_prepared<W: WatcherFactory>(
     state: &Arc<AppState>,
     root: &Path,
     config: &Config,
+    labels: &LabelRegistry,
     tasks: &[Task],
     prepared: W::Prepared,
     watcher: &W,
@@ -454,7 +488,11 @@ pub(crate) fn commit_app_state_with_prepared<W: WatcherFactory>(
     // 他 command（例: `update_card_order`）が「新 path + 旧 config」を観測して
     // 旧 config を新プロジェクトの `.spec-board/config.json` に書き出してしまう
     // cross-project corruption を起こしうる。
-    state.replace_project_and_config(Some(root.to_path_buf()), Some(config.clone()))?;
+    state.replace_project_config_and_labels(
+        Some(root.to_path_buf()),
+        Some(config.clone()),
+        Some(labels.clone()),
+    )?;
     state.replace_tasks_cache(cache)?;
     state.write_ignore().clear()?;
 

--- a/src-tauri/src/project/open_tests.rs
+++ b/src-tauri/src/project/open_tests.rs
@@ -29,7 +29,8 @@ fn open_with_noop(
     path: &str,
 ) -> Result<OpenProjectPayload, OpenProjectError> {
     let intent = OpenProjectIntent::try_from(path.to_string())?;
-    open_project_impl(&state, &intent, &NoopWatcherFactory)
+    let labels_store = crate::config::label_registry_store(intent.as_path());
+    open_project_impl(&state, &intent, &labels_store, &NoopWatcherFactory)
 }
 
 /// `prepare` で `WatcherInitFailed` を返すテスト用 factory。
@@ -578,8 +579,13 @@ fn watcher_init_failure_keeps_app_state_completely_unchanged() {
     let other_raw = other_dir.path().to_str().expect("utf-8").to_string();
     let intent = OpenProjectIntent::try_from(other_raw.clone()).expect("non-empty path");
     let factory = FailingPrepareFactory::new("synthetic init failure");
-    let err = open_project_impl(&state, &intent, &factory)
-        .expect_err("watcher init failure should be returned");
+    let err = open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &factory,
+    )
+    .expect_err("watcher init failure should be returned");
     assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
 
     // AppState の全フィールドが 1 回目の状態のまま残ることを確認する。
@@ -606,7 +612,13 @@ fn watcher_init_failure_does_not_write_guide_md_in_new_dir() {
 
     let intent = OpenProjectIntent::try_from(raw.clone()).expect("non-empty path");
     let factory = FailingPrepareFactory::new("synthetic init failure");
-    let err = open_project_impl(&state, &intent, &factory).expect_err("watcher init failure");
+    let err = open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &factory,
+    )
+    .expect_err("watcher init failure");
     assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
 
     let guide = dir.path().join(".spec-board").join("GUIDE.md");
@@ -630,7 +642,13 @@ fn watcher_init_failure_does_not_invoke_old_watcher_stop() {
 
     let intent = OpenProjectIntent::try_from(raw.clone()).expect("non-empty path");
     let factory = FailingPrepareFactory::new("synth");
-    let err = open_project_impl(&state, &intent, &factory).expect_err("watcher init failure");
+    let err = open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &factory,
+    )
+    .expect_err("watcher init failure");
     assert!(matches!(err, OpenProjectError::WatcherInitFailed { .. }));
 }
 
@@ -657,7 +675,13 @@ fn old_watcher_is_stopped_before_state_commit() {
         stop_calls: Arc::clone(&stop_counter),
         state: Arc::clone(&state),
     };
-    open_project_impl(&state, &intent, &factory).expect("open should succeed");
+    open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &factory,
+    )
+    .expect("open should succeed");
 
     assert_eq!(1, stop_counter.load(Ordering::SeqCst));
 }
@@ -819,4 +843,142 @@ fn open_project_payload_round_trip() {
     };
     let serialized = serde_json::to_string(&payload).unwrap();
     assert_eq!(serialized, r#"{"tasks":[],"columns":["Todo","Done"]}"#);
+}
+
+// ───────── labels.yml 読み込み（open_project 経由） ─────────
+
+fn write_labels_yml(root: &Path, content: &str) {
+    let dir = root.join(".spec-board");
+    fs::create_dir_all(&dir).expect("create .spec-board");
+    fs::write(dir.join("labels.yml"), content).expect("write labels.yml");
+}
+
+#[test]
+fn open_commits_labels_from_labels_yml() {
+    let state = Arc::new(AppState::new());
+    let dir = tempdir();
+    write_md(dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
+    write_labels_yml(
+        dir.path(),
+        "labels:\n  - name: bug\n    color: \"#D73A4A\"\n  - name: enhancement\n",
+    );
+
+    open_with_noop(Arc::clone(&state), dir.path().to_str().expect("utf-8"))
+        .expect("open should succeed");
+
+    let registry = state.labels().expect("readable").expect("labels committed");
+    let names: Vec<&str> = registry.labels.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(names, vec!["bug", "enhancement"]);
+}
+
+#[test]
+fn open_without_labels_yml_commits_empty_registry() {
+    let state = Arc::new(AppState::new());
+    let dir = tempdir();
+    write_md(dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
+
+    open_with_noop(Arc::clone(&state), dir.path().to_str().expect("utf-8"))
+        .expect("open should succeed");
+
+    let registry = state
+        .labels()
+        .expect("readable")
+        .expect("labels committed (default)");
+    assert!(registry.labels.is_empty());
+}
+
+#[test]
+fn open_fails_with_parse_category_for_broken_labels_yml() {
+    let state = Arc::new(AppState::new());
+    let dir = tempdir();
+    write_labels_yml(dir.path(), "labels:\n  - name: bug\n  invalid: : :\n");
+
+    let err = open_with_noop(Arc::clone(&state), dir.path().to_str().expect("utf-8"))
+        .expect_err("broken labels.yml should fail open");
+    assert!(
+        matches!(
+            err,
+            OpenProjectError::LabelsLoadFailed {
+                category: "parse",
+                ..
+            }
+        ),
+        "got {err:?}"
+    );
+    assert!(err.to_string().contains("labels load failed (parse)"));
+}
+
+#[test]
+fn open_fails_with_parse_category_for_duplicate_label_name() {
+    let state = Arc::new(AppState::new());
+    let dir = tempdir();
+    write_labels_yml(dir.path(), "labels:\n  - name: bug\n  - name: bug\n");
+
+    let err = open_with_noop(Arc::clone(&state), dir.path().to_str().expect("utf-8"))
+        .expect_err("duplicate name should fail open");
+    assert!(
+        matches!(
+            err,
+            OpenProjectError::LabelsLoadFailed {
+                category: "parse",
+                ..
+            }
+        ),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn reopen_into_project_without_labels_yml_resets_labels_to_empty() {
+    let state = Arc::new(AppState::new());
+
+    // 1 回目: labels.yml ありのプロジェクト
+    let dir1 = tempdir();
+    write_labels_yml(dir1.path(), "labels:\n  - name: bug\n");
+    open_with_noop(Arc::clone(&state), dir1.path().to_str().expect("utf-8"))
+        .expect("first open should succeed");
+    assert_eq!(
+        1,
+        state
+            .labels()
+            .expect("readable")
+            .expect("some")
+            .labels
+            .len()
+    );
+
+    // 2 回目: labels.yml 不在の別プロジェクト → 旧 labels が残らず Default(空) へ置換
+    let dir2 = tempdir();
+    open_with_noop(Arc::clone(&state), dir2.path().to_str().expect("utf-8"))
+        .expect("second open should succeed");
+    assert!(state
+        .labels()
+        .expect("readable")
+        .expect("some")
+        .labels
+        .is_empty());
+}
+
+#[test]
+fn failed_open_due_to_broken_labels_keeps_previous_state() {
+    let state = Arc::new(AppState::new());
+
+    // 1 回目: 正常プロジェクト
+    let dir1 = tempdir();
+    write_md(dir1.path(), "tasks/a.md", &task_md("A", "Todo", None));
+    write_labels_yml(dir1.path(), "labels:\n  - name: bug\n");
+    open_with_noop(Arc::clone(&state), dir1.path().to_str().expect("utf-8"))
+        .expect("first open should succeed");
+    let project_before = state.project_path().expect("readable");
+    let labels_before = state.labels().expect("readable");
+
+    // 2 回目: 壊れ labels.yml の別プロジェクト → load は commit より前なので旧 state 非破壊
+    let dir2 = tempdir();
+    write_labels_yml(dir2.path(), "labels:\n  - name: bug\n  invalid: : :\n");
+    let err = open_with_noop(Arc::clone(&state), dir2.path().to_str().expect("utf-8"))
+        .expect_err("broken labels.yml should fail open");
+    assert!(matches!(err, OpenProjectError::LabelsLoadFailed { .. }));
+
+    assert_eq!(project_before, state.project_path().expect("readable"));
+    assert_eq!(labels_before, state.labels().expect("readable"));
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -10,7 +10,7 @@
 //! AB-BA デッドロックを防ぐための運用規約である。
 //!
 //! ```text
-//! project_path → config → tasks_cache → watcher_handle → write_ignore
+//! project_path → config → labels → tasks_cache → watcher_handle → write_ignore
 //! ```
 //!
 //! - 単一フィールドのみを操作するアクセサは順序を意識する必要はない。
@@ -24,7 +24,7 @@
 //! 公開アクセサを通すことで以下を保証する。
 //!
 //! - `AppState` 自身が保持する `Mutex`（`project_path` / `config` /
-//!   `tasks_cache` / `watcher_handle`）の `PoisonError` を
+//!   `labels` / `tasks_cache` / `watcher_handle`）の `PoisonError` を
 //!   `AppStateError::LockPoisoned` へ統一変換する。
 //!   ただし `write_ignore` は `WriteIgnoreRegistry` 内部で独自の `Mutex` を
 //!   持つため例外で、forwarder 経由の操作は `WriteIgnoreError::LockPoisoned`
@@ -42,7 +42,7 @@ use thiserror::Error;
 use spec_board_fs::watcher::handle::WatcherHandle;
 use spec_board_fs::watcher::write_ignore::WriteIgnoreRegistry;
 
-use crate::config::Config;
+use crate::config::{Config, LabelRegistry};
 use crate::task::task_index::Task;
 
 /// `tauri::Builder::manage` に渡すために `'static` を含む trait object 型。
@@ -65,6 +65,7 @@ pub enum AppStateError {
 pub struct AppState {
     project_path: Mutex<Option<PathBuf>>,
     config: Mutex<Option<Config>>,
+    labels: Mutex<Option<LabelRegistry>>,
     tasks_cache: Mutex<HashMap<PathBuf, Task>>,
     watcher_handle: Mutex<Option<BoxedWatcherHandle>>,
     write_ignore: WriteIgnoreRegistry,
@@ -73,7 +74,7 @@ pub struct AppState {
 impl AppState {
     /// 全フィールドを初期状態にした `AppState` を生成する。
     ///
-    /// `project_path` / `config` / `watcher_handle` は `None`、
+    /// `project_path` / `config` / `labels` / `watcher_handle` は `None`、
     /// `tasks_cache` は空 HashMap、`write_ignore` は空 registry になる。
     ///
     /// 初期化エントリーポイントは `new()` のみとし、`Default` 実装は意図的に
@@ -83,6 +84,7 @@ impl AppState {
         Self {
             project_path: Mutex::new(None),
             config: Mutex::new(None),
+            labels: Mutex::new(None),
             tasks_cache: Mutex::new(HashMap::new()),
             watcher_handle: Mutex::new(None),
             write_ignore: WriteIgnoreRegistry::new(),
@@ -115,6 +117,22 @@ impl AppState {
         Ok(())
     }
 
+    /// 現在保持している `LabelRegistry` を clone して返す。
+    ///
+    /// プロジェクト未オープン時は `None`。labels.yml 不在で開いた場合は
+    /// `Some(LabelRegistry::default())`（空レジストリ）が入る。
+    pub fn labels(&self) -> Result<Option<LabelRegistry>, AppStateError> {
+        let guard = lock(&self.labels)?;
+        Ok(guard.clone())
+    }
+
+    /// `LabelRegistry` を丸ごと差し替える。`None` を渡すと未保持状態に戻せる。
+    pub fn replace_labels(&self, labels: Option<LabelRegistry>) -> Result<(), AppStateError> {
+        let mut guard = lock(&self.labels)?;
+        *guard = labels;
+        Ok(())
+    }
+
     /// `project_path` と `config` を**両方の lock を順に同時保持した状態で** snapshot する。
     ///
     /// 一方の lock だけを取得して順に読むと、両フィールドを別々に更新する writer と
@@ -123,7 +141,7 @@ impl AppState {
     /// ことで、その不整合観測を防ぐ atomic 読み取り API として機能する。lock 取得順序は
     /// AppState の契約に従って `project_path → config` を遵守する。
     ///
-    /// 同時更新側は [`Self::replace_project_and_config`] / [`Self::replace_config_if_project_matches`]
+    /// 同時更新側は [`Self::replace_project_config_and_labels`] / [`Self::replace_config_if_project_matches`]
     /// で同様に両 lock を同時保持して書き換えることで、reader 側の観測整合性を確保する。
     ///
     /// 戻り値はそれぞれ clone 済み snapshot のため、呼び出し側が長く保持しても
@@ -136,22 +154,28 @@ impl AppState {
         Ok((path_guard.clone(), config_guard.clone()))
     }
 
-    /// `project_path` と `config` を**両方の lock を順に同時保持した状態で** swap する。
+    /// `project_path` / `config` / `labels` を**3 つの lock を順に同時保持した状態で** swap する。
     ///
-    /// 両フィールドを別 lock で順次更新すると、その間に reader（例:
+    /// 各フィールドを別 lock で順次更新すると、その間に reader（例:
     /// `update_card_order`）が「新 path + 旧 config」を観測し、旧 config を新
     /// プロジェクトの `config.json` に書き出してしまう cross-project corruption が
-    /// 起き得る。本 API は両 lock を保持したまま swap することでその不整合を防ぐ。
-    /// lock 取得順序は AppState の契約に従って `project_path → config` を遵守する。
-    pub fn replace_project_and_config(
+    /// 起き得る。本 API は 3 つの lock を保持したまま swap することでその不整合を防ぐ。
+    /// lock 取得順序は AppState の契約に従って `project_path → config → labels` を遵守する。
+    ///
+    /// commit の整合範囲は `project_path / config / labels` の 3 フィールドに限定され、
+    /// `tasks_cache` 等との間は従来どおり非 atomic（別更新）である。
+    pub fn replace_project_config_and_labels(
         &self,
         path: Option<PathBuf>,
         config: Option<crate::config::Config>,
+        labels: Option<LabelRegistry>,
     ) -> Result<(), AppStateError> {
         let mut path_guard = lock(&self.project_path)?;
         let mut config_guard = lock(&self.config)?;
+        let mut labels_guard = lock(&self.labels)?;
         *path_guard = path;
         *config_guard = config;
+        *labels_guard = labels;
         Ok(())
     }
 
@@ -264,6 +288,15 @@ impl AppState {
         Ok(())
     }
 
+    /// `labels` 用 `Mutex` の健全性をチェックする副作用なしの probe。
+    ///
+    /// `labels()` と異なりクローンを行わないため、pre-flight 用途で
+    /// `LabelRegistry` のコピーコストを避けられる。
+    pub fn check_labels_lock(&self) -> Result<(), AppStateError> {
+        let _guard = lock(&self.labels)?;
+        Ok(())
+    }
+
     /// `tasks_cache` 用 `Mutex` の健全性をチェックする副作用なしの probe。
     ///
     /// `tasks_snapshot()` と異なり全 `Task` の clone+collect を行わないため、
@@ -283,7 +316,7 @@ impl AppState {
         Ok(())
     }
 
-    /// AppState が保持する 4 つの `Mutex` フィールドすべての lock 健全性を
+    /// AppState が保持する 5 つの `Mutex` フィールドすべての lock 健全性を
     /// 一括 probe する副作用なしの API。
     ///
     /// `WriteIgnoreRegistry` は AppState の `Mutex` ではなく内部に独自の
@@ -292,6 +325,7 @@ impl AppState {
     pub fn check_all_locks(&self) -> Result<(), AppStateError> {
         self.check_project_path_lock()?;
         self.check_config_lock()?;
+        self.check_labels_lock()?;
         self.check_tasks_cache_lock()?;
         self.check_watcher_handle_lock()?;
         Ok(())

--- a/src-tauri/src/state/state_tests.rs
+++ b/src-tauri/src/state/state_tests.rs
@@ -9,7 +9,7 @@ use std::thread;
 
 use spec_board_fs::watcher::handle::WatcherHandle;
 
-use crate::config::{CardOrder, Column, Config};
+use crate::config::{CardOrder, Column, Config, LabelDefinition, LabelRegistry};
 use crate::task::task_index::Task;
 
 fn sample_task(id: &str, file_path: &str) -> Task {
@@ -39,6 +39,18 @@ fn sample_config() -> Config {
         }],
         card_order: CardOrder::default(),
         done_column: None,
+    }
+}
+
+fn sample_labels() -> LabelRegistry {
+    LabelRegistry {
+        labels: vec![LabelDefinition {
+            name: "bug".to_string(),
+            description: None,
+            group: None,
+            color: None,
+            updated: None,
+        }],
     }
 }
 
@@ -72,6 +84,7 @@ fn new_initializes_all_fields_to_empty() {
 
     assert_eq!(None, state.project_path().expect("readable"));
     assert_eq!(None, state.config().expect("readable"));
+    assert_eq!(None, state.labels().expect("readable"));
     assert!(state.tasks_snapshot().expect("readable").is_empty());
     assert!(state.take_watcher_handle().expect("readable").is_none());
     assert!(state.write_ignore().is_empty().expect("readable"));
@@ -510,4 +523,109 @@ fn write_ignore_forwarder_routes_to_inner_registry() {
 fn app_state_is_send_sync_static() {
     fn assert_send_sync_static<T: Send + Sync + 'static>() {}
     assert_send_sync_static::<AppState>();
+}
+
+// ───────── labels（6 番目フィールド） ─────────
+
+#[test]
+fn replace_labels_round_trip_and_overwrite() {
+    let state = AppState::new();
+    state
+        .replace_labels(Some(sample_labels()))
+        .expect("writable");
+    assert_eq!(Some(sample_labels()), state.labels().expect("readable"));
+
+    state.replace_labels(None).expect("writable");
+    assert_eq!(None, state.labels().expect("readable"));
+}
+
+#[test]
+fn labels_lock_poison_is_reported() {
+    let state = Arc::new(AppState::new());
+    poison_mutex(Arc::clone(&state), |s| {
+        let _guard = s.labels.lock().expect("lockable before panic");
+        panic!("poison labels");
+    });
+
+    assert_eq!(
+        AppStateError::LockPoisoned,
+        state.labels().expect_err("poisoned read")
+    );
+    assert_eq!(
+        AppStateError::LockPoisoned,
+        state
+            .replace_labels(Some(sample_labels()))
+            .expect_err("poisoned write")
+    );
+}
+
+#[test]
+fn check_labels_lock_returns_ok_for_healthy_state() {
+    let state = AppState::new();
+    state.check_labels_lock().expect("healthy lock");
+}
+
+#[test]
+fn check_labels_lock_reports_poison() {
+    let state = Arc::new(AppState::new());
+    poison_mutex(Arc::clone(&state), |s| {
+        let _guard = s.labels.lock().expect("lockable before panic");
+        panic!("poison labels");
+    });
+
+    assert_eq!(
+        AppStateError::LockPoisoned,
+        state.check_labels_lock().expect_err("poisoned probe"),
+    );
+}
+
+#[test]
+fn check_all_locks_reports_poison_when_labels_is_poisoned() {
+    let state = Arc::new(AppState::new());
+    poison_mutex(Arc::clone(&state), |s| {
+        let _guard = s.labels.lock().expect("lockable before panic");
+        panic!("poison labels");
+    });
+
+    assert_eq!(
+        AppStateError::LockPoisoned,
+        state.check_all_locks().expect_err("poisoned"),
+    );
+}
+
+#[test]
+fn replace_project_config_and_labels_swaps_three_fields() {
+    let state = AppState::new();
+    let path = PathBuf::from("/tmp/project");
+    state
+        .replace_project_config_and_labels(
+            Some(path.clone()),
+            Some(sample_config()),
+            Some(sample_labels()),
+        )
+        .expect("writable");
+
+    assert_eq!(Some(path), state.project_path().expect("readable"));
+    assert_eq!(Some(sample_config()), state.config().expect("readable"));
+    assert_eq!(Some(sample_labels()), state.labels().expect("readable"));
+}
+
+#[test]
+fn replace_project_config_and_labels_can_clear_all_to_none() {
+    let state = AppState::new();
+    state
+        .replace_project_config_and_labels(
+            Some(PathBuf::from("/tmp/project")),
+            Some(sample_config()),
+            Some(sample_labels()),
+        )
+        .expect("writable");
+
+    state
+        .replace_project_config_and_labels(None, None, None)
+        .expect("writable");
+
+    assert_eq!(None, state.project_path().expect("readable"));
+    assert_eq!(None, state.config().expect("readable"));
+    assert_eq!(None, state.labels().expect("readable"));
 }

--- a/src-tauri/src/task/add_link/command_tests.rs
+++ b/src-tauri/src/task/add_link/command_tests.rs
@@ -24,7 +24,13 @@ fn tempdir() -> TempDir {
 fn open_with_noop(state: Arc<AppState>, path: &Path) {
     let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
         .expect("non-empty path");
-    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+    open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &NoopWatcherFactory,
+    )
+    .expect("open should succeed");
 }
 
 fn seed_md(root: &Path, rel: &str, content: &str) {

--- a/src-tauri/src/task/create/command_tests.rs
+++ b/src-tauri/src/task/create/command_tests.rs
@@ -21,7 +21,13 @@ fn tempdir() -> TempDir {
 fn open_with_noop(state: Arc<AppState>, path: &Path) {
     let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
         .expect("non-empty path");
-    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+    open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &NoopWatcherFactory,
+    )
+    .expect("open should succeed");
 }
 
 fn args_with_title(title: &str) -> CreateTaskArgs {

--- a/src-tauri/src/task/get_tests.rs
+++ b/src-tauri/src/task/get_tests.rs
@@ -11,7 +11,13 @@ use crate::project::OpenProjectIntent;
 
 fn open_with_noop(state: Arc<AppState>, path: &str) {
     let intent = OpenProjectIntent::try_from(path.to_string()).expect("non-empty path");
-    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+    open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &NoopWatcherFactory,
+    )
+    .expect("open should succeed");
 }
 
 fn tempdir() -> TempDir {

--- a/src-tauri/src/task/remove_link/command_tests.rs
+++ b/src-tauri/src/task/remove_link/command_tests.rs
@@ -24,7 +24,13 @@ fn tempdir() -> TempDir {
 fn open_with_noop(state: Arc<AppState>, path: &Path) {
     let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
         .expect("non-empty path");
-    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+    open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &NoopWatcherFactory,
+    )
+    .expect("open should succeed");
 }
 
 fn seed_md(root: &Path, rel: &str, content: &str) {

--- a/src-tauri/src/task/update/command_tests.rs
+++ b/src-tauri/src/task/update/command_tests.rs
@@ -23,7 +23,13 @@ fn tempdir() -> TempDir {
 fn open_with_noop(state: Arc<AppState>, path: &Path) {
     let intent = OpenProjectIntent::try_from(path.to_str().expect("utf-8").to_string())
         .expect("non-empty path");
-    open_project_impl(&state, &intent, &NoopWatcherFactory).expect("open should succeed");
+    open_project_impl(
+        &state,
+        &intent,
+        &crate::config::label_registry_store(intent.as_path()),
+        &NoopWatcherFactory,
+    )
+    .expect("open should succeed");
 }
 
 fn seed_md(root: &Path, rel: &str, content: &str) {

--- a/src/lib/tauri/index.ts
+++ b/src/lib/tauri/index.ts
@@ -13,6 +13,13 @@ export type {
 export { updateColumns } from "./columnCommands/updateColumns";
 export { openDirectoryDialog } from "./dialog/openDirectoryDialog";
 
+// labelCommands
+export { getLabels } from "./labelCommands/getLabels";
+export type {
+  GetLabelsPayload,
+  LabelDefinition,
+} from "./labelCommands/types";
+
 // linkCommands
 export { addLink } from "./linkCommands/addLink";
 export { removeLink } from "./linkCommands/removeLink";

--- a/src/lib/tauri/invokeWrapped/__tests__/invokeWrapped.behavior.test.ts
+++ b/src/lib/tauri/invokeWrapped/__tests__/invokeWrapped.behavior.test.ts
@@ -59,6 +59,7 @@ test("成功時は sink が呼ばれず Result.ok(value) を返す", async () =>
 test.for([
   "get_tasks",
   "get_columns",
+  "get_labels",
   "open_project",
 ] as const)("読み取り系 '%s' の reject では sink が発火しない", async (cmd) => {
   invokeMock.mockRejectedValueOnce(new Error("read boom"));

--- a/src/lib/tauri/labelCommands/getLabels/__tests__/getLabels.behavior.test.ts
+++ b/src/lib/tauri/labelCommands/getLabels/__tests__/getLabels.behavior.test.ts
@@ -1,0 +1,47 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, expect, test, vi } from "vitest";
+import type { LabelDefinition } from "@/lib/tauri";
+import { getLabels } from "@/lib/tauri";
+import { TauriError } from "@/lib/tauri/tauriError";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+const labelsFixture: LabelDefinition[] = [
+  { name: "bug", description: "バグ報告", group: "type", color: "#D73A4A" },
+  { name: "enhancement" },
+];
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+});
+
+test("invoke が 'get_labels' という command 名で呼ばれる", async () => {
+  vi.mocked(invoke).mockResolvedValue({ labels: [] });
+  await getLabels();
+  expect(vi.mocked(invoke).mock.calls[0]?.[0]).toBe("get_labels");
+});
+
+test("invoke 第 2 引数（payload）は undefined で呼ばれる", async () => {
+  vi.mocked(invoke).mockResolvedValue({ labels: [] });
+  await getLabels();
+  expect(vi.mocked(invoke).mock.calls[0]?.[1]).toBeUndefined();
+});
+
+test("成功時は Result.ok({labels}) を返し定義順を保持する", async () => {
+  vi.mocked(invoke).mockResolvedValue({ labels: labelsFixture });
+  const res = await getLabels();
+  // labels.yml 定義順（bug → enhancement）がそのまま payload に保持される
+  expect(res).toEqual({
+    ok: true,
+    value: { labels: [{ ...labelsFixture[0] }, { ...labelsFixture[1] }] },
+  });
+});
+
+test("invoke が reject すると throw せず Result.err(TauriError) を返す", async () => {
+  vi.mocked(invoke).mockRejectedValue(new Error("fail"));
+  const res = await getLabels();
+  expect(res.ok).toBe(false);
+  expect((res as { ok: false; error: unknown }).error).toBeInstanceOf(
+    TauriError,
+  );
+});

--- a/src/lib/tauri/labelCommands/getLabels/index.ts
+++ b/src/lib/tauri/labelCommands/getLabels/index.ts
@@ -1,0 +1,13 @@
+import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
+import type { TauriError } from "@/lib/tauri/tauriError";
+import type { Result } from "@/utils/result";
+import type { GetLabelsPayload } from "../types";
+
+/**
+ * 現在のプロジェクトのラベルマスタ定義一覧を取得する。
+ * labels.yml 不在時は空配列（暗黙ラベル）。読み取り系 command のため
+ * 失敗時に書き込み失敗トースト（mutation 通知）の対象にはしない。
+ * @returns 成功時は Result.ok({labels})、失敗時は Result.err(TauriError)
+ */
+export const getLabels = (): Promise<Result<GetLabelsPayload, TauriError>> =>
+  invokeWrapped<GetLabelsPayload>("get_labels");

--- a/src/lib/tauri/labelCommands/types.ts
+++ b/src/lib/tauri/labelCommands/types.ts
@@ -1,0 +1,19 @@
+/** ラベルマスタ定義 1 件。`name` のみ必須、他は任意。 */
+export type LabelDefinition = {
+  /** ラベル識別子（完全一致・未正規化） */
+  name: string;
+  /** ラベルの説明文 */
+  description?: string;
+  /** UI グルーピング用のグループ名 */
+  group?: string;
+  /** `#RRGGBB` 形式の色。不正・欠落時は省略され、既定色は表示層が適用する */
+  color?: string;
+  /** 最終更新日時（ISO 8601 推奨・文字列のまま保持） */
+  updated?: string;
+};
+
+/** get_labels 戻り値ペイロード。`labels` は labels.yml の定義順を保持する。 */
+export type GetLabelsPayload = {
+  /** ラベル定義の配列（定義順） */
+  labels: LabelDefinition[];
+};

--- a/src/lib/tauri/mutationFailureMessage/__tests__/mutationFailureMessage.behavior.test.ts
+++ b/src/lib/tauri/mutationFailureMessage/__tests__/mutationFailureMessage.behavior.test.ts
@@ -19,6 +19,7 @@ test.for([
 test.for([
   "get_tasks",
   "get_columns",
+  "get_labels",
   "open_project",
   "update_card_order",
 ] as const)("allowlist 外の cmd '%s' で isMutationCommand が false", (cmd) => {

--- a/src/lib/tauri/mutationFailureMessage/index.ts
+++ b/src/lib/tauri/mutationFailureMessage/index.ts
@@ -6,7 +6,7 @@ const HAS_CHILDREN_MESSAGE = "子タスクが存在するため削除できま�
  * 書き込み（ミューテーション）コマンド名 → 日本語操作ラベルの写像。
  * このテーブルに載っている cmd のみ失敗トースト対象（= allowlist）。
  * update_card_order は partial-move 専用文を useProject 側に残すため除外。
- * get_tasks / get_columns / open_project は読み取り系のため除外。
+ * get_tasks / get_columns / get_labels / open_project は読み取り系のため除外。
  *
  * `as const satisfies` でリテラルキーを保ちつつ値型を検証する。
  * （`Readonly<Record<string,string>>` 注釈だと keyof が string に潰れる）


### PR DESCRIPTION
## 概要

タスク frontmatter の自由文字列 `labels` に対し、プロジェクト単位のラベルマスタ定義ファイル `.spec-board/labels.yml`（説明・グループ・色などのメタ情報）を新規導入する。永続化フォーマット（スキーマ）・読み込み・取得コマンド・フロント連携をフルスタックで整備した。labels.yml 不在時は空レジストリで開けるため**完全後方互換**で、frontmatter `labels` は非破壊・未定義ラベルは警告なし暗黙許容とする。

## 変更の種類

- ✨ 新機能（New Feature）
- 📝 ドキュメント更新（docs/spec-board/ 3 件）

## 追加した内容

- **[BE] `SpecBoardDir`**（`crates/fs/config_io.rs`）: `.spec-board/` 配下の format 非依存 raw I/O を提供するリソース管理 struct（`read_file` / `write_file` / `ensure` / `file_path`）。path traversal 防止（単一 Normal コンポーネントのみ許可）込み。
- **[BE] ドメイン型**（`config.rs`）: `LabelRegistry` / `LabelDefinition` / `LabelColor`。`color` のみ lenient（`#RRGGBB` 以外は既定色へ）、他フィールドは strict string、name の空・重複は aggregate メソッド `validate` で検出。
- **[BE] 永続化抽象**: `LabelRegistryStore` trait + ファクトリ `label_registry_store` + `pub(crate)` 具象 `YamlLabelRegistryStore`。YAML 形式知識を具象へ閉じ込め、`serde_yaml_ng` はサブクレートに持ち込まない（境界規約）。
- **[BE] `get_labels` コマンド**（`config/get_labels.rs`）: 読み取り専用 3 段構成。`AppState.labels` から camelCase payload を返す。
- **[FE] `getLabels` invoke ラッパ + 型**（`lib/tauri/labelCommands/`）: `getColumns` 同型。読み取り系のため mutation 失敗トーストの対象外。

## 変更した内容

- **[BE] `AppState`**: 6 番目フィールド `labels: Mutex<Option<LabelRegistry>>` を追加。lock 取得順序契約を `project_path → config → labels → tasks_cache → watcher_handle → write_ignore` に更新し、`check_all_locks` / commit API を拡張。`replace_project_and_config` → `replace_project_config_and_labels`（3 フィールド atomic swap）にリネーム。
- **[BE] `open_project`**: `&dyn LabelRegistryStore` を注入し、config と同様に commit 前に labels をロード。失敗時は `labels load failed (io|parse)` で open に失敗（旧 state 非破壊）。
- **[BE] `read_config_json`**: `SpecBoardDir` への委譲にリファクタ（重複排除）。
- 既存テストヘルパー（task/config の各 `command_tests` 等）を `open_project_impl` のシグネチャ変更に追従。

## 削除した内容

なし。

## 仕様ドキュメント更新

`docs/spec-board/` 配下を**同 PR で更新済み**:
- `config-spec.md`: labels.yml スキーマ（フィールド定義・配置・color lenient/クォート必須・name 一意性・前方互換）を新設。
- `file-system-spec.md`: `get_labels` コマンドと open_project の labels 読み込み経路を追記。
- `task-format-spec.md`: frontmatter labels と labels.yml の整合（未定義ラベルは暗黙許容・非破壊）を明記。

## システム図

```mermaid
flowchart LR
    Y[".spec-board/labels.yml"] --> SBD["SpecBoardDir.read_file<br/>(format非依存 raw I/O)"]
    SBD -->|"Ok(Some/None)"| ST["YamlLabelRegistryStore.load<br/>(serde_yaml_ng / color lenient / validate)"]
    F["label_registry_store(root)<br/>factory → impl LabelRegistryStore"] -.注入.-> OP
    ST --> OP["open_project_impl<br/>(&dyn LabelRegistryStore)"]
    OP --> AS["AppState.labels<br/>(6番目フィールド)"]
    AS --> GL["#tauri::command get_labels"]
    GL -->|"camelCase payload"| FE["getLabels invokeWrapped<br/>(lib/tauri/labelCommands)"]
    style Y fill:#e8f5e9
    style SBD fill:#fff3cd
    style ST fill:#fff3cd
    style AS fill:#fff3cd
    style GL fill:#fff3cd
    style FE fill:#cfe2ff
```

## 関連Issue

Closes #260

## テスト

- **バックエンド**: `cargo test`（lib 736 + spec-board-fs 134 tests passed）/ `cargo clippy --all-targets`（警告なし）/ `cargo fmt` 適用済み
- **フロントエンド**: `pnpm test:run`（174 files / 1349 tests passed）/ `tsc --noEmit`（クリーン）/ Biome・oxlint（クリーン）
- **手動検証**: ヘッドレス環境のため Tauri GUI 操作確認は未実施。同等シナリオ（labels.yml 不在→Default / 定義パース / color 不正フォールバック / 壊れ YAML→parse 失敗 / 未定義ラベル暗黙許容）は自動テストでカバー済み。

## レビューポイント

- **境界規約**: `serde_yaml_ng` をサブクレート `spec-board-fs` に持ち込まず、raw I/O（`SpecBoardDir`）と YAML パース（`YamlLabelRegistryStore`）を 2 層分割している点。
- **format 抽象**: 単一実装ながら trait + ファクトリ + `pub(crate)` 具象で DI 可能にしている（計画レビュー反映）。テストでモック store を注入できる。
- **lenient の非対称**: `color` のみ lenient で None フォールバック、他フィールド（name/description/group/updated）は型不一致を `parse` エラーに倒す（数値/bool/mapping を拒否）。
- **AppState の lock 順序契約**と 3 フィールド atomic swap（cross-project corruption 防止）。
- **スコープ境界**: 本 PR は labels.yml スキーマ確定〜読み込み〜`get_labels`〜invoke ラッパまで。実際の `LabelTag` への色反映（既定色の具体値）は別 Issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)