### PR TITLE
♻️ [Refactoring]: #306 [FE] lib/tauri 公開 API の整理（toastSink を root barrel 経由に統一）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,7 @@ import { resolveCloseTarget } from "@/hooks/useAppView/resolveCloseTarget";
 import { useMilestones } from "@/hooks/useMilestones";
 import { useRecentProjects } from "@/hooks/useRecentProjects";
 import { useToasts } from "@/hooks/useToasts";
-import type { OrphanStrategy } from "@/lib/tauri";
-import { registerToastSink } from "@/lib/tauri/toastSink";
+import { type OrphanStrategy, registerToastSink } from "@/lib/tauri";
 import { basenameOf } from "@/utils/path";
 import {
   BoardWorkspace,

--- a/src/__tests__/App.mutationFailureToast.test.tsx
+++ b/src/__tests__/App.mutationFailureToast.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "vitest";
 import { App } from "@/App";
 import { DRAG_MIME_TYPE } from "@/features/board/components/Board/dragState";
-import { unregisterToastSink } from "@/lib/tauri/toastSink";
+import { unregisterToastSink } from "@/lib/tauri";
 import { createDragEvent } from "@/test-fixtures/createDragEvent";
 import type { TaskPayload } from "@/types/task";
 

--- a/src/__tests__/App.subIssuePartialFailure.test.tsx
+++ b/src/__tests__/App.subIssuePartialFailure.test.tsx
@@ -10,7 +10,7 @@ import {
   vi,
 } from "vitest";
 import { App } from "@/App";
-import { unregisterToastSink } from "@/lib/tauri/toastSink";
+import { unregisterToastSink } from "@/lib/tauri";
 import type { TaskPayload } from "@/types/task";
 
 // サブIssue 同時作成の部分失敗分岐（handleCreateTask）の App レベル統合テスト。

--- a/src/lib/tauri/index.ts
+++ b/src/lib/tauri/index.ts
@@ -1,5 +1,3 @@
-// dialog
-
 // cardOrderCommands
 export type { UpdateCardOrderParams } from "./cardOrderCommands/updateCardOrder";
 export { updateCardOrder } from "./cardOrderCommands/updateCardOrder";
@@ -11,8 +9,8 @@ export type {
   UpdateColumnsParams,
 } from "./columnCommands/types";
 export { updateColumns } from "./columnCommands/updateColumns";
+// dialog
 export { openDirectoryDialog } from "./dialog/openDirectoryDialog";
-
 // labelCommands
 export { getLabels } from "./labelCommands/getLabels";
 export type {
@@ -55,3 +53,6 @@ export { updateTask } from "./taskCommands/updateTask";
 // tauriError
 export type { TauriErrorCode } from "./tauriError";
 export { TauriError } from "./tauriError";
+// toastSink
+export type { ToastSink } from "./toastSink";
+export { registerToastSink, unregisterToastSink } from "./toastSink";


### PR DESCRIPTION
## 概要

invoke ラッパ層の規約「`src/lib/tauri/index.ts` を唯一の公開 API とする」から外れていた toastSink の import 経路を是正する。外部消費者（App.tsx / App 統合テスト）を root barrel 経由に統一し、index.ts のセクションコメントの対応を整理した。外部挙動は不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 変更した内容

- `src/lib/tauri/index.ts`
  - root barrel に `registerToastSink` / `unregisterToastSink` / `ToastSink` 型を export 追加
  - 孤立していた先頭の `// dialog` セクションコメントを削除し、`openDirectoryDialog` export の直前へ移動（コメントと export の対応を整理）
- `src/App.tsx` — `@/lib/tauri/toastSink` 直接 import を `@/lib/tauri` 経由へ変更（`OrphanStrategy` 型 import と統合）
- `src/__tests__/App.mutationFailureToast.test.tsx` — 同上（`unregisterToastSink`）
- `src/__tests__/App.subIssuePartialFailure.test.tsx` — 同上（`unregisterToastSink`）

`getToastSink` は `invokeWrapped` が循環参照回避のため個別 alias で内部参照する **lib/tauri 内部専用 API** のため barrel には公開しない。これは CLAUDE.md の既存の例外規定（「`invokeWrapped` / `tauriError` への参照は個別 alias を使う」）と整合する。`invokeWrapped` / `toastSink` 配下の内部テストも同様に直接 import のまま（lib/tauri 内部であり、本 Issue のスコープ外）。

## 削除した内容

なし

## 仕様ドキュメント更新

不要（純粋な内部リファクタリング。公開 API の挙動・データ形式・画面挙動・設定項目に変更なし。root barrel の export 追加は内部 import 経路の整理であり、外部利用面の挙動は不変）。CLAUDE.md の規約変更も不要（root barrel 経由へ寄せる方針は既存規約どおりで、`getToastSink` の個別 alias は既存の例外規定の範囲内）。

## システム図

```mermaid
flowchart LR
  App["App.tsx / App 統合テスト"]
  Barrel["@/lib/tauri (root barrel)"]
  ToastSink["toastSink/index.ts"]
  Invoke["invokeWrapped/index.ts"]

  App -->|"register/unregister (NEW: barrel 経由)"| Barrel
  Barrel --> ToastSink
  Invoke -->|"getToastSink (個別 alias / 内部・循環回避)"| ToastSink

  style Barrel fill:#dcfce7
```

## 関連Issue

Closes #306

## テスト

- `pnpm test:run` — 241 files / 2073 tests 全 pass
- `pnpm build`（tsc -b + vite build）— exit 0
- `pnpm lint`（oxlint）— 0 warnings / 0 errors
- `pnpm exec biome check`（変更 4 ファイル）— クリーン

外部挙動を変えないリファクタリングのため実機操作確認は省略（既存の App 統合テストがトースト発火経路を網羅）。

## レビューポイント

- `getToastSink` を barrel に公開せず個別 alias のまま残した判断（循環参照回避 + CLAUDE.md 例外規定との整合）が妥当か
- toastSink の内部テスト（`invokeWrapped/__tests__` / `toastSink/__tests__`）を直接 import のまま残した範囲設定が適切か

🤖 Generated with [Claude Code](https://claude.com/claude-code)