### PR TITLE
🐛 [Bug Fix]: [FE] create_task の IPC 引数を args キーでラップして引数契約の不整合を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-board",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "spec-board"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "spec-board"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Tauri desktop application for managing specification boards"
 authors = ["spec-board maintainers"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "spec-board",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"identifier": "io.github.dio0550.specboard",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/lib/tauri/taskCommands/createTask/__tests__/createTask.behavior.test.ts
+++ b/src/lib/tauri/taskCommands/createTask/__tests__/createTask.behavior.test.ts
@@ -36,8 +36,7 @@ test("必須フィールドのみ指定時は invoke 引数に title / status �
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await createTask({ title: "T", status: "Todo" });
   const args = vi.mocked(invoke).mock.calls[0]?.[1];
-  expect(args).toEqual({ title: "T", status: "Todo" });
-  expect(Object.keys(args ?? {})).toEqual(["title", "status"]);
+  expect(args).toEqual({ args: { title: "T", status: "Todo" } });
 });
 
 test("任意フィールドが全指定された場合 camelCase のまま invoke 引数に反映される", async () => {
@@ -51,12 +50,14 @@ test("任意フィールドが全指定された場合 camelCase のまま invok
     body: "本文",
   });
   expect(vi.mocked(invoke)).toHaveBeenCalledWith("create_task", {
-    title: "T",
-    status: "Todo",
-    priority: "High",
-    labels: ["a"],
-    parent: "tasks/p.md",
-    body: "本文",
+    args: {
+      title: "T",
+      status: "Todo",
+      priority: "High",
+      labels: ["a"],
+      parent: "tasks/p.md",
+      body: "本文",
+    },
   });
 });
 
@@ -67,15 +68,19 @@ test("links 配列を指定すると camelCase のまま invoke 引数に反映�
     status: "Todo",
     links: ["tasks/a.md", "tasks/b.md"],
   });
-  const args = vi.mocked(invoke).mock.calls[0]?.[1] as Record<string, unknown>;
-  expect(args.links).toEqual(["tasks/a.md", "tasks/b.md"]);
+  const args = vi.mocked(invoke).mock.calls[0]?.[1] as {
+    args: Record<string, unknown>;
+  };
+  expect(args.args.links).toEqual(["tasks/a.md", "tasks/b.md"]);
 });
 
 test("links 未指定時は invoke 引数に links キーが含まれない", async () => {
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await createTask({ title: "T", status: "Todo" });
-  const args = vi.mocked(invoke).mock.calls[0]?.[1] as Record<string, unknown>;
-  expect("links" in args).toBe(false);
+  const args = vi.mocked(invoke).mock.calls[0]?.[1] as {
+    args: Record<string, unknown>;
+  };
+  expect("links" in args.args).toBe(false);
 });
 
 test("optional に undefined を明示指定した場合 undefined のまま渡る（ラッパで加工しない）", async () => {
@@ -85,9 +90,11 @@ test("optional に undefined を明示指定した場合 undefined のまま渡�
     status: "Todo",
     priority: undefined,
   });
-  const args = vi.mocked(invoke).mock.calls[0]?.[1] as Record<string, unknown>;
-  expect("priority" in args).toBe(true);
-  expect(args.priority).toBeUndefined();
+  const args = vi.mocked(invoke).mock.calls[0]?.[1] as {
+    args: Record<string, unknown>;
+  };
+  expect("priority" in args.args).toBe(true);
+  expect(args.args.priority).toBeUndefined();
 });
 
 test("成功時は Result.ok(Task) を返す", async () => {

--- a/src/lib/tauri/taskCommands/createTask/index.ts
+++ b/src/lib/tauri/taskCommands/createTask/index.ts
@@ -13,6 +13,6 @@ import type { CreateTaskParams } from "../types";
 export const createTask = (
   params: CreateTaskParams,
 ): Promise<Result<Task, TauriError>> =>
-  invokeWrapped<TaskPayload>("create_task", params).then((result) =>
+  invokeWrapped<TaskPayload>("create_task", { args: params }).then((result) =>
     ResultDomain.map(result, Task.fromPayload),
   );


### PR DESCRIPTION
## 概要
- フロントエンドから `create_task` を呼ぶと `invalid args 'args' for command 'create_task': command create_task missing required key args` で失敗する不具合を修正。
- IPC 引数を `{ args: params }` でラップし、Rust command 側の引数契約（`args: CreateTaskArgs`）と一致させた。

## 変更の種類
- 🐛 Bug Fix

## 変更した内容
- `src/lib/tauri/taskCommands/createTask/index.ts`
  - `invokeWrapped("create_task", params)` → `invokeWrapped("create_task", { args: params })`
- `src/lib/tauri/taskCommands/createTask/__tests__/createTask.behavior.test.ts`
  - `invoke` の期待引数をフラット構造 → `{ args: {...} }` 構造に更新。従来テストはフラット呼び出しを期待しており、実機との乖離（実機 NG なのにテスト緑）を検知できていなかった。回帰の入口を塞いだ。

## 仕様ドキュメント更新
- 不要（内部の Tauri IPC 配線のバグ修正。公開 API・データ形式・画面挙動・設定項目のいずれも変わらない）。

## システム図
```mermaid
flowchart LR
    UI[task-form / useTaskCreate] --> CT[createTask ラッパ]
    CT -->|"invoke('create_task', { args: params })"| IPC[Tauri IPC]
    IPC --> CMD["create_task(state, args: CreateTaskArgs)"]
    CMD --> IMPL[create_task_impl]
    style CT fill:#fff3cd,stroke:#d39e00
```
変更点（黄色強調）: ラッパが `params` をフラットで渡していたのを `{ args: params }` でラップ。Rust 側 command の引数名 `args` が IPC のキーになるため、これでキーが一致する。

## 関連Issue
- なし

## テスト
- `pnpm test:run` — 全 2073 件パス（TDD で Red 5 件 → Green を確認）
- `pnpm run lint`（oxlint）— 0 warnings / 0 errors
- `pnpm run typecheck`（tsc -b）— エラーなし
- 実機（`pnpm tauri dev`）でのタスク作成成功の確認は未実施。レビュー後に動作確認予定。

## レビューポイント
- Tauri v2 の named argument 仕様では、command 引数名 `args` がそのまま IPC キーになる。`CreateTaskArgs` には `#[serde(rename_all = "camelCase")]` があり、フロントの `CreateTaskParams` も camelCase なので内側フィールドの変換は不要、という前提で `params` をそのままラップしている点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)