### PR TITLE
♻️ [Refactoring]: #298 [BE] crates/fs config_io の write 系 3 重実装を SpecBoardDir::write_file へ委譲

### DIFF
--- a/src-tauri/crates/fs/src/config/config_io.rs
+++ b/src-tauri/crates/fs/src/config/config_io.rs
@@ -42,8 +42,6 @@ pub const LABELS_FILE_NAME: &str = "labels.yml";
 /// labels.yml と同様、中身（YAML）のパース / シリアライズは本体クレート側の責務で
 /// あり、本サブクレートは [`SpecBoardDir`] 経由で raw `String` の読み書きのみを担当する。
 pub const MILESTONES_FILE_NAME: &str = "milestones.yml";
-static GUIDE_MARKDOWN_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-static CONFIG_JSON_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SPEC_BOARD_DIR_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// プロジェクトの `.spec-board/` ディレクトリを管理し、配下ファイルの
@@ -358,15 +356,9 @@ pub fn read_config_json(project_root: &Path) -> Result<Option<String>, ConfigIoE
 /// - `<project_root>/.spec-board/GUIDE.md` が symlink として存在する
 /// - 権限不足等で `.spec-board/` 作成または `GUIDE.md` 書き込みが失敗する
 pub fn write_guide_markdown(project_root: &Path, content: &str) -> Result<PathBuf, ConfigIoError> {
-    let spec_board_dir = ensure_spec_board_dir(project_root)?;
-    reject_existing_symlink(&spec_board_dir)?;
-    let guide_path = guide_markdown_path(project_root);
-    reject_existing_symlink(&guide_path)?;
-
-    let tmp_path = unique_guide_markdown_tmp_path(&spec_board_dir);
-    write_file_via_tmp(&guide_path, content, &tmp_path)?;
-
-    Ok(guide_path)
+    // 書き込みフロー（ensure → symlink 拒否 → tmp→rename）は format 非依存の
+    // `SpecBoardDir::write_file` に集約済みのため、ファイル名だけ渡して委譲する。
+    SpecBoardDir::new(project_root).write_file(GUIDE_MARKDOWN_FILE_NAME, content)
 }
 
 /// `<project_root>/.spec-board/config.json` へ JSON 文字列を書き込む。
@@ -383,24 +375,9 @@ pub fn write_guide_markdown(project_root: &Path, content: &str) -> Result<PathBu
 /// - `<project_root>/.spec-board/config.json` が symlink として存在する
 /// - 権限不足等で `.spec-board/` 作成または `config.json` 書き込みが失敗する
 pub fn write_config_json(project_root: &Path, content: &str) -> Result<PathBuf, ConfigIoError> {
-    let spec_board_dir = ensure_spec_board_dir(project_root)?;
-    reject_existing_symlink(&spec_board_dir)?;
-    let target = config_path(project_root);
-    reject_existing_symlink(&target)?;
-
-    let tmp_path = unique_config_json_tmp_path(&spec_board_dir);
-    write_file_via_tmp(&target, content, &tmp_path)?;
-
-    Ok(target)
-}
-
-fn unique_config_json_tmp_path(spec_board_dir: &Path) -> PathBuf {
-    let pid = std::process::id();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos());
-    let counter = CONFIG_JSON_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    spec_board_dir.join(format!("{CONFIG_FILE_NAME}.tmp.{pid}.{nanos}.{counter}"))
+    // 書き込みフロー（ensure → symlink 拒否 → tmp→rename）は format 非依存の
+    // `SpecBoardDir::write_file` に集約済みのため、ファイル名だけ渡して委譲する。
+    SpecBoardDir::new(project_root).write_file(CONFIG_FILE_NAME, content)
 }
 
 fn reject_existing_symlink(path: &Path) -> Result<(), ConfigIoError> {
@@ -416,17 +393,6 @@ fn reject_existing_symlink(path: &Path) -> Result<(), ConfigIoError> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(io_err(path, e)),
     }
-}
-
-fn unique_guide_markdown_tmp_path(spec_board_dir: &Path) -> PathBuf {
-    let pid = std::process::id();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos());
-    let counter = GUIDE_MARKDOWN_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    spec_board_dir.join(format!(
-        "{GUIDE_MARKDOWN_FILE_NAME}.tmp.{pid}.{nanos}.{counter}"
-    ))
 }
 
 fn write_file_via_tmp(dst: &Path, content: &str, tmp: &Path) -> Result<(), ConfigIoError> {
@@ -511,7 +477,7 @@ fn unique_sibling_path(base: &Path, suffix: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |duration| duration.as_nanos());
-    let counter = GUIDE_MARKDOWN_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let counter = SPEC_BOARD_DIR_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let file_name = base
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())


### PR DESCRIPTION
## 概要

`spec-board-fs` サブクレートの `config_io` で `write_config_json` / `write_guide_markdown` が `SpecBoardDir::write_file` と同一の書き込みフローを三重実装していた非対称を解消し、両関数を `SpecBoardDir::write_file` への委譲に置き換える。読み側（`read_config_json`）が既に `SpecBoardDir::read_file` へ委譲済みなのと対称になる。

## 変更の種類

- ♻️ リファクタリング（外部仕様の変更なし）

## 変更した内容

- `write_config_json` → `SpecBoardDir::new(project_root).write_file(CONFIG_FILE_NAME, content)` への委譲に置き換え
- `write_guide_markdown` → `SpecBoardDir::new(project_root).write_file(GUIDE_MARKDOWN_FILE_NAME, content)` への委譲に置き換え
- Windows 専用 `unique_sibling_path` の tmp カウンタ参照を、生き残る汎用カウンタ `SPEC_BOARD_DIR_TMP_COUNTER` に変更

`pub` API（`write_config_json` / `write_guide_markdown`）のシグネチャ・戻り値・`ConfigIoError` は不変。`SpecBoardDir::write_file` 経由でも ensure → symlink 拒否（`.spec-board/` と leaf の 2 段）→ unique tmp 生成 → tmp→rename の同一フローを通るため、symlink 拒否・既存上書き・hard link 維持・UTF-8/改行保持・`.spec-board/` 自動作成といった外部挙動はすべて維持される。

## 削除した内容

- 専用 unique tmp path 生成関数 2 本（`unique_config_json_tmp_path` / `unique_guide_markdown_tmp_path`）
- 専用 `AtomicU64` カウンタ 2 本（`CONFIG_JSON_TMP_COUNTER` / `GUIDE_MARKDOWN_TMP_COUNTER`）

汎用版 `unique_spec_board_tmp_path(dir, file_name)` + `SPEC_BOARD_DIR_TMP_COUNTER` 1 本に統合（汎用版は対象ファイル名をプレフィックスに含むため専用 2 本を完全に包含する）。

## システム図

```mermaid
flowchart TD
    subgraph before["変更前（三重実装）"]
        wcj1["write_config_json"] --> flow1["ensure → symlink拒否×2 → unique tmp → tmp→rename"]
        wgm1["write_guide_markdown"] --> flow2["ensure → symlink拒否×2 → unique tmp → tmp→rename"]
        wf1["SpecBoardDir::write_file"] --> flow3["ensure → symlink拒否×2 → unique tmp → tmp→rename"]
    end
    subgraph after["変更後（委譲）"]
        wcj2["write_config_json"] --> wf2["SpecBoardDir::write_file"]
        wgm2["write_guide_markdown"] --> wf2
        wf2 --> flow4["ensure → symlink拒否×2 → unique tmp → tmp→rename"]
    end
    style wf2 fill:#cfc
```

## 仕様ドキュメント更新

不要（純粋な内部リファクタリング）。公開 API のシグネチャ・エラー型・ファイル I/O の外部挙動はすべて不変のため、`docs/spec-board/` 配下の更新は伴わない。

## 関連Issue

Closes #298

## テスト

src-tauri にて以下を実行し全て通過:

- `cargo fmt`: 追加差分なし
- `cargo clippy --workspace --all-targets`: 警告ゼロ
- `cargo test --workspace`: 本体クレート 982 / `spec-board-fs` 135、計 1117 件すべて green（0 failed）

`config_io_tests.rs` の write 系テスト（symlink 拒否 / 既存上書き / hard link 維持 / UTF-8・改行保持 / `.spec-board/` 自動作成 / path traversal 拒否）が委譲後も全件通過することで外部挙動不変を確認。

## レビューポイント

- Windows 専用 `unique_sibling_path` が削除カウンタ（`GUIDE_MARKDOWN_TMP_COUNTER`）を参照していたため、生存カウンタ `SPEC_BOARD_DIR_TMP_COUNTER` に付け替えている点（カウンタは in-process 一意性のためだけに使われ、ファイル名プレフィックスで衝突回避するため共有化に問題なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)