### PR TITLE
♻️ [Refactoring]: #293 [BE] IPC 入力パス正規化の 3 重複を共有 VO InputTaskPath に集約

### DIFF
--- a/src-tauri/src/task.rs
+++ b/src-tauri/src/task.rs
@@ -5,6 +5,7 @@ pub mod delete;
 pub mod due;
 pub mod frontmatter;
 pub mod get;
+pub mod input_task_path;
 pub mod io;
 pub mod label;
 pub mod parse;

--- a/src-tauri/src/task/add_link/args.rs
+++ b/src-tauri/src/task/add_link/args.rs
@@ -1,14 +1,14 @@
 //! `add_link` Tauri command の引数 DTO。
 //!
 //! sourceFilePath / targetFilePath は絶対パスまたは project_root 相対のいずれも
-//! 受け、共通の path normalization helper で project_root 相対の正規形に倒す。
+//! 受け、共通の入力パス VO で project_root 相対の正規形に倒す。
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
 use crate::task::add_link::error::AddLinkError;
-use crate::task::path_lookup::normalize_relative_path_for_input;
+use crate::task::input_task_path::InputTaskPath;
 use crate::task::task_index::AddLinkIntent;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -22,54 +22,31 @@ impl AddLinkArgs {
     /// project_root を起点に sourceFilePath / targetFilePath を lexical 正規化し、
     /// `AddLinkIntent` に詰め直す。
     pub fn into_intent(self, project_root: &Path) -> Result<AddLinkIntent, AddLinkError> {
-        let source = normalize_input_path(&self.source_file_path, project_root, true)?;
-        let target = normalize_input_path(&self.target_file_path, project_root, false)?;
+        let source = resolve_input_path(&self.source_file_path, project_root, true)?;
+        let target = resolve_input_path(&self.target_file_path, project_root, false)?;
         Ok(AddLinkIntent { source, target })
     }
 }
 
-fn normalize_input_path(
+/// 入力 path を VO で正規化し、reject を source / target に応じたエラーへ詰め替える。
+fn resolve_input_path(
     raw: &str,
     project_root: &Path,
     is_source: bool,
 ) -> Result<PathBuf, AddLinkError> {
-    let make_err = |raw: &str| -> AddLinkError {
-        if is_source {
-            AddLinkError::SourceNotFound {
-                path: raw.to_string(),
+    InputTaskPath::resolve(raw, project_root, false)
+        .map(InputTaskPath::into_path_buf)
+        .map_err(|_| {
+            if is_source {
+                AddLinkError::SourceNotFound {
+                    path: raw.to_string(),
+                }
+            } else {
+                AddLinkError::TargetNotFound {
+                    path: raw.to_string(),
+                }
             }
-        } else {
-            AddLinkError::TargetNotFound {
-                path: raw.to_string(),
-            }
-        }
-    };
-
-    if raw.trim().is_empty() {
-        return Err(make_err(raw));
-    }
-
-    let candidate_text = if Path::new(raw).is_absolute() {
-        Path::new(raw)
-            .strip_prefix(project_root)
-            .map_err(|_| make_err(raw))?
-            .to_string_lossy()
-            .into_owned()
-    } else {
-        raw.to_string()
-    };
-
-    let normalized =
-        normalize_relative_path_for_input(&candidate_text).ok_or_else(|| make_err(raw))?;
-    let rel = Path::new(&normalized);
-    if rel.components().any(|c| matches!(c, Component::ParentDir)) {
-        return Err(make_err(raw));
-    }
-    if rel.as_os_str().is_empty() {
-        return Err(make_err(raw));
-    }
-
-    Ok(rel.to_path_buf())
+        })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task/input_task_path.rs
+++ b/src-tauri/src/task/input_task_path.rs
@@ -1,0 +1,79 @@
+//! IPC command の引数として渡されるユーザ入力 path を、project_root 相対の
+//! 正規形へ倒すための入力パス VO。
+//!
+//! add_link / remove_link / update_task の各 args DTO がほぼ同一の正規化・検証
+//! （空拒否・絶対パスの root 相対化・`..` 拒否・必要なら `.md` 検証）を行っていた
+//! ため、その共通知識をここに集約する。各 command はこの VO の reject を自身の
+//! エラー型へ詰め替えるだけにする。
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::task::path_lookup::normalize_relative_path_for_input;
+
+/// 入力 path の正規化・検証に失敗したことを表す marker。
+///
+/// どの検証段階で失敗したかを呼び出し元へ伝える必要はなく（各 command は失敗を
+/// 単一のエラー variant へ畳み込むため）、reject は値を持たない。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InputPathRejected;
+
+/// IPC 入力 path を project_root 相対の正規形へ倒した結果を表す VO。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputTaskPath(PathBuf);
+
+impl InputTaskPath {
+    /// `raw` を project_root 相対の正規 path へ解決する。
+    ///
+    /// - 空文字 / 空白のみは reject する。
+    /// - 絶対パスは `project_root` を strip して相対化し、root 外なら reject する。
+    /// - `.` や余分な区切り、Windows drive prefix を除去して正規化する。
+    /// - `..`（親ディレクトリ参照）を含む場合は reject する。
+    /// - 正規化の結果が空になる場合は reject する。
+    /// - `require_md_extension` が `true` の場合、拡張子が `.md` でなければ reject する。
+    pub fn resolve(
+        raw: &str,
+        project_root: &Path,
+        require_md_extension: bool,
+    ) -> Result<Self, InputPathRejected> {
+        if raw.trim().is_empty() {
+            return Err(InputPathRejected);
+        }
+
+        let candidate_text = if Path::new(raw).is_absolute() {
+            Path::new(raw)
+                .strip_prefix(project_root)
+                .map_err(|_| InputPathRejected)?
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            raw.to_string()
+        };
+
+        let normalized =
+            normalize_relative_path_for_input(&candidate_text).ok_or(InputPathRejected)?;
+        let rel = Path::new(&normalized);
+
+        if rel.components().any(|c| matches!(c, Component::ParentDir)) {
+            return Err(InputPathRejected);
+        }
+
+        if rel.as_os_str().is_empty() {
+            return Err(InputPathRejected);
+        }
+
+        if require_md_extension && rel.extension().and_then(|e| e.to_str()) != Some("md") {
+            return Err(InputPathRejected);
+        }
+
+        Ok(Self(rel.to_path_buf()))
+    }
+
+    /// 正規化済みの project_root 相対 path を取り出す。
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
+}
+
+#[cfg(test)]
+#[path = "input_task_path_tests.rs"]
+mod input_task_path_tests;

--- a/src-tauri/src/task/input_task_path_tests.rs
+++ b/src-tauri/src/task/input_task_path_tests.rs
@@ -1,0 +1,94 @@
+//! `InputTaskPath::resolve` の正規化・検証テスト。
+
+use std::path::{Path, PathBuf};
+
+use super::{InputPathRejected, InputTaskPath};
+
+fn resolve(raw: &str, require_md: bool) -> Result<PathBuf, InputPathRejected> {
+    InputTaskPath::resolve(raw, Path::new("/project"), require_md).map(InputTaskPath::into_path_buf)
+}
+
+#[test]
+fn relative_path_is_passed_through() {
+    assert_eq!(
+        resolve("tasks/a.md", false),
+        Ok(PathBuf::from("tasks/a.md"))
+    );
+}
+
+#[test]
+fn absolute_inside_root_is_stripped() {
+    assert_eq!(
+        resolve("/project/tasks/a.md", false),
+        Ok(PathBuf::from("tasks/a.md"))
+    );
+}
+
+#[test]
+fn absolute_outside_root_is_rejected() {
+    assert_eq!(resolve("/elsewhere/a.md", false), Err(InputPathRejected));
+}
+
+#[test]
+fn dot_prefix_and_backslash_are_normalized() {
+    assert_eq!(
+        resolve("./tasks\\a.md", false),
+        Ok(PathBuf::from("tasks/a.md"))
+    );
+}
+
+#[test]
+fn empty_is_rejected() {
+    assert_eq!(resolve("", false), Err(InputPathRejected));
+}
+
+#[test]
+fn whitespace_only_is_rejected() {
+    assert_eq!(resolve("   ", false), Err(InputPathRejected));
+}
+
+#[test]
+fn parent_dir_segment_is_rejected() {
+    assert_eq!(resolve("../foo.md", false), Err(InputPathRejected));
+}
+
+#[test]
+fn windows_drive_prefix_is_rejected() {
+    assert_eq!(resolve("C:\\Users\\foo.md", false), Err(InputPathRejected));
+}
+
+#[test]
+fn require_md_accepts_md_extension() {
+    assert_eq!(
+        resolve("tasks/foo.md", true),
+        Ok(PathBuf::from("tasks/foo.md"))
+    );
+}
+
+#[test]
+fn require_md_rejects_non_md_extension() {
+    assert_eq!(resolve("tasks/foo.txt", true), Err(InputPathRejected));
+}
+
+#[test]
+fn require_md_rejects_no_extension() {
+    assert_eq!(resolve("tasks/foo", true), Err(InputPathRejected));
+}
+
+#[test]
+fn require_md_rejects_double_extension() {
+    assert_eq!(resolve("tasks/foo.md.bak", true), Err(InputPathRejected));
+}
+
+#[test]
+fn require_md_rejects_directory_path() {
+    assert_eq!(resolve("tasks/", true), Err(InputPathRejected));
+}
+
+#[test]
+fn require_false_accepts_non_md_extension() {
+    assert_eq!(
+        resolve("tasks/a.txt", false),
+        Ok(PathBuf::from("tasks/a.txt"))
+    );
+}

--- a/src-tauri/src/task/remove_link/args.rs
+++ b/src-tauri/src/task/remove_link/args.rs
@@ -1,13 +1,13 @@
 //! `remove_link` Tauri command の引数 DTO。
 //!
 //! sourceFilePath / targetFilePath は絶対パスまたは project_root 相対のいずれも
-//! 受け、共通の path normalization helper で project_root 相対の正規形に倒す。
+//! 受け、共通の入力パス VO で project_root 相対の正規形に倒す。
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::task::path_lookup::normalize_relative_path_for_input;
+use crate::task::input_task_path::InputTaskPath;
 use crate::task::remove_link::error::RemoveLinkError;
 use crate::task::task_index::RemoveLinkIntent;
 
@@ -26,54 +26,31 @@ impl RemoveLinkArgs {
     /// `InvalidTargetPath` を返す（add_link と異なり target は aggregate での
     /// 存在検証を行わないため、不正 path はここで一元的に弾く）。
     pub fn into_intent(self, project_root: &Path) -> Result<RemoveLinkIntent, RemoveLinkError> {
-        let source = normalize_input_path(&self.source_file_path, project_root, true)?;
-        let target = normalize_input_path(&self.target_file_path, project_root, false)?;
+        let source = resolve_input_path(&self.source_file_path, project_root, true)?;
+        let target = resolve_input_path(&self.target_file_path, project_root, false)?;
         Ok(RemoveLinkIntent { source, target })
     }
 }
 
-fn normalize_input_path(
+/// 入力 path を VO で正規化し、reject を source / target に応じたエラーへ詰め替える。
+fn resolve_input_path(
     raw: &str,
     project_root: &Path,
     is_source: bool,
 ) -> Result<PathBuf, RemoveLinkError> {
-    let make_err = |raw: &str| -> RemoveLinkError {
-        if is_source {
-            RemoveLinkError::SourceNotFound {
-                path: raw.to_string(),
+    InputTaskPath::resolve(raw, project_root, false)
+        .map(InputTaskPath::into_path_buf)
+        .map_err(|_| {
+            if is_source {
+                RemoveLinkError::SourceNotFound {
+                    path: raw.to_string(),
+                }
+            } else {
+                RemoveLinkError::InvalidTargetPath {
+                    path: raw.to_string(),
+                }
             }
-        } else {
-            RemoveLinkError::InvalidTargetPath {
-                path: raw.to_string(),
-            }
-        }
-    };
-
-    if raw.trim().is_empty() {
-        return Err(make_err(raw));
-    }
-
-    let candidate_text = if Path::new(raw).is_absolute() {
-        Path::new(raw)
-            .strip_prefix(project_root)
-            .map_err(|_| make_err(raw))?
-            .to_string_lossy()
-            .into_owned()
-    } else {
-        raw.to_string()
-    };
-
-    let normalized =
-        normalize_relative_path_for_input(&candidate_text).ok_or_else(|| make_err(raw))?;
-    let rel = Path::new(&normalized);
-    if rel.components().any(|c| matches!(c, Component::ParentDir)) {
-        return Err(make_err(raw));
-    }
-    if rel.as_os_str().is_empty() {
-        return Err(make_err(raw));
-    }
-
-    Ok(rel.to_path_buf())
+        })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task/update/args.rs
+++ b/src-tauri/src/task/update/args.rs
@@ -1,14 +1,14 @@
 //! `update_task` Tauri command の引数 DTO。
 //!
-//! filePath は既存の path-normalization helper を再利用して
-//! `UpdateTaskIntent` に詰め直す。canonicalize は使わない。
+//! filePath は共通の入力パス VO で正規化して `UpdateTaskIntent` に詰め直す。
+//! canonicalize は使わない。
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
 use crate::task::frontmatter::Priority;
-use crate::task::path_lookup::normalize_relative_path_for_input;
+use crate::task::input_task_path::InputTaskPath;
 use crate::task::task_index::UpdateTaskIntent;
 use crate::task::update::error::UpdateTaskError;
 
@@ -36,7 +36,7 @@ pub struct UpdateTaskArgs {
 impl UpdateTaskArgs {
     /// project_root を起点に filePath を lexical 正規化し、`UpdateTaskIntent` に詰め直す。
     pub fn into_intent(self, project_root: &Path) -> Result<UpdateTaskIntent, UpdateTaskError> {
-        let rel_path = normalize_input_file_path(&self.file_path, project_root)?;
+        let rel_path = resolve_input_file_path(&self.file_path, project_root)?;
 
         let priority = self.priority.as_deref().and_then(Priority::from_ascii_ci);
 
@@ -54,39 +54,18 @@ impl UpdateTaskArgs {
     }
 }
 
-fn normalize_input_file_path(raw: &str, project_root: &Path) -> Result<PathBuf, UpdateTaskError> {
+/// 入力 filePath を VO で `.md` 必須として正規化し、reject を `InvalidPath` へ詰め替える。
+///
+/// 空文字 / 空白のみの入力は、既存の FE 文字列マッチ契約を維持するため
+/// raw ではなく `"empty"` を持つ `InvalidPath` にする。
+fn resolve_input_file_path(raw: &str, project_root: &Path) -> Result<PathBuf, UpdateTaskError> {
     if raw.trim().is_empty() {
         return Err(UpdateTaskError::InvalidPath("empty".into()));
     }
 
-    let candidate_text = if Path::new(raw).is_absolute() {
-        Path::new(raw)
-            .strip_prefix(project_root)
-            .map_err(|_| UpdateTaskError::InvalidPath(raw.into()))?
-            .to_string_lossy()
-            .into_owned()
-    } else {
-        raw.to_string()
-    };
-
-    let normalized = normalize_relative_path_for_input(&candidate_text)
-        .ok_or_else(|| UpdateTaskError::InvalidPath(raw.into()))?;
-
-    let rel = Path::new(&normalized);
-
-    if rel.components().any(|c| matches!(c, Component::ParentDir)) {
-        return Err(UpdateTaskError::InvalidPath(raw.into()));
-    }
-
-    if rel.extension().and_then(|e| e.to_str()) != Some("md") {
-        return Err(UpdateTaskError::InvalidPath(raw.into()));
-    }
-
-    if rel.as_os_str().is_empty() {
-        return Err(UpdateTaskError::InvalidPath(raw.into()));
-    }
-
-    Ok(rel.to_path_buf())
+    InputTaskPath::resolve(raw, project_root, true)
+        .map(InputTaskPath::into_path_buf)
+        .map_err(|_| UpdateTaskError::InvalidPath(raw.into()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

add_link / remove_link / update_task の各 args DTO に重複していた IPC 入力パス正規化・検証を、新規入力パス VO `InputTaskPath` に集約した。検証ルールが 1 箇所に閉じ、各 command は reject を自身のエラー型へ詰め替えるだけになる。外部挙動（各 Tauri command のエラー文字列）は不変。

## 変更の種類

- ♻️ リファクタリング（外部仕様の変更なし）

## 追加した内容

- `src-tauri/src/task/input_task_path.rs` — 入力パス VO。`InputTaskPath::resolve(raw, project_root, require_md_extension)` が空拒否・絶対パスの root 相対化・`..` 拒否・空結果拒否・任意の `.md` 検証を一手に担い、失敗は値なしの `InputPathRejected` で返す。
- `src-tauri/src/task/input_task_path_tests.rs` — VO の正常系/異常系/境界テスト 14 件。
- `src-tauri/src/task.rs` に `pub mod input_task_path;` を登録。

## 変更した内容

- `task/add_link/args.rs` / `task/remove_link/args.rs` / `task/update/args.rs`: ローカルの `normalize_input_path` / `normalize_input_file_path`（ほぼ同一の重複実装）を削除し、`InputTaskPath::resolve` 呼び出し + reject のエラー詰め替えに置き換え。
  - add_link: reject を source→`SourceNotFound` / target→`TargetNotFound` へ。
  - remove_link: reject を source→`SourceNotFound` / target→`InvalidTargetPath` へ。
  - update: `require_md_extension=true` を渡し reject を `InvalidPath(raw)` へ。空入力時の `InvalidPath("empty")` 文字列契約は呼び出し側で従来どおり維持。

## 削除した内容

- 上記 3 ファイルから重複していた正規化 free function（合計）。

## 仕様ドキュメント更新

不要（純粋な内部リファクタリング）。公開 API・データ形式・画面挙動・設定項目に変更はなく、各 Tauri command のエラー文字列契約も維持している。

## システム図

\`\`\`mermaid
flowchart LR
    A[add_link/args] --> V[InputTaskPath::resolve]
    R[remove_link/args] --> V
    U[update/args] --> V
    V -->|Ok PathBuf| OK[Intent へ詰め替え]
    V -->|InputPathRejected| ERR[各 command 固有のエラーへ詰め替え]
    style V fill:#dff,stroke:#066
\`\`\`

## 関連Issue

Closes #293

## テスト

- \`cargo fmt\`: 適用済み（差分整形のみ）
- \`cargo clippy --all-targets\`: 警告ゼロ（exit 0）
- \`cargo test\`: 996 passed / 0 failed（VO 新規 14 件を含む。既存 args テストは全件そのまま通過）

## レビューポイント

- VO に `.md` 検証の要否を `require_md_extension` 引数で持たせた点（update のみ true）。各 command のエラー文字列契約を崩さないため、reject の詰め替えは呼び出し側に残している。