### PR TITLE
♻️ [Refactor]: savePathPreview テストの条件分岐を test.each 化

### DIFF
--- a/src/features/task-form/lib/savePathPreview/__tests__/savePathPreview.behavior.test.ts
+++ b/src/features/task-form/lib/savePathPreview/__tests__/savePathPreview.behavior.test.ts
@@ -152,15 +152,14 @@ test("compute: title が記号のみで kebab base が空なら pending を返�
 });
 
 test.each([
-  ["a/b"],
-  ["a\\b"],
-] as const)("compute: セパレータ含み fileName %s は invalid + 該当文字を返す（BE from_explicit の拒否と整合）", (fileName) => {
+  ["a/b", "/"],
+  ["a\\b", "\\"],
+] as const)("compute: セパレータ含み fileName %s は invalid + 該当文字を返す（BE from_explicit の拒否と整合）", (fileName, char) => {
   const result = SavePathPreview.compute(computeInput({ fileName }));
-  expect(result.kind).toBe("invalid");
-  if (result.kind === "invalid") {
-    expect(result.error.code).toBe("FORBIDDEN_CHAR");
-    expect(result.error.chars.length).toBeGreaterThan(0);
-  }
+  expect(result).toMatchObject({
+    kind: "invalid",
+    error: { code: "FORBIDDEN_CHAR", chars: expect.arrayContaining([char]) },
+  });
 });
 
 test.each([


### PR DESCRIPTION
## 概要

`savePathPreview.behavior.test.ts` のセパレータ検証テストにあった `if` 型ガードを排除し、テストルール（テスト内の条件分岐禁止）に準拠させるリファクタリング。振る舞いは変更していない。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）
- 🧪 Tests（既存テストのルール準拠化）

## 変更した内容

- `if (result.kind === "invalid") { ... }` の型ガードを削除
- `test.each` のパラメータに期待文字（`/` / `\`）を追加し、`toMatchObject` + `expect.arrayContaining([char])` で検証する形へ変更
- 検証強度は据え置きではなく強化: 元の `chars.length > 0`（空でないことだけ）から「該当する禁止文字が `chars` に実際に含まれること」へ厳密化

```diff
-test.each([
-  ["a/b"],
-  ["a\\b"],
-] as const)("...", (fileName) => {
-  const result = SavePathPreview.compute(computeInput({ fileName }));
-  expect(result.kind).toBe("invalid");
-  if (result.kind === "invalid") {
-    expect(result.error.code).toBe("FORBIDDEN_CHAR");
-    expect(result.error.chars.length).toBeGreaterThan(0);
-  }
-});
+test.each([
+  ["a/b", "/"],
+  ["a\\b", "\\"],
+] as const)("...", (fileName, char) => {
+  const result = SavePathPreview.compute(computeInput({ fileName }));
+  expect(result).toMatchObject({
+    kind: "invalid",
+    error: { code: "FORBIDDEN_CHAR", chars: expect.arrayContaining([char]) },
+  });
+});
```

## 仕様ドキュメント更新

不要（純粋なテストコードのリファクタリングで、公開 API・データ形式・画面挙動・設定項目のいずれも変更していない）。

## 関連Issue

なし。`v0.2.0` タグ push 時の push 前検査フックが検出した既存テスト違反（PR #326 由来の `if` 型ガード）の事後修正。

## テスト

- `pnpm test:run src/features/task-form/lib/savePathPreview/__tests__/savePathPreview.behavior.test.ts` → **20 passed**
- `pnpm typecheck`（`tsc -b`）→ エラーなし
- `pnpm lint`（oxlint）→ 0 warnings / 0 errors

## レビューポイント

- `toMatchObject` + `arrayContaining` による検証が、元の型ガード版と同等以上の意図を表現できているか
- UI 変更を伴わないテストのみの変更のため実機確認は実施していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)