### PR TITLE
♻️ [Refactoring]: #310 [FE] BoardWorkspace のフィルタ間引きを render 中導出へ

### DIFF
--- a/src/features/board/components/BoardWorkspace/index.tsx
+++ b/src/features/board/components/BoardWorkspace/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import {
   type TabItem,
   TabNav,
@@ -13,7 +13,6 @@ import {
   useBoardViewMode,
 } from "../../hooks/useBoardViewMode";
 import { useTaskFilter } from "../../hooks/useTaskFilter";
-import { pruneTaskFilter } from "../../lib/applyTaskFilter";
 import { Board } from "../Board";
 import { CalendarView } from "../CalendarView";
 import type { ColumnDropParams, ColumnTaskDropParams } from "../Column";
@@ -169,8 +168,6 @@ const ActiveBoardView = ({
 export const BoardWorkspace = (props: BoardWorkspaceProps) => {
   const { tasks, columns, milestones } = props;
   const { viewMode, setViewMode } = useBoardViewMode();
-  const { criteria, setCriteria, clear, filtered, isActive } =
-    useTaskFilter(tasks);
 
   const availableLabels = useMemo(() => collectLabels(tasks), [tasks]);
   const statuses = useMemo(
@@ -183,21 +180,15 @@ export const BoardWorkspace = (props: BoardWorkspaceProps) => {
   );
 
   // カラムのリネーム/削除やマイルストーン削除で選択肢が消えると、UI に出ない条件が
-  // 「隠れフィルタ」として残り続ける。選択肢が変わるたびに条件を間引いて解消する。
-  useEffect(() => {
-    const pruned = pruneTaskFilter(criteria, {
-      statuses,
-      labels: availableLabels,
-      milestoneNames,
-    });
-    const changed =
-      pruned.statuses.length !== criteria.statuses.length ||
-      pruned.labels.length !== criteria.labels.length ||
-      pruned.milestone !== criteria.milestone;
-    if (changed) {
-      setCriteria(pruned);
-    }
-  }, [criteria, statuses, availableLabels, milestoneNames, setCriteria]);
+  // 「隠れフィルタ」として残り続ける。利用可能な選択肢を渡して render 中に間引く。
+  const filterOptions = useMemo(
+    () => ({ statuses, labels: availableLabels, milestoneNames }),
+    [statuses, availableLabels, milestoneNames],
+  );
+  const { criteria, setCriteria, clear, filtered, isActive } = useTaskFilter(
+    tasks,
+    filterOptions,
+  );
 
   return (
     <div className="flex h-full flex-col">

--- a/src/features/board/hooks/useTaskFilter/__tests__/useTaskFilter.pruning.test.tsx
+++ b/src/features/board/hooks/useTaskFilter/__tests__/useTaskFilter.pruning.test.tsx
@@ -1,0 +1,188 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
+import type {
+  TaskFilterCriteria,
+  TaskFilterOptions,
+} from "@/features/board/lib/applyTaskFilter";
+import { Task, type TaskPayload } from "@/types/task";
+import { type UseTaskFilterResult, useTaskFilter } from "../index";
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previous: boolean | undefined;
+
+beforeAll(() => {
+  previous = reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = previous;
+});
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const taskWith = (
+  id: string,
+  status: string,
+  labels: string[],
+  milestone: string | undefined,
+): Task => {
+  const payload: TaskPayload = {
+    id,
+    title: id,
+    status,
+    milestone,
+    labels,
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: `${id}.md`,
+    extras: {},
+    warnings: [],
+  };
+  return Task.fromPayload(payload);
+};
+
+const tasks: Task[] = [
+  taskWith("a", "Todo", ["bug"], "v0.3"),
+  taskWith("b", "Doing", ["chore"], "v0.4"),
+  taskWith("c", "Done", [], undefined),
+];
+
+type ProbeProps = {
+  options: TaskFilterOptions;
+  initialCriteria: TaskFilterCriteria;
+  onResult: (result: UseTaskFilterResult) => void;
+};
+
+const Probe = ({ options, initialCriteria, onResult }: ProbeProps) => {
+  const result = useTaskFilter(tasks, options);
+  const { setCriteria } = result;
+  useEffect(() => {
+    setCriteria(initialCriteria);
+  }, [initialCriteria, setCriteria]);
+  useEffect(() => {
+    onResult(result);
+  });
+  return null;
+};
+
+const mountWith = async (
+  options: TaskFilterOptions,
+  initialCriteria: TaskFilterCriteria,
+): Promise<UseTaskFilterResult | null> => {
+  let latest: UseTaskFilterResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      createElement(Probe, {
+        options,
+        initialCriteria,
+        onResult: (r) => {
+          latest = r;
+        },
+      }),
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return latest;
+};
+
+const allOptions: TaskFilterOptions = {
+  statuses: ["Todo", "Doing", "Done"],
+  labels: ["bug", "chore"],
+  milestoneNames: ["v0.3", "v0.4"],
+};
+
+test("選択肢に存在する条件はそのまま反映される", async () => {
+  const result = await mountWith(allOptions, {
+    keyword: "",
+    labels: [],
+    priorities: [],
+    statuses: ["Todo"],
+    milestone: { kind: "all" },
+  });
+  expect(result?.criteria.statuses).toEqual(["Todo"]);
+  expect(result?.filtered.map((t) => t.id)).toEqual(["a"]);
+  expect(result?.isActive).toBe(true);
+});
+
+test("選択肢から外れた status は render 中に間引かれ filtered に反映される", async () => {
+  // status "Doing" が選択肢から消えた状態。隠れフィルタを残さず全件が見える。
+  const result = await mountWith(
+    {
+      statuses: ["Todo", "Done"],
+      labels: ["bug", "chore"],
+      milestoneNames: ["v0.3", "v0.4"],
+    },
+    {
+      keyword: "",
+      labels: [],
+      priorities: [],
+      statuses: ["Doing"],
+      milestone: { kind: "all" },
+    },
+  );
+  expect(result?.criteria.statuses).toEqual([]);
+  expect(result?.filtered.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  expect(result?.isActive).toBe(false);
+});
+
+test("削除されたマイルストーン条件は render 中に all へ戻る", async () => {
+  const result = await mountWith(
+    {
+      statuses: ["Todo", "Doing", "Done"],
+      labels: ["bug", "chore"],
+      milestoneNames: ["v0.4"],
+    },
+    {
+      keyword: "",
+      labels: [],
+      priorities: [],
+      statuses: [],
+      milestone: { kind: "milestone", name: "v0.3" },
+    },
+  );
+  expect(result?.criteria.milestone).toEqual({ kind: "all" });
+  expect(result?.filtered.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  expect(result?.isActive).toBe(false);
+});
+
+test("選択肢に依存しない keyword / priorities は保持される", async () => {
+  const result = await mountWith(
+    {
+      statuses: ["Todo", "Done"],
+      labels: ["bug", "chore"],
+      milestoneNames: ["v0.4"],
+    },
+    {
+      keyword: "a",
+      labels: [],
+      priorities: [],
+      statuses: ["Doing"],
+      milestone: { kind: "milestone", name: "v0.3" },
+    },
+  );
+  expect(result?.criteria.keyword).toBe("a");
+  expect(result?.criteria.statuses).toEqual([]);
+  expect(result?.criteria.milestone).toEqual({ kind: "all" });
+  expect(result?.isActive).toBe(true);
+});

--- a/src/features/board/hooks/useTaskFilter/index.ts
+++ b/src/features/board/hooks/useTaskFilter/index.ts
@@ -4,12 +4,16 @@ import {
   applyTaskFilter,
   EMPTY_TASK_FILTER,
   isTaskFilterActive,
+  pruneTaskFilter,
   type TaskFilterCriteria,
+  type TaskFilterOptions,
 } from "../../lib/applyTaskFilter";
 
 /** useTaskFilter の返り値。 */
 export type UseTaskFilterResult = {
-  /** 現在の絞り込み条件 */
+  /**
+   * 現在の絞り込み条件。利用可能な選択肢から外れた条件は間引き済み（隠れフィルタを含まない）。
+   */
   criteria: TaskFilterCriteria;
   /**
    * 絞り込み条件を更新する。
@@ -27,16 +31,29 @@ export type UseTaskFilterResult = {
 /**
  * ボード上のタスクを検索キーワード / ラベル / 優先度 / ステータス / マイルストーンで
  * 横断的に絞り込むフィルタ state。board の全ビュー（board / list / tree / calendar）で共有する。
+ *
+ * カラムのリネーム/削除やマイルストーン削除で選択肢が消えると、UI に出ない条件が
+ * 「隠れフィルタ」として残り続ける。raw な条件を state に保持したまま、render 中に
+ * 利用可能な選択肢で間引いた条件を導出してフィルタ結果へ反映する（effect で書き戻さない）。
  * @param tasks - 絞り込み対象のタスク一覧
+ * @param options - 現在利用可能な選択肢（間引きの基準）
  * @returns 絞り込み state と結果
  */
-export const useTaskFilter = (tasks: Task[]): UseTaskFilterResult => {
-  const [criteria, setCriteria] =
+export const useTaskFilter = (
+  tasks: Task[],
+  options: TaskFilterOptions,
+): UseTaskFilterResult => {
+  const [rawCriteria, setCriteria] =
     useState<TaskFilterCriteria>(EMPTY_TASK_FILTER);
 
   const clear = useCallback(() => {
     setCriteria(EMPTY_TASK_FILTER);
   }, []);
+
+  const criteria = useMemo(
+    () => pruneTaskFilter(rawCriteria, options),
+    [rawCriteria, options],
+  );
 
   const filtered = useMemo(
     () => applyTaskFilter(tasks, criteria),


### PR DESCRIPTION
## 概要
- BoardWorkspace のフィルタ間引き（隠れフィルタ解消）を `useEffect + setCriteria` による派生 state の書き戻しから、render 中の純粋導出（`useMemo`）へ置き換える。
- props/state から計算できる derived value を effect で保持しないという React アンチパターンを解消する。

## 変更の種類
- ♻️ Refactoring（外部仕様の変更なし）
- 🧪 Tests

## 変更した内容
- `useTaskFilter(tasks)` → `useTaskFilter(tasks, options)`。raw な `criteria` を state に保持したまま、利用可能な選択肢 `TaskFilterOptions`（statuses / labels / milestoneNames）を受け取り `useMemo` で `pruneTaskFilter` を適用した間引き後 criteria を導出する。公開する `criteria` / `filtered` / `isActive` はすべて間引き後を基準にする。
- `BoardWorkspace` から間引き調整用の `useEffect` を撤去し、選択肢を `useMemo` でメモ化して `useTaskFilter` に渡すだけにした。未使用になった `pruneTaskFilter` / `useEffect` の import も除去。

## 追加した内容
- `useTaskFilter.pruning.test.tsx`: 選択肢から外れた status / 削除されたマイルストーン条件が render 中に間引かれ filtered / isActive / criteria に反映されること、選択肢非依存の keyword / priorities が保持されることを検証（4 ケース）。

## 解消する問題（Issue #310）
- 選択肢が消えた直後の 1 レンダーで隠れフィルタが適用されたままの `filtered` が描画され、その後余計な再レンダーが走っていた問題。
- `criteria` が依存配列にあるため、ユーザーのフィルタ操作のたびに調整 effect が実行されていた無駄。

## システム図
変更前後のデータフロー。

\`\`\`mermaid
flowchart LR
  subgraph before["変更前"]
    rawB["criteria(state)"] --> effB["useEffect: pruneTaskFilter<br/>+ setCriteria 書き戻し"]
    effB -.再レンダー.-> rawB
    rawB --> filtB["filtered / isActive"]
  end
  subgraph after["変更後 [NEW]"]
    rawA["rawCriteria(state)"] --> memoA["useMemo: pruneTaskFilter<br/>(render 中導出)"]
    memoA --> critA["criteria(間引き後)"]
    critA --> filtA["filtered / isActive"]
  end
  style effB fill:#fdd
  style memoA fill:#dfd
\`\`\`

## 仕様ドキュメント更新
不要（純粋なリファクタリング / 内部実装の変更。公開 API・画面挙動・データ形式に外部仕様の変更はない）。

## 関連Issue
Closes #310

## テスト
- `pnpm test:run`: 242 ファイル / 2077 件すべて pass（新規 4 件を含む）。
- `pnpm build`（`tsc -b && vite build`）: 成功。
- `pnpm lint`（oxlint）: 0 warnings / 0 errors。
- `pnpm biome check`（変更ファイル）: クリーン。

## レビューポイント
- 間引きの単一オーナーを `useTaskFilter` 内に集約し、`filtered` / `isActive` / 公開 `criteria` がすべて間引き後を基準にする設計判断。
- `useTaskFilter` は唯一の利用元が BoardWorkspace のため options 引数追加の影響は局所。`filterOptions` は `useMemo` で参照安定化し、間引き `useMemo` の不要な再計算を避けている。
- トレードオフ: raw criteria を保持するため、選択肢が消えて再び現れた場合に旧条件が復活しうる（隠れフィルタは render 中導出で常に解消される）。Issue が提案する render-phase パターンに沿った許容範囲の挙動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)