### PR TITLE
🧹 [Chore]: #299 [BE] crates/fs write_ignore / file_scanner の doc 陳腐化・API 重複を整理

### DIFF
--- a/docs/impl/add_link.md
+++ b/docs/impl/add_link.md
@@ -75,7 +75,7 @@ watcher が install されているとき、`io.write_existing` で source フ�
 書き換えると、自前 write が watcher event として戻ってきて FE に通知される
 おそれがある。それを抑止するために、書き込み前に `write_ignore.register`
 で source path を予約し、write が成功したらそのまま entry を残す
-（watcher event の handler 側で consume される）。write が失敗した場合は
+（watcher event の handler 側が `unregister` で取り除いて消費する）。write が失敗した場合は
 即 `unregister` で entry を回収して、放置しないようにする。これは
 `update_task_impl` と同型で、既存パターンを踏襲している。
 

--- a/docs/impl/dnd-current-state.md
+++ b/docs/impl/dnd-current-state.md
@@ -233,7 +233,7 @@ update_task IPC (command.rs:24-83)
   │
   ├─ FileIO::write_existing(&abs, file_content)
   │    └─ 書き込み失敗時のみ write_ignore.unregister(&abs) して early return
-  │       （success path では unregister せず、watcher 側で write_ignore.consume される設計）
+  │       （success path では呼び出し側では解除せず、watcher 側が write_ignore.unregister で消費する設計）
   │
   └─ commit_cache (needs_full_rebuild=true のときだけ TaskIndex を rebuild)
 ```
@@ -258,7 +258,7 @@ flowchart TD
     CC --> OK([Result.ok updated_task])
 
     WATCHER([fs watcher]) -.write event 検知.-> CONSUME{"write_ignore に<br/>登録あり?"}
-    CONSUME -->|あり| SKIP["consume してイベント抑止<br/>(自己発火回避)"]
+    CONSUME -->|あり| SKIP["unregister で取り除いてイベント抑止<br/>(自己発火回避)"]
     CONSUME -->|なし| EMIT["IPC で FE に通知"]
 
     style REG fill:#efe,stroke:#0a0
@@ -293,7 +293,7 @@ flowchart TD
 | 5 | `moveTask.ts:313-460` MoveExecution | crossColumn (90 行) / sameColumn (45 行) で 2 IPC を逐次実行 + 3 種 rollback パス | 成功 / updateTask 失敗 / updateCardOrder 失敗 (partial) の 3 終端 |
 | 6 | `LiveRegion/index.tsx:35-40` | 同文言再 announce のために id 奇数で zero-width-space を付け外し | SR 実装差吸収の hack |
 | 7 | `App.tsx:401-441` | onOptimisticApplied / onRollback を組んで moveTask に注入 | UI 通知と reducer dispatch を疎結合にした副作用。callback 例外は moveTask 内 safeCallback で握り潰し |
-| 8 | `update/command.rs` + `write_ignore` | 自前 write を watcher に無視させる register。success path では unregister せず watcher 側で `consume`、write 失敗時のみ unregister | 自前 write → watcher → IPC → reducer の自己発火ループを切る必要があるが、register / consume / 失敗時 unregister の責務が両側に分散して読み解きにくい |
+| 8 | `update/command.rs` + `write_ignore` | 自前 write を watcher に無視させる register。success path では呼び出し側で解除せず watcher 側が `unregister` で消費、write 失敗時のみ呼び出し側で `unregister` | 自前 write → watcher → IPC → reducer の自己発火ループを切る必要があるが、register / 消費 / 失敗時 unregister の責務が両側に分散して読み解きにくい |
 | 9 | `task_index.rs:341-451` plan_update | parent_changed 判定 (3 分岐) + lookup-normalized + 全体 hierarchy 再検証 + needs_full_rebuild (parent_changed のみで true) | move では status しか変えないが、共通 update 経路に乗っているため parent 関連の重いロジックも通る（move 経由なら needs_full_rebuild は常に false） |
 | 10 | docs と実装の乖離 | `docs/impl/dnd-board.md` は「楽観 UI 採用しない / 2 IPC」と書いてあるが現状は「楽観 UI 採用 + 2 IPC + 3 段 rollback」 | 設計判断の history が更新されておらず、現状の根拠が読めない |
 

--- a/docs/impl/remove_link.md
+++ b/docs/impl/remove_link.md
@@ -79,8 +79,8 @@ tasks_cache → watcher_handle → write_ignore` に従い、`remove_link_impl` 
 同じ順番で各 accessor を呼ぶ。
 
 watcher install 済みの場合は書き込み前に `write_ignore.register` で source path
-を予約し、write 成功後はそのまま entry を残す（watcher event の handler 側で
-consume される）。`io.write_existing` が失敗した場合は即 `unregister` で entry を
+を予約し、write 成功後はそのまま entry を残す（watcher event の handler 側が
+`unregister` で取り除いて消費する）。`io.write_existing` が失敗した場合は即 `unregister` で entry を
 回収する。`commit_cache` が `SourceVanished` で失敗した場合も同様に
 `unregister` してから返す（disk への write は完了しているため、watcher event を
 通常経路で処理して cache を disk に追従させる必要がある）。`add_link_impl` /

--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -345,8 +345,8 @@ spec-board 自身がmdファイルを書き込んだ直後に、ファイル監�
 
 - 書き込みパスセットは `HashSet<PathBuf>` で管理し、`Mutex` で排他制御
 - セット登録後に対応するイベントが来なかった場合の解除は呼び出し側が明示的に行う
-- **パス表現は絶対パス**で揃える。`FsEvent` から渡される `PathBuf` をそのまま key として比較するため、書き込み側も `register` 時に絶対パスを使うこと。相対表記や区切り違い（`./tasks/x.md` と `tasks/x.md` 等）は別キーとして扱われ、`consume` がヒットせずに自己書き込みが二重通知される
-- **stale entry の TTL cleanup は行わない**。書き込み後に対応するイベントが届かなかった場合の登録は、`open_project` で別プロジェクトを開いたタイミングの `WriteIgnoreRegistry::clear()` でのみ解消される。プロジェクトを開き直さずに長時間動作させても自己書き込み判定が壊れない仕様にしたい場合は、呼び出し側で `unregister` または `consume` を明示する
+- **パス表現は絶対パス**で揃える。`FsEvent` から渡される `PathBuf` をそのまま key として比較するため、書き込み側も `register` 時に絶対パスを使うこと。相対表記や区切り違い（`./tasks/x.md` と `tasks/x.md` 等）は別キーとして扱われ、`unregister` がヒットせずに自己書き込みが二重通知される
+- **stale entry の TTL cleanup は行わない**。書き込み後に対応するイベントが届かなかった場合の登録は、`open_project` で別プロジェクトを開いたタイミングの `WriteIgnoreRegistry::clear()` でのみ解消される。プロジェクトを開き直さずに長時間動作させても自己書き込み判定が壊れない仕様にしたい場合は、呼び出し側で `unregister` を明示する
 
 ## エラーハンドリング
 
@@ -408,8 +408,8 @@ pub struct WriteIgnoreRegistry;
 impl WriteIgnoreRegistry {
     pub fn new() -> Self;
     pub fn register(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
+    pub fn register_bulk(&self, paths: &[PathBuf]) -> Result<(), WriteIgnoreError>;
     pub fn should_ignore(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
-    pub fn consume(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
     pub fn unregister(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError>;
     pub fn len(&self) -> Result<usize, WriteIgnoreError>;
     pub fn is_empty(&self) -> Result<bool, WriteIgnoreError>;
@@ -428,19 +428,19 @@ pub enum WriteIgnoreError {
 | 配置 | `src-tauri/crates/fs/src/watcher/write_ignore.rs`（サブクレート `spec-board-fs`）。呼び出しは `spec_board_fs::watcher::write_ignore::WriteIgnoreRegistry` |
 | 内部状態 | `Mutex<HashSet<PathBuf>>` で登録済みパスを保持する |
 | `register` | パスを登録し、新規追加なら `Ok(true)`、重複なら `Ok(false)` を返す |
+| `register_bulk` | 複数パスを 1 回の lock 内でまとめて登録する。空スライスは何もせず `Ok(())`。重複は `HashSet` により 1 件に丸まる |
 | `should_ignore` | パスが登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す。状態は変更しない |
-| `consume` | 1回の lock 内でパスを確認して解除し、登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す。ファイル監視イベントの one-shot 消費に使う |
-| `unregister` | パスを解除し、登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す |
+| `unregister` | 1回の lock 内でパスを確認して解除し、登録済みなら `Ok(true)`、未登録なら `Ok(false)` を返す。ファイル監視イベントの one-shot 消費（自己書き込み判定）と、登録のロールバックの両方に使う |
 | `clear` | 登録済みパスを全て消去する。Mutex poison 時のみ `Err(WriteIgnoreError::LockPoisoned)` を返す。プロジェクト再オープン等のライフサイクル境界で呼ぶ |
-| 解除責務 | `consume` / `unregister` による明示的な解除を呼び出し側が行う |
+| 解除責務 | `unregister` による明示的な解除を呼び出し側が行う |
 | タイムアウト | registry 自体は timeout cleanup を行わない。イベント未到達時の stale entry 防止が必要な場合は呼び出し側で解除タイミングを管理する |
 | 重複登録 | 同一 path の重複 `register` は `Ok(false)` を返し、状態を変更しない |
-| 再登録 | `consume` / `unregister` 後に同一 path が再登録された場合は、新規登録として `Ok(true)` を返す |
+| 再登録 | `unregister` 後に同一 path が再登録された場合は、新規登録として `Ok(true)` を返す |
 | パス比較 | canonicalize / normalize は行わず、渡された `PathBuf` 表現の完全一致で扱う |
 | エラー | public API では Mutex が poison された場合に `Err(WriteIgnoreError::LockPoisoned)` を返す。`CleanupWorkerSpawnFailed` は互換性維持のため enum variant として残すが、現在の `HashSet` registry 実装では返さない |
 | Tauri 依存 | なし。Tauri state やファイル監視コンポーネントへの保持・統合は呼び出し側で行う |
 
-`WriteIgnoreRegistry` は自己書き込み抑制用の registry を担当する。ファイル監視イベントを無視する判定では race-free な `consume` を使う。対応する監視イベントが届かない場合の解除は呼び出し側の責務とする。
+`WriteIgnoreRegistry` は自己書き込み抑制用の registry を担当する。ファイル監視イベントを無視する判定では race-free な `unregister`（確認と解除を 1 lock で行う）を使う。対応する監視イベントが届かない場合の解除は呼び出し側の責務とする。
 
 ### `Watcher` / `FsEvent` / `WatcherError`
 
@@ -507,7 +507,7 @@ pub enum WatcherError {
 
 - 拡張子フィルタ（`.md` 等）— `watcher_event::handler::rel_md_path` で root 配下の `.md` のみを処理
 - Tauri IPC 経由のフロントエンド emit（`task-created` / `task-updated` / `task-deleted` への変換）— `watcher_event::handler::handle_event` + `EmittingWatcherHandle`
-- `WriteIgnoreRegistry` との統合（自己書き込み抑制）— `watcher_event::handler` 内で `consume(abs_path)` を呼ぶ
+- `WriteIgnoreRegistry` との統合（自己書き込み抑制）— `watcher_event::handler` 内で `unregister(abs_path)` を呼ぶ
 
 引き続き後続 Issue で扱うもの:
 

--- a/src-tauri/crates/fs/src/task/file_scanner.rs
+++ b/src-tauri/crates/fs/src/task/file_scanner.rs
@@ -83,9 +83,13 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
 /// 1. root 自身ではない（`depth() > 0`）
 /// 2. 通常ファイル
 /// 3. 拡張子 `.md`（大文字小文字非区別）
-/// 4. ファイル名がドットで始まらない
-/// 5. サイズが [`MAX_FILE_SIZE`] byte 以下
-/// 6. 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
+/// 4. サイズが [`MAX_FILE_SIZE`] byte 以下
+/// 5. 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
+///
+/// ドット始まり名（`.hidden.md` 等）の除外はここでは行わない。`scan_md_files`
+/// は walker に [`should_descend`] を `filter_entry` として渡しており、ドット始まり
+/// エントリはファイル・ディレクトリを問わず descend 段階で枝刈りされ、本関数には
+/// 到達しないため。
 ///
 /// I/O 失敗（metadata 取得失敗 / open 失敗 / read 失敗）は `false`（除外側）として扱う。
 ///
@@ -101,14 +105,6 @@ fn should_include(entry: &walkdir::DirEntry) -> bool {
     }
     let path = entry.path();
     if !is_md_extension(path) {
-        return false;
-    }
-    let starts_with_dot = path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .map(|name| name.starts_with('.'))
-        .unwrap_or(true);
-    if starts_with_dot {
         return false;
     }
     if !is_size_within_limit(entry) {

--- a/src-tauri/crates/fs/src/watcher/core_tests.rs
+++ b/src-tauri/crates/fs/src/watcher/core_tests.rs
@@ -930,13 +930,14 @@ fn spawn_adapter_slides_deadline_when_same_path_arrives_within_window() {
     let (fs_rx, handle) = spawn_adapter(notify_rx);
     let path = PathBuf::from("/tmp/test_slide");
 
-    // 同一 path に 2 回連続投入。間に短い sleep を挟むのは「2 回目を
-    // 1 回目の debounce window 内に入れる」ためだが、CI 負荷で sleep
-    // が 100ms+ にブレた場合でも sliding 集約の最終結果（投入 N 回 →
-    // 発火 1 件）は変わらないため、sleep + try_recv による「まだ届い
-    // ていない」アサーションは行わず、件数のみで検証する。
+    // 同一 path に 2 回連続投入。間の sleep は「2 回目を 1 回目の
+    // debounce window (DEBOUNCE_DURATION = 100ms) 内に入れる」ため
+    // に挟む。2 回目が window を跨ぐと別イベントとして 2 件発火し
+    // 件数アサーションが崩れるため、sleep は window に対して十分
+    // 小さく（10ms）し、低速 CI でのスケジューリング遅延に対する
+    // 余裕（約 90ms）を確保する。
     notify_tx.send(Ok(modify_event(&path))).unwrap();
-    std::thread::sleep(Duration::from_millis(50));
+    std::thread::sleep(Duration::from_millis(10));
     notify_tx.send(Ok(modify_event(&path))).unwrap();
 
     let ev = fs_rx
@@ -964,8 +965,10 @@ fn spawn_adapter_flushes_pending_on_notify_tx_drop() {
     let path = PathBuf::from("/tmp/test_flush");
 
     notify_tx.send(Ok(modify_event(&path))).unwrap();
-    // ウィンドウ満了前に上流を drop する。
-    std::thread::sleep(Duration::from_millis(30));
+    // ウィンドウ満了 (DEBOUNCE_DURATION = 100ms) より十分前に上流を
+    // drop する。drop が遅れて満了を跨ぐと先に通常発火してしまうため、
+    // sleep は短く（10ms）して低速 CI での遅延余裕を確保する。
+    std::thread::sleep(Duration::from_millis(10));
     drop(notify_tx);
 
     // flush で保留イベントが届く。
@@ -990,10 +993,12 @@ fn spawn_adapter_forwards_rescan_immediately_bypassing_pending_events() {
     let (fs_rx, handle) = spawn_adapter(notify_rx);
     let path = PathBuf::from("/tmp/test_rescan_bypass");
 
-    // Modified を投入して pending 入りさせ、20ms 後に Rescan を投入する。
-    // 保留 Modified は DEBOUNCE_DURATION (100ms) 経過後に発火する仕様。
+    // Modified を投入して pending 入りさせ、短い間隔を空けて Rescan を
+    // 投入する。保留 Modified は DEBOUNCE_DURATION (100ms) 経過後に発火
+    // する仕様のため、sleep は window より十分小さく（5ms）して、
+    // Rescan 投入前に保留が満了してしまう余地を最小化する。
     notify_tx.send(Ok(modify_event(&path))).unwrap();
-    std::thread::sleep(Duration::from_millis(20));
+    std::thread::sleep(Duration::from_millis(5));
     notify_tx.send(Ok(ev_rescan())).unwrap();
 
     // 絶対時間ではなく **順序** で bypass 仕様を検証する。CI 負荷時の
@@ -1025,8 +1030,11 @@ fn spawn_adapter_overwrites_renamed_entry_when_modified_arrives_for_same_to_path
     let from = PathBuf::from("/tmp/test_rename_from");
     let to = PathBuf::from("/tmp/test_rename_to");
 
+    // Modify を Renamed の debounce window (DEBOUNCE_DURATION = 100ms)
+    // 内に入れるための sleep。window を跨ぐと 2 件に分かれて上書き検証
+    // が崩れるため、sleep は window より十分小さく（10ms）する。
     notify_tx.send(Ok(rename_both_event(&from, &to))).unwrap();
-    std::thread::sleep(Duration::from_millis(50));
+    std::thread::sleep(Duration::from_millis(10));
     notify_tx.send(Ok(modify_event(&to))).unwrap();
 
     // 2 回目から 100ms 以上待って 1 件のみ届く。
@@ -1139,8 +1147,12 @@ fn watcher_emits_separate_events_when_writes_are_spaced_beyond_window() {
     let (watcher, rx) = Watcher::start(dir.path()).expect("start should succeed");
     drain_events(&rx, Duration::from_millis(300));
 
+    // 2 回の書き込みを別イベントとして発火させるには、間隔が debounce
+    // window (DEBOUNCE_DURATION = 100ms) を確実に超える必要がある。
+    // 実 FS / inotify の配信遅延が CI 負荷でブレても 1 件に collapse
+    // しないよう、window の数倍 (400ms) の間隔を空ける。
     std::fs::write(&target, b"v1").unwrap();
-    std::thread::sleep(Duration::from_millis(250));
+    std::thread::sleep(Duration::from_millis(400));
     std::fs::write(&target, b"v2").unwrap();
 
     let events = collect_events_for(

--- a/src-tauri/crates/fs/src/watcher/handle.rs
+++ b/src-tauri/crates/fs/src/watcher/handle.rs
@@ -12,10 +12,10 @@
 ///
 /// # Panic
 ///
-/// 一般に `stop()` の panic safety は呼び出し側の責務だが、tauri 側の状態管理
-/// (AppState) が内部 Mutex の guard を保持したまま `stop()` を呼び出すケース
-/// では、panic は guard 経由で伝播し Mutex が poison 状態に遷移する。
-/// 次回アクセサ呼び出しで lock poison エラーが返る運用を前提とする。
+/// 一般に `stop()` の panic safety は呼び出し側の責務である。呼び出し側が
+/// 内部 Mutex の guard を保持したまま `stop()` を呼び出すケースでは、panic は
+/// guard 経由で伝播し Mutex が poison 状態に遷移し得る。その場合は次回の
+/// アクセサ呼び出しで lock poison エラーが返る運用を前提とする。
 /// 一方、ハンドルを取り出して guard 外から呼び出す場合（例: take 経由）は
 /// この限りではなく、呼び出し側で適宜 `catch_unwind` 等を行うこと。
 pub trait WatcherHandle: Send {
@@ -25,10 +25,9 @@ pub trait WatcherHandle: Send {
 
 /// 何もしない [`WatcherHandle`] 実装。
 ///
-/// 具象 watcher を install する前の初期値や、テストでのスタブとして
-/// `AppState::install_watcher_handle` に渡せる最小実装として用いる。
-/// `stop()` は冪等で副作用を持たないため、同一インスタンスに対して
-/// 複数回呼び出しても安全。
+/// notify 等の具象 watcher が未導入の段階で、ハンドルを保持する呼び出し側に
+/// 渡せる最小実装として用いる。`stop()` は冪等で副作用を持たないため、
+/// 同一インスタンスに対して複数回呼び出しても安全。
 #[derive(Debug, Default)]
 pub struct NoopWatcherHandle;
 

--- a/src-tauri/crates/fs/src/watcher/write_ignore.rs
+++ b/src-tauri/crates/fs/src/watcher/write_ignore.rs
@@ -1,4 +1,8 @@
-//! Registry for write-originated paths that the file watcher can ignore.
+//! Registry of write-originated paths that the file watcher should ignore.
+//!
+//! 自前の書き込みで生じた path を一時的に登録しておき、watcher 由来の
+//! イベントを処理する側がその path を取り除いて（既登録なら自己書き込みと
+//! 判定して）二重処理を抑止するために使う。
 //!
 //! Paths are stored exactly as provided. The registry does not canonicalize,
 //! normalize, or otherwise resolve path representations.
@@ -72,17 +76,8 @@ impl WriteIgnoreRegistry {
 
     /// Atomically removes a path and returns whether it was present.
     ///
-    /// This is kept as a compatibility alias for callers that consume ignored
-    /// write events exactly once.
-    ///
-    /// # Errors
-    ///
-    /// - 内部の Mutex が poison 状態になっている場合 → [`WriteIgnoreError::LockPoisoned`]
-    pub fn consume(&self, path: impl AsRef<Path>) -> Result<bool, WriteIgnoreError> {
-        self.unregister(path)
-    }
-
-    /// Removes a path and returns whether it was present.
+    /// 自己書き込みイベントを 1 度だけ消費する用途（既登録なら `true` を返して
+    /// 取り除く）と、登録のロールバック用途の両方で使う単一の取り除き API。
     ///
     /// # Errors
     ///
@@ -128,8 +123,9 @@ impl WriteIgnoreRegistry {
 
     /// Test 用に内部 Mutex を poison させる。
     ///
-    /// `update_columns_impl` の preflight / register 経路で `WriteIgnoreError::LockPoisoned`
-    /// → `StateLockPoisoned` 変換を effect 層レベルで再現するために公開する。
+    /// 呼び出し側の preflight / register 経路で `WriteIgnoreError::LockPoisoned`
+    /// が返り、それを呼び出し側のエラー型へ変換する挙動を effect 層レベルで
+    /// 再現するために公開する。
     /// `cfg(test)` 内または `test-utils` feature 有効時のみコンパイルされ、本番 build では存在しない。
     #[cfg(any(test, feature = "test-utils"))]
     pub fn poison_lock_for_testing(&self) {

--- a/src-tauri/crates/fs/src/watcher/write_ignore_tests.rs
+++ b/src-tauri/crates/fs/src/watcher/write_ignore_tests.rs
@@ -86,7 +86,7 @@ fn unregister_missing_path_returns_false() {
 }
 
 #[test]
-fn consume_returns_true_once_and_removes_path() {
+fn unregister_returns_true_once_and_removes_path() {
     let registry = WriteIgnoreRegistry::new();
 
     registry
@@ -94,10 +94,10 @@ fn consume_returns_true_once_and_removes_path() {
         .expect("registry should be writable");
 
     assert!(registry
-        .consume("tasks/example.md")
+        .unregister("tasks/example.md")
         .expect("registry should be writable"));
     assert!(!registry
-        .consume("tasks/example.md")
+        .unregister("tasks/example.md")
         .expect("registry should be writable"));
     assert!(!registry
         .should_ignore("tasks/example.md")
@@ -106,7 +106,7 @@ fn consume_returns_true_once_and_removes_path() {
 }
 
 #[test]
-fn concurrent_consume_allows_only_one_success() {
+fn concurrent_unregister_allows_only_one_success() {
     const THREAD_COUNT: usize = 8;
 
     let registry = Arc::new(WriteIgnoreRegistry::new());
@@ -125,8 +125,8 @@ fn concurrent_consume_allows_only_one_success() {
                 barrier.wait();
 
                 registry
-                    .consume("tasks/example.md")
-                    .expect("consume should work")
+                    .unregister("tasks/example.md")
+                    .expect("unregister should work")
             })
         })
         .collect::<Vec<_>>();

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -129,10 +129,10 @@ fn rel_md_path_lenient(abs_path: &Path, root: &Path) -> Option<TaskFilePath> {
     Some(normalized_task_file_path(rel))
 }
 
-/// write_ignore registry を consume し、自己書き込みなら `true` を返して
-/// 呼び出し側に skip させる。
+/// write_ignore registry から該当 path を取り除き、自己書き込みなら `true` を
+/// 返して呼び出し側に skip させる。
 fn try_consume_write_ignore(ctx: &AdapterContext, abs_path: &Path) -> Result<bool, HandleError> {
-    Ok(ctx.state.write_ignore().consume(abs_path)?)
+    Ok(ctx.state.write_ignore().unregister(abs_path)?)
 }
 
 fn handle_upsert(


### PR DESCRIPTION
## 概要

`spec-board-fs` サブクレートのレビューで見つかった、陳腐化した doc コメント・呼び出し側内部への結合・冗長 API をまとめて整理する。外部挙動はすべて不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）
- 📝 Doc
- 🧪 Tests
- 🔥 Remove（冗長コード / alias API の削除）

## 変更した内容

1. **write_ignore モジュール doc**: 「a future file watcher can ignore」という陳腐化した経緯記述を、現状（自前 write を一時登録し watcher 側が取り除いて二重処理を抑止する）に書き換え。
2. **本体クレート内部の名指し doc を一般化**:
   - `write_ignore.rs` の `poison_lock_for_testing` doc が名指ししていた `update_columns_impl` / `StateLockPoisoned` を「呼び出し側」の一般表現へ。
   - `handle.rs` の `WatcherHandle` / `NoopWatcherHandle` doc が名指ししていた本体クレートの `AppState` を一般表現へ（tauri 非依存のサブクレートに整合）。
3. **`consume` / `unregister` を統一**: `consume` は `unregister` の単純 alias（doc 自ら「compatibility alias」と記載）だったため `consume` を削除。唯一の本番呼び出し元 `watcher_event::handler` と関連 test を `unregister` に揃える。`unregister` は one-shot 消費（自己書き込み判定）とロールバックの両用途を担う単一 API として doc を統一。
4. **`file_scanner::should_include` の冗長判定を削除**: ドット始まりファイル名の除外は walker の `filter_entry(should_descend)` が descend 段階で枝刈り済みで `should_include` に到達しないため、冗長な分岐を削除し責務の所在を doc に明記。
5. **core_tests のフレーク耐性向上**: debounce window (100ms) に対する実時間 sleep のマージンを調整。window 内投入狙いの sleep は小さく（50/30/20ms → 10/10/5ms）して跨ぎ余地を減らし、window 超え分離狙いの実 FS テストは間隔を 250ms → 400ms に拡大。検証する不変条件は不変。

## 削除した内容

- `WriteIgnoreRegistry::consume`（`unregister` への単純 alias）
- `file_scanner::should_include` のドット始まり名チェック（到達不能な冗長分岐）

## 仕様ドキュメント更新

`docs/spec-board/file-system-spec.md` を更新（公開 API である `WriteIgnoreRegistry` から `consume` を除去し、抜けていた `register_bulk` を追記、`unregister` を単一の取り除き API として記述統一）。あわせて design narrative の `docs/impl/{add_link,remove_link,dnd-current-state}.md` の `consume` 名指しを追従。`file_scanner` のドット除外は挙動不変のため `BL-002a` 等の spec は変更不要。

## 関連Issue

Closes #299

## テスト

- `cargo fmt --check`: pass
- `cargo clippy --workspace --all-targets`: 警告ゼロ
- `cargo test --workspace`: 全通過（spec-board-fs 135 件 / spec-board lib watcher_event 含む全件）
- FE は無変更。

## レビューポイント

- Issue 提案 3 の前提（`unregister` がテスト経由でしか使われていない）は実コードと異なり、`unregister` は本番のロールバック経路 8 箇所で使用中だった。逆に `consume` は handler の 1 箇所のみ。よって「`consume` を削除して `unregister` に統一」という方向で統合した（呼び出し側のローカル fn 名 `try_consume_write_ignore` は消費セマンティクスとして維持）。
- core_tests の sleep 調整: window 内に入れたい test は sleep を「広げる」のではなく「縮める」方が跨ぎ余地が減りフレークしにくいため、その方向で調整している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)