### PR TITLE
♻️ [Refactoring]: #292 [BE] update_card_order を plan メソッド + effect の2段構成に統一

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -369,6 +369,43 @@ impl Config {
             is_noop: false,
         })
     }
+
+    /// `cardOrder[column_name]` を `file_paths` で上書きした新しい `Config` を返す
+    /// （副作用なし）。
+    ///
+    /// `column_name` が [`Self::columns`] に存在しなければ
+    /// [`UpdateCardOrderPlanError::UnknownColumn`] を返し、`self` は変更しない。
+    /// `file_paths` のうち `existing_paths` に含まれないエントリは
+    /// 「実体が消えたタスク」として除外する。入力順は保持する。
+    ///
+    /// 実在判定の走査（fs アクセス）は呼び出し側の責務で、本メソッドは
+    /// `existing_paths` を真値として扱う純粋関数。これにより
+    /// 「未知カラムの拒否」「除去ルール」という cardOrder のドメイン不変条件を
+    /// aggregate 側に集約する。
+    ///
+    /// # Errors
+    ///
+    /// - [`UpdateCardOrderPlanError::UnknownColumn`] — `column_name` が
+    ///   [`Self::columns`] のいずれにも一致しない
+    pub fn plan_update_card_order(
+        &self,
+        column_name: String,
+        file_paths: Vec<String>,
+        existing_paths: &HashSet<String>,
+    ) -> Result<Config, UpdateCardOrderPlanError> {
+        if !self.has_column(&column_name) {
+            return Err(UpdateCardOrderPlanError::UnknownColumn { column_name });
+        }
+
+        let retained: Vec<String> = file_paths
+            .into_iter()
+            .filter(|rel| existing_paths.contains(rel.as_str()))
+            .collect();
+
+        let mut next = self.clone();
+        next.card_order.insert(column_name, retained);
+        Ok(next)
+    }
 }
 
 /// `Config::plan_update_columns` の戻り値。
@@ -380,6 +417,17 @@ pub struct UpdateColumnsPlan {
     pub rename_targets: Vec<RenameTarget>,
     /// 何も変更しない no-op フラグ（args 全 None 時 true）
     pub is_noop: bool,
+}
+
+/// [`Config::plan_update_card_order`] の検証失敗。
+///
+/// 指定カラムが [`Config::columns`] に存在しない場合のみ発生する。effect 層は
+/// このバリアントを IPC エラー（`UnknownColumn`）へ詰め替える。
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum UpdateCardOrderPlanError {
+    /// 指定された `column_name` が [`Config::columns`] に存在しない。
+    #[error("unknown column: `{column_name}`")]
+    UnknownColumn { column_name: String },
 }
 
 /// rename 対象 1 件分。`rel_path` はプロジェクトルートからの相対パス。

--- a/src-tauri/src/config/config_tests.rs
+++ b/src-tauri/src/config/config_tests.rs
@@ -1782,3 +1782,117 @@ fn rename_preserves_column_color() {
         Some("#1a2b3c")
     );
 }
+
+// ───────── Config::plan_update_card_order ─────────
+
+fn card_order_base_config() -> Config {
+    Config {
+        version: 1,
+        columns: vec![col("Todo", 0), col("In Progress", 1), col("Done", 2)],
+        card_order: BTreeMap::new(),
+        done_column: Some("Done".into()),
+    }
+}
+
+#[test]
+fn plan_update_card_order_overwrites_existing_entry() {
+    let mut config = card_order_base_config();
+    config
+        .card_order
+        .insert("Todo".to_string(), vec!["old.md".to_string()]);
+    let existing: HashSet<String> = ["a.md".to_string(), "b.md".to_string()]
+        .into_iter()
+        .collect();
+
+    let next = config
+        .plan_update_card_order(
+            "Todo".to_string(),
+            vec!["a.md".to_string(), "b.md".to_string()],
+            &existing,
+        )
+        .expect("known column should succeed");
+
+    assert_eq!(
+        next.card_order.get("Todo"),
+        Some(&vec!["a.md".to_string(), "b.md".to_string()])
+    );
+}
+
+#[test]
+fn plan_update_card_order_inserts_new_entry_for_known_column() {
+    let config = card_order_base_config();
+    let existing: HashSet<String> = ["x.md".to_string()].into_iter().collect();
+
+    let next = config
+        .plan_update_card_order(
+            "In Progress".to_string(),
+            vec!["x.md".to_string()],
+            &existing,
+        )
+        .expect("known column should succeed");
+
+    assert_eq!(
+        next.card_order.get("In Progress"),
+        Some(&vec!["x.md".to_string()])
+    );
+}
+
+#[test]
+fn plan_update_card_order_rejects_unknown_column_without_mutation() {
+    let config = card_order_base_config();
+    let existing: HashSet<String> = HashSet::new();
+
+    let err = config
+        .plan_update_card_order("Ghost".to_string(), vec!["a.md".to_string()], &existing)
+        .expect_err("unknown column should fail");
+
+    assert_eq!(
+        err,
+        UpdateCardOrderPlanError::UnknownColumn {
+            column_name: "Ghost".to_string()
+        }
+    );
+    assert!(config.card_order.is_empty(), "self は変更されない");
+}
+
+#[test]
+fn plan_update_card_order_drops_paths_absent_from_existing_set() {
+    let config = card_order_base_config();
+    let existing: HashSet<String> = ["exists-1.md".to_string(), "exists-2.md".to_string()]
+        .into_iter()
+        .collect();
+
+    let next = config
+        .plan_update_card_order(
+            "Todo".to_string(),
+            vec![
+                "exists-1.md".to_string(),
+                "missing.md".to_string(),
+                "exists-2.md".to_string(),
+            ],
+            &existing,
+        )
+        .expect("known column should succeed");
+
+    assert_eq!(
+        next.card_order.get("Todo"),
+        Some(&vec!["exists-1.md".to_string(), "exists-2.md".to_string()]),
+        "存在しないパスを除外しつつ入力順を保持する"
+    );
+}
+
+#[test]
+fn plan_update_card_order_keeps_empty_vec_when_all_paths_missing() {
+    let config = card_order_base_config();
+    let existing: HashSet<String> = HashSet::new();
+
+    let next = config
+        .plan_update_card_order(
+            "Todo".to_string(),
+            vec!["missing-1.md".to_string(), "missing-2.md".to_string()],
+            &existing,
+        )
+        .expect("known column should succeed");
+
+    assert_eq!(next.card_order.get("Todo"), Some(&Vec::<String>::new()));
+}

--- a/src-tauri/src/config/update_card_order.rs
+++ b/src-tauri/src/config/update_card_order.rs
@@ -35,6 +35,7 @@
 //! `ConfigIo` を `IO_ERROR` 系（内側メッセージ次第で `NOT_FOUND` /
 //! `PERMISSION_DENIED` に転ぶ）として扱う想定。
 
+use std::collections::HashSet;
 use std::io::ErrorKind;
 use std::path::Path;
 use std::sync::Arc;
@@ -43,6 +44,7 @@ use spec_board_fs::config::config_io::{write_config_json, ConfigIoError};
 use tauri::State;
 use thiserror::Error;
 
+use crate::config::UpdateCardOrderPlanError;
 use crate::state::{AppState, AppStateError};
 
 /// `update_card_order` コマンドのエラー。
@@ -78,6 +80,16 @@ impl From<AppStateError> for UpdateCardOrderError {
     }
 }
 
+impl From<UpdateCardOrderPlanError> for UpdateCardOrderError {
+    fn from(err: UpdateCardOrderPlanError) -> Self {
+        match err {
+            UpdateCardOrderPlanError::UnknownColumn { column_name } => {
+                UpdateCardOrderError::UnknownColumn { column_name }
+            }
+        }
+    }
+}
+
 /// Tauri command 薄層。`update_card_order_impl` を呼び、エラーを文字列化して返す。
 ///
 /// 戻り値の `Result<_, String>` の Err 文字列は `UpdateCardOrderError` の
@@ -95,8 +107,9 @@ pub fn update_card_order(
 ///
 /// 1. `snapshot_project_and_config` で `project_path` と `config` を
 ///    両 lock 同時保持下で atomic に取得（どちらかが `None` → `NoProjectOpen`）
-/// 2. `column_name` が `Config.columns` に存在するか検証
-/// 3. snapshot の `card_order[column_name]` を `file_paths` で上書き
+/// 2. `file_paths` のうち実在するパス集合を fs 走査で求める（effect 層責務）
+/// 3. `Config::plan_update_card_order` でカラム検証 + `cardOrder` 上書きを行い、
+///    書き出し対象の新しい `Config` を得る（未知カラムは `UnknownColumn`）
 /// 4. `serde_json::to_string_pretty` でシリアライズ
 /// 5. `write_config_json` で disk に書き込み
 /// 6. `replace_config_if_project_matches` で `project_path` が snapshot 時と
@@ -115,14 +128,11 @@ pub(crate) fn update_card_order_impl(
     // （単独の `project_path()? → config()?` 連続呼びでは race window が生じる）。
     let (project_root, config) = state.snapshot_project_and_config()?;
     let project_root = project_root.ok_or(UpdateCardOrderError::NoProjectOpen)?;
-    let mut config = config.ok_or(UpdateCardOrderError::NoProjectOpen)?;
+    let config = config.ok_or(UpdateCardOrderError::NoProjectOpen)?;
 
-    if !config.has_column(&column_name) {
-        return Err(UpdateCardOrderError::UnknownColumn { column_name });
-    }
-
-    let cleaned = cleanup_missing_paths(&project_root, file_paths);
-    config.card_order.insert(column_name, cleaned);
+    // 実在判定（fs 走査）は effect 層の責務。除去ルール自体は aggregate に寄せる。
+    let existing_paths = collect_existing_paths(&project_root, &file_paths);
+    let config = config.plan_update_card_order(column_name, file_paths, &existing_paths)?;
 
     let json = serde_json::to_string_pretty(&config)?;
     write_config_json(&project_root, &json)?;
@@ -138,19 +148,21 @@ pub(crate) fn update_card_order_impl(
     Ok(())
 }
 
-/// `file_paths` のうち `project_root` 配下に実在しないエントリを除外して返す。
+/// `file_paths` のうち `project_root` 配下で「保持すべき」パスの集合を返す。
 ///
 /// 各パスを `project_root.join(rel)` で解決し `std::fs::metadata` で判定する。
-/// `Err(NotFound)` のみ除外し、`permission denied` など他の I/O エラーは
-/// ユーザーのカード並びを誤って失わないために保守的に保持する。
-/// 入力順は保持する。
-fn cleanup_missing_paths(project_root: &Path, file_paths: Vec<String>) -> Vec<String> {
+/// `Err(NotFound)` のみ除外対象（集合に入れない）とし、`permission denied` など
+/// 他の I/O エラーは、ユーザーのカード並びを誤って失わないために保守的に集合へ含める。
+/// この集合は `Config::plan_update_card_order` の `existing_paths` 引数として渡し、
+/// 実際の除去（および入力順の保持）は aggregate 側で行う。
+fn collect_existing_paths(project_root: &Path, file_paths: &[String]) -> HashSet<String> {
     file_paths
-        .into_iter()
+        .iter()
         .filter(|rel| match std::fs::metadata(project_root.join(rel)) {
             Ok(_) => true,
             Err(e) => e.kind() != ErrorKind::NotFound,
         })
+        .cloned()
         .collect()
 }
 

--- a/src-tauri/src/config/update_card_order_tests.rs
+++ b/src-tauri/src/config/update_card_order_tests.rs
@@ -267,11 +267,11 @@ fn keeps_path_when_metadata_returns_non_notfound_error() {
     let dir = tempdir();
 
     // NUL バイトを含む相対パスは fs::metadata で ErrorKind::InvalidInput を返す
-    // （非 NotFound）。保守的に保持されることを確認する。
+    // （非 NotFound）。保守的に保持対象集合へ含まれることを確認する。
     let nul_path = "tasks/with\0nul.md".to_string();
     let input = vec![nul_path.clone()];
 
-    let result = super::cleanup_missing_paths(dir.path(), input);
+    let result = super::collect_existing_paths(dir.path(), &input);
 
-    assert_eq!(result, vec![nul_path]);
+    assert!(result.contains(&nul_path));
 }


### PR DESCRIPTION
## 概要

`update_card_order` だけ他の config 書き込み command（`plan_update_columns` / `plan_create_label` 等）の「aggregate plan メソッド + effect 層」2段構成から外れていた問題を解消する。カラム検証と `cardOrder` 上書き・除去ルールを `Config` aggregate に集約し、effect 層は plan の結果を書き込むだけにする。外部仕様（引数・戻り値・エラー文字列）は不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 追加した内容

- `Config::plan_update_card_order(column_name, file_paths, &existing_paths) -> Result<Config, UpdateCardOrderPlanError>` — カラム検証 + `cardOrder` 上書き + 実在しないパス除去を行う純粋な aggregate メソッド
- `UpdateCardOrderPlanError::UnknownColumn` — 未知カラムを表す plan エラー
- aggregate メソッドの単体テスト 5 件（上書き / 新規挿入 / 未知カラム拒否+self不変 / 不在パス除去+順序保持 / 全件不在で空 Vec）

## 変更した内容

- `update_card_order_impl`（effect 層）: これまで command 層が直接行っていた `has_column` 検証・`card_order.insert(...)`・`fs::metadata` ベースの除去ロジックを撤去し、`Config::plan_update_card_order` へ委譲。effect 層は「実在パス集合の走査（`collect_existing_paths`）」と「plan 結果の書き込み」だけを担う
- `cleanup_missing_paths`（filter して `Vec` を返す）→ `collect_existing_paths`（保持すべきパスの `HashSet` を返す）へ役割変更。`NotFound` のみ除外し、`permission denied` 等の非 NotFound エラーは保守的に保持する挙動はそのまま維持
- effect 層テスト 1 件を新ヘルパー名・戻り値（`HashSet`）に追従

## 削除した内容

- なし（関数のリネーム + ロジック移譲のみ）

## 仕様ドキュメント更新

不要（純粋なリファクタリング / 内部実装の再配置）。`update_card_order` の引数・戻り値・エラー文字列契約は不変のため、`docs/spec-board/config-spec.md` 等の更新は発生しない。

## システム図

\`\`\`mermaid
flowchart TD
    cmd[update_card_order_impl<br/>effect 層] --> snap[snapshot_project_and_config]
    snap --> collect["collect_existing_paths<br/>fs 走査で実在集合を作る<br/>(NEW: HashSet を返す)"]
    collect --> plan["Config::plan_update_card_order<br/>(NEW: カラム検証 + cardOrder 上書き + 除去)"]
    plan -->|UnknownColumn| err[UpdateCardOrderError::UnknownColumn]
    plan -->|新 Config| write[serialize + write_config_json]
    write --> replace[replace_config_if_project_matches]
    style collect fill:#e6f7ff
    style plan fill:#e6ffe6
\`\`\`

## 関連Issue

Closes #292

## テスト

バックエンド（CI と同じコマンド）:
- \`cargo fmt --all -- --check\` — exit 0
- \`cargo clippy --workspace --all-targets -- -D warnings\` — exit 0（警告ゼロ）
- \`cargo test --workspace\` — 全通過。lib 987 テスト（新規 aggregate 5 件含む）/ 0 failed

新規 5 件・既存 update_card_order_impl の E2E テスト群がすべて green であることを確認済み。UI 変更なし。

## レビューポイント

- effect 層が `existing_paths`（保持すべきパス集合）を用意し、除去そのものは aggregate 側で行う責務分割が、メモリの「ドメイン中心の plan + impl 2段構成」方針に沿っているか
- `collect_existing_paths` の非 NotFound エラー保守保持の挙動が旧 `cleanup_missing_paths` と完全に等価か（NUL パスの非 NotFound 保持テストで担保）

🤖 Generated with [Claude Code](https://claude.com/claude-code)