### PR TITLE
♻️ [Refactoring]: #291 [BE] cycle member の parent=None + warning 維持ルールを Task メソッドに一元化

### DIFF
--- a/src-tauri/src/task/add_link/command.rs
+++ b/src-tauri/src/task/add_link/command.rs
@@ -159,18 +159,13 @@ fn commit_cache(
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);
-            let preserved_parent = if was_cycle_member {
-                source_entry.parent.take()
-            } else {
-                updated.parent.clone()
-            };
             *source_entry = Task {
                 children: preserved_children,
                 reverse_links: preserved_reverse,
                 warnings: preserved_warnings,
-                parent: preserved_parent,
                 ..updated.clone()
             };
+            source_entry.preserve_parent_cycle_state(was_cycle_member, false);
             let returned_task = source_entry.clone();
 
             // target の reverse_links に source を append。既に push 済みなら冪等に skip。

--- a/src-tauri/src/task/remove_link/command.rs
+++ b/src-tauri/src/task/remove_link/command.rs
@@ -151,18 +151,13 @@ fn commit_cache(
             let preserved_children = std::mem::take(&mut source_entry.children);
             let preserved_reverse = std::mem::take(&mut source_entry.reverse_links);
             let preserved_warnings = std::mem::take(&mut source_entry.warnings);
-            let preserved_parent = if was_cycle_member {
-                source_entry.parent.take()
-            } else {
-                updated.parent.clone()
-            };
             *source_entry = Task {
                 children: preserved_children,
                 reverse_links: preserved_reverse,
                 warnings: preserved_warnings,
-                parent: preserved_parent,
                 ..updated.clone()
             };
+            source_entry.preserve_parent_cycle_state(was_cycle_member, false);
 
             // target の reverse_links から source を除去。cache に target が存在
             // しない場合は orphan link 掃除のユースケースを許容するため fail にせず

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -76,6 +76,37 @@ fn is_false(v: &bool) -> bool {
     !*v
 }
 
+impl Task {
+    /// scan で cycle member と判定された task の正規化状態（parent=None +
+    /// parentCycle warning）を、disk 由来の生の値で再構築したこの task に引き継ぐ。
+    ///
+    /// effect 層（update / add_link / remove_link / watcher_event）が cache を
+    /// 差分更新する際、非 parent 変更や link 操作で循環判定が崩れないよう、直前の
+    /// cache 値が cycle member だったかどうか（`was_cycle_member`）を踏まえて
+    /// parent と warning を上書きする。判定→preserve の規則を 1 箇所に集約し、
+    /// 経路ごとの挙動差分を防ぐ。
+    ///
+    /// `drop_when_parent_absent` が true のとき、この task の parent が None なら
+    /// 外部編集で親参照が消えて循環が解消されたとみなし、引き継がない。watcher
+    /// 経由の disk 反映だけがこの解消判定を行い、新規循環の検出はフル再 scan に
+    /// 委ねる。それ以外の経路は disk と一致した parent を握り潰してでも cycle
+    /// 状態を維持する（false を渡す）。
+    pub fn preserve_parent_cycle_state(
+        &mut self,
+        was_cycle_member: bool,
+        drop_when_parent_absent: bool,
+    ) {
+        if !was_cycle_member {
+            return;
+        }
+        if drop_when_parent_absent && self.parent.is_none() {
+            return;
+        }
+        self.parent = None;
+        ensure_parent_cycle_warning(&mut self.warnings);
+    }
+}
+
 /// 親チェーン違反の理由（循環 / 深さ超過）。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParentHierarchyErrorReason {
@@ -1457,6 +1488,10 @@ mod task_index_clear_children_tests;
 #[cfg(test)]
 #[path = "task_index_plan_delete_abort_tests.rs"]
 mod task_index_plan_delete_abort_tests;
+
+#[cfg(test)]
+#[path = "task_index_cycle_preservation_tests.rs"]
+mod task_index_cycle_preservation_tests;
 
 #[cfg(test)]
 #[path = "task_index_plan_add_link_tests.rs"]

--- a/src-tauri/src/task/task_index_cycle_preservation_tests.rs
+++ b/src-tauri/src/task/task_index_cycle_preservation_tests.rs
@@ -1,0 +1,111 @@
+//! `Task::preserve_parent_cycle_state` の単体テスト。
+//!
+//! scan で cycle member と判定された task の正規化状態（parent=None +
+//! parentCycle warning）を、effect 層の cache 差分更新でどう引き継ぐかを
+//! ドメイン側で 1 箇所に集約したメソッドの振る舞いを検証する。
+
+use std::path::PathBuf;
+
+use super::Task;
+use crate::task::parse::{task_from_markdown, TaskParseContext};
+use crate::task::warning::{ensure_parent_cycle_warning, TaskWarningCode};
+
+fn context(path: &str) -> TaskParseContext {
+    TaskParseContext {
+        file_path: PathBuf::from(path),
+        default_status: "Todo".into(),
+    }
+}
+
+fn task_with_parent(parent: Option<&str>) -> Task {
+    let mut markdown = String::from("---\ntitle: Task\nstatus: Todo\n");
+    if let Some(parent) = parent {
+        markdown.push_str(&format!("parent: {parent}\n"));
+    }
+    markdown.push_str("---\n");
+    task_from_markdown(markdown.as_bytes(), &context("tasks/a.md")).unwrap()
+}
+
+fn has_cycle_warning(task: &Task) -> bool {
+    task.warnings
+        .iter()
+        .any(|w| w.code == TaskWarningCode::ParentCycle && w.field.as_deref() == Some("parent"))
+}
+
+#[test]
+fn preserves_parent_none_and_warning_when_was_cycle_member() {
+    let mut task = task_with_parent(Some("tasks/b.md"));
+
+    task.preserve_parent_cycle_state(true, false);
+
+    assert!(
+        task.parent.is_none(),
+        "cycle member の parent は None 化される"
+    );
+    assert!(has_cycle_warning(&task), "parentCycle warning が付与される");
+}
+
+#[test]
+fn does_nothing_when_not_cycle_member() {
+    let mut task = task_with_parent(Some("tasks/b.md"));
+
+    task.preserve_parent_cycle_state(false, false);
+
+    assert_eq!(
+        task.parent.as_ref().map(|p| p.as_str()),
+        Some("tasks/b.md"),
+        "非 cycle member の parent はそのまま"
+    );
+    assert!(!has_cycle_warning(&task), "warning は付与されない");
+}
+
+#[test]
+fn does_not_duplicate_warning_when_already_present() {
+    let mut task = task_with_parent(None);
+    ensure_parent_cycle_warning(&mut task.warnings);
+
+    task.preserve_parent_cycle_state(true, false);
+
+    let cycle_count = task
+        .warnings
+        .iter()
+        .filter(|w| w.code == TaskWarningCode::ParentCycle)
+        .count();
+    assert_eq!(cycle_count, 1, "parentCycle warning は重複しない");
+}
+
+#[test]
+fn drops_preservation_when_parent_absent_and_flag_set() {
+    let mut task = task_with_parent(None);
+
+    task.preserve_parent_cycle_state(true, true);
+
+    assert!(task.parent.is_none());
+    assert!(
+        !has_cycle_warning(&task),
+        "parent が None かつ drop フラグ有効なら循環解消とみなし warning を付けない"
+    );
+}
+
+#[test]
+fn keeps_preservation_when_parent_present_even_with_flag() {
+    let mut task = task_with_parent(Some("tasks/b.md"));
+
+    task.preserve_parent_cycle_state(true, true);
+
+    assert!(
+        task.parent.is_none(),
+        "parent が Some なら drop フラグ有効でも None 化"
+    );
+    assert!(has_cycle_warning(&task), "warning も付与される");
+}
+
+#[test]
+fn does_not_inject_warning_into_non_member_even_with_flag() {
+    let mut task = task_with_parent(Some("tasks/b.md"));
+
+    task.preserve_parent_cycle_state(false, true);
+
+    assert_eq!(task.parent.as_ref().map(|p| p.as_str()), Some("tasks/b.md"));
+    assert!(!has_cycle_warning(&task));
+}

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -13,7 +13,7 @@ use crate::task::io::{FsTaskIo, TaskIo, TaskIoError};
 use crate::task::task_index::{Task, TaskIndex, UpdateTaskOutcome};
 use crate::task::update::args::UpdateTaskArgs;
 use crate::task::update::error::{UpdateTaskCommandError, UpdateTaskError};
-use crate::task::warning::{ensure_parent_cycle_warning, has_parent_cycle_warning};
+use crate::task::warning::has_parent_cycle_warning;
 
 /// `update_task` Tauri command 薄層。
 #[tauri::command]
@@ -129,10 +129,7 @@ fn commit_cache(
                     .map(|prev| has_parent_cycle_warning(&prev.warnings))
                     .unwrap_or(false);
                 let mut next = outcome.updated_task.clone();
-                if was_cycle_member {
-                    next.parent = None;
-                    ensure_parent_cycle_warning(&mut next.warnings);
-                }
+                next.preserve_parent_cycle_state(was_cycle_member, false);
                 cache.insert(cache_key.clone(), next.clone());
                 Ok(Some(next))
             }

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -19,7 +19,7 @@ use serde_json::json;
 
 use crate::task::parse::{normalized_task_file_path, task_from_markdown, TaskParseContext};
 use crate::task::task_file_path::TaskFilePath;
-use crate::task::warning::{ensure_parent_cycle_warning, has_parent_cycle_warning};
+use crate::task::warning::has_parent_cycle_warning;
 use spec_board_fs::task::file_scanner::task_md_relative_path;
 use spec_board_fs::watcher::core::FsEvent;
 
@@ -197,10 +197,7 @@ fn handle_upsert(
             .map(|prev| has_parent_cycle_warning(&prev.warnings))
             .unwrap_or(false);
         let mut next = task;
-        if was_cycle_member && next.parent.is_some() {
-            next.parent = None;
-            ensure_parent_cycle_warning(&mut next.warnings);
-        }
+        next.preserve_parent_cycle_state(was_cycle_member, true);
         cache.insert(cache_key, next.clone());
         (event, next)
     })?;


### PR DESCRIPTION
## 概要

「scan で cycle member と判定された task は parent=None + parentCycle warning を維持する」ビジネスルールが 4 つの effect 層に重複実装されていたため、`Task` entity のメソッド `Task::preserve_parent_cycle_state` に 1 箇所へ集約し、各経路からはそれを呼ぶ形に置き換えた。外部から観測可能な挙動は不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 追加した内容

- `Task::preserve_parent_cycle_state(was_cycle_member: bool, drop_when_parent_absent: bool)`（`src-tauri/src/task/task_index.rs`）
  - cycle member の正規化状態（parent=None + parentCycle warning）を、disk 由来の raw `parent:` で再構築した task に引き継ぐ規則を集約。
  - `watcher_event` 経由だけ「新しい parsed task の parent が None なら循環解消とみなし preserve しない」差分があるため、その差分を `drop_when_parent_absent` 引数で表現。
- 単体テスト `src-tauri/src/task/task_index_cycle_preservation_tests.rs`（6 件）

## 変更した内容

以下 4 経路のインライン重複（判定→preserve）をドメインメソッド呼び出しに置換:

- `src-tauri/src/task/update/command.rs`（`drop_when_parent_absent=false`）
- `src-tauri/src/task/add_link/command.rs`（`false`）
- `src-tauri/src/task/remove_link/command.rs`（`false`）
- `src-tauri/src/watcher_event/handler.rs`（`true` — 既存の循環解消判定を維持）

`add_link` / `remove_link` では、新 Task を `updated.parent` で組み立てたうえでメソッドを呼ぶ構成に変更。cycle member 時にメソッドが parent を None 化し warning を ensure（既存の preserve 済み warnings に対しては no-op）するため、従来の `source_entry.parent.take()` + 条件分岐と等価。

handler.rs の条件差分は意図的（watcher 経由のみ disk 反映で循環解消を検出する）であることを確認し、`drop_when_parent_absent` 引数として明示化した。

## 仕様ドキュメント更新

不要（純粋なリファクタリング / 内部実装の重複排除のみ。公開 API・データ形式・画面挙動・設定項目に変更なし）。

## システム図

```mermaid
flowchart TD
    subgraph before["Before: 同一ルールが 4 箇所に重複"]
        U1["update::command\nparent=None + ensure_warning"]
        A1["add_link::command\nparent.take() 分岐"]
        R1["remove_link::command\nparent.take() 分岐"]
        H1["watcher_event::handler\nparent.is_some() 分岐"]
    end
    subgraph after["After: ドメインメソッドへ一元化"]
        M["Task::preserve_parent_cycle_state\n(was_cycle_member, drop_when_parent_absent)"]
        U2["update::command"] --> M
        A2["add_link::command"] --> M
        R2["remove_link::command"] --> M
        H2["watcher_event::handler\n(drop_when_parent_absent=true)"] --> M
    end
    style M fill:#d4f7d4
```

## 関連Issue

Closes #291
Relates to #290

## テスト

- `cargo fmt`: 適用済み
- `cargo clippy --all-targets`: 警告ゼロ（exit 0）
- `cargo test`: 988 passed / 0 failed（ベースライン 982 + 新規ドメインテスト 6 件）

## レビューポイント

- `add_link` / `remove_link` で、`parent: preserved_parent` の事前分岐を廃し「`updated.parent` で組み立て → メソッドで上書き」に変えた等価性。
- `drop_when_parent_absent` 引数の真偽が watcher 経由のみ `true` で、`modify_event_drops_parent_cycle_warning_when_disk_parent_is_removed` などの既存テストを満たすこと。