### PR TITLE
♻️ [Refactoring]: #312 [FE] useRecentProjects の updater から localStorage 副作用を分離

### DIFF
--- a/src/hooks/useRecentProjects/__tests__/useRecentProjects.behavior.test.tsx
+++ b/src/hooks/useRecentProjects/__tests__/useRecentProjects.behavior.test.tsx
@@ -1,0 +1,110 @@
+import { act, createElement, StrictMode, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import {
+  RECENT_PROJECTS_STORAGE_KEY,
+  type UseRecentProjectsResult,
+  useRecentProjects,
+} from "../index";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  localStorage.clear();
+});
+
+/**
+ * useRecentProjects の戻り値を観測する Probe。
+ * @param props - 最新値を受け取るコールバック
+ * @returns null
+ */
+const Probe = (props: { onResult: (r: UseRecentProjectsResult) => void }) => {
+  const result = useRecentProjects();
+  useEffect(() => {
+    props.onResult(result);
+  });
+  return null;
+};
+
+/**
+ * Probe を StrictMode 下でマウントし、最新値を取得する。
+ * @returns latest accessor
+ */
+const renderHook = () => {
+  let latest: UseRecentProjectsResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const handleResult = (r: UseRecentProjectsResult) => {
+    latest = r;
+  };
+  act(() => {
+    root?.render(
+      createElement(
+        StrictMode,
+        null,
+        createElement(Probe, { onResult: handleResult }),
+      ),
+    );
+  });
+  return {
+    get latest(): UseRecentProjectsResult {
+      return latest as UseRecentProjectsResult;
+    },
+  };
+};
+
+const readStored = (): unknown =>
+  JSON.parse(localStorage.getItem(RECENT_PROJECTS_STORAGE_KEY) ?? "null");
+
+test("add は projects state を更新し localStorage へ永続化する", () => {
+  const probe = renderHook();
+  act(() => {
+    probe.latest.add("/home/user/proj");
+  });
+  expect(probe.latest.projects).toEqual([
+    { path: "/home/user/proj", name: "proj" },
+  ]);
+  expect(readStored()).toEqual([{ path: "/home/user/proj", name: "proj" }]);
+});
+
+test("StrictMode の updater 二重実行でも履歴が二重追加されない", () => {
+  const probe = renderHook();
+  act(() => {
+    probe.latest.add("/a");
+  });
+  act(() => {
+    probe.latest.add("/a");
+  });
+  expect(probe.latest.projects.map((project) => project.path)).toEqual(["/a"]);
+  expect(readStored()).toEqual([{ path: "/a", name: "a" }]);
+});
+
+test("連続 add は最新を先頭にして永続化する", () => {
+  const probe = renderHook();
+  act(() => {
+    probe.latest.add("/a");
+  });
+  act(() => {
+    probe.latest.add("/b");
+  });
+  expect(probe.latest.projects.map((project) => project.path)).toEqual([
+    "/b",
+    "/a",
+  ]);
+  expect(readStored()).toEqual([
+    { path: "/b", name: "b" },
+    { path: "/a", name: "a" },
+  ]);
+});

--- a/src/hooks/useRecentProjects/index.ts
+++ b/src/hooks/useRecentProjects/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** 最近開いたプロジェクト 1 件。 */
 export type RecentProject = {
@@ -112,18 +112,29 @@ export type UseRecentProjectsResult = {
  */
 export const useRecentProjects = (): UseRecentProjectsResult => {
   const [projects, setProjects] = useState<RecentProject[]>(loadRecentProjects);
+  // 初回マウントは localStorage から復元した値そのものなので、書き戻しを抑止する。
+  const isHydratedRef = useRef(false);
 
+  // updater は純粋に保ち、localStorage への永続化（副作用）は projects の
+  // 変化に追従する外部システム同期として effect 側に分離する。
   const add = useCallback((path: string) => {
-    setProjects((prev) => {
-      const next = addRecentProject(prev, path);
-      try {
-        localStorage.setItem(RECENT_PROJECTS_STORAGE_KEY, JSON.stringify(next));
-      } catch {
-        // 永続化失敗は履歴を揮発させるだけなので黙殺する
-      }
-      return next;
-    });
+    setProjects((prev) => addRecentProject(prev, path));
   }, []);
+
+  useEffect(() => {
+    if (!isHydratedRef.current) {
+      isHydratedRef.current = true;
+      return;
+    }
+    try {
+      localStorage.setItem(
+        RECENT_PROJECTS_STORAGE_KEY,
+        JSON.stringify(projects),
+      );
+    } catch {
+      // 永続化失敗は履歴を揮発させるだけなので黙殺する
+    }
+  }, [projects]);
 
   return { projects, add };
 };


### PR DESCRIPTION
## 概要

`useRecentProjects` の `add` で `setProjects` の updater 関数内に置かれていた `localStorage.setItem` 副作用を除去し、updater を純粋に保つ。永続化は `projects` の変化に追従する `useEffect` 側へ分離した。外部挙動は不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）
- 🧪 Tests（回帰テスト追加）

## 変更した内容

- `src/hooks/useRecentProjects/index.ts`
  - `add` の updater を `setProjects((prev) => addRecentProject(prev, path))` の純粋関数に変更（副作用を含まない）
  - `localStorage.setItem` を `projects` 依存の `useEffect` へ移動（外部システム同期として分離）
  - `add` の依存配列は空のまま維持し参照安定性を保つ
  - 初回マウントは localStorage 復元値そのものなので、`isHydratedRef` で書き戻しを抑止し書き込みタイミングを従来と一致させる

## 追加した内容

- `src/hooks/useRecentProjects/__tests__/useRecentProjects.behavior.test.tsx`
  - `add` が state 更新 + 永続化を行うこと、StrictMode の updater 二重実行でも履歴が二重追加されないこと、連続 add が最新先頭で永続化されることを固定する回帰テスト 3 件

## 仕様ドキュメント更新

不要（純粋な内部実装リファクタリング。公開 API・データ形式・画面挙動・設定項目に変更なし。`add` のシグネチャ・`projects` の値・localStorage の保存形式はすべて不変）。

## システム図

\`\`\`mermaid
flowchart LR
  subgraph Before["Before（副作用が updater 内）"]
    A1["add(path)"] --> B1["setProjects(updater)"]
    B1 --> C1["updater 内で<br/>addRecentProject + localStorage.setItem"]
  end
  subgraph After["After（副作用を effect へ分離）"]
    A2["add(path)"] --> B2["setProjects(pure updater)<br/>= addRecentProject のみ"]
    B2 --> D2["projects 変化"]
    D2 --> E2["useEffect([projects])<br/>localStorage.setItem"]
  end
  style C1 fill:#ffd5d5
  style E2 fill:#d5ffd5
\`\`\`

## 関連Issue

Closes #312

## テスト

- \`pnpm test:run\`: 242 ファイル / 2076 テスト 全パス
- \`pnpm build\`: 成功（tsc -b + vite build）
- \`pnpm lint\`（oxlint）: 0 warnings / 0 errors
- Biome check: クリーン
- 回帰確認: 当初 updater を残したまま `projects` を `add` の依存に入れる素朴案は、App 側の「読み込み完了時に履歴へ記録する」effect が `add` 参照変化で再実行され無限ループ（Maximum update depth exceeded）になることを `App.interaction` テストで検出。effect 分離 + `add` 参照安定化で解消済み。

## レビューポイント

- `add` の参照安定性を維持した理由: `src/App.tsx` の `useEffect(() => { addRecentProject(loadedPath) }, [loadedPath, addRecentProject])` が `add` を依存に持つため、`add` の identity を変えると永続化のたびに effect が再発火し無限ループ化する。よって updater を純粋化しつつ `add` は空依存を維持し、副作用は別 effect に逃がす設計とした。
- `isHydratedRef` による初回書き戻し抑止は、従来「add 時のみ書き込む」挙動を保つための措置（StrictMode 二重実行・本番いずれでも復元値の冪等な書き込みに留まり実害なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)