### PR TITLE
♻️ [Refactoring]: #301 [FE] domains/milestone ⇄ lib/tauri の双方向依存を解消

### DIFF
--- a/src/domains/milestone/__tests__/milestone.behavior.test.ts
+++ b/src/domains/milestone/__tests__/milestone.behavior.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "vitest";
-import type { MilestoneDefinition } from "@/lib/tauri";
 import { Task } from "@/types/task";
-import { Milestone } from "../index";
+import { Milestone, type MilestoneDefinition } from "../index";
 
 test.each([
   ["closed", "closed"],

--- a/src/domains/milestone/index.ts
+++ b/src/domains/milestone/index.ts
@@ -1,5 +1,25 @@
-import type { MilestoneDefinition, MilestoneState } from "@/lib/tauri";
 import type { Task } from "@/types/task";
+
+/** マイルストーンの開閉状態。`open` / `closed` 以外の未知値も保持する。 */
+export type MilestoneState = "open" | "closed" | (string & {});
+
+/** マイルストーンマスタ定義 1 件。`name` のみ必須、他は任意。 */
+export type MilestoneDefinition = {
+  /** マイルストーン識別子（完全一致・未正規化）。frontmatter `milestone` から参照される */
+  name: string;
+  /** 人間可読な表示名。未指定時は表示層が name をフォールバックする */
+  title?: string;
+  /** マイルストーンの説明文 */
+  description?: string;
+  /** 期日（ISO 8601 推奨・文字列のまま保持） */
+  due?: string;
+  /** 表示順序（昇順・非負整数） */
+  order?: number;
+  /** 開閉状態（open / closed 等。未知値も保持） */
+  state?: MilestoneState;
+  /** 最終更新日時（ISO 8601 推奨・文字列のまま保持） */
+  updated?: string;
+};
 
 /** マイルストーンの表示・参照に使う共有ドメイン companion。 */
 export const Milestone = {

--- a/src/lib/tauri/milestoneCommands/types.ts
+++ b/src/lib/tauri/milestoneCommands/types.ts
@@ -1,23 +1,7 @@
-/** マイルストーンの開閉状態。`open` / `closed` 以外の未知値も保持する。 */
-export type MilestoneState = "open" | "closed" | (string & {});
+import type { MilestoneDefinition, MilestoneState } from "@/domains/milestone";
 
-/** マイルストーンマスタ定義 1 件。`name` のみ必須、他は任意。 */
-export type MilestoneDefinition = {
-  /** マイルストーン識別子（完全一致・未正規化）。frontmatter `milestone` から参照される */
-  name: string;
-  /** 人間可読な表示名。未指定時は表示層が name をフォールバックする */
-  title?: string;
-  /** マイルストーンの説明文 */
-  description?: string;
-  /** 期日（ISO 8601 推奨・文字列のまま保持） */
-  due?: string;
-  /** 表示順序（昇順・非負整数） */
-  order?: number;
-  /** 開閉状態（open / closed 等。未知値も保持） */
-  state?: MilestoneState;
-  /** 最終更新日時（ISO 8601 推奨・文字列のまま保持） */
-  updated?: string;
-};
+// ドメイン型を IPC 公開 API としても利用できるよう再公開する（依存方向は lib/tauri → domains）。
+export type { MilestoneDefinition, MilestoneState };
 
 /**
  * get_milestones 戻り値ペイロード。`milestones` は milestones.yml の定義順を保持する。


### PR DESCRIPTION
## 概要
- ドメイン層（`src/domains/milestone`）と IPC 層（`src/lib/tauri`）の双方向依存を解消し、依存方向を `lib/tauri → domains` に統一した。
- `MilestoneDefinition` / `MilestoneState` の型定義を `domains/milestone` 側へ移し、`lib/tauri/milestoneCommands/types.ts` は domains 型を import + 再公開する形に変更した。

## 変更の種類
- ♻️ リファクタリング（外部仕様の変更なし）

## 詳細な変更内容
- `src/domains/milestone/index.ts`
  - `MilestoneDefinition` / `MilestoneState` の型定義を追加（ここを source of truth に）。
  - これまでの `import type { ... } from "@/lib/tauri"` を削除し、ドメイン層が IPC 層へ逆依存しないようにした。
- `src/lib/tauri/milestoneCommands/types.ts`
  - 型定義の実体を削除し、`@/domains/milestone` から import。
  - 既存の `@/lib/tauri` 公開 API を壊さないよう、両型を `export type` で再公開（`taskCommands/types.ts → @/domains/priority` と同じ「lib/tauri → domains」方向に揃えた）。
- `src/domains/milestone/__tests__/milestone.behavior.test.ts`
  - `MilestoneDefinition` の import を `@/lib/tauri` 経由から自ドメイン `../index` へ付け替え、テストが IPC 層へ逆依存しない自己完結な参照にした。

## 依存方向

\`\`\`mermaid
flowchart LR
  subgraph before["変更前（双方向）"]
    D1[domains/milestone]
    L1[lib/tauri/milestoneCommands]
    D1 -->|import type| L1
    L1 -->|import type| D1
  end
  subgraph after["変更後（一方向）"]
    D2[domains/milestone<br/>型の source of truth]
    L2[lib/tauri/milestoneCommands]
    L2 -->|import + 再公開| D2
  end
  style D2 fill:#d3f9d8
\`\`\`

## 動作変更なし契約
- IPC payload の形（serde 互換）と各関数のシグネチャは維持。型の置き場とテスト import のみの移動で、`@/lib/tauri` から `MilestoneDefinition` / `MilestoneState` を import する既存の消費側（TaskCard / MilestoneBadge / useMilestones 等）は無変更で動作する。
- 仕様（公開 API・データ形式・画面挙動・設定）の変更はないため `docs/spec-board/` の更新は不要。

## テスト
- `pnpm test:run`: 241 files / 2073 tests 全パス
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- biome check（変更ディレクトリ）: クリーン

## レビューポイント
- 依存方向が `lib/tauri → domains` の一方向に揃っているか（`grep @/lib/tauri src/domains` が空・`grep @/domains src/lib/tauri` は priority / milestone の 2 件のみ）。
- 循環参照防止ルール（`types.ts` から root barrel `@/lib/tauri` を import しない）を守れているか。

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)