### PR TITLE
♻️ [Refactoring]: #304 [FE] 重複ロジックの集約（todayLocal / basenameOf / ラベル追加ルール）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { useRecentProjects } from "@/hooks/useRecentProjects";
 import { useToasts } from "@/hooks/useToasts";
 import type { OrphanStrategy } from "@/lib/tauri";
 import { registerToastSink } from "@/lib/tauri/toastSink";
+import { basenameOf } from "@/utils/path";
 import {
   BoardWorkspace,
   EmptyState,
@@ -345,12 +346,7 @@ export const App = () => {
   // / / \ どちらにも対応する (Windows / POSIX 双方)。
   const displayedPath = state.kind === "loaded" ? state.path : null;
   const projectName =
-    displayedPath !== null
-      ? (displayedPath
-          .split(/[\\/]/)
-          .filter((seg) => seg.length > 0)
-          .pop() ?? displayedPath)
-      : undefined;
+    displayedPath !== null ? basenameOf(displayedPath) : undefined;
   const selectedTask = resolveSelectedTask(
     selectedTaskId,
     tasks,

--- a/src/components/DueBadge/index.tsx
+++ b/src/components/DueBadge/index.tsx
@@ -1,17 +1,5 @@
 import { Due } from "@/domains/due";
 
-/**
- * クライアントのローカル日付を `YYYY-MM-DD` で返す。
- * @returns ローカルタイムゾーンでの今日の日付
- */
-const todayLocal = (): string => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
-
 type DueBadgeProps = {
   /** 期限の生文字列（未検証・未設定可） */
   due: string | undefined;
@@ -24,7 +12,7 @@ type DueBadgeProps = {
  * @param props - {@link DueBadgeProps}
  * @returns 期限バッジ要素。未設定・不正時は null。overdue は赤系背景で強調。
  */
-export const DueBadge = ({ due, today = todayLocal() }: DueBadgeProps) => {
+export const DueBadge = ({ due, today = Due.todayLocal() }: DueBadgeProps) => {
   const label = Due.format(due, today);
   if (label === undefined) {
     return null;

--- a/src/domains/due/__tests__/due.behavior.test.ts
+++ b/src/domains/due/__tests__/due.behavior.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { Due } from "..";
 
 const TODAY = "2026-06-01";
@@ -57,4 +57,18 @@ test.each([
   { due: "2026/6/30", expected: false, label: "不正値" },
 ])("isOverdue $label は $expected", ({ due, expected }) => {
   expect(Due.isOverdue(due, TODAY)).toBe(expected);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test.each([
+  { now: new Date(2026, 5, 1, 9, 30), expected: "2026-06-01" },
+  { now: new Date(2026, 0, 5, 0, 0), expected: "2026-01-05" },
+  { now: new Date(2026, 11, 31, 23, 59), expected: "2026-12-31" },
+])("todayLocal はローカル日付を $expected で返す", ({ now, expected }) => {
+  vi.useFakeTimers();
+  vi.setSystemTime(now);
+  expect(Due.todayLocal()).toBe(expected);
 });

--- a/src/domains/due/index.ts
+++ b/src/domains/due/index.ts
@@ -38,6 +38,20 @@ const toUtcEpoch = (date: string): number | undefined => {
 /** Due の companion API。 */
 export const Due = {
   /**
+   * クライアントのローカルタイムゾーンでの今日の日付を `YYYY-MM-DD` で返す。
+   * 各セグメントはゼロ詰めする（例: 2026 年 6 月 1 日 → "2026-06-01"）。
+   *
+   * @returns ローカル日付の `YYYY-MM-DD` 文字列
+   */
+  todayLocal: (): string => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  },
+
+  /**
    * 任意の文字列を検証済み Due | undefined に正規化する。
    * 空文字・未設定・不正フォーマットはすべて undefined。
    * 成功時のみ branded Due を返す（cast はこの 1 箇所に閉じる）。

--- a/src/domains/label-add-rule/__tests__/label-add-rule.behavior.test.ts
+++ b/src/domains/label-add-rule/__tests__/label-add-rule.behavior.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "vitest";
+import { LabelAddRule } from "..";
+
+test('classify([], "x") は added で value="x"', () => {
+  expect(LabelAddRule.classify([], "x")).toEqual({ kind: "added", value: "x" });
+});
+
+test('classify(["a"], "  b  ") は trim して added で value="b"', () => {
+  expect(LabelAddRule.classify(["a"], "  b  ")).toEqual({
+    kind: "added",
+    value: "b",
+  });
+});
+
+test.each([
+  { input: "", label: "空文字" },
+  { input: "   ", label: "空白のみ" },
+])("classify(current, $label) は empty", ({ input }) => {
+  expect(LabelAddRule.classify(["a"], input)).toEqual({ kind: "empty" });
+});
+
+test('classify(["a"], "a") は duplicate で value="a"', () => {
+  expect(LabelAddRule.classify(["a"], "a")).toEqual({
+    kind: "duplicate",
+    value: "a",
+  });
+});
+
+test('classify(["b"], "  b  ") は trim 後一致で duplicate', () => {
+  expect(LabelAddRule.classify(["b"], "  b  ")).toEqual({
+    kind: "duplicate",
+    value: "b",
+  });
+});

--- a/src/domains/label-add-rule/index.ts
+++ b/src/domains/label-add-rule/index.ts
@@ -1,0 +1,37 @@
+/**
+ * ラベルを追加候補に取り込む際の判定結果（discriminated union）。
+ * trim 後の文字列を基準に「空 / 重複 / 追加可」を区別する。
+ * - `empty`: trim 後が空文字。追加候補にならない
+ * - `duplicate`: trim 後の値が既存ラベルに含まれる
+ * - `added`: 追加できる新規ラベル（`value` は trim 済み）
+ */
+export type LabelAddDecision =
+  | { kind: "empty" }
+  | { kind: "duplicate"; value: string }
+  | { kind: "added"; value: string };
+
+/**
+ * ラベル追加の判定ルール companion。
+ * 「trim 後空なら拒否・既存に含まれるなら重複・それ以外は追加可」という
+ * 単一ルールを集約し、state 形状の異なる各 feature から委譲して使う。
+ */
+export const LabelAddRule = {
+  /**
+   * 入力をトリムし、既存ラベルに対して追加可否を分類する。
+   * 比較は完全一致（trim 済みの値同士）で行う。
+   *
+   * @param current - 既存ラベル一覧
+   * @param input - 追加候補の文字列（trim 前）
+   * @returns 判定結果。`added` の場合 `value` は trim 済みの新規ラベル
+   */
+  classify: (current: readonly string[], input: string): LabelAddDecision => {
+    const trimmed = input.trim();
+    if (trimmed.length === 0) {
+      return { kind: "empty" };
+    }
+    if (current.includes(trimmed)) {
+      return { kind: "duplicate", value: trimmed };
+    }
+    return { kind: "added", value: trimmed };
+  },
+} as const;

--- a/src/features/board/components/CalendarView/index.tsx
+++ b/src/features/board/components/CalendarView/index.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Due } from "@/domains/due";
 import type { Task } from "@/types/task";
 import {
   addMonth,
@@ -31,17 +32,6 @@ const currentYearMonth = (): YearMonth => {
 };
 
 /**
- * クライアントのローカル日付を `YYYY-MM-DD` で返す。
- * @returns 今日の日付文字列
- */
-const todayLocal = (): string => {
-  const now = new Date();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${now.getFullYear()}-${month}-${day}`;
-};
-
-/**
  * 期限日でタスクを配置する月間カレンダービュー。前後の月へ移動でき、
  * 期限なし / 不正な期限のタスクは下部にまとめて表示する。
  * @param props - {@link CalendarViewProps}
@@ -50,7 +40,7 @@ const todayLocal = (): string => {
 export const CalendarView = ({ tasks, onTaskClick }: CalendarViewProps) => {
   const [visibleMonth, setVisibleMonth] = useState<YearMonth>(currentYearMonth);
   // 「今日」ハイライトが深夜 0 時跨ぎでも当日に追従するよう、軽量なので都度計算する。
-  const today = todayLocal();
+  const today = Due.todayLocal();
 
   const weeks = useMemo(
     () => buildMonthGrid(visibleMonth.year, visibleMonth.month),

--- a/src/features/detail/domains/label/index.ts
+++ b/src/features/detail/domains/label/index.ts
@@ -1,3 +1,5 @@
+import { LabelAddRule } from "@/domains/label-add-rule";
+
 /** ラベル一覧（不変） */
 export type Labels = readonly string[];
 
@@ -8,19 +10,17 @@ export type Labels = readonly string[];
 export const Labels = {
   /**
    * 入力をトリムして追加可能なら新しい配列を返す。空文字・空白のみ・重複は null。
+   * 追加可否の判定は共有ルール {@link LabelAddRule.classify} に委譲する。
    * @param current - 現在のラベル一覧
    * @param input - 追加候補の文字列（trim 前）
    * @returns 追加成功時は新しい配列、追加不可なら null
    */
   tryAdd: (current: Labels, input: string): Labels | null => {
-    const trimmed = input.trim();
-    if (trimmed.length === 0) {
+    const decision = LabelAddRule.classify(current, input);
+    if (decision.kind !== "added") {
       return null;
     }
-    if (current.includes(trimmed)) {
-      return null;
-    }
-    return [...current, trimmed];
+    return [...current, decision.value];
   },
 
   /**

--- a/src/features/task-form/lib/fields/labels/index.ts
+++ b/src/features/task-form/lib/fields/labels/index.ts
@@ -1,3 +1,5 @@
+import { LabelAddRule } from "@/domains/label-add-rule";
+
 /** LabelsField が保持する値の型 */
 export type LabelsField = {
   /** 確定済みラベル一覧 */
@@ -10,19 +12,21 @@ export type LabelsField = {
  * 指定の生文字列を labels に取り込む共通規則。
  * trim 後空なら field 不変、重複なら labelInput だけクリア、新規なら追加 + クリア。
  * `commit`（labelInput の取り込み）と `commitValue`（サジェスト確定値の取り込み）で共有する。
+ * 追加可否の判定は共有ルール {@link LabelAddRule.classify} に委譲し、field 形状への
+ * 反映だけをこの関数で行う。
  * @param field - 現在の field
  * @param raw - 取り込む生文字列
  * @returns 新しい field
  */
 const takeIn = (field: LabelsField, raw: string): LabelsField => {
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) {
+  const decision = LabelAddRule.classify(field.labels, raw);
+  if (decision.kind === "empty") {
     return field;
   }
-  if (field.labels.includes(trimmed)) {
+  if (decision.kind === "duplicate") {
     return { ...field, labelInput: "" };
   }
-  return { labels: [...field.labels, trimmed], labelInput: "" };
+  return { labels: [...field.labels, decision.value], labelInput: "" };
 };
 
 /**

--- a/src/hooks/useRecentProjects/__tests__/useRecentProjects.unit.test.ts
+++ b/src/hooks/useRecentProjects/__tests__/useRecentProjects.unit.test.ts
@@ -1,19 +1,9 @@
 import { expect, test } from "vitest";
 import {
   addRecentProject,
-  basenameOf,
   normalizeRecentProjects,
   type RecentProject,
 } from "../index";
-
-test.each([
-  ["/home/user/my-project", "my-project"],
-  ["/home/user/my-project/", "my-project"],
-  ["C:\\Users\\me\\proj", "proj"],
-  ["single", "single"],
-])("basenameOf(%s) は末尾セグメントを返す", (input, expected) => {
-  expect(basenameOf(input)).toBe(expected);
-});
 
 test("addRecentProject は新規パスを先頭に name 付きで追加する", () => {
   const result = addRecentProject([], "/home/user/proj");

--- a/src/hooks/useRecentProjects/index.ts
+++ b/src/hooks/useRecentProjects/index.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { basenameOf } from "@/utils/path";
 
 /** 最近開いたプロジェクト 1 件。 */
 export type RecentProject = {
@@ -13,16 +14,6 @@ export const RECENT_PROJECTS_STORAGE_KEY = "spec-board:recentProjects";
 
 /** 履歴の最大保持件数。 */
 const MAX_RECENT_PROJECTS = 8;
-
-/**
- * パスの末尾セグメント（フォルダ名）を取り出す。区切りは `/` と `\` の両方を許容する。
- * @param path - プロジェクトの絶対パス
- * @returns 末尾セグメント。取り出せなければパス全体
- */
-export const basenameOf = (path: string): string => {
-  const segments = path.split(/[\\/]+/).filter((segment) => segment !== "");
-  return segments[segments.length - 1] ?? path;
-};
 
 /**
  * 履歴へパスを追加する。既存の同一パスは先頭へ繰り上げ、上限件数で切り詰める。

--- a/src/utils/path/__tests__/path.behavior.test.ts
+++ b/src/utils/path/__tests__/path.behavior.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "vitest";
+import { basenameOf } from "..";
+
+test.each([
+  ["/home/user/my-project", "my-project"],
+  ["/home/user/my-project/", "my-project"],
+  ["C:\\Users\\me\\proj", "proj"],
+  ["single", "single"],
+  ["/home//user///proj", "proj"],
+  ["", ""],
+])("basenameOf(%s) は末尾セグメントを返す", (input, expected) => {
+  expect(basenameOf(input)).toBe(expected);
+});

--- a/src/utils/path/index.ts
+++ b/src/utils/path/index.ts
@@ -1,0 +1,11 @@
+/**
+ * パスの末尾セグメント（フォルダ名 / ファイル名）を取り出す。
+ * 区切りは `/` と `\` の両方を許容し、末尾の区切りや連続した区切りは無視する。
+ *
+ * @param path - 任意のパス文字列（POSIX / Windows どちらの区切りでも可）
+ * @returns 末尾セグメント。空にならなければそれを、取り出せなければパス全体を返す
+ */
+export const basenameOf = (path: string): string => {
+  const segments = path.split(/[\\/]+/).filter((segment) => segment !== "");
+  return segments[segments.length - 1] ?? path;
+};


### PR DESCRIPTION
## 概要

別実装で重複していた 3 組のロジックを共有 domains / utils へ集約し、各呼び出し側を委譲した。外部挙動は不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 追加した内容

- `src/domains/due` に `Due.todayLocal()`（ローカル今日を `YYYY-MM-DD` で返す）
- `src/utils/path` に汎用ユーティリティ `basenameOf`（パス末尾セグメント抽出）+ テスト
- `src/domains/label-add-rule` に `LabelAddRule.classify`（trim 後の `empty` / `duplicate` / `added` を返す判定ルール）+ テスト

## 変更した内容

- **todayLocal**: `DueBadge` / `CalendarView` に同一実装で重複していた `todayLocal` を削除し、`Due.todayLocal()` を参照
- **basenameOf**: `useRecentProjects` 内に閉じていた `basenameOf` を `@/utils/path` へ移設し、`App.tsx` のインライン末尾セグメント抽出もこれに委譲（両実装は末尾の空セグメント除外で等価のため挙動不変）。`basenameOf` のテストも `useRecentProjects` のテストから `utils/path` 側へ移設
- **ラベル追加ルール**: detail の `Labels.tryAdd` と task-form の `LabelsField.takeIn` がそれぞれ持っていた「trim 後空なら拒否・重複なら拒否」判定を `LabelAddRule.classify` へ委譲。state 形状（配列 / field）への反映だけを各 feature 側に残す

## 削除した内容

- `DueBadge` / `CalendarView` のローカル `todayLocal` 関数
- `useRecentProjects` のローカル `basenameOf` 関数
- `Labels.tryAdd` / `takeIn` 内の重複した trim・重複判定ロジック

## 仕様ドキュメント更新

不要（純粋なリファクタリング / 内部実装の集約のみ。公開挙動・データ形式・画面挙動・設定項目に変更なし）。

## システム図

```mermaid
flowchart LR
  subgraph before["集約前（重複実装）"]
    DB1["DueBadge.todayLocal"]
    CV1["CalendarView.todayLocal"]
    APP1["App.tsx inline split"]
    URP1["useRecentProjects.basenameOf"]
    LT1["Labels.tryAdd 判定"]
    TI1["takeIn 判定"]
  end
  subgraph after["集約後（単一実装に委譲）"]
    DUE["Due.todayLocal"]
    PATH["utils/path.basenameOf"]
    RULE["LabelAddRule.classify"]
  end
  DB1 --> DUE
  CV1 --> DUE
  APP1 --> PATH
  URP1 --> PATH
  LT1 --> RULE
  TI1 --> RULE
```

## 関連Issue

Closes #304

## テスト

- `pnpm test:run`: 243 files / 2084 tests すべて pass
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- `pnpm exec biome check src`: clean
- UI の見た目・挙動に変更はないため実機操作確認は対象外（集約前後で出力同一）

## レビューポイント

- 3 組とも「重複が本当に等価か」を確認したうえで統合している。特に `basenameOf` は App.tsx 側が `/[\\/]/`（`+` なし）、useRecentProjects 側が `/[\\/]+/` だが、いずれも空セグメントを `filter` で除外するため出力は同一
- `LabelAddRule.classify` は配列を持つ detail と `{ labels, labelInput }` を持つ task-form で state 形状が異なるため、判定（empty / duplicate / added）のみを共有し、反映は各 feature に残す設計にした