### PR TITLE
⚰️ [Dead Code]: #297 [BE] greet / FileNotFound / CleanupWorkerSpawnFailed のデッドコード除去

### DIFF
--- a/src-tauri/crates/fs/src/watcher/write_ignore.rs
+++ b/src-tauri/crates/fs/src/watcher/write_ignore.rs
@@ -13,8 +13,6 @@ use thiserror::Error;
 pub enum WriteIgnoreError {
     #[error("write_ignore registry lock poisoned")]
     LockPoisoned,
-    #[error("failed to start write_ignore cleanup worker")]
-    CleanupWorkerSpawnFailed,
 }
 
 #[derive(Debug, Default)]

--- a/src-tauri/src/config/update_columns.rs
+++ b/src-tauri/src/config/update_columns.rs
@@ -122,9 +122,6 @@ pub enum UpdateColumnsError {
         #[source]
         source: std::io::Error,
     },
-
-    #[error("watcher の補助スレッド起動に失敗しました")]
-    WriteIgnoreWorkerSpawnFailed,
 }
 
 impl From<AppStateError> for UpdateColumnsError {
@@ -135,13 +132,8 @@ impl From<AppStateError> for UpdateColumnsError {
 
 impl From<WriteIgnoreError> for UpdateColumnsError {
     fn from(err: WriteIgnoreError) -> Self {
-        // 将来 `WriteIgnoreError` に variant が追加されても誤って StateLockPoisoned に
-        // 潰さないよう、variant ごとに明示マッピングする。
         match err {
             WriteIgnoreError::LockPoisoned => UpdateColumnsError::StateLockPoisoned,
-            WriteIgnoreError::CleanupWorkerSpawnFailed => {
-                UpdateColumnsError::WriteIgnoreWorkerSpawnFailed
-            }
         }
     }
 }

--- a/src-tauri/src/config/update_columns_tests.rs
+++ b/src-tauri/src/config/update_columns_tests.rs
@@ -271,23 +271,6 @@ fn write_ignore_lock_poisoned_converts_to_state_lock_poisoned() {
 }
 
 #[test]
-fn write_ignore_cleanup_worker_spawn_failed_maps_to_dedicated_variant() {
-    let err: UpdateColumnsError = WriteIgnoreError::CleanupWorkerSpawnFailed.into();
-    assert!(matches!(
-        err,
-        UpdateColumnsError::WriteIgnoreWorkerSpawnFailed
-    ));
-}
-
-#[test]
-fn write_ignore_worker_spawn_failed_display() {
-    assert_eq!(
-        UpdateColumnsError::WriteIgnoreWorkerSpawnFailed.to_string(),
-        "watcher の補助スレッド起動に失敗しました"
-    );
-}
-
-#[test]
 fn column_rename_deserializes_camel_case() {
     let json = r#"{ "from": "A", "to": "B" }"#;
     let r: ColumnRename = serde_json::from_str(json).expect("should deserialize");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,18 +8,6 @@ use std::sync::Arc;
 
 use crate::state::AppState;
 
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-/// Returns a greeting string for the given name.
-///
-/// This command is registered with Tauri so the frontend can invoke it through IPC.
-///
-/// @param name Greeting target name supplied by the frontend IPC caller.
-/// @returns Greeting message including the supplied name.
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
-
 /// Builds and runs the Tauri application with the configured plugins and commands.
 ///
 /// @returns 戻り値なし。Tauri runtime が終了するまでアプリケーションを実行する。
@@ -30,7 +18,6 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .manage(Arc::new(AppState::new()))
         .invoke_handler(tauri::generate_handler![
-            greet,
             project::open::open_project,
             task::get::get_tasks,
             task::create::create_task,

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -168,17 +168,10 @@ impl From<AppStateError> for OpenProjectError {
 impl From<WriteIgnoreError> for OpenProjectError {
     /// `WriteIgnoreError` を意味別に詰め直す。
     ///
-    /// - `LockPoisoned` のみ `StateLockPoisoned` として「内部状態のロック破損」
-    ///   と扱う
-    /// - `CleanupWorkerSpawnFailed` 等の非 poison 系（現実装では返らないが将来
-    ///   返り得る variant）は `ScanFailed` として io 系の致命扱いにし、
-    ///   利用者へ「ロック破損」と誤通知しない
+    /// - `LockPoisoned` を `StateLockPoisoned` として「内部状態のロック破損」と扱う
     fn from(err: WriteIgnoreError) -> Self {
         match err {
             WriteIgnoreError::LockPoisoned => OpenProjectError::StateLockPoisoned,
-            other => OpenProjectError::ScanFailed {
-                message: other.to_string(),
-            },
         }
     }
 }

--- a/src-tauri/src/project/open_tests.rs
+++ b/src-tauri/src/project/open_tests.rs
@@ -741,18 +741,6 @@ fn write_ignore_error_lock_poisoned_maps_to_state_lock_poisoned() {
 }
 
 #[test]
-fn write_ignore_error_non_poison_maps_to_scan_failed() {
-    use spec_board_fs::watcher::write_ignore::WriteIgnoreError;
-    let err: OpenProjectError = WriteIgnoreError::CleanupWorkerSpawnFailed.into();
-    match err {
-        OpenProjectError::ScanFailed { ref message } => {
-            assert!(!message.is_empty());
-        }
-        other => panic!("expected ScanFailed, got {other:?}"),
-    }
-}
-
-#[test]
 fn payload_serialization_uses_camel_case() {
     let payload = OpenProjectPayload {
         tasks: Vec::new(),

--- a/src-tauri/src/task/add_link/error.rs
+++ b/src-tauri/src/task/add_link/error.rs
@@ -4,8 +4,6 @@
 //! 自体は Serialize を実装しない。`add_link_impl(...).map_err(|e| e.to_string())` で
 //! 文字列化する（既存 `update_task` と同型）。
 
-use std::path::PathBuf;
-
 use thiserror::Error;
 
 use crate::state::AppStateError;
@@ -36,11 +34,6 @@ pub enum AddLinkError {
     /// `frontmatter::serialize` 後の本文が scanner eligible でない場合。
     #[error("content not scanner eligible: {reason}")]
     ContentRejected { reason: ContentRejectReason },
-    /// IPC args が読み込んだ既存ファイルにアクセスする際の I/O 失敗系で、
-    /// effect 層側で具体的な NotFound 等を `SourceNotFound` に詰め直す途中で
-    /// 使う path 形式の error。aggregate 内では使わない。
-    #[error("file not found: {}", .0.display())]
-    FileNotFound(PathBuf),
 }
 
 #[derive(Debug, Error)]

--- a/src-tauri/src/task/remove_link/error.rs
+++ b/src-tauri/src/task/remove_link/error.rs
@@ -5,8 +5,6 @@
 //! `remove_link_impl(...).map_err(|e| e.to_string())` で文字列化する
 //! （既存 `add_link` / `update_task` と同型）。
 
-use std::path::PathBuf;
-
 use thiserror::Error;
 
 use crate::state::AppStateError;
@@ -34,9 +32,6 @@ pub enum RemoveLinkError {
     /// `frontmatter::serialize` 後の本文が scanner eligible でない場合。
     #[error("content not scanner eligible: {reason}")]
     ContentRejected { reason: ContentRejectReason },
-    /// 効果層側で具体的な NotFound 等を `SourceNotFound` に詰め直す途中で使う path 形式。
-    #[error("file not found: {}", .0.display())]
-    FileNotFound(PathBuf),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## 概要

DDD レビューで見つかった、どこからも到達しないバックエンドのデッドコード 3 箇所を除去する。いずれも `pub` のためコンパイラ警告が出ず残存していたもの。

## 変更の種類

- ⚰️ デッドコード削除（🔥 [Remove] 系）

## 削除した内容

1. **Tauri テンプレート由来の `greet` command** (`src-tauri/src/lib.rs`)
   - サンプル command `greet` 関数・doc コメント・`// Learn more about Tauri commands...` テンプレートコメント・`invoke_handler` 登録を削除。

2. **`add_link` / `remove_link` の未使用 `FileNotFound(PathBuf)` variant** (`src-tauri/src/task/add_link/error.rs` / `src-tauri/src/task/remove_link/error.rs`)
   - どこからも構築されないデッド variant を両 error enum から削除。doc コメントは「`SourceNotFound` に詰め直す途中で使う」と述べていたが該当経路は存在しなかった。
   - 不要になった `use std::path::PathBuf;` も併せて削除。
   - 注: `task/update/error.rs` の `FileNotFound` は実際に構築・使用されているため対象外（issue スコープ通り温存）。

3. **`WriteIgnoreError::CleanupWorkerSpawnFailed` variant** (`src-tauri/crates/fs/src/watcher/write_ignore.rs`)
   - cleanup worker 機構自体が存在せず、サブクレート内のどこからも構築されない死にバリアントを削除。
   - 本体側の `From` マッピングを更新:
     - `config/update_columns.rs`: 専用 arm と、それ専用に存在していた `UpdateColumnsError::WriteIgnoreWorkerSpawnFailed` variant を削除（`From` は `LockPoisoned` のみの単一 arm match に）。
     - `project/open.rs`: 削除後に到達不能となる catch-all `other =>` arm を除去し、`LockPoisoned` のみを扱う形に簡素化（doc コメントも追従）。
   - 関連テスト 3 件を削除（`update_columns_tests.rs` 2 件 / `open_tests.rs` 1 件）。

## 仕様ドキュメント更新

不要（純粋なデッドコード除去で、公開 API・データ形式・画面挙動・設定項目に変更なし）。FE 側のエラー文字列契約にも影響しない（削除した variant はいずれも構築されておらず、FE へ流れるエラー文字列は変化しない）。`tauriError` の汎用 `"file not found" → NOT_FOUND` 分類テストは特定 variant に依存しないため不変。

## テスト

src-tauri のみの変更。全ゲート pass:

- `cargo fmt --all --check` — exit 0
- `cargo clippy --all-targets --all-features` — 警告ゼロ（exit 0）
- `cargo test --all-features` — 979 passed / 0 failed

FE は未変更のため `pnpm` 系は実行不要。

## 関連Issue

Closes #297

## レビューポイント

- `project/open.rs` の `From<WriteIgnoreError>` は、削除前は catch-all `other =>` で `ScanFailed` に詰め直していた。variant が `LockPoisoned` 1 本になったため catch-all を除去して exhaustive な単一 arm に変更している（`ScanFailed` 自体は他経路で引き続き使用）。
- `UpdateColumnsError::WriteIgnoreWorkerSpawnFailed` は削除対象の variant をマップするためだけに存在していたため、連鎖的にデッド化するものとして同 PR で除去した。