### PR TITLE
♻️ [Refactoring]: #303 [FE] useMilestones の戻り値参照を安定化（不要再レンダー抑制）

### DIFF
--- a/src/hooks/useMilestones/__tests__/useMilestones.stability.test.tsx
+++ b/src/hooks/useMilestones/__tests__/useMilestones.stability.test.tsx
@@ -1,0 +1,139 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { type MilestonesResource, useMilestones } from "@/hooks/useMilestones";
+import { getMilestones } from "@/lib/tauri";
+import { Result } from "@/utils/result";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    getMilestones: vi.fn(),
+  };
+});
+
+const getMilestonesMock = vi.mocked(getMilestones);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+
+beforeAll(() => {
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+});
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  getMilestonesMock.mockReset();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const captured: { current: MilestonesResource | null } = { current: null };
+
+const capture = (r: MilestonesResource): void => {
+  captured.current = r;
+};
+
+const Probe = ({
+  projectKey,
+  onResult,
+}: {
+  projectKey: string | undefined;
+  onResult: (result: MilestonesResource) => void;
+}) => {
+  const result = useMilestones(projectKey);
+  useEffect(() => {
+    onResult(result);
+  });
+  return null;
+};
+
+const mount = async (
+  projectKey: string | undefined,
+): Promise<MilestonesResource | null> => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(Probe, { projectKey, onResult: capture }));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return captured.current;
+};
+
+const rerender = async (
+  projectKey: string | undefined,
+): Promise<MilestonesResource | null> => {
+  await act(async () => {
+    root?.render(createElement(Probe, { projectKey, onResult: capture }));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return captured.current;
+};
+
+test("同一 projectKey で再レンダーしても戻り値オブジェクトの参照が変わらない", async () => {
+  getMilestonesMock.mockResolvedValue(
+    Result.ok({
+      milestones: [{ name: "v0.3", title: "v0.3 リリース" }],
+      usageCounts: { "v0.3": 1 },
+    }),
+  );
+  const first = await mount("proj-1");
+  const second = await rerender("proj-1");
+  expect(second).toBe(first);
+});
+
+test("同一 projectKey で再レンダーしても byName の Map 参照が変わらない", async () => {
+  getMilestonesMock.mockResolvedValue(
+    Result.ok({
+      milestones: [{ name: "v0.3", title: "v0.3 リリース" }],
+      usageCounts: { "v0.3": 1 },
+    }),
+  );
+  const first = await mount("proj-1");
+  const firstByName = first?.byName;
+  const second = await rerender("proj-1");
+  expect(second?.byName).toBe(firstByName);
+});
+
+test("同一 projectKey で再レンダーしても reload 関数の参照が変わらない", async () => {
+  getMilestonesMock.mockResolvedValue(
+    Result.ok({ milestones: [], usageCounts: {} }),
+  );
+  const first = await mount("proj-1");
+  const firstReload = first?.reload;
+  const second = await rerender("proj-1");
+  expect(second?.reload).toBe(firstReload);
+});

--- a/src/hooks/useMilestones/index.ts
+++ b/src/hooks/useMilestones/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Milestone } from "@/domains/milestone";
 import { getMilestones, type MilestoneDefinition } from "@/lib/tauri";
 
@@ -53,15 +53,12 @@ export const useMilestones = (
   projectKey: string | undefined,
 ): MilestonesResource => {
   const [state, setState] = useState<ResourceState>(IDLE_STATE);
-  // reload() が現在の projectKey で再取得するために最新 key を保持する。
-  const latestKeyRef = useRef<string | undefined>(undefined);
   // 各 load 呼び出しに採番する世代 id。最新世代の応答だけが state を確定する。
   // key 比較だけでは同一 projectKey の重複ロード（初回 + reload）で古い応答が
   // 後勝ちしてしまうため、key ではなく世代 id で stale 応答を破棄する。
   const requestIdRef = useRef(0);
 
   const load = useCallback(async (key: string | undefined): Promise<void> => {
-    latestKeyRef.current = key;
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
     if (key === undefined) {
@@ -93,18 +90,42 @@ export const useMilestones = (
 
   useEffect(() => {
     void load(projectKey);
+    // unmount / 依存変更時に世代 id を進め、解決済みでない in-flight 応答を
+    // stale として破棄する（unmount 後の setState を防ぐ）。
+    return () => {
+      requestIdRef.current += 1;
+    };
   }, [load, projectKey]);
 
   const reload = useCallback((): Promise<void> => {
-    return load(latestKeyRef.current);
-  }, [load]);
+    return load(projectKey);
+  }, [load, projectKey]);
 
-  return {
-    milestones: state.milestones,
-    usageCounts: state.usageCounts,
-    byName: Milestone.byName(state.milestones),
-    status: state.status,
-    error: state.error,
-    reload,
-  };
+  // name → 定義の Map は milestones が変わらない限り同一参照を保ち、
+  // 消費側（memo 化された子コンポーネント）の不要再レンダーを抑える。
+  const byName = useMemo(
+    () => Milestone.byName(state.milestones),
+    [state.milestones],
+  );
+
+  // 戻り値オブジェクトも依存が変わらない限り同一参照を返し、
+  // App 側の useMemo 連鎖が意図どおり効くようにする。
+  return useMemo(
+    () => ({
+      milestones: state.milestones,
+      usageCounts: state.usageCounts,
+      byName,
+      status: state.status,
+      error: state.error,
+      reload,
+    }),
+    [
+      state.milestones,
+      state.usageCounts,
+      byName,
+      state.status,
+      state.error,
+      reload,
+    ],
+  );
 };


### PR DESCRIPTION
## 概要
- `useMilestones` の戻り値オブジェクトと `byName` Map を毎 render 新規生成していたため、memo 化された子コンポーネントの不要再レンダーを誘発していた問題を `useMemo` / `useCallback` で参照安定化して解消する。

## 変更の種類
- ♻️ Refactoring（外部仕様の変更なし）

## 変更した内容
- `byName` Map を `state.milestones` 依存の `useMemo` で安定化（milestones 不変なら同一参照）
- 戻り値オブジェクトを `useMemo` で包み、依存が変わらない限り同一参照を返す
- `reload` を `latestKeyRef` 経由から `projectKey` 依存の `useCallback` に変更し、`useRef` による最新値保持を排除（規約上 ref 保持は最後の手段のため）
- load effect に cleanup を追加し、世代 id (`requestIdRef`) を進めることで unmount 後の in-flight 応答による setState を防止

これにより `src/App.tsx` の `settingsMilestonesResource` useMemo 連鎖が意図どおり効き、`byName` prop の identity 変化に起因する子（BoardWorkspace / DetailScreen 等）の再レンダーが抑制される。

## 削除した内容
- `latestKeyRef`（`useRef` による最新 projectKey 保持）

## 仕様ドキュメント更新
- 不要（純粋なリファクタリング / 内部実装の最適化のみ。公開 API・データ形式・画面挙動・設定項目に変更なし）

## システム図

```mermaid
flowchart TD
  state["state (milestones / usageCounts / status / error)"]
  byName["byName: useMemo(Milestone.byName, [milestones])"]
  reload["reload: useCallback(() => load(projectKey), [load, projectKey])"]
  ret["return: useMemo({...}, [...deps])"]
  consumer["App.tsx settingsMilestonesResource useMemo → memo 子"]

  state --> byName
  state --> ret
  byName --> ret
  reload --> ret
  ret --> consumer

  style byName fill:#dff,stroke:#09c
  style reload fill:#dff,stroke:#09c
  style ret fill:#dff,stroke:#09c
```

## 関連Issue
- Closes #303

## テスト
- `pnpm test:run`: 242 files / 2076 tests すべて green
- `pnpm build`: 成功（tsc -b + vite build）
- `pnpm lint` (oxlint): 0 warnings / 0 errors、Biome check も clean
- 追加テスト（`useMilestones.stability.test.tsx`）: 同一 projectKey 再レンダー時に戻り値オブジェクト / `byName` Map / `reload` の参照が変わらないことを検証
- UI 変更なし（内部参照安定化のみ）のため実機操作確認は対象外

## レビューポイント
- `reload` の依存を `latestKeyRef.current` から `projectKey` に変更した点。load effect が settle した後は両者が一致するため挙動は不変。既存の競合制御テスト（初回 + reload の後勝ち防止）も green を維持している。
- load effect の cleanup による世代 id インクリメントは、`load` 起動時の世代採番と二重に効くが、いずれも古い in-flight を stale 化する方向のみで外部挙動は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)