### PR TITLE
♻️ [Refactoring]: #302 [FE] マイルストーン表示ルール（badgeLabel / 並べ替え）のドメイン集約

### DIFF
--- a/src/domains/milestone/__tests__/milestone.behavior.test.ts
+++ b/src/domains/milestone/__tests__/milestone.behavior.test.ts
@@ -76,3 +76,51 @@ test("usageCounts は未設定（undefined / 空文字）のタスクを数え�
 test("usageCounts はタスク 0 件で空オブジェクトを返す", () => {
   expect(Milestone.usageCounts([])).toEqual({});
 });
+
+test("sortByOrder は order 昇順に並べ替える", () => {
+  const milestones: MilestoneDefinition[] = [
+    { name: "b", order: 2 },
+    { name: "a", order: 1 },
+    { name: "c", order: 3 },
+  ];
+  expect(Milestone.sortByOrder(milestones).map((m) => m.name)).toEqual([
+    "a",
+    "b",
+    "c",
+  ]);
+});
+
+test("sortByOrder は order 未指定を末尾に置く", () => {
+  const milestones: MilestoneDefinition[] = [
+    { name: "noOrder" },
+    { name: "ordered", order: 1 },
+  ];
+  expect(Milestone.sortByOrder(milestones).map((m) => m.name)).toEqual([
+    "ordered",
+    "noOrder",
+  ]);
+});
+
+test("sortByOrder は order 同値のとき定義順を保つ（安定）", () => {
+  const milestones: MilestoneDefinition[] = [
+    { name: "x", order: 1 },
+    { name: "y", order: 1 },
+  ];
+  expect(Milestone.sortByOrder(milestones).map((m) => m.name)).toEqual([
+    "x",
+    "y",
+  ]);
+});
+
+test("sortByOrder は order 全件未指定のとき定義順を保つ（安定）", () => {
+  const milestones: MilestoneDefinition[] = [
+    { name: "p" },
+    { name: "q" },
+    { name: "r" },
+  ];
+  expect(Milestone.sortByOrder(milestones).map((m) => m.name)).toEqual([
+    "p",
+    "q",
+    "r",
+  ]);
+});

--- a/src/domains/milestone/index.ts
+++ b/src/domains/milestone/index.ts
@@ -64,4 +64,32 @@ export const Milestone = {
     milestones: readonly MilestoneDefinition[],
   ): Map<string, MilestoneDefinition> =>
     new Map(milestones.map((m) => [m.name, m])),
+
+  /**
+   * マイルストーンを表示順に並べ替える。
+   * order 昇順を基本とし、order 未指定は末尾へ送る。order 同値・両方未指定の場合は
+   * 元の定義順を保つ（安定ソート）。
+   * @param milestones - マイルストーン定義の配列（定義順）
+   * @returns 並べ替え済みの新しい配列
+   */
+  sortByOrder: (
+    milestones: readonly MilestoneDefinition[],
+  ): MilestoneDefinition[] =>
+    milestones
+      .map((m, index) => ({ m, index }))
+      .sort((a, b) => {
+        const ao = a.m.order;
+        const bo = b.m.order;
+        if (ao === undefined && bo === undefined) {
+          return a.index - b.index;
+        }
+        if (ao === undefined) {
+          return 1;
+        }
+        if (bo === undefined) {
+          return -1;
+        }
+        return ao === bo ? a.index - b.index : ao - bo;
+      })
+      .map((entry) => entry.m),
 } as const;

--- a/src/features/board/components/MilestoneFilter/index.tsx
+++ b/src/features/board/components/MilestoneFilter/index.tsx
@@ -1,3 +1,4 @@
+import { Milestone } from "@/domains/milestone";
 import type { MilestoneDefinition } from "@/lib/tauri";
 import type { MilestoneFilter as MilestoneFilterValue } from "../../hooks/useMilestoneFilter";
 
@@ -71,7 +72,7 @@ export const MilestoneFilter = ({
       <option value={UNASSIGNED_VALUE}>未割当</option>
       {milestones.map((m) => (
         <option key={m.name} value={`${MILESTONE_PREFIX}${m.name}`}>
-          {m.title ?? m.name}
+          {Milestone.badgeLabel(m.name, m)}
         </option>
       ))}
     </select>

--- a/src/features/milestoneView/components/MilestoneViewScreen/index.tsx
+++ b/src/features/milestoneView/components/MilestoneViewScreen/index.tsx
@@ -1,34 +1,7 @@
 import { Milestone } from "@/domains/milestone";
 import type { MilestonesResource } from "@/hooks/useMilestones";
-import type { MilestoneDefinition } from "@/lib/tauri";
 import type { Task } from "@/types/task";
 import { useMilestoneProgress } from "../../hooks/useMilestoneProgress";
-
-/**
- * マイルストーンを表示順（order 昇順・未指定は末尾・定義順安定）に並べ替える。
- * @param milestones - マイルストーン定義の配列（定義順）
- * @returns 並べ替え済み配列
- */
-const sortByOrder = (
-  milestones: readonly MilestoneDefinition[],
-): MilestoneDefinition[] =>
-  milestones
-    .map((m, index) => ({ m, index }))
-    .sort((a, b) => {
-      const ao = a.m.order;
-      const bo = b.m.order;
-      if (ao === undefined && bo === undefined) {
-        return a.index - b.index;
-      }
-      if (ao === undefined) {
-        return 1;
-      }
-      if (bo === undefined) {
-        return -1;
-      }
-      return ao === bo ? a.index - b.index : ao - bo;
-    })
-    .map((entry) => entry.m);
 
 type MilestoneViewScreenProps = {
   /** マイルストーンリソース（唯一の取得点から配る） */
@@ -50,7 +23,7 @@ export const MilestoneViewScreen = ({
   tasks,
   doneColumn,
 }: MilestoneViewScreenProps) => {
-  const sorted = sortByOrder(resource.milestones);
+  const sorted = Milestone.sortByOrder(resource.milestones);
   const names = sorted.map((m) => m.name);
   const progress = useMilestoneProgress(names, tasks, doneColumn);
 
@@ -78,7 +51,9 @@ export const MilestoneViewScreen = ({
             className="flex flex-col gap-1 rounded border border-border p-3"
           >
             <div className="flex items-center gap-2">
-              <span className="font-medium">{def.title ?? def.name}</span>
+              <span className="font-medium">
+                {Milestone.badgeLabel(def.name, def)}
+              </span>
               {def.due !== undefined ? (
                 <span className="text-sm text-muted">{def.due}</span>
               ) : null}

--- a/src/features/settings/components/MilestoneSettingsTab/index.tsx
+++ b/src/features/settings/components/MilestoneSettingsTab/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Milestone } from "@/domains/milestone";
 import type { MilestonesResource } from "@/hooks/useMilestones";
 import type { CreateMilestoneArgs, MilestoneDefinition } from "@/lib/tauri";
 import { useMilestoneMutations } from "../../hooks/useMilestoneMutations";
@@ -175,7 +176,9 @@ export const MilestoneSettingsTab = ({
               className="flex items-center gap-2 text-sm"
               data-testid="milestone-row"
             >
-              <span className="font-medium">{def.title ?? def.name}</span>
+              <span className="font-medium">
+                {Milestone.badgeLabel(def.name, def)}
+              </span>
               <span className="text-muted">{def.name}</span>
               {def.due !== undefined ? (
                 <span className="text-muted">{def.due}</span>


### PR DESCRIPTION
## 概要

`src/domains/milestone` に companion API があるにもかかわらず、マイルストーンの表示ルール（表示名フォールバック・並べ替え）を各 feature が直書きしており、表示が箇所によって揺れていた。これらの業務ルールをドメイン層 `domains/milestone` に集約し、呼び出し側を委譲する。外部挙動は不変（空文字 title 時の表示統一を除く。後述）。

## 変更の種類

- ♻️ リファクタリング

## 詳細な変更内容

### 追加
- `Milestone.sortByOrder`（`src/domains/milestone/index.ts`）— order 昇順・未指定末尾・定義順安定の並べ替えを companion API として追加。`MilestoneViewScreen` のコンポーネント内ローカル関数を移設。
- `sortByOrder` の振る舞いテスト 4 件（昇順 / 未指定末尾 / 同値安定 / 全件未指定安定）。

### 変更（呼び出し側の委譲）
- `MilestoneFilter`（board）: option ラベルを `m.title ?? m.name` → `Milestone.badgeLabel(m.name, m)`。
- `MilestoneViewScreen`（milestoneView）: 表示名を `def.title ?? def.name` → `Milestone.badgeLabel(def.name, def)`、並べ替えを `Milestone.sortByOrder` に委譲、ローカル `sortByOrder` を削除。
- `MilestoneSettingsTab`（settings）: 一覧の表示名を `def.title ?? def.name` → `Milestone.badgeLabel(def.name, def)`。

```mermaid
flowchart LR
  subgraph before[Before]
    F1[MilestoneFilter] -->|title ?? name| X1[表示]
    V1[MilestoneViewScreen] -->|local sortByOrder + title ?? name| X2[表示]
    S1[MilestoneSettingsTab] -->|title ?? name| X3[表示]
  end
  subgraph after[After]
    F2[MilestoneFilter] --> D[Milestone companion]
    V2[MilestoneViewScreen] --> D
    S2[MilestoneSettingsTab] --> D
    D -->|badgeLabel / sortByOrder| X[表示]
  end
  style D fill:#cef,stroke:#06c
```

## 動作変更について

`badgeLabel` は空文字 `title` も `name` にフォールバックする（`title ?? name` は空文字をそのまま表示する）。このため **空文字 title 時の表示が 3 箇所で統一**される。`config-spec.md` は title 未指定時に `name` をフォールバック表示すると規定済みであり、空文字を未指定相当に倒す本変更は仕様により近づくため、spec ドキュメントの更新は不要。

## テスト

- `pnpm test:run`: 241 ファイル / 2077 件 全パス
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- `biome check src`: クリーン

## レビューポイント

- `Milestone.sortByOrder` の移設前後でロジックが同一であること（順序契約は `config-spec.md` の order 並び規則と一致）。
- 空文字 title 時のフォールバック統一が許容される変更であること。

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)