### PR TITLE
✨ [New Feature]: #262 [BE] ラベルレジストリ CRUD + 使用数集計

### DIFF
--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -97,7 +97,7 @@ labels:
 | labels | `LabelDefinition[]` | いいえ | `[]` | ラベル定義の配列。トップレベルキー欠落 / `null` / 空配列はいずれも空レジストリ（= 全ラベル暗黙扱い）に正規化される |
 | labels[].name | `string` | はい | - | ラベル識別子。完全一致・未正規化（trim / 大文字小文字統一なし）。空文字 `""` は不可 |
 | labels[].description | `string` | いいえ | なし | ラベルの説明文 |
-| labels[].group | `string` | いいえ | なし | UI 上のグルーピングに使うグループ名（グルーピングの表示は表示層の責務） |
+| labels[].group | `string` | いいえ | なし | UI 上のグルーピングに使うグループ名（グルーピングの表示は表示層の責務）。空文字 `""` は未指定として扱い `None` に正規化する（trim / 大文字小文字統一はしない） |
 | labels[].color | `string` | いいえ | なし（既定色） | `#RRGGBB` 形式の色。不正形式は lenient に「色なし（既定色）」へ倒す（後述） |
 | labels[].updated | `string` | いいえ | なし | 最終更新日時。ISO 8601 を推奨するが形式は検証せず文字列のまま保持する |
 
@@ -125,7 +125,40 @@ labels:
 - lenient なのは `color` のみ。`name` / `description` / `group` / `updated` は文字列型を strict に検証し、文字列以外（数値 `123` / bool / mapping / sequence 等）が来た場合は `labels load failed (parse)` として扱う（`description: "123"` のようにクォートすれば文字列として受理される）。
 - `get_labels` payload は labels.yml の定義順をそのまま保持する（並べ替えない）。`group` での UI グルーピングは表示層の責務。
 
-> **スコープ境界**: 本仕様は labels.yml のスキーマ確定・読み込み・`get_labels` コマンド・invoke ラッパまでを対象とする。実際のラベル色の UI 反映（既定色の具体値 / design token 定義）は別 Issue で扱う。
+### get_labels の使用数集計
+
+`get_labels` の payload は定義（labels.yml 由来）と派生値（使用数）を別フィールドで返す（1 オブジェクトに混ぜない）。
+
+```ts
+type GetLabelsPayload = {
+  labels: LabelDefinition[];          // 定義順を保持
+  usageCounts: { [name: string]: number }; // ラベル名 → 使用タスク件数
+};
+```
+
+- `usageCounts` は「そのラベルを使っているタスクの件数」。1 タスク内で同じラベルが重複していても 1 件（タスク単位で重複排除）。照合は完全一致・未正規化。
+- `usageCounts` はタスク側（frontmatter）由来のため、labels.yml に未定義の暗黙ラベルのキーも含み得る。FE は `labels[].name` で引くため余分なキーは無害（暗黙ラベルは `labels` に現れない）。
+- 集計は表示用のため eventual consistency を許容する（labels と tasks を厳密に同一トランザクションでは観測しない）。
+- **FE 型ドリフト注意**: FE の TS 型は手書きのため、Rust 側の `usageCounts` 追加だけでは TS ビルドは壊れない。`GetLabelsPayload` の TS 型に `usageCounts` を追加して追従する必要がある（FE 実装は別 Issue）。
+
+### ラベル CRUD コマンド
+
+ラベルマスタの書き込みは 3 コマンドで行う。いずれも成功時に `.spec-board/labels.yml` を atomic に上書きし、in-memory state にも反映する。
+
+| コマンド | 引数 | 戻り値 | 説明 |
+|:---------|:-----|:-------|:-----|
+| `create_label` | `{ name, description?, group?, color? }` | `Unit` | 新規ラベルを追記する。`name` 重複・空文字 `""` は拒否。`group` 空文字 / `color` 不正 hex は未指定に倒す（lenient）。`updated` はサーバが現在時刻を自動セット |
+| `update_label` | `{ name, description?, group?, color? }` | `Unit` | 既存ラベルの metadata を更新する。`name` は同一性キーで **rename しない**。不在 `name` は拒否。`updated` をサーバが自動更新 |
+| `delete_label` | `{ name }` | `{ usageCount }` | 指定ラベルを削除する。不在 `name` は拒否。削除前の使用タスク件数を返す |
+
+- **`update_label` は PUT セマンティクス**: FE は全フィールドを送る契約。`description` / `group` / `color` を未指定（または `null`）で送ると、その既存値は**クリアされる**（部分更新ではない）。`color` の不正 hex も既定色（未指定）へ倒れる。
+- **`updated` の自動セット**: `create_label` / `update_label` 時にサーバが現在時刻を ISO 8601 / RFC 3339（UTC・`Z` 終端）でセットする。FE / 引数からは指定できない。
+- **`delete_label` の usageCount**: 削除前に算出した使用タスク件数（`get_labels` の `usageCounts` と同じ意味）。`usageCount > 0`（使用中）でも削除は実行し、タスク frontmatter の `labels` は一切変更しない（タスク側は暗黙ラベルとして残る）。delete の usageCount は labels と tasks を整合スナップショットで観測した値。
+- **エラー文字列契約**（FE のパターンマッチ整合のため `get_labels` と完全一致）:
+  - プロジェクト未オープン → `"プロジェクトが開かれていません"`
+  - 内部状態の lock 破損 → `"内部状態のロックが破損しました"`
+
+> **スコープ境界**: 本仕様は labels.yml のスキーマ確定・読み込み・`get_labels`（使用数集計含む）・`create_label` / `update_label` / `delete_label`・invoke ラッパまでを対象とする（Rust バックエンド）。FE 連携（`usageCounts` の TS 型追従・ラベル編集 UI）と実際のラベル色の UI 反映（既定色の具体値 / design token 定義）は別 Issue で扱う。
 
 ## 設定の初期化
 

--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -20,6 +20,9 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | `get_labels` | ラベルマスタ定義を取得（[config-spec.md](./config-spec.md) 「labels.yml スキーマ」参照） |
 | `update_columns` | カラム設定を更新（[config-spec.md](./config-spec.md) 参照） |
 | `update_card_order` | カラム内のカード並び順を更新（[config-spec.md](./config-spec.md) 参照） |
+| `create_label` | ラベルマスタに新規ラベルを追加（[config-spec.md](./config-spec.md) 「ラベル CRUD コマンド」参照） |
+| `update_label` | 既存ラベルの metadata を更新（PUT・[config-spec.md](./config-spec.md) 参照） |
+| `delete_label` | ラベルを削除し削除前の使用数を返す（[config-spec.md](./config-spec.md) 参照） |
 | `add_link` | タスク間の関連リンクを追加 |
 | `remove_link` | タスク間の関連リンクを削除 |
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3560,6 +3560,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
 thiserror = "2"
+time = { version = "0.3", features = ["formatting"] }
 spec-board-fs = { path = "crates/fs" }
 
 [dev-dependencies]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -52,11 +52,17 @@
 //! [`build_config_from_statuses`] は本モジュールに同居する。
 //! md ファイルの走査・フロントマター抽出・`config.json` への書き出しは別レイヤの責務。
 
+pub mod clock;
 pub mod column_name;
+pub mod create_label;
+pub mod delete_label;
 pub mod get_columns;
 pub mod get_labels;
 pub mod update_card_order;
 pub mod update_columns;
+pub mod update_label;
+
+pub use clock::{Clock, SystemClock};
 
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -1243,12 +1249,14 @@ pub struct LabelDefinition {
         skip_serializing_if = "Option::is_none"
     )]
     pub description: Option<String>,
+    /// 分類グループ（任意）。`color` と同様にドメイン VO で表し、空文字は `None`
+    /// （未指定）へ正規化する（生の `String` をドメイン/IPC 境界に漏らさない）。
     #[serde(
         default,
-        deserialize_with = "LabelDefinition::deserialize_opt_string",
+        deserialize_with = "LabelGroup::deserialize_opt",
         skip_serializing_if = "Option::is_none"
     )]
-    pub group: Option<String>,
+    pub group: Option<LabelGroup>,
     /// `#RRGGBB`。不正形式・型不一致（`123` / `{}` 等）は lenient に `None`（既定色）へ倒す。
     #[serde(
         default,
@@ -1346,6 +1354,50 @@ impl LabelColor {
     }
 }
 
+/// ラベルの分類グループを表す値オブジェクト。
+///
+/// `LabelColor` と同様にドメイン型として扱い、生の `String` をドメイン / IPC 境界へ
+/// 漏らさない。group には色のような形式制約はない（未正規化の自由文字列）ため、
+/// 空文字のみを「未指定」(`None`) に倒す lenient 構築とする（trim / case 正規化はしない）。
+/// `#[serde(transparent)]` により labels.yml 上は文字列としてそのまま round-trip する。
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct LabelGroup(String);
+
+impl LabelGroup {
+    /// 空文字は `None`（未指定）へ。それ以外はそのまま保持する。
+    pub fn from_lenient(value: impl Into<String>) -> Option<Self> {
+        let s = value.into();
+        if s.is_empty() {
+            None
+        } else {
+            Some(Self(s))
+        }
+    }
+
+    /// 保持しているグループ名を返す。
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// `group` フィールドの lenient deserialize。`null` / 空文字は `None`、非空文字列は
+    /// `Some(LabelGroup)`、それ以外の型（数値 / mapping 等）は型不一致エラーに倒す。
+    /// LabelGroup 固有ロジックなので関連関数として型に紐づける。
+    fn deserialize_opt<'de, D>(de: D) -> Result<Option<LabelGroup>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match serde_yaml_ng::Value::deserialize(de)? {
+            serde_yaml_ng::Value::Null => Ok(None),
+            serde_yaml_ng::Value::String(s) => Ok(LabelGroup::from_lenient(s)),
+            other => Err(serde::de::Error::custom(format!(
+                "expected a string, found {}",
+                yaml_value_type(&other)
+            ))),
+        }
+    }
+}
+
 /// ラベルマスタの整合性違反。`LabelRegistry::validate` が返すドメインエラー。
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum LabelValidationError {
@@ -1355,6 +1407,106 @@ pub enum LabelValidationError {
     /// `name` が空文字（`""`）。識別子として無効。空白のみ（`"   "`）は trim しない方針のため許容する。
     #[error("label name must not be empty in labels.yml")]
     EmptyLabelName,
+}
+
+/// `LabelRegistry::plan_update_label` の入力。
+///
+/// `name` を同一性キーとし rename を構造的に不可能にする（target と new name を
+/// 分離するフィールドを持たないため）。`group` / `color` は command 側でドメイン VO
+/// （`LabelGroup` / `LabelColor`）へ lenient 変換済みの値を受ける。
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdateLabelIntent {
+    pub name: String,
+    pub description: Option<String>,
+    pub group: Option<LabelGroup>,
+    pub color: Option<LabelColor>,
+}
+
+/// `LabelRegistry::plan_update_label` のドメインエラー。command 層がこれを wrap する。
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum UpdateLabelPlanError {
+    /// 更新対象 `name` が空文字。
+    #[error("label name must not be empty")]
+    EmptyName,
+    /// 指定 `name` のラベルが存在しない。
+    #[error("label not found: `{name}`")]
+    NotFound { name: String },
+    /// 更新後のレジストリが不変条件に違反した。
+    #[error(transparent)]
+    Validation(#[from] LabelValidationError),
+}
+
+/// `LabelRegistry::plan_delete_label` のドメインエラー。command 層がこれを wrap する。
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DeleteLabelPlanError {
+    /// 指定 `name` のラベルが存在しない。
+    #[error("label not found: `{name}`")]
+    NotFound { name: String },
+}
+
+impl LabelRegistry {
+    /// 新ラベルを追加した新 registry を返す（副作用なし）。
+    ///
+    /// `updated` は `clock` の現在時刻で自動セットする。空名・完全一致重複は既存
+    /// [`LabelRegistry::validate`] の再利用で拒否する。ドメイン不変条件の検証を
+    /// aggregate に同居させる方針。
+    pub fn plan_create_label(
+        &self,
+        mut definition: LabelDefinition,
+        clock: &dyn Clock,
+    ) -> Result<LabelRegistry, LabelValidationError> {
+        definition.updated = Some(clock.now_iso8601());
+        let mut next = self.clone();
+        next.labels.push(definition);
+        next.validate()?;
+        Ok(next)
+    }
+
+    /// 既存ラベルの metadata を更新した新 registry を返す（副作用なし）。
+    ///
+    /// `intent.name` は同一性キーで rename しない。不在なら `NotFound`、空名なら
+    /// `EmptyName`。未指定 optional はクリアする（PUT セマンティクス）。`updated` を
+    /// `clock` で更新する。
+    pub fn plan_update_label(
+        &self,
+        intent: UpdateLabelIntent,
+        clock: &dyn Clock,
+    ) -> Result<LabelRegistry, UpdateLabelPlanError> {
+        if intent.name.is_empty() {
+            return Err(UpdateLabelPlanError::EmptyName);
+        }
+        let mut next = self.clone();
+        let slot = next
+            .labels
+            .iter_mut()
+            .find(|l| l.name == intent.name)
+            .ok_or_else(|| UpdateLabelPlanError::NotFound {
+                name: intent.name.clone(),
+            })?;
+        // name は維持し metadata のみ差し替える（未指定 = None = クリア）。
+        slot.description = intent.description;
+        slot.group = intent.group;
+        slot.color = intent.color;
+        slot.updated = Some(clock.now_iso8601());
+        next.validate()?;
+        Ok(next)
+    }
+
+    /// 指定 `name` のラベルを削除した新 registry を返す（副作用なし）。不在なら `NotFound`。
+    pub fn plan_delete_label(
+        &self,
+        target_name: &str,
+    ) -> Result<LabelRegistry, DeleteLabelPlanError> {
+        let exists = self.labels.iter().any(|l| l.name == target_name);
+        if !exists {
+            return Err(DeleteLabelPlanError::NotFound {
+                name: target_name.to_string(),
+            });
+        }
+        let mut next = self.clone();
+        next.labels.retain(|l| l.name != target_name);
+        Ok(next)
+    }
 }
 
 /// `labels.yml` の読み込みエラー。`labels load failed (io|parse)` 方針に揃える。

--- a/src-tauri/src/config/clock.rs
+++ b/src-tauri/src/config/clock.rs
@@ -1,0 +1,58 @@
+//! ラベル `create` / `update` 時の `updated` 自動セットに使う時刻供給源。
+//!
+//! 実時刻に依存すると `updated` の値がテストごとに変わり assertion できないため、
+//! [`Clock`] trait で時刻取得を抽象化し、本番は [`SystemClock`]、テストは固定値を
+//! 返すスタブ（`FixedClock`）を `_impl` / `plan_*` に注入する。
+
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+/// 現在時刻（UTC, ISO 8601 / RFC 3339, `Z` サフィックス）の供給源。
+///
+/// テスト時は固定値を返すスタブへ差し替えることで `updated` の自動セットを
+/// 決定論的に検証できる。
+pub trait Clock {
+    /// 現在時刻を ISO 8601 / RFC 3339（UTC・`Z` 終端）文字列で返す。
+    fn now_iso8601(&self) -> String;
+}
+
+/// 本番用 [`Clock`]。`OffsetDateTime::now_utc()` を RFC 3339(`Z`) で整形する。
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_iso8601(&self) -> String {
+        // RFC 3339 は ISO 8601 のサブセット。UTC のため `Z` サフィックスになる。
+        // now_utc() の RFC 3339 整形は西暦 9999 年までは失敗しないため、失敗時は
+        // 不変条件違反として panic させる（空文字を保存して updated 契約を破らない）。
+        OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .expect("RFC 3339 formatting of OffsetDateTime::now_utc should not fail")
+    }
+}
+
+/// 固定の ISO 8601 文字列を返すテスト用 [`Clock`]。
+///
+/// `plan_create_label` / `plan_update_label` の `updated` 自動セットや、
+/// `create_label_impl` / `update_label_impl` の effect テストで時刻を固定する。
+#[cfg(test)]
+pub(crate) struct FixedClock {
+    iso: String,
+}
+
+#[cfg(test)]
+impl FixedClock {
+    pub(crate) fn new(iso: impl Into<String>) -> Self {
+        Self { iso: iso.into() }
+    }
+}
+
+#[cfg(test)]
+impl Clock for FixedClock {
+    fn now_iso8601(&self) -> String {
+        self.iso.clone()
+    }
+}
+
+#[cfg(test)]
+#[path = "clock_tests.rs"]
+mod clock_tests;

--- a/src-tauri/src/config/clock_tests.rs
+++ b/src-tauri/src/config/clock_tests.rs
@@ -1,0 +1,31 @@
+//! `Clock` / `SystemClock` / `FixedClock` のユニットテスト。
+
+use super::{Clock, FixedClock, SystemClock};
+
+#[test]
+fn system_clock_returns_iso8601_utc_with_z_suffix() {
+    let now = SystemClock.now_iso8601();
+
+    // ISO 8601 / RFC 3339（UTC, `Z` 終端）の形を文字列レベルで検証する
+    // （`time` の parsing 機能に依存しないよう構造のみを確認）。
+    let bytes = now.as_bytes();
+    assert!(now.ends_with('Z'), "UTC の RFC 3339 は Z 終端: {now}");
+    assert!(now.contains('T'), "日付と時刻は T 区切り: {now}");
+    assert!(
+        now.len() >= 20,
+        "最低でも YYYY-MM-DDTHH:MM:SSZ の長さ: {now}"
+    );
+    assert_eq!(bytes[4], b'-', "年-月の区切り位置: {now}");
+    assert_eq!(bytes[7], b'-', "月-日の区切り位置: {now}");
+    assert_eq!(bytes[10], b'T', "日付と時刻の区切り位置: {now}");
+    assert_eq!(bytes[13], b':', "時:分の区切り位置: {now}");
+    assert_eq!(bytes[16], b':', "分:秒の区切り位置: {now}");
+}
+
+#[test]
+fn fixed_clock_returns_the_configured_value() {
+    let clock = FixedClock::new("2026-05-31T00:00:00Z");
+    assert_eq!(clock.now_iso8601(), "2026-05-31T00:00:00Z");
+    // 何度呼んでも同じ値（決定論的）。
+    assert_eq!(clock.now_iso8601(), "2026-05-31T00:00:00Z");
+}

--- a/src-tauri/src/config/create_label.rs
+++ b/src-tauri/src/config/create_label.rs
@@ -1,0 +1,114 @@
+//! `create_label` Tauri command 本体。
+//!
+//! 新しいラベルを `.spec-board/labels.yml` に追記する書き込み専用 command。
+//! `update_card_order` と同じ「preflight lock → snapshot → plan（副作用ゼロ）→ disk write →
+//! project 一致時のみ in-memory commit」の 4 段で進める。ドメイン不変条件（空名拒否・
+//! 完全一致重複拒否）の検証と `updated` 自動セットは aggregate [`LabelRegistry::plan_create_label`]
+//! に委譲する。
+//!
+//! # ロック取得順序
+//!
+//! `project_path → labels`（`snapshot_label_write` / `replace_labels_if_project_matches`）。
+//!
+//! # エラー文字列の契約
+//!
+//! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`（`get_labels` と一致）
+//! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`（同上）
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tauri::State;
+use thiserror::Error;
+
+use crate::config::{
+    label_registry_store, Clock, LabelColor, LabelDefinition, LabelGroup, LabelRegistryStore,
+    LabelValidationError, SaveLabelsError, SystemClock,
+};
+use crate::state::{AppState, AppStateError};
+
+/// `create_label` コマンドの引数。FE は camelCase で送る。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateLabelArgs {
+    pub name: String,
+    pub description: Option<String>,
+    pub group: Option<String>,
+    pub color: Option<String>,
+}
+
+impl From<CreateLabelArgs> for LabelDefinition {
+    fn from(args: CreateLabelArgs) -> Self {
+        LabelDefinition {
+            name: args.name,
+            description: args.description,
+            // group / color はドメイン VO へ lenient 変換（空 group は None・不正 hex は None）。
+            group: args.group.and_then(LabelGroup::from_lenient),
+            color: args.color.as_deref().and_then(LabelColor::from_hex),
+            // updated は plan_create_label が clock でセットする。
+            updated: None,
+        }
+    }
+}
+
+/// `create_label` コマンドのエラー。
+#[derive(Debug, Error)]
+pub enum CreateLabelError {
+    /// プロジェクト未オープン（`project_path` / `labels` が `None`）。
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+    /// `AppState` 内部 mutex が poison 状態。
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+    /// ドメイン不変条件違反（空名 / 完全一致重複）。
+    #[error(transparent)]
+    Validation(#[from] LabelValidationError),
+    /// labels.yml への保存失敗。
+    #[error(transparent)]
+    Save(#[from] SaveLabelsError),
+}
+
+impl From<AppStateError> for CreateLabelError {
+    fn from(_: AppStateError) -> Self {
+        CreateLabelError::StateLockPoisoned
+    }
+}
+
+/// Tauri command 薄層。`create_label_impl` を呼び、エラーを文字列化して返す。
+#[tauri::command]
+pub fn create_label(state: State<'_, Arc<AppState>>, args: CreateLabelArgs) -> Result<(), String> {
+    create_label_impl(state.inner(), args, &SystemClock).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の本体関数。
+///
+/// 1. preflight: `check_labels_lock` で副作用前に lock 健全性を確認
+/// 2. snapshot: `snapshot_label_write` で `project_path` / `labels` を整合取得
+/// 3. plan: `plan_create_label`（副作用ゼロ・updated 自動セット・validate 再利用）
+/// 4. write: `store.save` で disk へ atomic 書き込み
+/// 5. commit: `replace_labels_if_project_matches` で snapshot 時と同一プロジェクトのときのみ反映
+///
+/// disk write 失敗時は commit を呼ばないため in-memory は汚れない。
+pub(crate) fn create_label_impl(
+    state: &AppState,
+    args: CreateLabelArgs,
+    clock: &dyn Clock,
+) -> Result<(), CreateLabelError> {
+    state.check_labels_lock()?;
+    let ctx = state.snapshot_label_write()?;
+    let project_root = ctx.project_root.ok_or(CreateLabelError::NoProjectOpen)?;
+    let registry = ctx.labels.ok_or(CreateLabelError::NoProjectOpen)?;
+
+    let definition = LabelDefinition::from(args);
+    let next = registry.plan_create_label(definition, clock)?;
+
+    let store = label_registry_store(&project_root);
+    store.save(&next)?;
+
+    state.replace_labels_if_project_matches(&project_root, next)?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "create_label_tests.rs"]
+mod create_label_tests;

--- a/src-tauri/src/config/create_label_tests.rs
+++ b/src-tauri/src/config/create_label_tests.rs
@@ -1,0 +1,222 @@
+//! `create_label_impl` / `LabelRegistry::plan_create_label` / `From<CreateLabelArgs>` のテスト。
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::{create_label_impl, CreateLabelArgs, CreateLabelError};
+use crate::config::clock::FixedClock;
+use crate::config::{
+    label_registry_store, LabelColor, LabelDefinition, LabelGroup, LabelRegistry,
+    LabelRegistryStore,
+};
+use crate::state::{AppState, AppStateError};
+
+const FIXED_NOW: &str = "2026-05-31T12:00:00Z";
+
+fn fixed_clock() -> FixedClock {
+    FixedClock::new(FIXED_NOW)
+}
+
+fn args(name: &str) -> CreateLabelArgs {
+    CreateLabelArgs {
+        name: name.to_string(),
+        description: None,
+        group: None,
+        color: None,
+    }
+}
+
+fn definition(name: &str) -> LabelDefinition {
+    LabelDefinition {
+        name: name.to_string(),
+        description: None,
+        group: None,
+        color: None,
+        updated: None,
+    }
+}
+
+fn opened_state(root: &Path, registry: LabelRegistry) -> AppState {
+    let state = AppState::new();
+    state
+        .set_project_path(Some(root.to_path_buf()))
+        .expect("writable");
+    state.replace_labels(Some(registry)).expect("writable");
+    state
+}
+
+// ───────── plan_create_label（純粋ロジック） ─────────
+
+#[test]
+fn plan_appends_new_label() {
+    let registry = LabelRegistry::default();
+    let next = registry
+        .plan_create_label(definition("bug"), &fixed_clock())
+        .expect("create ok");
+    assert_eq!(next.labels.len(), 1);
+    assert_eq!(next.labels[0].name, "bug");
+}
+
+#[test]
+fn plan_sets_updated_from_clock() {
+    let next = LabelRegistry::default()
+        .plan_create_label(definition("bug"), &fixed_clock())
+        .expect("create ok");
+    assert_eq!(next.labels[0].updated.as_deref(), Some(FIXED_NOW));
+}
+
+#[test]
+fn plan_preserves_existing_labels() {
+    let registry = LabelRegistry {
+        labels: vec![definition("feat")],
+    };
+    let next = registry
+        .plan_create_label(definition("bug"), &fixed_clock())
+        .expect("create ok");
+    let names: Vec<&str> = next.labels.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(names, vec!["feat", "bug"]);
+}
+
+#[test]
+fn plan_allows_optional_fields_unset() {
+    let next = LabelRegistry::default()
+        .plan_create_label(definition("bug"), &fixed_clock())
+        .expect("create ok");
+    let label = &next.labels[0];
+    assert!(label.description.is_none());
+    assert!(label.group.is_none());
+    assert!(label.color.is_none());
+}
+
+#[test]
+fn plan_rejects_duplicate_name() {
+    let registry = LabelRegistry {
+        labels: vec![definition("bug")],
+    };
+    let err = registry
+        .plan_create_label(definition("bug"), &fixed_clock())
+        .expect_err("duplicate rejected");
+    assert!(matches!(
+        err,
+        crate::config::LabelValidationError::DuplicateLabelName { .. }
+    ));
+}
+
+#[test]
+fn plan_rejects_empty_name() {
+    let err = LabelRegistry::default()
+        .plan_create_label(definition(""), &fixed_clock())
+        .expect_err("empty rejected");
+    assert!(matches!(
+        err,
+        crate::config::LabelValidationError::EmptyLabelName
+    ));
+}
+
+// ───────── From<CreateLabelArgs>（lenient 変換） ─────────
+
+#[test]
+fn from_args_lenient_color_invalid_hex_is_none() {
+    let mut a = args("bug");
+    a.color = Some("red".to_string());
+    let def = LabelDefinition::from(a);
+    assert!(def.color.is_none());
+}
+
+#[test]
+fn from_args_valid_hex_color_is_some() {
+    let mut a = args("bug");
+    a.color = Some("#1A2B3C".to_string());
+    let def = LabelDefinition::from(a);
+    assert_eq!(def.color.as_ref().map(LabelColor::as_str), Some("#1A2B3C"));
+}
+
+#[test]
+fn from_args_empty_group_is_none() {
+    let mut a = args("bug");
+    a.group = Some(String::new());
+    let def = LabelDefinition::from(a);
+    assert!(def.group.is_none());
+}
+
+#[test]
+fn from_args_group_wraps_label_group() {
+    let mut a = args("bug");
+    a.group = Some("type".to_string());
+    let def = LabelDefinition::from(a);
+    assert_eq!(def.group.as_ref().map(LabelGroup::as_str), Some("type"));
+}
+
+// ───────── create_label_impl（effect 層） ─────────
+
+#[test]
+fn impl_creates_label_and_persists() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(tmp.path(), LabelRegistry::default());
+
+    create_label_impl(&state, args("bug"), &fixed_clock()).expect("create ok");
+
+    // disk へ反映。
+    let on_disk = label_registry_store(tmp.path()).load().expect("load");
+    assert_eq!(on_disk.labels.len(), 1);
+    assert_eq!(on_disk.labels[0].name, "bug");
+    assert_eq!(on_disk.labels[0].updated.as_deref(), Some(FIXED_NOW));
+    // in-memory へ commit。
+    let in_mem = state.labels().expect("labels").expect("some");
+    assert_eq!(in_mem.labels.len(), 1);
+}
+
+#[test]
+fn impl_creates_file_when_absent() {
+    let tmp = TempDir::new().unwrap();
+    // labels.yml は存在しない状態（空レジストリで open）。
+    let state = opened_state(tmp.path(), LabelRegistry::default());
+
+    create_label_impl(&state, args("bug"), &fixed_clock()).expect("create ok");
+
+    assert!(tmp.path().join(".spec-board").join("labels.yml").exists());
+}
+
+#[test]
+fn impl_returns_no_project_open() {
+    let state = AppState::new();
+    let err = create_label_impl(&state, args("bug"), &fixed_clock()).expect_err("no project");
+    assert!(matches!(err, CreateLabelError::NoProjectOpen));
+}
+
+#[test]
+fn from_app_state_error_maps_to_state_lock_poisoned() {
+    // lock poison は state 層で `AppStateError::LockPoisoned` として検出され、
+    // command 層は `From` でこれを `StateLockPoisoned` に変換する（文字列契約一致）。
+    let err: CreateLabelError = AppStateError::LockPoisoned.into();
+    assert!(matches!(err, CreateLabelError::StateLockPoisoned));
+    assert_eq!(err.to_string(), "内部状態のロックが破損しました");
+}
+
+#[test]
+fn impl_no_commit_on_duplicate_name() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![definition("bug")],
+        },
+    );
+
+    let err = create_label_impl(&state, args("bug"), &fixed_clock()).expect_err("duplicate");
+    assert!(matches!(err, CreateLabelError::Validation(_)));
+    // in-memory は変化しない（1 件のまま）。
+    let in_mem = state.labels().expect("labels").expect("some");
+    assert_eq!(in_mem.labels.len(), 1);
+    // labels.yml は書き込まれていない。
+    assert!(!tmp.path().join(".spec-board").join("labels.yml").exists());
+}
+
+#[test]
+fn no_project_open_display_matches_contract() {
+    assert_eq!(
+        CreateLabelError::NoProjectOpen.to_string(),
+        "プロジェクトが開かれていません"
+    );
+}

--- a/src-tauri/src/config/delete_label.rs
+++ b/src-tauri/src/config/delete_label.rs
@@ -1,0 +1,115 @@
+//! `delete_label` Tauri command 本体。
+//!
+//! 指定 name のラベルを `.spec-board/labels.yml` から削除する書き込み専用 command。
+//! 削除前に「そのラベルを使っているタスク件数」を算出して payload で返す。usageCount > 0
+//! でも削除は実行し、タスク frontmatter（`task.labels`）は一切変更しない。
+//!
+//! 使用数は「削除前に何件で使われていたか」という操作結果のため、`snapshot_label_delete`
+//! で labels と tasks を整合した 1 回の観測から算出する（`get_labels` の eventual-consistent な
+//! 集計とは異なる）。
+//!
+//! # ロック取得順序
+//!
+//! `project_path → labels → tasks_cache`（preflight `check_labels_lock` + `check_tasks_cache_lock`、
+//! `snapshot_label_delete`、`replace_labels_if_project_matches`）。
+//!
+//! # エラー文字列の契約
+//!
+//! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`（`get_labels` と一致）
+//! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`（同上）
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use thiserror::Error;
+
+use crate::config::{
+    label_registry_store, DeleteLabelPlanError, LabelRegistryStore, SaveLabelsError,
+};
+use crate::state::{AppState, AppStateError};
+use crate::task::task_index::TaskIndex;
+
+/// `delete_label` コマンドの引数。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteLabelArgs {
+    pub name: String,
+}
+
+/// `delete_label` の payload。削除前に算出した使用数（使用タスク件数）を返す。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteLabelPayload {
+    pub usage_count: usize,
+}
+
+/// `delete_label` コマンドのエラー。
+#[derive(Debug, Error)]
+pub enum DeleteLabelError {
+    /// プロジェクト未オープン（`project_path` / `labels` が `None`）。
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+    /// `AppState` 内部 mutex が poison 状態。
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+    /// ドメイン plan エラー（不在）。
+    #[error(transparent)]
+    Plan(#[from] DeleteLabelPlanError),
+    /// labels.yml への保存失敗。
+    #[error(transparent)]
+    Save(#[from] SaveLabelsError),
+}
+
+impl From<AppStateError> for DeleteLabelError {
+    fn from(_: AppStateError) -> Self {
+        DeleteLabelError::StateLockPoisoned
+    }
+}
+
+/// Tauri command 薄層。`delete_label_impl` を呼び、エラーを文字列化して返す。
+#[tauri::command]
+pub fn delete_label(
+    state: State<'_, Arc<AppState>>,
+    args: DeleteLabelArgs,
+) -> Result<DeleteLabelPayload, String> {
+    delete_label_impl(state.inner(), args).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の本体関数。
+///
+/// 1. preflight: `check_labels_lock` + `check_tasks_cache_lock`（副作用前の lock 健全性確認）
+/// 2. snapshot: `snapshot_label_delete` で `project_path` / `labels` / `tasks` を整合取得
+/// 3. 削除前 usageCount を `TaskIndex::label_usage_counts` から算出（frontmatter 不変のため
+///    削除後も同値）
+/// 4. plan: `plan_delete_label`（不在なら `NotFound`）
+/// 5. write: `store.save`
+/// 6. commit: `replace_labels_if_project_matches`
+pub(crate) fn delete_label_impl(
+    state: &AppState,
+    args: DeleteLabelArgs,
+) -> Result<DeleteLabelPayload, DeleteLabelError> {
+    state.check_labels_lock()?;
+    state.check_tasks_cache_lock()?;
+    let ctx = state.snapshot_label_delete()?;
+    let project_root = ctx.project_root.ok_or(DeleteLabelError::NoProjectOpen)?;
+    let registry = ctx.labels.ok_or(DeleteLabelError::NoProjectOpen)?;
+
+    // 削除前の使用数（タスク単位・完全一致）。task 集約へ委譲する。
+    let usage_count = TaskIndex::label_usage_counts(&ctx.tasks)
+        .get(&args.name)
+        .copied()
+        .unwrap_or(0);
+
+    let next = registry.plan_delete_label(&args.name)?;
+
+    let store = label_registry_store(&project_root);
+    store.save(&next)?;
+
+    state.replace_labels_if_project_matches(&project_root, next)?;
+    Ok(DeleteLabelPayload { usage_count })
+}
+
+#[cfg(test)]
+#[path = "delete_label_tests.rs"]
+mod delete_label_tests;

--- a/src-tauri/src/config/delete_label_tests.rs
+++ b/src-tauri/src/config/delete_label_tests.rs
@@ -1,0 +1,217 @@
+//! `delete_label_impl` / `LabelRegistry::plan_delete_label` のテスト。
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use super::{delete_label_impl, DeleteLabelArgs, DeleteLabelError, DeleteLabelPayload};
+use crate::config::{
+    label_registry_store, DeleteLabelPlanError, LabelDefinition, LabelRegistry, LabelRegistryStore,
+};
+use crate::state::{AppState, AppStateError};
+use crate::task::label::Label;
+use crate::task::task_index::Task;
+
+fn definition(name: &str) -> LabelDefinition {
+    LabelDefinition {
+        name: name.to_string(),
+        description: None,
+        group: None,
+        color: None,
+        updated: None,
+    }
+}
+
+fn task_with_labels(id: &str, labels: &[&str]) -> Task {
+    Task {
+        id: id.into(),
+        file_path: id.into(),
+        title: format!("title-{id}").into(),
+        status: "Todo".into(),
+        priority: None,
+        labels: labels.iter().map(|l| Label::from(*l)).collect(),
+        parent: None,
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: Default::default(),
+        warnings: Vec::new(),
+    }
+}
+
+fn args(name: &str) -> DeleteLabelArgs {
+    DeleteLabelArgs {
+        name: name.to_string(),
+    }
+}
+
+fn opened_state(root: &Path, registry: LabelRegistry, tasks: Vec<Task>) -> AppState {
+    let state = AppState::new();
+    state
+        .set_project_path(Some(root.to_path_buf()))
+        .expect("writable");
+    state.replace_labels(Some(registry)).expect("writable");
+    let cache = tasks
+        .into_iter()
+        .enumerate()
+        .map(|(i, t)| (PathBuf::from(format!("{i}.md")), t))
+        .collect();
+    state.replace_tasks_cache(cache).expect("writable");
+    state
+}
+
+// ───────── plan_delete_label（純粋ロジック） ─────────
+
+#[test]
+fn plan_removes_label() {
+    let registry = LabelRegistry {
+        labels: vec![definition("bug"), definition("feat")],
+    };
+    let next = registry.plan_delete_label("bug").expect("delete ok");
+    let names: Vec<&str> = next.labels.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(names, vec!["feat"]);
+}
+
+#[test]
+fn plan_rejects_unknown_name() {
+    let registry = LabelRegistry {
+        labels: vec![definition("bug")],
+    };
+    let err = registry
+        .plan_delete_label("ghost")
+        .expect_err("unknown rejected");
+    assert!(matches!(err, DeleteLabelPlanError::NotFound { .. }));
+}
+
+// ───────── delete_label_impl（effect 層） ─────────
+
+#[test]
+fn impl_deletes_and_persists_with_zero_usage() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![definition("bug")],
+        },
+        Vec::new(),
+    );
+
+    let payload = delete_label_impl(&state, args("bug")).expect("delete ok");
+    assert_eq!(payload, DeleteLabelPayload { usage_count: 0 });
+
+    let on_disk = label_registry_store(tmp.path()).load().expect("load");
+    assert!(on_disk.labels.iter().all(|l| l.name != "bug"));
+    let in_mem = state.labels().expect("labels").expect("some");
+    assert!(in_mem.labels.iter().all(|l| l.name != "bug"));
+}
+
+#[test]
+fn impl_returns_pre_delete_usage_count() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![definition("bug")],
+        },
+        vec![
+            task_with_labels("a", &["bug"]),
+            task_with_labels("b", &["bug"]),
+        ],
+    );
+
+    let payload = delete_label_impl(&state, args("bug")).expect("delete ok");
+    // 2 タスクで使用中でも削除は実行され、削除前の件数を返す。
+    assert_eq!(payload.usage_count, 2);
+    let on_disk = label_registry_store(tmp.path()).load().expect("load");
+    assert!(on_disk.labels.iter().all(|l| l.name != "bug"));
+}
+
+#[test]
+fn impl_usage_count_counts_task_not_occurrences() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![definition("bug")],
+        },
+        vec![
+            task_with_labels("a", &["bug", "bug"]),
+            task_with_labels("b", &["bug"]),
+        ],
+    );
+
+    let payload = delete_label_impl(&state, args("bug")).expect("delete ok");
+    // 1 タスク内重複は 1 件。タスク件数で数える。
+    assert_eq!(payload.usage_count, 2);
+}
+
+#[test]
+fn impl_does_not_touch_task_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![definition("bug")],
+        },
+        vec![task_with_labels("a", &["bug"])],
+    );
+
+    delete_label_impl(&state, args("bug")).expect("delete ok");
+
+    // tasks_cache のラベルは変化しない。
+    let tasks = state.tasks_snapshot().expect("tasks");
+    assert_eq!(tasks.len(), 1);
+    assert!(tasks[0].labels.iter().any(|l| l.as_str() == "bug"));
+}
+
+#[test]
+fn impl_returns_no_project_open() {
+    let state = AppState::new();
+    let err = delete_label_impl(&state, args("bug")).expect_err("no project");
+    assert!(matches!(err, DeleteLabelError::NoProjectOpen));
+}
+
+#[test]
+fn from_app_state_error_maps_to_state_lock_poisoned() {
+    // labels / tasks_cache いずれの lock poison も state 層で `AppStateError::LockPoisoned`
+    // となり、command 層は `From` で `StateLockPoisoned`（文字列契約一致）に変換する。
+    // 個別フィールドの poison 検出は state 層テスト（snapshot_label_delete_reports_poison_*）が担う。
+    let err: DeleteLabelError = AppStateError::LockPoisoned.into();
+    assert!(matches!(err, DeleteLabelError::StateLockPoisoned));
+    assert_eq!(err.to_string(), "内部状態のロックが破損しました");
+}
+
+#[test]
+fn impl_no_commit_on_unknown_name() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![definition("bug")],
+        },
+        Vec::new(),
+    );
+
+    let err = delete_label_impl(&state, args("ghost")).expect_err("unknown");
+    assert!(matches!(err, DeleteLabelError::Plan(_)));
+    // in-memory は bug を保持。
+    let in_mem = state.labels().expect("labels").expect("some");
+    assert!(in_mem.labels.iter().any(|l| l.name == "bug"));
+    // disk は書き換わっていない。
+    assert!(!tmp.path().join(".spec-board").join("labels.yml").exists());
+}
+
+#[test]
+fn payload_serializes_usage_count_as_camel_case() {
+    let json = serde_json::to_value(DeleteLabelPayload { usage_count: 3 }).expect("serialize");
+    assert_eq!(json, serde_json::json!({ "usageCount": 3 }));
+}
+
+#[test]
+fn no_project_open_display_matches_contract() {
+    assert_eq!(
+        DeleteLabelError::NoProjectOpen.to_string(),
+        "プロジェクトが開かれていません"
+    );
+}

--- a/src-tauri/src/config/get_labels.rs
+++ b/src-tauri/src/config/get_labels.rs
@@ -1,18 +1,29 @@
 //! `get_labels` Tauri command 本体。
 //!
 //! `AppState.labels` に commit 済みの `LabelRegistry` からラベル定義一覧を取得し、
-//! FE のラベル表示用 payload として返す読み取り専用 command。`get_columns` と同じ
-//! 3 段構成（payload 型 + `#[tauri::command]` 薄層 + `_impl`）を採用する。
+//! 各ラベルの使用数（`tasks_cache` から算出）と合わせて FE のラベル表示用 payload として
+//! 返す読み取り専用 command。`get_columns` と同じ 3 段構成（payload 型 +
+//! `#[tauri::command]` 薄層 + `_impl`）を採用する。
 //!
 //! payload は labels.yml の定義順をそのまま保持する（並べ替えない）。labels.yml 不在
 //! （= 空レジストリ・暗黙ラベル）でも `Ok(空配列)` を返す。プロジェクト未オープン
 //! （`labels` が `None`）のときのみ `NoProjectOpen`。
+//!
+//! ドメイン定義（labels.yml 由来の `LabelDefinition`）と派生値（使用数）は 1 つの
+//! オブジェクトに混ぜず、`labels` / `usage_counts` の別フィールドで返す。使用数集計は
+//! task 集約 [`TaskIndex::label_usage_counts`] に委譲し、依存方向を label/config → task の
+//! 一方向に保つ。
+//!
+//! # ロック取得順序
+//!
+//! `labels`（先）→ `tasks_cache`（後）の順で取得する（AppState の lock 契約に従う）。
 //!
 //! # エラー文字列の契約
 //!
 //! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`（`get_columns` と一致）
 //! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`（同上）
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -21,14 +32,19 @@ use thiserror::Error;
 
 use crate::config::LabelDefinition;
 use crate::state::{AppState, AppStateError};
+use crate::task::task_index::TaskIndex;
 
 /// `get_labels` コマンドが FE へ返す payload。
 ///
-/// 各定義は name / description / group / color / updated を含み、labels.yml の定義順を保持する。
+/// `labels` は labels.yml 由来のドメイン定義（name / description / group / color /
+/// updated）を定義順で保持する。`usage_counts` はラベル名 → 使用タスク件数のマップで、
+/// task 集約由来のため registry 未定義の暗黙ラベルのキーも含み得る（FE は `labels[].name`
+/// で引くため余分なキーは無害）。定義と派生値を型レベルで分離する（flatten しない）。
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetLabelsPayload {
     pub labels: Vec<LabelDefinition>,
+    pub usage_counts: HashMap<String, usize>,
 }
 
 /// `get_labels` コマンドのエラー。
@@ -37,7 +53,7 @@ pub enum GetLabelsError {
     /// `AppState.labels` が `None`（プロジェクト未オープン）。
     #[error("プロジェクトが開かれていません")]
     NoProjectOpen,
-    /// `AppState` 内部 mutex (`labels`) が poison 状態。
+    /// `AppState` 内部 mutex (`labels` / `tasks_cache`) が poison 状態。
     #[error("内部状態のロックが破損しました")]
     StateLockPoisoned,
 }
@@ -53,25 +69,31 @@ impl From<AppStateError> for GetLabelsError {
 /// # Errors
 ///
 /// - プロジェクト未オープン時に `"プロジェクトが開かれていません"`
-/// - `labels` の `Mutex` が poison している場合に `"内部状態のロックが破損しました"`
+/// - `labels` / `tasks_cache` の `Mutex` が poison している場合に `"内部状態のロックが破損しました"`
 #[tauri::command]
 pub fn get_labels(state: State<'_, Arc<AppState>>) -> Result<GetLabelsPayload, String> {
     get_labels_impl(state.inner()).map_err(|e| e.to_string())
 }
 
-/// 単体テスト境界の本体関数。`AppState.labels` から payload を組む。
+/// 単体テスト境界の本体関数。`AppState.labels` と `tasks_cache` から payload を組む。
 ///
-/// labels.yml 不在 = 空レジストリ（暗黙ラベル）でも `Ok(空配列)`。
-/// プロジェクト未オープン（labels が `None`）のみ `NoProjectOpen`。
+/// labels.yml 不在 = 空レジストリ（暗黙ラベル）でも `Ok(空配列)`。プロジェクト未オープン
+/// （labels が `None`）のみ `NoProjectOpen`。使用数集計は表示用のため eventual consistency を
+/// 許容する（labels と tasks の取得は同一トランザクションにしない）。
 ///
 /// # Errors
 ///
 /// - `AppState.labels` が `None` の場合 `GetLabelsError::NoProjectOpen`
-/// - `labels` の `Mutex` が poison している場合 `GetLabelsError::StateLockPoisoned`
+/// - `labels` / `tasks_cache` の `Mutex` が poison している場合 `GetLabelsError::StateLockPoisoned`
 pub(crate) fn get_labels_impl(state: &AppState) -> Result<GetLabelsPayload, GetLabelsError> {
+    // lock 取得順序契約: labels（先）→ tasks_cache（後）。
     let registry = state.labels()?.ok_or(GetLabelsError::NoProjectOpen)?;
+    let tasks = state.tasks_snapshot()?;
+    // 集計は task 集約 TaskIndex のメソッドへ委譲（free function を config 側に作らない）。
+    let usage_counts = TaskIndex::label_usage_counts(&tasks);
     Ok(GetLabelsPayload {
         labels: registry.labels,
+        usage_counts,
     })
 }
 

--- a/src-tauri/src/config/get_labels_tests.rs
+++ b/src-tauri/src/config/get_labels_tests.rs
@@ -1,8 +1,12 @@
 //! `get_labels_impl` のユニットテスト。
 
+use std::path::PathBuf;
+
 use super::{get_labels_impl, GetLabelsError, GetLabelsPayload};
-use crate::config::{LabelColor, LabelDefinition, LabelRegistry};
+use crate::config::{LabelColor, LabelDefinition, LabelGroup, LabelRegistry};
 use crate::state::{AppState, AppStateError};
+use crate::task::label::Label;
+use crate::task::task_index::Task;
 
 fn label(name: &str, color: Option<&str>) -> LabelDefinition {
     LabelDefinition {
@@ -12,6 +16,33 @@ fn label(name: &str, color: Option<&str>) -> LabelDefinition {
         color: color.and_then(LabelColor::from_hex),
         updated: None,
     }
+}
+
+fn task_with_labels(id: &str, labels: &[&str]) -> Task {
+    Task {
+        id: id.into(),
+        file_path: id.into(),
+        title: format!("title-{id}").into(),
+        status: "Todo".into(),
+        priority: None,
+        labels: labels.iter().map(|l| Label::from(*l)).collect(),
+        parent: None,
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: Default::default(),
+        warnings: Vec::new(),
+    }
+}
+
+fn set_tasks(state: &AppState, tasks: Vec<Task>) {
+    let cache = tasks
+        .into_iter()
+        .enumerate()
+        .map(|(i, t)| (PathBuf::from(format!("{i}.md")), t))
+        .collect();
+    state.replace_tasks_cache(cache).expect("writable");
 }
 
 #[test]
@@ -24,13 +55,14 @@ fn returns_err_when_no_project_open() {
 #[test]
 fn returns_empty_payload_when_registry_is_empty() {
     let state = AppState::new();
-    // labels.yml 不在 = 空レジストリでも Ok（暗黙ラベル）
+    // labels.yml 不在 = 空レジストリでも Ok（暗黙ラベル）。タスクも無いので usage は空。
     state
         .replace_labels(Some(LabelRegistry::default()))
         .expect("writable");
 
     let payload = get_labels_impl(&state).expect("正常系");
-    assert_eq!(payload, GetLabelsPayload { labels: vec![] });
+    assert!(payload.labels.is_empty());
+    assert!(payload.usage_counts.is_empty());
 }
 
 #[test]
@@ -60,7 +92,7 @@ fn returns_all_fields_in_payload() {
         labels: vec![LabelDefinition {
             name: "bug".to_string(),
             description: Some("バグ".to_string()),
-            group: Some("type".to_string()),
+            group: LabelGroup::from_lenient("type"),
             color: LabelColor::from_hex("#D73A4A"),
             updated: Some("2026-05-30T00:00:00Z".to_string()),
         }],
@@ -71,12 +103,91 @@ fn returns_all_fields_in_payload() {
     let label = &payload.labels[0];
     assert_eq!(label.name, "bug");
     assert_eq!(label.description.as_deref(), Some("バグ"));
-    assert_eq!(label.group.as_deref(), Some("type"));
+    assert_eq!(label.group.as_ref().map(LabelGroup::as_str), Some("type"));
     assert_eq!(
         label.color.as_ref().map(LabelColor::as_str),
         Some("#D73A4A")
     );
     assert_eq!(label.updated.as_deref(), Some("2026-05-30T00:00:00Z"));
+}
+
+#[test]
+fn usage_counts_empty_when_no_task_uses_labels() {
+    let state = AppState::new();
+    state
+        .replace_labels(Some(LabelRegistry {
+            labels: vec![label("bug", None)],
+        }))
+        .expect("writable");
+    set_tasks(&state, Vec::new());
+
+    let payload = get_labels_impl(&state).expect("正常系");
+    assert_eq!(payload.usage_counts.get("bug"), None);
+}
+
+#[test]
+fn usage_counts_counts_matching_task_labels() {
+    let state = AppState::new();
+    state
+        .replace_labels(Some(LabelRegistry {
+            labels: vec![label("bug", None), label("feat", None)],
+        }))
+        .expect("writable");
+    set_tasks(
+        &state,
+        vec![
+            task_with_labels("a", &["bug"]),
+            task_with_labels("b", &["bug", "feat"]),
+            task_with_labels("c", &["bug"]),
+        ],
+    );
+
+    let payload = get_labels_impl(&state).expect("正常系");
+    assert_eq!(payload.usage_counts.get("bug"), Some(&3));
+    assert_eq!(payload.usage_counts.get("feat"), Some(&1));
+}
+
+#[test]
+fn duplicate_label_within_task_counts_once() {
+    let state = AppState::new();
+    state
+        .replace_labels(Some(LabelRegistry {
+            labels: vec![label("bug", None)],
+        }))
+        .expect("writable");
+    set_tasks(&state, vec![task_with_labels("a", &["bug", "bug"])]);
+
+    let payload = get_labels_impl(&state).expect("正常系");
+    assert_eq!(payload.usage_counts.get("bug"), Some(&1));
+}
+
+#[test]
+fn implicit_label_appears_in_counts_not_in_labels() {
+    let state = AppState::new();
+    // registry には bug のみ定義。タスクは registry 未定義の "impl" を使う。
+    state
+        .replace_labels(Some(LabelRegistry {
+            labels: vec![label("bug", None)],
+        }))
+        .expect("writable");
+    set_tasks(&state, vec![task_with_labels("a", &["impl"])]);
+
+    let payload = get_labels_impl(&state).expect("正常系");
+    // 暗黙ラベルは usage_counts に現れるが labels には現れない。
+    assert_eq!(payload.usage_counts.get("impl"), Some(&1));
+    let names: Vec<&str> = payload.labels.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(names, vec!["bug"]);
+}
+
+#[test]
+fn payload_separates_labels_and_usage_counts() {
+    // payload 型は labels（定義）と usage_counts（派生値）を別フィールドで持つ。
+    let payload = GetLabelsPayload {
+        labels: vec![label("bug", None)],
+        usage_counts: [("bug".to_string(), 2usize)].into_iter().collect(),
+    };
+    assert_eq!(payload.labels.len(), 1);
+    assert_eq!(payload.usage_counts.get("bug"), Some(&2));
 }
 
 #[test]

--- a/src-tauri/src/config/label_registry_tests.rs
+++ b/src-tauri/src/config/label_registry_tests.rs
@@ -2,8 +2,8 @@
 //! ユニットテスト。load / save / color lenient / validate / format 抽象（trait モック）を網羅する。
 
 use super::{
-    label_registry_store, LabelColor, LabelDefinition, LabelRegistry, LabelRegistryStore,
-    LabelValidationError, LoadLabelsError, SaveLabelsError,
+    label_registry_store, LabelColor, LabelDefinition, LabelGroup, LabelRegistry,
+    LabelRegistryStore, LabelValidationError, LoadLabelsError, SaveLabelsError,
 };
 use tempfile::TempDir;
 
@@ -30,7 +30,7 @@ fn load_parses_definitions_with_all_fields() {
     let label = &registry.labels[0];
     assert_eq!(label.name, "bug");
     assert_eq!(label.description.as_deref(), Some("バグ報告"));
-    assert_eq!(label.group.as_deref(), Some("type"));
+    assert_eq!(label.group.as_ref().map(LabelGroup::as_str), Some("type"));
     assert_eq!(
         label.color.as_ref().map(LabelColor::as_str),
         Some("#D73A4A")
@@ -252,7 +252,7 @@ fn save_then_load_roundtrips_registry() {
             LabelDefinition {
                 name: "bug".to_string(),
                 description: Some("バグ".to_string()),
-                group: Some("type".to_string()),
+                group: LabelGroup::from_lenient("type"),
                 color: LabelColor::from_hex("#D73A4A"),
                 updated: Some("2026-05-30T00:00:00Z".to_string()),
             },

--- a/src-tauri/src/config/update_label.rs
+++ b/src-tauri/src/config/update_label.rs
@@ -1,0 +1,104 @@
+//! `update_label` Tauri command 本体。
+//!
+//! 既存ラベルの metadata（description / group / color）を更新する書き込み専用 command。
+//! `create_label` と同型の 4 段（preflight → snapshot → plan → disk write → commit）で進める。
+//! `name` は同一性キーで **rename しない**。未指定フィールドはクリアする（PUT セマンティクス）。
+//! `updated` はサーバが現在時刻で自動セットする。ドメイン不変条件と存在確認は aggregate
+//! [`LabelRegistry::plan_update_label`] に委譲する。
+//!
+//! # ロック取得順序
+//!
+//! `project_path → labels`（`snapshot_label_write` / `replace_labels_if_project_matches`）。
+//!
+//! # エラー文字列の契約
+//!
+//! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`（`get_labels` と一致）
+//! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`（同上）
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tauri::State;
+use thiserror::Error;
+
+use crate::config::{
+    label_registry_store, Clock, LabelColor, LabelGroup, LabelRegistryStore, SaveLabelsError,
+    SystemClock, UpdateLabelIntent, UpdateLabelPlanError,
+};
+use crate::state::{AppState, AppStateError};
+
+/// `update_label` コマンドの引数。FE は全フィールドを camelCase で送る（PUT）。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateLabelArgs {
+    /// 更新対象ラベルの name（同一性キー・rename しない）。
+    pub name: String,
+    pub description: Option<String>,
+    pub group: Option<String>,
+    pub color: Option<String>,
+}
+
+impl From<UpdateLabelArgs> for UpdateLabelIntent {
+    fn from(args: UpdateLabelArgs) -> Self {
+        UpdateLabelIntent {
+            name: args.name,
+            description: args.description,
+            // group / color の lenient 変換（空 group は None・不正 hex は None）。create と共通方針。
+            group: args.group.and_then(LabelGroup::from_lenient),
+            color: args.color.as_deref().and_then(LabelColor::from_hex),
+        }
+    }
+}
+
+/// `update_label` コマンドのエラー。
+#[derive(Debug, Error)]
+pub enum UpdateLabelError {
+    /// プロジェクト未オープン（`project_path` / `labels` が `None`）。
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+    /// `AppState` 内部 mutex が poison 状態。
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+    /// ドメイン plan エラー（空名 / 不在 / 不変条件違反）。
+    #[error(transparent)]
+    Plan(#[from] UpdateLabelPlanError),
+    /// labels.yml への保存失敗。
+    #[error(transparent)]
+    Save(#[from] SaveLabelsError),
+}
+
+impl From<AppStateError> for UpdateLabelError {
+    fn from(_: AppStateError) -> Self {
+        UpdateLabelError::StateLockPoisoned
+    }
+}
+
+/// Tauri command 薄層。`update_label_impl` を呼び、エラーを文字列化して返す。
+#[tauri::command]
+pub fn update_label(state: State<'_, Arc<AppState>>, args: UpdateLabelArgs) -> Result<(), String> {
+    update_label_impl(state.inner(), args, &SystemClock).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の本体関数。create と同型の 4 段 effect 層。
+pub(crate) fn update_label_impl(
+    state: &AppState,
+    args: UpdateLabelArgs,
+    clock: &dyn Clock,
+) -> Result<(), UpdateLabelError> {
+    state.check_labels_lock()?;
+    let ctx = state.snapshot_label_write()?;
+    let project_root = ctx.project_root.ok_or(UpdateLabelError::NoProjectOpen)?;
+    let registry = ctx.labels.ok_or(UpdateLabelError::NoProjectOpen)?;
+
+    let next = registry.plan_update_label(UpdateLabelIntent::from(args), clock)?;
+
+    let store = label_registry_store(&project_root);
+    store.save(&next)?;
+
+    state.replace_labels_if_project_matches(&project_root, next)?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "update_label_tests.rs"]
+mod update_label_tests;

--- a/src-tauri/src/config/update_label_tests.rs
+++ b/src-tauri/src/config/update_label_tests.rs
@@ -1,0 +1,206 @@
+//! `update_label_impl` / `LabelRegistry::plan_update_label` のテスト。
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::{update_label_impl, UpdateLabelArgs, UpdateLabelError};
+use crate::config::clock::FixedClock;
+use crate::config::{
+    label_registry_store, LabelColor, LabelDefinition, LabelGroup, LabelRegistry,
+    LabelRegistryStore, UpdateLabelIntent, UpdateLabelPlanError,
+};
+use crate::state::{AppState, AppStateError};
+
+const FIXED_NOW: &str = "2026-05-31T12:00:00Z";
+
+fn fixed_clock() -> FixedClock {
+    FixedClock::new(FIXED_NOW)
+}
+
+fn label(
+    name: &str,
+    description: Option<&str>,
+    group: Option<&str>,
+    color: Option<&str>,
+) -> LabelDefinition {
+    LabelDefinition {
+        name: name.to_string(),
+        description: description.map(str::to_string),
+        group: group.and_then(LabelGroup::from_lenient),
+        color: color.and_then(LabelColor::from_hex),
+        updated: None,
+    }
+}
+
+fn intent(
+    name: &str,
+    description: Option<&str>,
+    group: Option<&str>,
+    color: Option<&str>,
+) -> UpdateLabelIntent {
+    UpdateLabelIntent {
+        name: name.to_string(),
+        description: description.map(str::to_string),
+        group: group.and_then(LabelGroup::from_lenient),
+        color: color.and_then(LabelColor::from_hex),
+    }
+}
+
+fn args(name: &str) -> UpdateLabelArgs {
+    UpdateLabelArgs {
+        name: name.to_string(),
+        description: None,
+        group: None,
+        color: None,
+    }
+}
+
+fn opened_state(root: &Path, registry: LabelRegistry) -> AppState {
+    let state = AppState::new();
+    state
+        .set_project_path(Some(root.to_path_buf()))
+        .expect("writable");
+    state.replace_labels(Some(registry)).expect("writable");
+    state
+}
+
+// ───────── plan_update_label（純粋ロジック） ─────────
+
+#[test]
+fn plan_updates_existing_label_fields() {
+    let registry = LabelRegistry {
+        labels: vec![
+            label("bug", Some("old"), Some("type"), Some("#111111")),
+            label("feat", None, None, None),
+        ],
+    };
+    let next = registry
+        .plan_update_label(
+            intent("bug", Some("new"), Some("kind"), Some("#222222")),
+            &fixed_clock(),
+        )
+        .expect("update ok");
+
+    let bug = next.labels.iter().find(|l| l.name == "bug").unwrap();
+    assert_eq!(bug.description.as_deref(), Some("new"));
+    assert_eq!(bug.group.as_ref().map(LabelGroup::as_str), Some("kind"));
+    assert_eq!(bug.color.as_ref().map(LabelColor::as_str), Some("#222222"));
+    // 他ラベルは不変。
+    let feat = next.labels.iter().find(|l| l.name == "feat").unwrap();
+    assert!(feat.description.is_none());
+}
+
+#[test]
+fn plan_refreshes_updated_from_clock() {
+    let registry = LabelRegistry {
+        labels: vec![label("bug", None, None, None)],
+    };
+    let next = registry
+        .plan_update_label(intent("bug", None, None, None), &fixed_clock())
+        .expect("update ok");
+    assert_eq!(next.labels[0].updated.as_deref(), Some(FIXED_NOW));
+}
+
+#[test]
+fn plan_clears_optional_when_unset() {
+    // PUT セマンティクス: 未指定フィールドは既存値をクリアする。
+    let registry = LabelRegistry {
+        labels: vec![label("bug", Some("old"), Some("type"), Some("#111111"))],
+    };
+    let next = registry
+        .plan_update_label(intent("bug", None, None, None), &fixed_clock())
+        .expect("update ok");
+    let bug = &next.labels[0];
+    assert!(bug.description.is_none());
+    assert!(bug.group.is_none());
+    assert!(bug.color.is_none());
+}
+
+#[test]
+fn plan_rejects_unknown_name() {
+    let registry = LabelRegistry {
+        labels: vec![label("bug", None, None, None)],
+    };
+    let err = registry
+        .plan_update_label(intent("ghost", None, None, None), &fixed_clock())
+        .expect_err("unknown rejected");
+    assert!(matches!(err, UpdateLabelPlanError::NotFound { .. }));
+}
+
+#[test]
+fn plan_rejects_empty_name() {
+    let err = LabelRegistry::default()
+        .plan_update_label(intent("", None, None, None), &fixed_clock())
+        .expect_err("empty rejected");
+    assert!(matches!(err, UpdateLabelPlanError::EmptyName));
+}
+
+// ───────── update_label_impl（effect 層） ─────────
+
+#[test]
+fn impl_updates_and_persists() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![label("bug", Some("old"), None, None)],
+        },
+    );
+
+    let mut a = args("bug");
+    a.description = Some("new".to_string());
+    update_label_impl(&state, a, &fixed_clock()).expect("update ok");
+
+    let on_disk = label_registry_store(tmp.path()).load().expect("load");
+    assert_eq!(on_disk.labels[0].description.as_deref(), Some("new"));
+    assert_eq!(on_disk.labels[0].updated.as_deref(), Some(FIXED_NOW));
+    let in_mem = state.labels().expect("labels").expect("some");
+    assert_eq!(in_mem.labels[0].description.as_deref(), Some("new"));
+}
+
+#[test]
+fn impl_returns_no_project_open() {
+    let state = AppState::new();
+    let err = update_label_impl(&state, args("bug"), &fixed_clock()).expect_err("no project");
+    assert!(matches!(err, UpdateLabelError::NoProjectOpen));
+}
+
+#[test]
+fn from_app_state_error_maps_to_state_lock_poisoned() {
+    let err: UpdateLabelError = AppStateError::LockPoisoned.into();
+    assert!(matches!(err, UpdateLabelError::StateLockPoisoned));
+    assert_eq!(err.to_string(), "内部状態のロックが破損しました");
+}
+
+#[test]
+fn impl_no_commit_on_unknown_name() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(
+        tmp.path(),
+        LabelRegistry {
+            labels: vec![label("bug", None, None, None)],
+        },
+    );
+
+    let err = update_label_impl(&state, args("ghost"), &fixed_clock()).expect_err("unknown");
+    assert!(matches!(err, UpdateLabelError::Plan(_)));
+    // disk へ書き込まれていない。
+    assert!(!tmp.path().join(".spec-board").join("labels.yml").exists());
+}
+
+#[test]
+fn no_project_open_display_matches_contract() {
+    assert_eq!(
+        UpdateLabelError::NoProjectOpen.to_string(),
+        "プロジェクトが開かれていません"
+    );
+}
+
+#[test]
+fn state_lock_poisoned_display_matches_contract() {
+    assert_eq!(
+        UpdateLabelError::StateLockPoisoned.to_string(),
+        "内部状態のロックが破損しました"
+    );
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,7 +40,10 @@ pub fn run() {
             config::get_columns::get_columns,
             config::get_labels::get_labels,
             config::update_card_order::update_card_order,
-            config::update_columns::update_columns
+            config::update_columns::update_columns,
+            config::create_label::create_label,
+            config::update_label::update_label,
+            config::delete_label::delete_label
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -71,6 +71,33 @@ pub struct AppState {
     write_ignore: WriteIgnoreRegistry,
 }
 
+/// ラベル `create` / `update` コマンドが書き込み前に必要とするスナップショット。
+///
+/// `project_path` と `labels` を **同一の lock 取得トランザクション**で観測した値を
+/// まとめて運ぶ。複数フィールドの取得を `snapshot_..._and_...` のように `and` 連結した
+/// 関数名で表す代わりに、運ぶ内容を表す専用 context 型として定義する。
+#[derive(Debug, Clone)]
+pub struct LabelWriteContext {
+    /// snapshot 時点の project root。未オープン時は `None`。
+    pub project_root: Option<PathBuf>,
+    /// snapshot 時点のラベルレジストリ。未オープン時は `None`。
+    pub labels: Option<LabelRegistry>,
+}
+
+/// ラベル `delete` コマンドが書き込み前に必要とするスナップショット。
+///
+/// 削除前 usageCount を「labels と tasks の整合した観測」から算出するため、
+/// `project_path` / `labels` に加えて `tasks_cache` も同一トランザクションで取得する。
+#[derive(Debug, Clone)]
+pub struct LabelDeleteContext {
+    /// snapshot 時点の project root。未オープン時は `None`。
+    pub project_root: Option<PathBuf>,
+    /// snapshot 時点のラベルレジストリ。未オープン時は `None`。
+    pub labels: Option<LabelRegistry>,
+    /// snapshot 時点の全タスク（usageCount 算出用）。
+    pub tasks: Vec<Task>,
+}
+
 impl AppState {
     /// 全フィールドを初期状態にした `AppState` を生成する。
     ///
@@ -197,6 +224,64 @@ impl AppState {
         let mut config_guard = lock(&self.config)?;
         if path_guard.as_deref() == Some(expected_path) {
             *config_guard = Some(config);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// `project_path` と `labels` を**両方の lock を順に同時保持した状態で** snapshot する。
+    ///
+    /// `create_label` / `update_label` が書き込み前に使う。別々に `project_path()?` →
+    /// `labels()?` と取得すると、その間に `open_project` が project を swap して
+    /// 「新 path + 旧 labels」を観測する race window が生じる。本 API は両 lock を順に
+    /// 同時保持して両フィールドを clone することで整合 snapshot を返す。lock 取得順序は
+    /// AppState の契約に従って `project_path → labels` を遵守する。
+    pub fn snapshot_label_write(&self) -> Result<LabelWriteContext, AppStateError> {
+        let path_guard = lock(&self.project_path)?;
+        let labels_guard = lock(&self.labels)?;
+        Ok(LabelWriteContext {
+            project_root: path_guard.clone(),
+            labels: labels_guard.clone(),
+        })
+    }
+
+    /// `project_path` / `labels` / `tasks_cache` を**3 つの lock を順に同時保持した状態で**
+    /// snapshot する。
+    ///
+    /// `delete_label` が使う。削除前 usageCount は「削除前に何件のタスクで使われていたか」
+    /// という操作結果のため、labels と tasks を整合した 1 回の観測から算出する必要がある
+    /// （別々に取得すると不整合な組を観測し得る）。lock 取得順序は AppState の契約に従って
+    /// `project_path → labels → tasks_cache` を遵守する。
+    pub fn snapshot_label_delete(&self) -> Result<LabelDeleteContext, AppStateError> {
+        let path_guard = lock(&self.project_path)?;
+        let labels_guard = lock(&self.labels)?;
+        let tasks_guard = lock(&self.tasks_cache)?;
+        Ok(LabelDeleteContext {
+            project_root: path_guard.clone(),
+            labels: labels_guard.clone(),
+            tasks: tasks_guard.values().cloned().collect(),
+        })
+    }
+
+    /// 現在の `project_path` が `expected_path` と一致する場合のみ `labels` を差し替える。
+    ///
+    /// `snapshot_label_write` / `snapshot_label_delete` で読んだ snapshot を mutate し
+    /// disk write 成功後に書き戻す flow で、snapshot 取得から書き戻しまでの間に
+    /// `open_project` が project を swap したケースを検出するための atomic check-and-set。
+    /// lock 取得順序は `project_path → labels` を遵守する。
+    ///
+    /// - `expected_path` が一致 → `labels` を更新して `Ok(true)`
+    /// - 不一致（並行 `open_project` 等） → 何も変更せず `Ok(false)`
+    pub fn replace_labels_if_project_matches(
+        &self,
+        expected_path: &std::path::Path,
+        labels: LabelRegistry,
+    ) -> Result<bool, AppStateError> {
+        let path_guard = lock(&self.project_path)?;
+        let mut labels_guard = lock(&self.labels)?;
+        if path_guard.as_deref() == Some(expected_path) {
+            *labels_guard = Some(labels);
             Ok(true)
         } else {
             Ok(false)
@@ -348,3 +433,6 @@ fn lock<T>(m: &Mutex<T>) -> Result<MutexGuard<'_, T>, AppStateError> {
 
 #[cfg(test)]
 mod state_tests;
+
+#[cfg(test)]
+mod state_label_tests;

--- a/src-tauri/src/state/state_label_tests.rs
+++ b/src-tauri/src/state/state_label_tests.rs
@@ -1,0 +1,166 @@
+//! ラベル書き込み系 race 回避 API のユニットテスト。
+//!
+//! `snapshot_label_write` / `snapshot_label_delete` / `replace_labels_if_project_matches`
+//! の取得・整合 snapshot・check-and-set（一致 commit / 不一致 no-op）・poison 伝播を検証する。
+
+use super::{AppState, AppStateError};
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+
+use crate::config::{LabelDefinition, LabelRegistry};
+use crate::task::task_index::Task;
+
+fn sample_labels() -> LabelRegistry {
+    LabelRegistry {
+        labels: vec![LabelDefinition {
+            name: "bug".to_string(),
+            description: None,
+            group: None,
+            color: None,
+            updated: None,
+        }],
+    }
+}
+
+fn sample_task(id: &str) -> Task {
+    Task {
+        id: id.into(),
+        file_path: id.into(),
+        title: format!("title-{id}").into(),
+        status: "Todo".into(),
+        priority: None,
+        labels: Vec::new(),
+        parent: None,
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: Default::default(),
+        warnings: Vec::new(),
+    }
+}
+
+/// 指定フィールドの lock を保持したまま別スレッドで panic させ、その `Mutex` を poison する。
+fn poison_labels(state: Arc<AppState>) {
+    let handle = thread::spawn(move || {
+        let _guard = state.labels.lock().expect("lockable before panic");
+        panic!("poison labels");
+    });
+    let _ = handle.join();
+}
+
+fn poison_tasks_cache(state: Arc<AppState>) {
+    let handle = thread::spawn(move || {
+        let _guard = state.tasks_cache.lock().expect("lockable before panic");
+        panic!("poison tasks_cache");
+    });
+    let _ = handle.join();
+}
+
+#[test]
+fn snapshot_label_write_returns_project_and_labels() {
+    let state = AppState::new();
+    let path = PathBuf::from("/tmp/project");
+    state
+        .set_project_path(Some(path.clone()))
+        .expect("writable");
+    state
+        .replace_labels(Some(sample_labels()))
+        .expect("writable");
+
+    let ctx = state.snapshot_label_write().expect("snapshot");
+    assert_eq!(ctx.project_root, Some(path));
+    assert_eq!(ctx.labels, Some(sample_labels()));
+}
+
+#[test]
+fn snapshot_label_write_returns_none_when_unopened() {
+    let state = AppState::new();
+    let ctx = state.snapshot_label_write().expect("snapshot");
+    assert_eq!(ctx.project_root, None);
+    assert_eq!(ctx.labels, None);
+}
+
+#[test]
+fn snapshot_label_delete_returns_context_with_tasks() {
+    let state = AppState::new();
+    let path = PathBuf::from("/tmp/project");
+    state
+        .set_project_path(Some(path.clone()))
+        .expect("writable");
+    state
+        .replace_labels(Some(sample_labels()))
+        .expect("writable");
+    let mut cache = HashMap::new();
+    cache.insert(PathBuf::from("a.md"), sample_task("a.md"));
+    cache.insert(PathBuf::from("b.md"), sample_task("b.md"));
+    state.replace_tasks_cache(cache).expect("writable");
+
+    let ctx = state.snapshot_label_delete().expect("snapshot");
+    assert_eq!(ctx.project_root, Some(path));
+    assert_eq!(ctx.labels, Some(sample_labels()));
+    assert_eq!(ctx.tasks.len(), 2);
+}
+
+#[test]
+fn replace_labels_if_project_matches_commits_on_match() {
+    let state = AppState::new();
+    let path = PathBuf::from("/tmp/project");
+    state
+        .set_project_path(Some(path.clone()))
+        .expect("writable");
+
+    let committed = state
+        .replace_labels_if_project_matches(&path, sample_labels())
+        .expect("writable");
+    assert!(committed);
+    assert_eq!(state.labels().expect("labels"), Some(sample_labels()));
+}
+
+#[test]
+fn replace_labels_if_project_matches_noop_on_mismatch() {
+    let state = AppState::new();
+    state
+        .set_project_path(Some(PathBuf::from("/tmp/project-a")))
+        .expect("writable");
+    state
+        .replace_labels(Some(LabelRegistry::default()))
+        .expect("writable");
+
+    let committed = state
+        .replace_labels_if_project_matches(&PathBuf::from("/tmp/project-b"), sample_labels())
+        .expect("writable");
+    assert!(!committed);
+    // snapshot 時と project が変わっているため labels は元のまま（no-op）。
+    assert_eq!(
+        state.labels().expect("labels"),
+        Some(LabelRegistry::default())
+    );
+}
+
+#[test]
+fn snapshot_label_write_reports_poison() {
+    let state = Arc::new(AppState::new());
+    poison_labels(Arc::clone(&state));
+
+    assert_eq!(
+        AppStateError::LockPoisoned,
+        state.snapshot_label_write().expect_err("poisoned snapshot"),
+    );
+}
+
+#[test]
+fn snapshot_label_delete_reports_poison_on_tasks_cache() {
+    let state = Arc::new(AppState::new());
+    poison_tasks_cache(Arc::clone(&state));
+
+    assert_eq!(
+        AppStateError::LockPoisoned,
+        state
+            .snapshot_label_delete()
+            .expect_err("poisoned snapshot"),
+    );
+}

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -108,6 +108,30 @@ impl TaskIndex {
         &self.tasks
     }
 
+    /// 各ラベル名を「何件のタスクで使われているか」を数えて返す。
+    ///
+    /// 1 タスク内で同じラベルが重複していても 1 件（タスク単位で重複排除）。完全一致・
+    /// 未正規化（trim / case 変換なし）。キーは所有 `String` で返し、呼び出し側
+    /// （`get_labels` / `delete_label`）が借用ライフタイムに縛られないようにする。
+    /// 使用数集計は label/config ドメインではなく task 集約に置くことで、依存方向を
+    /// label/config → task の一方向に保つ（task は label を知らない）。
+    pub fn label_usage_counts(tasks: &[Task]) -> HashMap<String, usize> {
+        tasks
+            .iter()
+            // 各タスクを「そのタスクが持つ distinct なラベル集合」へ変換（タスク内重複排除）。
+            .flat_map(|task| {
+                task.labels
+                    .iter()
+                    .map(|label| label.as_str())
+                    .collect::<HashSet<&str>>()
+            })
+            // distinct ラベルを 1 件ずつ畳み込んで件数マップへ集約する。
+            .fold(HashMap::new(), |mut counts, label| {
+                *counts.entry(label.to_owned()).or_insert(0) += 1;
+                counts
+            })
+    }
+
     /// aggregate が保持する `Task` を `id` 昇順に並べた `Vec<Task>` を返す。
     ///
     /// `get_tasks` 等の読み取り API が依存する「id 昇順」契約をこの aggregate に
@@ -1306,6 +1330,10 @@ mod task_index_tests;
 #[cfg(test)]
 #[path = "task_index_parent_chain_tests.rs"]
 mod task_index_parent_chain_tests;
+
+#[cfg(test)]
+#[path = "task_index_label_usage_tests.rs"]
+mod task_index_label_usage_tests;
 
 #[cfg(test)]
 #[path = "task_index_plan_create_tests.rs"]

--- a/src-tauri/src/task/task_index_label_usage_tests.rs
+++ b/src-tauri/src/task/task_index_label_usage_tests.rs
@@ -1,0 +1,61 @@
+//! `TaskIndex::label_usage_counts` のユニットテスト。
+//!
+//! 使用タスク件数（タスク単位の重複排除）・完全一致・未正規化を検証する。
+
+use super::{Task, TaskIndex};
+use crate::task::label::Label;
+
+fn task_with_labels(id: &str, labels: &[&str]) -> Task {
+    Task {
+        id: id.into(),
+        file_path: id.into(),
+        title: format!("title-{id}").into(),
+        status: "Todo".into(),
+        priority: None,
+        labels: labels.iter().map(|l| Label::from(*l)).collect(),
+        parent: None,
+        links: Vec::new(),
+        children: Vec::new(),
+        reverse_links: Vec::new(),
+        body: String::new(),
+        extras: Default::default(),
+        warnings: Vec::new(),
+    }
+}
+
+#[test]
+fn empty_for_no_tasks() {
+    let counts = TaskIndex::label_usage_counts(&[]);
+    assert!(counts.is_empty());
+}
+
+#[test]
+fn counts_tasks_using_each_label() {
+    let tasks = vec![
+        task_with_labels("a", &["bug"]),
+        task_with_labels("b", &["bug", "feat"]),
+        task_with_labels("c", &["bug"]),
+    ];
+    let counts = TaskIndex::label_usage_counts(&tasks);
+    assert_eq!(counts.get("bug"), Some(&3));
+    assert_eq!(counts.get("feat"), Some(&1));
+}
+
+#[test]
+fn dedupes_duplicate_label_within_a_task() {
+    // 1 タスク内で同じラベルが 2 回出現しても 1 件（タスク単位で数える）。
+    let tasks = vec![task_with_labels("a", &["bug", "bug"])];
+    let counts = TaskIndex::label_usage_counts(&tasks);
+    assert_eq!(counts.get("bug"), Some(&1));
+}
+
+#[test]
+fn exact_match_is_case_sensitive_and_not_normalized() {
+    let tasks = vec![
+        task_with_labels("a", &["Bug"]),
+        task_with_labels("b", &["bug"]),
+    ];
+    let counts = TaskIndex::label_usage_counts(&tasks);
+    assert_eq!(counts.get("Bug"), Some(&1));
+    assert_eq!(counts.get("bug"), Some(&1));
+}


### PR DESCRIPTION
## 概要

ラベルレジストリ（`.spec-board/labels.yml`）の書き込み側 3 コマンド（`create_label` / `update_label` / `delete_label`）を新設し、`get_labels` に各ラベルの使用数集計（`usageCounts`）を統合する Rust バックエンド実装です。読み取り側 `get_labels` は #260 で実装済みのため、本 PR は write 系コマンドと使用数の追加が中心です。

## 変更の種類

- ✨ New Feature（[BE] Rust バックエンドのみ）
- ➕ Add Dep（`time` crate）
- 📝 Doc（config-spec.md / file-system-spec.md）

## 追加した内容

- `config/clock.rs`（NEW）: `Clock` trait / `SystemClock`（`time` crate で RFC 3339(Z) 整形）/ `FixedClock`（テスト用）
- `config.rs`: `LabelGroup` 値オブジェクト・`UpdateLabelIntent`・`UpdateLabelPlanError` / `DeleteLabelPlanError`・`LabelRegistry::plan_create_label` / `plan_update_label` / `plan_delete_label`（副作用ゼロの aggregate メソッド）
- `state.rs`: `LabelWriteContext` / `LabelDeleteContext` + `snapshot_label_write` / `snapshot_label_delete` / `replace_labels_if_project_matches`
- `task/task_index.rs`: `TaskIndex::label_usage_counts`（宣言的・タスク単位で重複排除）
- `config/create_label.rs` / `update_label.rs` / `delete_label.rs`（NEW）: `#[tauri::command]` 薄層 + `_impl` effect 層
- テスト: clock / state_label / task_index_label_usage / create / update / delete_label_tests

## 変更した内容

- `get_labels` payload を `{ labels: LabelDefinition[], usageCounts: { [name]: number } }` に分離（定義と派生値を型レベルで分離・`LabelWithUsage` の flatten は不採用）。集計は `TaskIndex::label_usage_counts` へ委譲
- `LabelDefinition.group` を `Option<String>` → `Option<LabelGroup>` に変更（`#[serde(transparent)]` で labels.yml 表現は不変。空文字は `None` へ正規化）
- `lib.rs` の `generate_handler!` に 3 コマンドを登録

## 仕様ドキュメント更新

- `docs/spec-board/config-spec.md`: ラベル CRUD コマンド・`get_labels` の `usageCounts`・`update_label` の PUT セマンティクス（未指定 = クリア・`name` は rename 不可）・`updated` サーバ自動セット・`group` の VO 化（空文字 → `None`）・エラー文字列契約・FE 型ドリフト注意を追記
- `docs/spec-board/file-system-spec.md`: Tauri コマンド一覧に `create_label` / `update_label` / `delete_label` を追加

## システム図

書き込み系コマンド（create/update/delete）の 4 段フロー（[NEW] が本 PR 追加分）:

\`\`\`mermaid
flowchart TD
    A["#[tauri::command] 薄層<br/>create/update/delete_label"] --> B["preflight<br/>check_labels_lock<br/>(delete は +check_tasks_cache_lock)"]
    B -->|lock poison| E1["StateLockPoisoned<br/>「内部状態のロックが破損しました」"]
    B --> C["snapshot [NEW]<br/>snapshot_label_write / snapshot_label_delete<br/>→ LabelWriteContext / LabelDeleteContext"]
    C -->|project_root/labels = None| E2["NoProjectOpen<br/>「プロジェクトが開かれていません」"]
    C --> P["plan (副作用ゼロ) [NEW]<br/>LabelRegistry::plan_create/update/delete_label<br/>validate 再利用・updated 自動セット"]
    P -->|空名/重複/不在| E3["Validation / Plan エラー"]
    P --> W["write<br/>LabelRegistryStore::save<br/>(validate + YAML + tmp→rename atomic)"]
    W -->|save 失敗| E4["SaveLabelsError<br/>(commit しない)"]
    W --> CM["commit [NEW]<br/>replace_labels_if_project_matches<br/>(disk 成功後・project 一致時のみ)"]
    CM --> D["Ok(())<br/>delete: Ok({ usageCount })"]
    style C fill:#e3f2fd
    style P fill:#e8f5e9
    style CM fill:#fff3e0
\`\`\`

`get_labels`（読み取り）は `labels`（先）→ `tasks_cache`（後）を取得し `TaskIndex::label_usage_counts` で `{ labels, usageCounts }` を返します。

## 関連Issue

Closes #262

## テスト

- `cargo test`（src-tauri lib）: **792 passed / 0 failed**
- `cargo fmt --check`: クリーン
- `cargo clippy --all-targets -- -D warnings`: 警告ゼロ
- codex AI レビュー実施（`.specs/.../code-review/review-001.md`）
- `pnpm tauri dev` 手動確認: **未実施**（ヘッドレス環境のため。create→get_labels の usageCount 反映 / update→updated 自動更新 / delete→usageCount 返却・labels.yml 反映の実機確認が別途必要）

## レビューポイント

- **同一プロジェクト内の並行 write（lost update）**: 本 PR は `snapshot→plan→save→commit` がプロジェクト切替 race のみを防ぎ、同一 project での同時 CRUD は last-writer-wins です。これは既存 config write（`update_card_order` / `update_columns`）と**同じ並行モデル**であり、単一ユーザー UI（順次 invoke）では実質発生しません。書き込み直列化（専用 mutex）/ registry CAS は config write と合わせた横断改善として**別 Issue 化を推奨**し、本 PR ではスコープ外（implementation-plan.md「制約・リスク」で明記済み・codex レビューでも同点を指摘）。
- **FE 型ドリフト**: `GetLabelsPayload` に `usageCounts` が増えます。FE の TS 型は手書きのため別途追従が必要（FE 実装は別 Issue）。
- **`update_label` の PUT セマンティクス**: 未指定フィールドは既存値をクリアします（部分更新ではない）。