### PR TITLE
♻️ [Refactoring]: #262 Args → ドメイン型変換を .into() に統一

### DIFF
--- a/src-tauri/src/config/create_label.rs
+++ b/src-tauri/src/config/create_label.rs
@@ -99,7 +99,7 @@ pub(crate) fn create_label_impl(
     let project_root = ctx.project_root.ok_or(CreateLabelError::NoProjectOpen)?;
     let registry = ctx.labels.ok_or(CreateLabelError::NoProjectOpen)?;
 
-    let definition = LabelDefinition::from(args);
+    let definition: LabelDefinition = args.into();
     let next = registry.plan_create_label(definition, clock)?;
 
     let store = label_registry_store(&project_root);

--- a/src-tauri/src/config/update_label.rs
+++ b/src-tauri/src/config/update_label.rs
@@ -90,7 +90,8 @@ pub(crate) fn update_label_impl(
     let project_root = ctx.project_root.ok_or(UpdateLabelError::NoProjectOpen)?;
     let registry = ctx.labels.ok_or(UpdateLabelError::NoProjectOpen)?;
 
-    let next = registry.plan_update_label(UpdateLabelIntent::from(args), clock)?;
+    let intent: UpdateLabelIntent = args.into();
+    let next = registry.plan_update_label(intent, clock)?;
 
     let store = label_registry_store(&project_root);
     store.save(&next)?;


### PR DESCRIPTION
## 概要

ラベル CRUD コマンド（#262 / PR #275）の `Args` → ドメイン型変換の呼び出しを `Type::from(args)` から `args.into()` に統一するリファクタリングです。

## 変更内容

| ファイル | 変更前 | 変更後 |
|:--|:--|:--|
| `src-tauri/src/config/create_label.rs` | `LabelDefinition::from(args)` | `let definition: LabelDefinition = args.into();` |
| `src-tauri/src/config/update_label.rs` | `UpdateLabelIntent::from(args)` | `let intent: UpdateLabelIntent = args.into();` |

## 意図

- `impl From<Args> for Domain` の定義はそのまま（Rust idiom 通り・`clippy::from_over_into` を踏まない・clippy clean を維持）。
- 呼び出し側だけ `args.into()` に寄せることで「**Args 主体で変換する**」という読み味にする。
- 依存方向は不変。`From` impl は command 層（`create_label.rs` / `update_label.rs`）に住み、ドメイン層 `config.rs` は `Args` を一切 import しない。

## 補足（既知のトレードオフ）

`From<Args> for Domain` は実装対象（`for` の後ろ）がドメイン型のため、将来ドメインを別 crate に切り出した場合は orphan rule によりドメイン crate 側へ impl を置く必要が生じ、依存逆転の火種となりうる。今回は single-crate のため顕在化せず、idiom 重視で `From` + `.into()` を採用。crate 分割を行う段階で inherent method 等へ移行する想定。

## 動作確認

- ✅ `cargo clippy --all-targets -- -D warnings` クリーン
- ✅ label 関連テスト 113 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)