### PR TITLE
♻️ [Refactoring]: #300 [FE] サブIssue 進捗集計・完了判定ルールを src/domains に一元化

### DIFF
--- a/src/domains/project-columns/__tests__/project-columns.done-column.test.ts
+++ b/src/domains/project-columns/__tests__/project-columns.done-column.test.ts
@@ -81,3 +81,22 @@ test("validateDoneColumn は doneColumn が columns に存在すれば ok を返
 
   expect(result.ok).toBe(true);
 });
+
+test("resolveDoneColumn は override 指定があればそれを返す", () => {
+  expect(
+    ProjectColumns.resolveDoneColumn(columns("Todo", "Done"), "Custom"),
+  ).toBe("Custom");
+});
+
+test('resolveDoneColumn は空 columns かつ override 未指定なら "Done"', () => {
+  expect(ProjectColumns.resolveDoneColumn([], undefined)).toBe("Done");
+});
+
+test("resolveDoneColumn は override 未指定なら order 最大のカラム名を返す", () => {
+  const cols: Column[] = [
+    { name: "A", order: 0 },
+    { name: "B", order: 5 },
+    { name: "C", order: 3 },
+  ];
+  expect(ProjectColumns.resolveDoneColumn(cols, undefined)).toBe("B");
+});

--- a/src/domains/project-columns/index.ts
+++ b/src/domains/project-columns/index.ts
@@ -17,6 +17,9 @@ export type ProjectColumnsValidationError = {
   message: string;
 };
 
+/** doneColumn が解決できないときに使う既定の完了カラム名。 */
+export const DEFAULT_DONE_COLUMN = "Done";
+
 /**
  * change 適用後に既存 column が削除されるか判定する。
  *
@@ -28,6 +31,20 @@ const isColumnRemoved = (
   column: Column,
   change: ProjectColumnsChange,
 ): boolean => !change.columns.some((next) => next.name === column.name);
+
+/**
+ * order が最大の column を返す（同 order は先勝ち）。空配列なら undefined。
+ *
+ * @param columns 対象 column 一覧
+ * @returns order 最大の column。空なら undefined
+ */
+const maxOrderColumn = (columns: readonly Column[]): Column | undefined =>
+  columns.reduce<Column | undefined>((currentMax, column) => {
+    if (currentMax === undefined || column.order > currentMax.order) {
+      return column;
+    }
+    return currentMax;
+  }, undefined);
 
 export const ProjectColumns = {
   /**
@@ -81,5 +98,26 @@ export const ProjectColumns = {
     }
 
     return Result.ok(undefined);
+  },
+
+  /**
+   * 完了として扱うカラム名を解決する。
+   *
+   * 明示指定（`override`）があればそれを最優先で返し、なければ order が最大の
+   * カラムを完了カラムとみなす。columns が空など解決できないときは既定値 "Done" を返す。
+   * ビューをまたいだ「完了カラムの解決ルール」の単一の真実源。
+   *
+   * @param columns カラム一覧
+   * @param override 明示的な完了カラム名（任意）
+   * @returns 完了カラム名
+   */
+  resolveDoneColumn: (
+    columns: readonly Column[],
+    override: string | undefined,
+  ): string => {
+    if (override !== undefined) {
+      return override;
+    }
+    return maxOrderColumn(columns)?.name ?? DEFAULT_DONE_COLUMN;
   },
 } as const;

--- a/src/domains/task-hierarchy/__tests__/taskHierarchy.countSubIssueProgress.test.ts
+++ b/src/domains/task-hierarchy/__tests__/taskHierarchy.countSubIssueProgress.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 import { makeTask } from "@/domains/__tests__/taskFixtures";
 import { TaskHierarchy } from "@/domains/task-hierarchy";
 
-test("countSubIssueProgress は完了数と総数を返す", () => {
+test("countSubIssueProgress は完了数・総数・進捗率を返す", () => {
   const descendants = [
     makeTask({ id: "a", status: "Done" }),
     makeTask({ id: "b", status: "Todo" }),
@@ -11,17 +11,19 @@ test("countSubIssueProgress は完了数と総数を返す", () => {
   expect(TaskHierarchy.countSubIssueProgress(descendants, "Done")).toEqual({
     done: 2,
     total: 3,
+    percentage: 67,
   });
 });
 
-test("countSubIssueProgress は子孫が空なら done/total ともに 0", () => {
+test("countSubIssueProgress は子孫が空なら done/total/percentage ともに 0", () => {
   expect(TaskHierarchy.countSubIssueProgress([], "Done")).toEqual({
     done: 0,
     total: 0,
+    percentage: 0,
   });
 });
 
-test("countSubIssueProgress は全件完了なら done と total が一致する", () => {
+test("countSubIssueProgress は全件完了なら done と total が一致し percentage=100", () => {
   const descendants = [
     makeTask({ id: "a", status: "Done" }),
     makeTask({ id: "b", status: "Done" }),
@@ -29,6 +31,7 @@ test("countSubIssueProgress は全件完了なら done と total が一致する
   expect(TaskHierarchy.countSubIssueProgress(descendants, "Done")).toEqual({
     done: 2,
     total: 2,
+    percentage: 100,
   });
 });
 
@@ -40,5 +43,19 @@ test("countSubIssueProgress は doneColumn 以外のステータスを未完了�
   expect(TaskHierarchy.countSubIssueProgress(descendants, "Done")).toEqual({
     done: 1,
     total: 2,
+    percentage: 50,
+  });
+});
+
+test("countSubIssueProgress は percentage を Math.round で丸める（3 件中 1 件 done で 33）", () => {
+  const descendants = [
+    makeTask({ id: "a", status: "Done" }),
+    makeTask({ id: "b", status: "Todo" }),
+    makeTask({ id: "c", status: "Todo" }),
+  ];
+  expect(TaskHierarchy.countSubIssueProgress(descendants, "Done")).toEqual({
+    done: 1,
+    total: 3,
+    percentage: 33,
   });
 });

--- a/src/domains/task-hierarchy/index.ts
+++ b/src/domains/task-hierarchy/index.ts
@@ -1,5 +1,5 @@
 import { parentReferencesTaskPath } from "@/domains/task-path";
-import type { Task } from "@/types/task";
+import { Task } from "@/types/task";
 
 /** Task の親子階層情報 */
 export type TaskHierarchy = {
@@ -7,6 +7,16 @@ export type TaskHierarchy = {
   parentFilePath?: string;
   /** 子タスクのファイルパスの配列（parent から逆引き） */
   childFilePaths: string[];
+};
+
+/** サブ Issue 進捗の集計結果。X/Y サマリと進捗バーが共有する単一の真実源。 */
+export type SubIssueProgress = {
+  /** 完了している件数 */
+  done: number;
+  /** 集計対象の総数 */
+  total: number;
+  /** 進捗率（0-100、Math.round。総数 0 のときは 0） */
+  percentage: number;
 };
 
 /**
@@ -176,19 +186,23 @@ export const TaskHierarchy = {
   },
 
   /**
-   * 子孫タスクの完了数 / 総数を集計する。
-   * カードフッターと進捗バーが同じ値を表示するための X/Y サマリの単一の真実源。
+   * 子孫タスクの完了数 / 総数 / 進捗率を集計する。
+   * カードフッター・進捗バー・サブIssue セクションが同じ値を表示するための
+   * サブIssue 進捗の単一の真実源。完了判定は `Task.isDone` に委譲する。
    *
    * @param descendantTasks 集計対象の子孫タスク（`collectDescendants` の結果を想定）
    * @param doneColumn 完了として扱うカラム名
-   * @returns 完了数 `done` と総数 `total`
+   * @returns 完了数 `done` / 総数 `total` / 進捗率 `percentage`（総数 0 のときは 0）
    */
   countSubIssueProgress: (
     descendantTasks: readonly Task[],
     doneColumn: string,
-  ): { done: number; total: number } => {
+  ): SubIssueProgress => {
     const total = descendantTasks.length;
-    const done = descendantTasks.filter((t) => t.status === doneColumn).length;
-    return { done, total };
+    const done = descendantTasks.filter((task) =>
+      Task.isDone(task, doneColumn),
+    ).length;
+    const percentage = total === 0 ? 0 : Math.round((done / total) * 100);
+    return { done, total, percentage };
   },
 } as const;

--- a/src/features/board/components/SubIssueProgress/index.tsx
+++ b/src/features/board/components/SubIssueProgress/index.tsx
@@ -1,4 +1,4 @@
-import type { Task } from "@/types/task";
+import { Task } from "@/types/task";
 
 type SubIssueProgressProps = {
   /** 直下子（<details> 内の名前一覧用） */
@@ -64,7 +64,7 @@ export const SubIssueProgress = ({
         <ul className="mt-1 ml-4 space-y-0.5 text-xs text-foreground">
           {childTasks.map((child) => (
             <li key={child.id} className="flex items-center gap-1.5">
-              <StatusIcon isDone={child.status === doneColumn} />
+              <StatusIcon isDone={Task.isDone(child, doneColumn)} />
               <span>{child.title || child.filePath}</span>
             </li>
           ))}

--- a/src/features/board/components/TaskCard/index.tsx
+++ b/src/features/board/components/TaskCard/index.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { DueBadge } from "@/components/DueBadge";
 import { ParseErrorIcon } from "@/components/ParseErrorIcon";
 import { WarningIcon } from "@/components/WarningIcon";
+import { DEFAULT_DONE_COLUMN } from "@/domains/project-columns";
 import { TaskHierarchy } from "@/domains/task-hierarchy";
 import type { MilestoneDefinition } from "@/lib/tauri";
 import type { Task } from "@/types/task";
@@ -71,7 +72,7 @@ const CardContent = ({
   task,
   childTasks = [],
   descendantTasks,
-  doneColumn = "Done",
+  doneColumn = DEFAULT_DONE_COLUMN,
   milestonesByName,
   hasBrokenLink = false,
   hasParseError = false,

--- a/src/features/detail/components/SubIssueSection/index.tsx
+++ b/src/features/detail/components/SubIssueSection/index.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 import { BrokenRefLabel } from "@/components/BrokenRefLabel";
 import { buildTasksByNormalizedPath } from "@/domains/broken-link";
+import { TaskHierarchy } from "@/domains/task-hierarchy";
 import { normalizeRefPathForLookup } from "@/domains/task-path";
-import { SubIssue } from "@/features/detail/domains/sub-issue";
-import type { Task } from "@/types/task";
+import { Task } from "@/types/task";
 
 type SubIssueSectionProps = {
   /** 親タスク */
@@ -98,7 +98,7 @@ export const SubIssueSection = ({
   onChildClick,
   brokenChildPaths,
 }: SubIssueSectionProps) => {
-  const { total, doneCount, percentage } = SubIssue.progress(
+  const { total, done, percentage } = TaskHierarchy.countSubIssueProgress(
     descendantTasks,
     doneColumn,
   );
@@ -120,7 +120,7 @@ export const SubIssueSection = ({
     <div data-testid="sub-issue-section">
       <div className="mb-2 flex items-center justify-between">
         <span className="text-xs font-medium text-muted">
-          サブIssue {showProgress ? `(${doneCount}/${total})` : ""}
+          サブIssue {showProgress ? `(${done}/${total})` : ""}
         </span>
       </div>
       {showProgress && (
@@ -131,7 +131,7 @@ export const SubIssueSection = ({
             aria-valuenow={percentage}
             aria-valuemin={0}
             aria-valuemax={100}
-            aria-label={`進捗 ${doneCount}/${total}`}
+            aria-label={`進捗 ${done}/${total}`}
           >
             <div
               className="h-full rounded-full bg-green-500 transition-all"
@@ -139,7 +139,7 @@ export const SubIssueSection = ({
             />
           </div>
           <span className="text-xs text-muted">
-            {doneCount}/{total}
+            {done}/{total}
           </span>
         </div>
       )}
@@ -160,7 +160,7 @@ export const SubIssueSection = ({
               );
             }
             const child = row.task;
-            const isDone = child.status === doneColumn;
+            const isDone = Task.isDone(child, doneColumn);
             const label = child.title || child.filePath;
             return (
               <li key={child.id}>

--- a/src/features/detail/domains/sub-issue/__tests__/sub-issue.behavior.test.ts
+++ b/src/features/detail/domains/sub-issue/__tests__/sub-issue.behavior.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "vitest";
-import type { Column } from "@/types/column";
 import { Task, type TaskPayload } from "@/types/task";
 import { SubIssue } from "../index";
 
@@ -56,69 +55,4 @@ test("SubIssue.filter は parent の軽量正規化で子タスクを返す", ()
 test("SubIssue.filter は該当なしの場合に空配列を返す", () => {
   const t1 = makeTask({ id: "1", parent: "/other" });
   expect(SubIssue.filter([t1], "/parent")).toEqual([]);
-});
-
-test("SubIssue.progress({total:0}) は {0,0,0}", () => {
-  expect(SubIssue.progress([], "Done")).toEqual({
-    total: 0,
-    doneCount: 0,
-    percentage: 0,
-  });
-});
-
-test("SubIssue.progress 全件完了で percentage=100", () => {
-  const tasks = [
-    makeTask({ id: "1", status: "Done" }),
-    makeTask({ id: "2", status: "Done" }),
-  ];
-  expect(SubIssue.progress(tasks, "Done")).toEqual({
-    total: 2,
-    doneCount: 2,
-    percentage: 100,
-  });
-});
-
-test("SubIssue.progress 4 件中 2 件 done で percentage=50", () => {
-  const tasks = [
-    makeTask({ id: "1", status: "Done" }),
-    makeTask({ id: "2", status: "Done" }),
-    makeTask({ id: "3", status: "Todo" }),
-    makeTask({ id: "4", status: "Todo" }),
-  ];
-  expect(SubIssue.progress(tasks, "Done")).toEqual({
-    total: 4,
-    doneCount: 2,
-    percentage: 50,
-  });
-});
-
-test("SubIssue.progress 3 件中 1 件 done で percentage=33（Math.round）", () => {
-  const tasks = [
-    makeTask({ id: "1", status: "Done" }),
-    makeTask({ id: "2", status: "Todo" }),
-    makeTask({ id: "3", status: "Todo" }),
-  ];
-  expect(SubIssue.progress(tasks, "Done")).toEqual({
-    total: 3,
-    doneCount: 1,
-    percentage: 33,
-  });
-});
-
-test("SubIssue.resolveDoneColumn(override 指定) は override を返す", () => {
-  const columns: Column[] = [{ name: "A", order: 0 }];
-  expect(SubIssue.resolveDoneColumn(columns, "Custom")).toBe("Custom");
-});
-
-test('SubIssue.resolveDoneColumn(空 columns) は "Done"', () => {
-  expect(SubIssue.resolveDoneColumn([], undefined)).toBe("Done");
-});
-
-test("SubIssue.resolveDoneColumn は order 最大のカラムを返す", () => {
-  const columns: Column[] = [
-    { name: "A", order: 0 },
-    { name: "B", order: 5 },
-    { name: "C", order: 3 },
-  ];
-  expect(SubIssue.resolveDoneColumn(columns, undefined)).toBe("B");
 });

--- a/src/features/detail/domains/sub-issue/index.ts
+++ b/src/features/detail/domains/sub-issue/index.ts
@@ -1,20 +1,13 @@
 import { parentReferencesTaskPath } from "@/domains/task-path";
-import type { Column } from "@/types/column";
 import type { Task } from "@/types/task";
-
-/** サブ Issue の進捗集計 */
-export type SubIssueProgress = {
-  /** 子タスクの総件数 */
-  total: number;
-  /** 完了している件数 */
-  doneCount: number;
-  /** 進捗率（0-100、Math.round） */
-  percentage: number;
-};
 
 /**
  * サブ Issue ドメインの companion。
- * 子タスクの抽出、進捗計算、完了カラムの解決を提供する純粋関数群。
+ * 親タスク配下の直接の子タスク抽出を提供する純粋関数群。
+ *
+ * 進捗集計（`TaskHierarchy.countSubIssueProgress`）・完了判定（`Task.isDone`）・
+ * 完了カラム解決（`ProjectColumns.resolveDoneColumn`）はビュー横断の単一の真実源として
+ * `src/domains/` に一元化されており、ここでは扱わない。
  */
 export const SubIssue = {
   /**
@@ -33,48 +26,5 @@ export const SubIssue = {
     return allTasks.filter((t) =>
       parentReferencesTaskPath(t.hierarchy.parentFilePath, parentFilePath),
     );
-  },
-
-  /**
-   * 子タスク群の進捗を集計する。
-   * @param childTasks - 子タスクの配列
-   * @param doneColumn - 完了として扱うカラム名
-   * @returns 進捗集計結果
-   */
-  progress: (
-    childTasks: readonly Task[],
-    doneColumn: string,
-  ): SubIssueProgress => {
-    const total = childTasks.length;
-    if (total === 0) {
-      return { total: 0, doneCount: 0, percentage: 0 };
-    }
-    const doneCount = childTasks.filter((t) => t.status === doneColumn).length;
-    const percentage = Math.round((doneCount / total) * 100);
-    return { total, doneCount, percentage };
-  },
-
-  /**
-   * 完了カラム名を解決する。明示的な指定があればそれを優先し、
-   * なければカラム順序が最大のカラムを選ぶ（フォールバック: "Done"）。
-   * @param columns - カラム一覧
-   * @param override - 明示的な完了カラム名（任意）
-   * @returns 完了カラム名
-   */
-  resolveDoneColumn: (
-    columns: readonly Column[],
-    override: string | undefined,
-  ): string => {
-    if (override !== undefined) {
-      return override;
-    }
-    const maxOrderColumn = columns.reduce<Column | undefined>(
-      (currentMax, column) =>
-        currentMax === undefined || column.order > currentMax.order
-          ? column
-          : currentMax,
-      undefined,
-    );
-    return maxOrderColumn?.name ?? "Done";
   },
 } as const;

--- a/src/features/detail/hooks/useChildTasks/index.ts
+++ b/src/features/detail/hooks/useChildTasks/index.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { ProjectColumns } from "@/domains/project-columns";
 import { TaskHierarchy } from "@/domains/task-hierarchy";
 import { SubIssue } from "@/features/detail/domains/sub-issue";
 import type { Column } from "@/types/column";
@@ -51,7 +52,7 @@ export const useChildTasks = (args: UseChildTasksArgs): UseChildTasksResult => {
     return TaskHierarchy.collectDescendants(allTasks, parentFilePath);
   }, [allTasks, parentFilePath]);
   const effectiveDoneColumn = useMemo(
-    () => SubIssue.resolveDoneColumn(columns, doneColumn),
+    () => ProjectColumns.resolveDoneColumn(columns, doneColumn),
     [columns, doneColumn],
   );
   return { childTasks, descendantTasks, effectiveDoneColumn };

--- a/src/features/milestoneView/hooks/useMilestoneProgress/index.ts
+++ b/src/features/milestoneView/hooks/useMilestoneProgress/index.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { Task } from "@/types/task";
+import { Task } from "@/types/task";
 
 /** マイルストーン 1 件分の進捗。 */
 export type MilestoneProgress = {
@@ -46,7 +46,7 @@ export const computeMilestoneProgress = (
       continue;
     }
     entry.total += 1;
-    if (task.status === doneColumn) {
+    if (Task.isDone(task, doneColumn)) {
       entry.done += 1;
     }
   }

--- a/src/types/__tests__/task.isDone.test.ts
+++ b/src/types/__tests__/task.isDone.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+
+/**
+ * テスト用の Task を生成するファクトリ。
+ * @param overrides - 上書きするフィールド
+ * @returns Task オブジェクト
+ */
+const makeTask = (overrides: Partial<TaskPayload>): Task =>
+  Task.fromPayload({
+    id: "id",
+    title: "title",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "/p",
+    ...overrides,
+  });
+
+test("Task.isDone は status が doneColumn と一致すれば true", () => {
+  const task = makeTask({ status: "Done" });
+  expect(Task.isDone(task, "Done")).toBe(true);
+});
+
+test("Task.isDone は status が doneColumn と異なれば false", () => {
+  const task = makeTask({ status: "In Progress" });
+  expect(Task.isDone(task, "Done")).toBe(false);
+});
+
+test("Task.isDone は doneColumn が undefined のとき常に false", () => {
+  const task = makeTask({ status: "Done" });
+  expect(Task.isDone(task, undefined)).toBe(false);
+});

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -144,4 +144,15 @@ export const Task = {
       childFilePaths: payload.children,
     },
   }),
+
+  /**
+   * タスクが完了しているか判定する。
+   * 「完了」の唯一の真実源として、`status` が完了カラム名と一致するかだけで判定する。
+   *
+   * @param task 判定対象のタスク
+   * @param doneColumn 完了として扱うカラム名（未解決のときは undefined）
+   * @returns `status` が `doneColumn` と一致すれば true。`doneColumn` が undefined のときは常に false
+   */
+  isDone: (task: Task, doneColumn: string | undefined): boolean =>
+    doneColumn !== undefined && task.status === doneColumn,
 } as const;


### PR DESCRIPTION
## 概要

サブIssue の進捗集計・完了判定・完了カラム解決という業務ルールが複数 feature に別実装で散在し、ビューによって判定がズレうる状態だったため、これらを `src/domains`（および `Task` companion）に一元化し、呼び出し側を委譲に置き換える。外部挙動は不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 追加した内容

- `Task.isDone(task, doneColumn)`（`src/types/task.ts`）— 完了判定の単一の真実源。`doneColumn` が undefined のときは常に false。
- `ProjectColumns.resolveDoneColumn(columns, override)` / `DEFAULT_DONE_COLUMN`（`src/domains/project-columns`）— 完了カラム解決ルールの単一の真実源（override 優先 → order 最大カラム → 既定値 "Done"）。

## 変更した内容

- `TaskHierarchy.countSubIssueProgress` の戻り値に `percentage` を追加し進捗集計を統合（`{ done, total, percentage }`）。完了判定は `Task.isDone` へ委譲。
- 呼び出し側を一元化 API へ委譲:
  - `TaskCard`: `"Done"` 直書きを `DEFAULT_DONE_COLUMN` 参照に置換
  - `SubIssueProgress` / `SubIssueSection` / `useMilestoneProgress`: 子タスクの完了判定を `Task.isDone` へ委譲
  - `SubIssueSection`: 進捗集計を `countSubIssueProgress` へ委譲
  - `useChildTasks`: 完了カラム解決を `ProjectColumns.resolveDoneColumn` へ委譲

## 削除した内容

- detail feature の `SubIssue` companion から重複していた `progress` / `resolveDoneColumn` を削除（直接子抽出の `filter` のみ残置）。`SubIssueProgress` 型も同 companion から削除。

## 仕様ドキュメント更新

不要（純粋な内部一元化リファクタリングで外部挙動は不変）。`config-spec.md`（doneColumn 既定値=最後のカラム名）・`board-view-spec.md`（進捗バーは全子孫の完了カラム一致件数）の記述と挙動は一致しており、乖離はない。

## システム図

```mermaid
flowchart TD
  subgraph domains["src/domains + Task companion （単一の真実源）"]
    isDone["Task.isDone（NEW）"]
    count["TaskHierarchy.countSubIssueProgress（+percentage）"]
    resolve["ProjectColumns.resolveDoneColumn / DEFAULT_DONE_COLUMN（NEW）"]
    count --> isDone
  end

  TaskCard --> count
  TaskCard --> resolve
  SubIssueProgress --> isDone
  SubIssueSection --> count
  SubIssueSection --> isDone
  useChildTasks --> resolve
  useMilestoneProgress --> isDone

  style isDone fill:#dff5dd
  style count fill:#dff5dd
  style resolve fill:#dff5dd
```

## 関連Issue

Closes #300

## テスト

- `pnpm test:run`: 242 files / 2073 tests すべて pass
- `pnpm build`（`tsc -b && vite build`）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- biome check: クリーン

進捗集計・完了判定の単体テストは新 API 側（`task.isDone.test.ts` / `taskHierarchy.countSubIssueProgress.test.ts` / `project-columns.done-column.test.ts`）へ集約し、重複していた `sub-issue.behavior.test.ts` の progress / resolveDoneColumn ケースは削除。

## レビューポイント

- `Task.isDone` の undefined 安全化（`doneColumn === undefined` で false）が既存の `status === doneColumn` 直書きと等価であること（実タスク status は undefined にならないため、`useMilestoneProgress` を含め挙動不変）。
- `TaskCard` は `columns` を受け取らないため、`"Done"` 既定値を `resolveDoneColumn` の最大 order 解決には置き換えず、解決ルールの既定値 `DEFAULT_DONE_COLUMN` の参照に留めた（外部挙動不変を優先）。