### PR TITLE
♻️ [Refactoring]: #294 [BE] cache 再構築・task 引き当て・usage_counts を TaskIndex の aggregate に集約

### DIFF
--- a/src-tauri/src/config/delete_label.rs
+++ b/src-tauri/src/config/delete_label.rs
@@ -96,7 +96,8 @@ pub(crate) fn delete_label_impl(
     let registry = ctx.labels.ok_or(DeleteLabelError::NoProjectOpen)?;
 
     // 削除前の使用数（タスク単位・完全一致）。task 集約へ委譲する。
-    let usage_count = TaskIndex::label_usage_counts(&ctx.tasks)
+    let usage_count = TaskIndex::new(ctx.tasks)
+        .label_usage_counts()
         .get(&args.name)
         .copied()
         .unwrap_or(0);

--- a/src-tauri/src/config/delete_milestone.rs
+++ b/src-tauri/src/config/delete_milestone.rs
@@ -93,7 +93,8 @@ pub(crate) fn delete_milestone_impl(
     let registry = ctx.milestones.ok_or(DeleteMilestoneError::NoProjectOpen)?;
 
     // 削除前の使用数（タスク単位・完全一致）。task 集約へ委譲する。
-    let usage_count = TaskIndex::milestone_usage_counts(&ctx.tasks)
+    let usage_count = TaskIndex::new(ctx.tasks)
+        .milestone_usage_counts()
         .get(&args.name)
         .copied()
         .unwrap_or(0);

--- a/src-tauri/src/config/get_labels.rs
+++ b/src-tauri/src/config/get_labels.rs
@@ -90,7 +90,7 @@ pub(crate) fn get_labels_impl(state: &AppState) -> Result<GetLabelsPayload, GetL
     let registry = state.labels()?.ok_or(GetLabelsError::NoProjectOpen)?;
     let tasks = state.tasks_snapshot()?;
     // 集計は task 集約 TaskIndex のメソッドへ委譲（free function を config 側に作らない）。
-    let usage_counts = TaskIndex::label_usage_counts(&tasks);
+    let usage_counts = TaskIndex::new(tasks).label_usage_counts();
     Ok(GetLabelsPayload {
         labels: registry.labels,
         usage_counts,

--- a/src-tauri/src/config/get_milestones.rs
+++ b/src-tauri/src/config/get_milestones.rs
@@ -75,7 +75,7 @@ pub(crate) fn get_milestones_impl(
     let ctx = state.snapshot_milestone_delete()?;
     let registry = ctx.milestones.ok_or(GetMilestonesError::NoProjectOpen)?;
     // 集計は task 集約 TaskIndex のメソッドへ委譲（free function を config 側に作らない）。
-    let usage_counts = TaskIndex::milestone_usage_counts(&ctx.tasks);
+    let usage_counts = TaskIndex::new(ctx.tasks).milestone_usage_counts();
     Ok(GetMilestonesPayload {
         milestones: registry.milestones,
         usage_counts,

--- a/src-tauri/src/task/add_link/command.rs
+++ b/src-tauri/src/task/add_link/command.rs
@@ -43,9 +43,9 @@ pub(crate) fn add_link_impl(
     let source_abs = project_root.join(&source_rel);
 
     let snapshot = state.tasks_snapshot()?;
-    let existing_source = snapshot
-        .iter()
-        .find(|t| Path::new(t.file_path.as_str()) == source_rel.as_path())
+    let index = TaskIndex::new(snapshot);
+    let existing_source = index
+        .find_by_path(source_rel.as_path())
         .cloned()
         .ok_or_else(|| AddLinkError::SourceNotFound {
             path: source_rel.to_string_lossy().into_owned(),
@@ -66,7 +66,6 @@ pub(crate) fn add_link_impl(
         .map_err(|e| AddLinkError::ParseFailed(e.to_string()))?
         .ok_or_else(|| AddLinkError::ParseFailed("no frontmatter delimiter found".to_string()))?;
 
-    let index = TaskIndex::new(snapshot);
     let outcome = index
         .plan_add_link(
             project_root.as_path(),

--- a/src-tauri/src/task/remove_link/command.rs
+++ b/src-tauri/src/task/remove_link/command.rs
@@ -41,9 +41,9 @@ pub(crate) fn remove_link_impl(
     let source_abs = project_root.join(&source_rel);
 
     let snapshot = state.tasks_snapshot()?;
-    let existing_source = snapshot
-        .iter()
-        .find(|t| Path::new(t.file_path.as_str()) == source_rel.as_path())
+    let index = TaskIndex::new(snapshot);
+    let existing_source = index
+        .find_by_path(source_rel.as_path())
         .cloned()
         .ok_or_else(|| RemoveLinkError::SourceNotFound {
             path: source_rel.to_string_lossy().into_owned(),
@@ -66,7 +66,6 @@ pub(crate) fn remove_link_impl(
             RemoveLinkError::ParseFailed("no frontmatter delimiter found".to_string())
         })?;
 
-    let index = TaskIndex::new(snapshot);
     let outcome = index
         .plan_remove_link(
             project_root.as_path(),

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -277,6 +277,30 @@ impl TaskIndex {
         }
     }
 
+    /// `replaced` で同一 path の slot を差し替え（無ければ末尾に追加）たうえで、
+    /// parent hierarchy 検証 → `children` 再構築 → `reverse_links` 再構築までを
+    /// 一括で行う aggregate メソッド。
+    ///
+    /// parent 変更を伴う `update_task` の cache full-rebuild 手順を aggregate に
+    /// 集約することが目的。slot 差し替えの引き当ては `find_by_path` と同じ
+    /// `normalize_task_path_for_lookup` 基準で行い、表記揺れがあっても同一 task を
+    /// 差し替える（raw string 比較で重複 slot を作らない）。
+    pub(crate) fn rebuild_with_replaced(self, replaced: Task) -> Result<Self, TaskParseError> {
+        let mut values = self.tasks;
+        let target = normalize_task_path_for_lookup(replaced.file_path.as_str());
+        match values
+            .iter_mut()
+            .find(|t| normalize_task_path_for_lookup(t.file_path.as_str()) == target)
+        {
+            Some(slot) => *slot = replaced,
+            None => values.push(replaced),
+        }
+        Self::new(values)
+            .validate_parent_hierarchy()?
+            .build_children()
+            .map(Self::build_reverse_links)
+    }
+
     /// 新規 task が指す parent 文字列を既存 task 集合に対して解決する。
     pub fn resolve_parent_for_new_task(&self, parent: &str) -> Option<usize> {
         resolve_parent_for_new_task(parent, &self.tasks)

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -875,7 +875,7 @@ impl TaskIndex {
             })?;
 
             let default_status = self
-                .find_task_by_path(&path)
+                .find_by_path(&path)
                 .map(|t| t.status.clone())
                 .unwrap_or_else(|| ColumnName::from_lenient(""));
             let context = TaskParseContext {
@@ -894,8 +894,13 @@ impl TaskIndex {
         Ok(ClearChildrenOutcome { entries })
     }
 
-    /// 内部 helper: snapshot 上で `path` と一致する task を返す（正規化済み比較）。
-    fn find_task_by_path(&self, path: &Path) -> Option<&Task> {
+    /// snapshot 上で `path` と一致する task を返す aggregate query（正規化済み比較）。
+    ///
+    /// 引き当ては `normalize_task_path_for_lookup` を介して行うため、`./tasks/x.md` /
+    /// `tasks\x.md` のような表記揺れがあっても aggregate が一貫して使う lookup 基準で
+    /// 同一 task を引き当てる。command 層が `Path::new(t.file_path.as_str()) == rel_path`
+    /// の raw 比較を各自で行うのを避け、引き当て規則を aggregate に集約するために公開する。
+    pub(crate) fn find_by_path(&self, path: &Path) -> Option<&Task> {
         let target = normalize_task_path_for_lookup(&path.to_string_lossy());
         self.tasks
             .iter()

--- a/src-tauri/src/task/task_index.rs
+++ b/src-tauri/src/task/task_index.rs
@@ -131,9 +131,10 @@ impl TaskIndex {
     /// 未正規化（trim / case 変換なし）。キーは所有 `String` で返し、呼び出し側
     /// （`get_labels` / `delete_label`）が借用ライフタイムに縛られないようにする。
     /// 使用数集計は label/config ドメインではなく task 集約に置くことで、依存方向を
-    /// label/config → task の一方向に保つ（task は label を知らない）。
-    pub fn label_usage_counts(tasks: &[Task]) -> HashMap<String, usize> {
-        tasks
+    /// label/config → task の一方向に保つ（task は label を知らない）。aggregate が
+    /// 保持する task 集合を集計対象とするため `&self` メソッドとして公開する。
+    pub fn label_usage_counts(&self) -> HashMap<String, usize> {
+        self.tasks
             .iter()
             // 各タスクを「そのタスクが持つ distinct なラベル集合」へ変換（タスク内重複排除）。
             .flat_map(|task| {
@@ -153,9 +154,10 @@ impl TaskIndex {
     ///
     /// labels（複数）と異なり milestone は単数 string のため、`Option` を 0/1 件に
     /// 展開して畳み込む（タスク内重複は構造的に発生しない）。マスタ未定義の値も
-    /// 出現名で計上する（完全一致・未正規化）。未割当（`None`）は計上しない。
-    pub fn milestone_usage_counts(tasks: &[Task]) -> HashMap<String, usize> {
-        tasks
+    /// 出現名で計上する（完全一致・未正規化）。未割当（`None`）は計上しない。aggregate が
+    /// 保持する task 集合を集計対象とするため `&self` メソッドとして公開する。
+    pub fn milestone_usage_counts(&self) -> HashMap<String, usize> {
+        self.tasks
             .iter()
             .filter_map(|task| task.milestone.as_deref())
             .fold(HashMap::new(), |mut counts, name| {

--- a/src-tauri/src/task/task_index_label_usage_tests.rs
+++ b/src-tauri/src/task/task_index_label_usage_tests.rs
@@ -28,7 +28,7 @@ fn task_with_labels(id: &str, labels: &[&str]) -> Task {
 
 #[test]
 fn empty_for_no_tasks() {
-    let counts = TaskIndex::label_usage_counts(&[]);
+    let counts = TaskIndex::new(Vec::new()).label_usage_counts();
     assert!(counts.is_empty());
 }
 
@@ -39,7 +39,7 @@ fn counts_tasks_using_each_label() {
         task_with_labels("b", &["bug", "feat"]),
         task_with_labels("c", &["bug"]),
     ];
-    let counts = TaskIndex::label_usage_counts(&tasks);
+    let counts = TaskIndex::new(tasks).label_usage_counts();
     assert_eq!(counts.get("bug"), Some(&3));
     assert_eq!(counts.get("feat"), Some(&1));
 }
@@ -48,7 +48,7 @@ fn counts_tasks_using_each_label() {
 fn dedupes_duplicate_label_within_a_task() {
     // 1 タスク内で同じラベルが 2 回出現しても 1 件（タスク単位で数える）。
     let tasks = vec![task_with_labels("a", &["bug", "bug"])];
-    let counts = TaskIndex::label_usage_counts(&tasks);
+    let counts = TaskIndex::new(tasks).label_usage_counts();
     assert_eq!(counts.get("bug"), Some(&1));
 }
 
@@ -58,7 +58,7 @@ fn exact_match_is_case_sensitive_and_not_normalized() {
         task_with_labels("a", &["Bug"]),
         task_with_labels("b", &["bug"]),
     ];
-    let counts = TaskIndex::label_usage_counts(&tasks);
+    let counts = TaskIndex::new(tasks).label_usage_counts();
     assert_eq!(counts.get("Bug"), Some(&1));
     assert_eq!(counts.get("bug"), Some(&1));
 }

--- a/src-tauri/src/task/task_index_milestone_usage_tests.rs
+++ b/src-tauri/src/task/task_index_milestone_usage_tests.rs
@@ -27,7 +27,7 @@ fn task_with_milestone(id: &str, milestone: Option<&str>) -> Task {
 
 #[test]
 fn empty_for_no_tasks() {
-    let counts = TaskIndex::milestone_usage_counts(&[]);
+    let counts = TaskIndex::new(Vec::new()).milestone_usage_counts();
     assert!(counts.is_empty());
 }
 
@@ -39,7 +39,7 @@ fn counts_tasks_per_milestone_and_ignores_unassigned() {
         task_with_milestone("c", Some("v0.4")),
         task_with_milestone("d", None),
     ];
-    let counts = TaskIndex::milestone_usage_counts(&tasks);
+    let counts = TaskIndex::new(tasks).milestone_usage_counts();
     assert_eq!(counts.get("v0.3"), Some(&2));
     assert_eq!(counts.get("v0.4"), Some(&1));
     // 未割当は計上しない（キーが存在しない）。
@@ -53,7 +53,7 @@ fn counts_master_undefined_value_by_occurrence() {
         task_with_milestone("a", Some("undefined-ms")),
         task_with_milestone("b", Some("undefined-ms")),
     ];
-    let counts = TaskIndex::milestone_usage_counts(&tasks);
+    let counts = TaskIndex::new(tasks).milestone_usage_counts();
     assert_eq!(counts.get("undefined-ms"), Some(&2));
 }
 
@@ -63,7 +63,7 @@ fn exact_match_is_case_sensitive_and_not_normalized() {
         task_with_milestone("a", Some("V0.3")),
         task_with_milestone("b", Some("v0.3")),
     ];
-    let counts = TaskIndex::milestone_usage_counts(&tasks);
+    let counts = TaskIndex::new(tasks).milestone_usage_counts();
     assert_eq!(counts.get("V0.3"), Some(&1));
     assert_eq!(counts.get("v0.3"), Some(&1));
 }

--- a/src-tauri/src/task/task_index_tests.rs
+++ b/src-tauri/src/task/task_index_tests.rs
@@ -113,6 +113,51 @@ fn task_index_build_children_via_aggregate() {
 }
 
 #[test]
+fn rebuild_with_replaced_replaces_slot_and_rebuilds_derived_fields() {
+    // 既存 child は parent 未指定。replaced で parent を付けると children 逆引きが再構築される。
+    let tasks = vec![
+        task_without_parent("tasks/child.md"),
+        task_without_parent("tasks/parent.md"),
+    ];
+    let replaced = task_with_parent("tasks/child.md", "tasks/parent.md");
+
+    let rebuilt = TaskIndex::new(tasks)
+        .rebuild_with_replaced(replaced)
+        .unwrap();
+    let result = rebuilt.into_tasks();
+
+    let parent = result
+        .iter()
+        .find(|t| t.file_path == "tasks/parent.md")
+        .unwrap();
+    assert_eq!(parent.children, vec![TaskFilePath::from("tasks/child.md")]);
+}
+
+#[test]
+fn rebuild_with_replaced_appends_when_no_matching_slot() {
+    let tasks = vec![task_without_parent("tasks/a.md")];
+    let replaced = task_without_parent("tasks/b.md");
+
+    let rebuilt = TaskIndex::new(tasks)
+        .rebuild_with_replaced(replaced)
+        .unwrap();
+    let result = rebuilt.into_tasks();
+
+    assert_eq!(result.len(), 2);
+    assert!(result.iter().any(|t| t.file_path == "tasks/b.md"));
+}
+
+#[test]
+fn rebuild_with_replaced_propagates_hierarchy_error() {
+    let tasks = vec![task_with_parent("tasks/a.md", "tasks/b.md")];
+    // replaced で b → a の親を張ると a ↔ b の循環になる。
+    let replaced = task_with_parent("tasks/b.md", "tasks/a.md");
+
+    let result = TaskIndex::new(tasks).rebuild_with_replaced(replaced);
+    assert!(matches!(result, Err(TaskParseError::CycleOrTooDeep { .. })));
+}
+
+#[test]
 fn task_index_validate_parent_hierarchy_via_aggregate() {
     let tasks = vec![
         task_with_parent("tasks/a.md", "tasks/b.md"),

--- a/src-tauri/src/task/task_index_tests.rs
+++ b/src-tauri/src/task/task_index_tests.rs
@@ -136,6 +136,38 @@ fn task_index_resolve_parent_for_new_task_via_aggregate() {
 }
 
 #[test]
+fn find_by_path_returns_matching_task() {
+    let tasks = vec![
+        task_without_parent("tasks/a.md"),
+        task_without_parent("tasks/b.md"),
+    ];
+    let index = TaskIndex::new(tasks);
+
+    let found = index.find_by_path(&PathBuf::from("tasks/b.md")).unwrap();
+    assert_eq!(found.file_path, TaskFilePath::from("tasks/b.md"));
+}
+
+#[test]
+fn find_by_path_normalizes_notation_variants() {
+    // 表記揺れ（`./tasks/a.md` / `tasks\a.md`）でも lookup 正規化で同一 task を引き当てる。
+    let tasks = vec![task_without_parent("tasks/a.md")];
+    let index = TaskIndex::new(tasks);
+
+    assert!(index.find_by_path(&PathBuf::from("./tasks/a.md")).is_some());
+    assert!(index.find_by_path(&PathBuf::from("tasks\\a.md")).is_some());
+}
+
+#[test]
+fn find_by_path_returns_none_for_missing() {
+    let tasks = vec![task_without_parent("tasks/a.md")];
+    let index = TaskIndex::new(tasks);
+
+    assert!(index
+        .find_by_path(&PathBuf::from("tasks/missing.md"))
+        .is_none());
+}
+
+#[test]
 fn task_json_byte_level_round_trip() {
     let json = r#"{"id":"tasks/foo.md","filePath":"tasks/foo.md","title":"Fix bug","status":"Doing","priority":"High","labels":["bug","api"],"parent":"tasks/parent.md","links":["tasks/related.md"],"children":["tasks/child.md"],"reverseLinks":["tasks/source.md"],"body":"description","extras":{},"warnings":[]}"#;
     let parsed: Task = serde_json::from_str(json).unwrap();

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -41,9 +41,9 @@ pub(crate) fn update_task_impl(
     let abs = project_root.join(&rel_path);
 
     let snapshot = state.tasks_snapshot()?;
-    let existing_task = snapshot
-        .iter()
-        .find(|t| Path::new(t.file_path.as_str()) == rel_path.as_path())
+    let index = TaskIndex::new(snapshot);
+    let existing_task = index
+        .find_by_path(rel_path.as_path())
         .cloned()
         .ok_or_else(|| UpdateTaskError::FileNotFound(abs.clone()))?;
 
@@ -61,7 +61,6 @@ pub(crate) fn update_task_impl(
             UpdateTaskError::ParseFailed("no frontmatter delimiter found".to_string())
         })?;
 
-    let index = TaskIndex::new(snapshot);
     let outcome: UpdateTaskOutcome = index
         .plan_update(project_root.as_path(), intent, &existing_task, parsed)
         .map_err(UpdateTaskCommandError::Validation)?;

--- a/src-tauri/src/task/update/command.rs
+++ b/src-tauri/src/task/update/command.rs
@@ -97,22 +97,10 @@ fn commit_cache(
     let returned: Result<Option<Task>, UpdateTaskError> =
         state.with_tasks_cache_mut(|cache: &mut HashMap<PathBuf, Task>| {
             if outcome.needs_full_rebuild {
-                let mut values: Vec<Task> = cache.values().cloned().collect();
-                let target_str = rel_path.to_string_lossy();
-                if let Some(slot) = values
-                    .iter_mut()
-                    .find(|t| t.file_path.as_str() == target_str.as_ref())
-                {
-                    *slot = outcome.updated_task.clone();
-                } else {
-                    values.push(outcome.updated_task.clone());
-                }
+                let values: Vec<Task> = cache.values().cloned().collect();
                 let index = TaskIndex::new(values)
-                    .validate_parent_hierarchy()
-                    .map_err(UpdateTaskError::from)?
-                    .build_children()
-                    .map_err(UpdateTaskError::from)?
-                    .build_reverse_links();
+                    .rebuild_with_replaced(outcome.updated_task.clone())
+                    .map_err(UpdateTaskError::from)?;
                 cache.clear();
                 for task in index.into_tasks() {
                     cache.insert(PathBuf::from(task.file_path.as_str()), task);


### PR DESCRIPTION
## 概要

aggregate メソッド中心方針の仕上げとして、`TaskIndex` の知識が command / config 層に分散していた 3 箇所を aggregate query / メソッドへ集約するリファクタリング。外部仕様（IPC の入出力・画面挙動）は不変。

## 変更の種類

- ♻️ リファクタリング（外部仕様の変更なし）

## 詳細な変更内容

#294 の 3 つの問題に対応（コミットも 3 つに分割）。

### 1. task 引き当てを `TaskIndex::find_by_path` に集約
- `update` / `add_link` / `remove_link` の各 command が `Path::new(t.file_path.as_str()) == rel_path` の raw 比較で task を引き当てていたのを、aggregate が一貫して使う `normalize_task_path_for_lookup` 基準の `TaskIndex::find_by_path` に委譲。
- 既存 private `find_task_by_path` を `pub(crate) find_by_path` に昇格して共有（`plan_clear_children_of` 内の caller も追従）。
- 表記揺れ（`./tasks/x.md` / `tasks\x.md`）吸収の引き当て規則を aggregate に一本化。

### 2. cache full-rebuild 手順を `TaskIndex::rebuild_with_replaced` に集約
- `update_task` の `commit_cache` full-rebuild 分岐が「対象 slot 差し替え → `validate_parent_hierarchy` → `build_children` → `build_reverse_links`」を command 層でオーケストレーションしており、slot 差し替えの知識が `plan_update` と 2 箇所に分散していた。
- 再構築手順を aggregate メソッド `rebuild_with_replaced(self, replaced)` に集約。slot 引き当ても `normalize_task_path_for_lookup` 基準に統一（旧 raw string 比較）。

### 3. `usage_counts` を `&self` メソッド化
- `label_usage_counts` / `milestone_usage_counts` が `tasks: &[Task]` を取る関連関数で、呼び出し側が aggregate を構築せず生 slice を渡していた。両者を `&self` メソッドに変更。
- config 側 caller（`get_labels` / `get_milestones` / `delete_label` / `delete_milestone`）が `TaskIndex` を構築してから集計を呼ぶ形に統一。

## 関連 Issue

Closes #294

## テスト

- 追加: `find_by_path`（一致 / 表記揺れ正規化 / 不在）3 件、`rebuild_with_replaced`（slot 差し替え + 派生再構築 / 末尾追加 / hierarchy エラー伝播）3 件。
- 既存: `label_usage_counts` / `milestone_usage_counts` のテストを `&self` 呼び出しに追従。
- 品質ゲート（src-tauri）すべて pass:
  - \`cargo fmt --check\`: クリーン
  - \`cargo clippy --all-targets\`: 警告ゼロ
  - \`cargo test --lib\`: 988 passed; 0 failed

## レビューポイント

- 外部挙動の不変性: いずれも内部の引き当て / 再構築手順の集約であり、IPC の入出力やエラー型は変えていない。`find_by_path` は正規化引き当てに変わるが、command 層は元々 `rel_path`（正規化済み相対パス）を渡すため挙動は等価。

## 仕様変更

なし（純粋な内部リファクタリングのため `docs/spec-board/` 更新不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)