### PR TITLE
♻️ [Refactoring]: #311 [FE] deleteFlow の所有権を DetailScreen へリフトアップ（PropertiesSidebar の effect 2 件を解消）

### DIFF
--- a/src/features/detail/components/DetailScreen/index.tsx
+++ b/src/features/detail/components/DetailScreen/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getBrokenLinks } from "@/domains/broken-link";
 import { useChildTasks } from "@/features/detail/hooks/useChildTasks";
+import { useDeleteFlow } from "@/features/detail/hooks/useDeleteFlow";
 import { useDetailFieldHandlers } from "@/features/detail/hooks/useDetailFieldHandlers";
 import { useEscToClose } from "@/features/detail/hooks/useEscToClose";
 import { useParentTask } from "@/features/detail/hooks/useParentTask";
@@ -85,7 +86,9 @@ export type DetailScreenProps = {
  * 全画面2ペイン詳細ビュー。左=本文（DetailBody）/ 右=プロパティサイドバー（PropertiesSidebar）。
  * `<main>` を占有する feature コンポーネント（SettingsScreen 同様の全画面区分）。
  * Esc / 「← 戻る」で board へ戻る。useChildTasks / useParentTask / getBrokenLinks /
- * useDetailFieldHandlers をコンテナとして呼び、計算済みの値・ハンドラを共通部品へ渡す。
+ * useDetailFieldHandlers / useDeleteFlow をコンテナとして呼び、計算済みの値・ハンドラを
+ * 共通部品へ渡す。削除フロー（useDeleteFlow + orphanStrategy）の所有権はここにあり、
+ * PropertiesSidebar には props で渡す。
  * @param props - {@link DetailScreenProps}
  * @returns 全画面詳細ビュー要素
  */
@@ -119,13 +122,30 @@ export const DetailScreen = (props: DetailScreenProps) => {
     [task, tasksByNormalizedPath],
   );
 
-  // 削除 ConfirmDialog 表示中は Esc を「戻る」に使わない。PropertiesSidebar から
-  // 開閉通知を受けて disabled に反映する。
-  const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  // 削除フローの所有権はコンテナ（DetailScreen）が持つ。PropertiesSidebar は
+  // この state を props で受け取って描画するだけ。これにより子側で必要だった
+  // 「開閉のミラー通知 effect」「orphanStrategy リセット effect」が不要になる。
+  const [orphanStrategy, setOrphanStrategy] = useState<OrphanStrategy>("clear");
+  const handleDelete = useCallback(() => {
+    if (task.hierarchy.childFilePaths.length > 0) {
+      return onDelete(task.id, orphanStrategy);
+    }
+    return onDelete(task.id);
+  }, [task.id, task.hierarchy.childFilePaths.length, orphanStrategy, onDelete]);
+  const deleteFlow = useDeleteFlow({ onDelete: handleDelete });
+
+  // 削除ダイアログを開く操作の起点（event handler）で orphanStrategy を初期値へ戻す。
+  // state 変化に反応する effect ではなくクリック時に同期実行するため、ダイアログが開いた
+  // 最初の render から常に "clear" が選択された状態で描画される。
+  const requestDelete = useCallback(() => {
+    setOrphanStrategy("clear");
+    deleteFlow.requestDelete();
+  }, [deleteFlow.requestDelete]);
 
   // 削除ダイアログ または 上位モーダル（作成モーダル等）表示中は Esc（戻る）を停止し、
-  // モーダル自身の Esc と競合（戻る誤発火）しないようにする。
-  const escSuspended = isDeleteDialogOpen || isUpperModalOpen;
+  // モーダル自身の Esc と競合（戻る誤発火）しないようにする。削除ダイアログの開閉は
+  // deleteFlow.isOpen を直接参照するため、render 1 周遅れの窓が生じない。
+  const escSuspended = deleteFlow.isOpen || isUpperModalOpen;
 
   // 全画面ビュー展開時に section 自身へフォーカスを移す（ビュー先頭へ移動）。
   // DetailScreen は modal ではなく、HeaderBar / AppSidebar が detail 区分でも常時
@@ -173,8 +193,9 @@ export const DetailScreen = (props: DetailScreenProps) => {
           onSelectTask={onSelectTask}
           onAddLink={onAddLink}
           onRemoveLink={onRemoveLink}
-          onDelete={onDelete}
-          onDeleteFlowOpenChange={setDeleteDialogOpen}
+          deleteFlow={{ ...deleteFlow, requestDelete }}
+          orphanStrategy={orphanStrategy}
+          onOrphanStrategyChange={setOrphanStrategy}
         />
       </div>
     </section>

--- a/src/features/detail/components/PropertiesSidebar/__tests__/PropertiesSidebar.interaction.test.tsx
+++ b/src/features/detail/components/PropertiesSidebar/__tests__/PropertiesSidebar.interaction.test.tsx
@@ -2,6 +2,7 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import type { BrokenLinkSet } from "@/domains/broken-link";
+import type { UseDeleteFlowResult } from "@/features/detail/hooks/useDeleteFlow";
 import { Task, type TaskPayload } from "@/types/task";
 import { PropertiesSidebar } from "..";
 
@@ -52,6 +53,25 @@ function createTask(overrides: Partial<TaskPayload> = {}): Task {
 }
 
 /**
+ * 削除フロー（DetailScreen が所有する state）のスタブを生成する。
+ * @param overrides - 上書きするフィールド
+ * @returns UseDeleteFlowResult スタブ
+ */
+function buildDeleteFlow(
+  overrides: Partial<UseDeleteFlowResult> = {},
+): UseDeleteFlowResult {
+  return {
+    state: { kind: "idle" },
+    isOpen: false,
+    isBusy: false,
+    requestDelete: vi.fn(),
+    cancelDelete: vi.fn(),
+    confirmDelete: vi.fn(),
+    ...overrides,
+  };
+}
+
+/**
  * PropertiesSidebar の必須 props にデフォルトを与えるヘルパー。
  * @param overrides - 上書きする props
  * @returns PropertiesSidebar の props
@@ -77,7 +97,9 @@ function buildProps(
       onLabelRemove: vi.fn(),
       onChangeDraft: vi.fn(),
     },
-    onDelete: vi.fn(),
+    deleteFlow: buildDeleteFlow(),
+    orphanStrategy: "clear",
+    onOrphanStrategyChange: vi.fn(),
     ...overrides,
   };
 }
@@ -107,64 +129,66 @@ const click = (testId: string): void => {
   });
 };
 
-test("削除ボタン押下で ConfirmDialog が表示される", () => {
-  render(buildProps());
+test("削除ボタン押下で deleteFlow.requestDelete が呼ばれる", () => {
+  const requestDelete = vi.fn();
+  render(buildProps({ deleteFlow: buildDeleteFlow({ requestDelete }) }));
   click("detail-delete-button");
+  expect(requestDelete).toHaveBeenCalledTimes(1);
+});
+
+test("deleteFlow.isOpen が false の間は ConfirmDialog を描画しない", () => {
+  render(buildProps({ deleteFlow: buildDeleteFlow({ isOpen: false }) }));
+  expect(document.querySelector('[data-testid="confirm-dialog"]')).toBeNull();
+});
+
+test("deleteFlow.isOpen が true なら ConfirmDialog を描画する", () => {
+  render(buildProps({ deleteFlow: buildDeleteFlow({ isOpen: true }) }));
   expect(document.querySelector('[data-testid="confirm-dialog"]')).toBeTruthy();
 });
 
-test("子なし削除の確定で onDelete(id) が呼ばれる", () => {
-  const onDelete = vi.fn();
-  render(
-    buildProps({ task: createTask({ id: "t-x", children: [] }), onDelete }),
-  );
-  click("detail-delete-button");
-  click("confirm-confirm-button");
-  expect(onDelete.mock.calls[0]).toEqual(["t-x"]);
-});
-
-test("子あり削除（clear のまま）の確定で onDelete(id, 'clear')", () => {
-  const onDelete = vi.fn();
+test("確定ボタン押下で deleteFlow.confirmDelete が呼ばれる", () => {
+  const confirmDelete = vi.fn();
   render(
     buildProps({
-      task: createTask({ id: "t-c", children: ["a.md"] }),
-      onDelete,
+      deleteFlow: buildDeleteFlow({ isOpen: true, confirmDelete }),
     }),
   );
-  click("detail-delete-button");
   click("confirm-confirm-button");
-  expect(onDelete.mock.calls[0]).toEqual(["t-c", "clear"]);
+  expect(confirmDelete).toHaveBeenCalledTimes(1);
 });
 
-test("子あり削除（abort 切替）の確定で onDelete(id, 'abort')", () => {
-  const onDelete = vi.fn();
+test("キャンセルボタン押下で deleteFlow.cancelDelete が呼ばれる", () => {
+  const cancelDelete = vi.fn();
+  render(
+    buildProps({ deleteFlow: buildDeleteFlow({ isOpen: true, cancelDelete }) }),
+  );
+  click("confirm-cancel-button");
+  expect(cancelDelete).toHaveBeenCalledTimes(1);
+});
+
+test("子あり: abort ラジオ選択で onOrphanStrategyChange('abort') が呼ばれる", () => {
+  const onOrphanStrategyChange = vi.fn();
   render(
     buildProps({
-      task: createTask({ id: "t-a", children: ["a.md"] }),
-      onDelete,
+      task: createTask({ children: ["a.md"] }),
+      deleteFlow: buildDeleteFlow({ isOpen: true }),
+      onOrphanStrategyChange,
     }),
   );
-  click("detail-delete-button");
   click("delete-orphan-strategy-abort");
-  click("confirm-confirm-button");
-  expect(onDelete.mock.calls[0]).toEqual(["t-a", "abort"]);
+  expect(onOrphanStrategyChange).toHaveBeenCalledWith("abort");
 });
 
-test("キャンセルで onDelete が呼ばれない", () => {
-  const onDelete = vi.fn();
-  render(buildProps({ onDelete }));
-  click("detail-delete-button");
-  click("confirm-cancel-button");
-  expect(onDelete).not.toHaveBeenCalled();
-});
-
-test("削除ダイアログの開閉で onDeleteFlowOpenChange が値変化時のみ通知される（初回 false の誤通知なし）", () => {
-  const onDeleteFlowOpenChange = vi.fn();
-  render(buildProps({ onDeleteFlowOpenChange }));
-  // 初回マウントでは通知されない
-  expect(onDeleteFlowOpenChange).not.toHaveBeenCalled();
-  click("detail-delete-button");
-  expect(onDeleteFlowOpenChange).toHaveBeenLastCalledWith(true);
-  click("confirm-cancel-button");
-  expect(onDeleteFlowOpenChange).toHaveBeenLastCalledWith(false);
+test("子あり: orphanStrategy='abort' なら abort ラジオが checked", () => {
+  render(
+    buildProps({
+      task: createTask({ children: ["a.md"] }),
+      deleteFlow: buildDeleteFlow({ isOpen: true }),
+      orphanStrategy: "abort",
+    }),
+  );
+  const abort = document.querySelector(
+    '[data-testid="delete-orphan-strategy-abort"]',
+  ) as HTMLInputElement;
+  expect(abort.checked).toBe(true);
 });

--- a/src/features/detail/components/PropertiesSidebar/__tests__/PropertiesSidebar.rendering.test.tsx
+++ b/src/features/detail/components/PropertiesSidebar/__tests__/PropertiesSidebar.rendering.test.tsx
@@ -2,6 +2,7 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import type { BrokenLinkSet } from "@/domains/broken-link";
+import type { UseDeleteFlowResult } from "@/features/detail/hooks/useDeleteFlow";
 import { Task, type TaskPayload } from "@/types/task";
 import { PropertiesSidebar } from "..";
 
@@ -12,6 +13,25 @@ const noBrokenLinks: BrokenLinkSet = {
   children: new Set<string>(),
   reverseLinks: new Set<string>(),
 };
+
+/**
+ * 削除フロー（DetailScreen が所有する state）のスタブを生成する。
+ * @param overrides - 上書きするフィールド
+ * @returns UseDeleteFlowResult スタブ
+ */
+function buildDeleteFlow(
+  overrides: Partial<UseDeleteFlowResult> = {},
+): UseDeleteFlowResult {
+  return {
+    state: { kind: "idle" },
+    isOpen: false,
+    isBusy: false,
+    requestDelete: vi.fn(),
+    cancelDelete: vi.fn(),
+    confirmDelete: vi.fn(),
+    ...overrides,
+  };
+}
 
 let container: HTMLDivElement | null = null;
 let root: ReturnType<typeof createRoot> | null = null;
@@ -77,7 +97,9 @@ function buildProps(
       onLabelRemove: vi.fn(),
       onChangeDraft: vi.fn(),
     },
-    onDelete: vi.fn(),
+    deleteFlow: buildDeleteFlow(),
+    orphanStrategy: "clear",
+    onOrphanStrategyChange: vi.fn(),
     ...overrides,
   };
 }

--- a/src/features/detail/components/PropertiesSidebar/index.tsx
+++ b/src/features/detail/components/PropertiesSidebar/index.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import type { BrokenLinkSet } from "@/domains/broken-link";
 import type { UseChildTasksResult } from "@/features/detail/hooks/useChildTasks";
-import { useDeleteFlow } from "@/features/detail/hooks/useDeleteFlow";
+import type { UseDeleteFlowResult } from "@/features/detail/hooks/useDeleteFlow";
 import type { DetailFieldHandlers } from "@/features/detail/hooks/useDetailFieldHandlers";
 import type { OrphanStrategy } from "@/lib/tauri";
 import type { Column } from "@/types/column";
@@ -28,6 +27,18 @@ export type PropertiesSidebarProps = {
   brokenLinks: BrokenLinkSet;
   /** ステータス/優先度/ラベルの編集ハンドラ */
   handlers: DetailFieldHandlers;
+  /**
+   * 削除フロー（DetailScreen が所有する useDeleteFlow の戻り値）。
+   * 削除ボタン押下 / ConfirmDialog の開閉・確定・キャンセルに利用する。
+   */
+  deleteFlow: UseDeleteFlowResult;
+  /** 子タスクがある場合の削除方針（clear / abort）。子なし時は無視される */
+  orphanStrategy: OrphanStrategy;
+  /**
+   * 削除方針の変更ハンドラ。
+   * @param strategy - 選択された削除方針
+   */
+  onOrphanStrategyChange: (strategy: OrphanStrategy) => void;
   /**
    * サブIssue 追加ハンドラ。
    * @param parentFilePath - 親タスクのファイルパス
@@ -58,30 +69,14 @@ export type PropertiesSidebarProps = {
     sourceFilePath: string,
     targetFilePath: string,
   ) => Promise<Result<Task, unknown>>;
-  /**
-   * タスク削除ハンドラ。
-   * @param id - 削除対象のタスク ID
-   * @param orphanStrategy - 子タスクがある場合の処理方針（子なし時は未指定）
-   */
-  onDelete: (
-    id: string,
-    orphanStrategy?: OrphanStrategy,
-  ) => void | Promise<void>;
-  /**
-   * 削除 ConfirmDialog の開閉が変化したらコンテナへ通知する。
-   * DetailScreen はこれを useEscToClose の disabled に渡し、
-   * ダイアログ表示中の Esc が「戻る」を誤発火しないようにする。
-   * @param open - ダイアログが開いているか
-   */
-  onDeleteFlowOpenChange?: (open: boolean) => void;
 };
 
 /**
  * 詳細のプロパティペイン。DetailScreen の右サイドバー専用。
  * 最上部に ParentLink / BrokenParentRow（Parent はサイドバー集約）、続いて
  * DetailFields（Compound: Status/Priority・Labels・SubIssue・Links）、最下部に削除ボタンを置く。
- * 削除フロー（useDeleteFlow + orphanStrategy + ConfirmDialog）を内包し、
- * 開閉を onDeleteFlowOpenChange でコンテナへ通知する。
+ * 削除フロー（useDeleteFlow + orphanStrategy）の所有権は DetailScreen にあり、本コンポーネントは
+ * props で受け取った state を描画するだけの presentational コンポーネントとして振る舞う。
  * @param props - {@link PropertiesSidebarProps}
  * @returns プロパティペイン要素
  */
@@ -94,39 +89,14 @@ export const PropertiesSidebar = (props: PropertiesSidebarProps) => {
     parentTask,
     brokenLinks,
     handlers,
+    deleteFlow,
+    orphanStrategy,
+    onOrphanStrategyChange,
     onAddSubIssue,
     onSelectTask,
     onAddLink,
     onRemoveLink,
-    onDelete,
-    onDeleteFlowOpenChange,
   } = props;
-
-  const [orphanStrategy, setOrphanStrategy] = useState<OrphanStrategy>("clear");
-
-  const handleDelete = useCallback(() => {
-    if (task.hierarchy.childFilePaths.length > 0) {
-      return onDelete(task.id, orphanStrategy);
-    }
-    return onDelete(task.id);
-  }, [task.id, task.hierarchy.childFilePaths.length, orphanStrategy, onDelete]);
-  const deleteFlow = useDeleteFlow({ onDelete: handleDelete });
-
-  useEffect(() => {
-    if (deleteFlow.isOpen) {
-      setOrphanStrategy("clear");
-    }
-  }, [deleteFlow.isOpen]);
-
-  // ダイアログ開閉が「変化したときのみ」通知する。初回 false の誤通知を避けるため
-  // prevOpenRef で前回値と比較する（StrictMode 二重 effect でも重複しない）。
-  const prevOpenRef = useRef(deleteFlow.isOpen);
-  useEffect(() => {
-    if (prevOpenRef.current !== deleteFlow.isOpen) {
-      prevOpenRef.current = deleteFlow.isOpen;
-      onDeleteFlowOpenChange?.(deleteFlow.isOpen);
-    }
-  }, [deleteFlow.isOpen, onDeleteFlowOpenChange]);
 
   const hasChildren = task.hierarchy.childFilePaths.length > 0;
 
@@ -203,7 +173,7 @@ export const PropertiesSidebar = (props: PropertiesSidebarProps) => {
                   name="orphan-strategy"
                   value="clear"
                   checked={orphanStrategy === "clear"}
-                  onChange={() => setOrphanStrategy("clear")}
+                  onChange={() => onOrphanStrategyChange("clear")}
                   data-testid="delete-orphan-strategy-clear"
                 />
                 子タスクの親リンクを解除して削除（clear）
@@ -214,7 +184,7 @@ export const PropertiesSidebar = (props: PropertiesSidebarProps) => {
                   name="orphan-strategy"
                   value="abort"
                   checked={orphanStrategy === "abort"}
-                  onChange={() => setOrphanStrategy("abort")}
+                  onChange={() => onOrphanStrategyChange("abort")}
                   data-testid="delete-orphan-strategy-abort"
                 />
                 削除を中止（abort）


### PR DESCRIPTION
## 概要

詳細画面の削除フローについて、`useDeleteFlow` / `orphanStrategy` state の所有権を子（PropertiesSidebar）から親（DetailScreen）へリフトアップした。これにより useEffect 規約に反していた effect 2 件を解消し、React の state lifting / 単方向データフローに準拠させる。

PropertiesSidebar は delete flow を props で受け取って描画するだけの presentational コンポーネントになった。`DetailScreen` の公開 props・外部挙動（UI / IPC / `onDelete` 契約）は不変。

## 変更の種類

- ♻️ リファクタリング

## 詳細な変更内容

- **state リセット effect の撤去**: `useEffect(() => { if (deleteFlow.isOpen) setOrphanStrategy("clear") })` を削除。代わりに削除ボタンの `onClick`（event handler 起点）で `requestDelete` と同時に `orphanStrategy` を `"clear"` へ戻す。ダイアログが開いた最初の render から常に正しい選択状態で描画され、一瞬古い選択が見える問題を解消
- **ミラー通知 effect の撤去**: 子の `deleteFlow.isOpen` を親へ通知する `useEffect + prevOpenRef` と、親の `useState` ミラー（`isDeleteDialogOpen`）/ `onDeleteFlowOpenChange` prop を削除。DetailScreen が `deleteFlow.isOpen` を直接参照して `escSuspended` を導出するため、render 1 周遅れで Esc の disabled が反映される 1 フレームの窓を解消
- PropertiesSidebar に `deleteFlow` / `orphanStrategy` / `onOrphanStrategyChange` props を追加し、`useDeleteFlow` / `useState` / `useEffect` / `useRef` の呼び出しを撤去
- PropertiesSidebar のテストを presentational な契約（ボタン押下で `requestDelete` 呼び出し、`isOpen` での描画分岐、ラジオ変更で `onOrphanStrategyChange` 呼び出し等）に更新。削除フロー全体の振る舞い（request→confirm→onDelete + orphanStrategy）は所有元の `DetailScreen.delete.test.tsx` が引き続きカバー

## 状態フロー

```mermaid
flowchart LR
  subgraph DetailScreen [DetailScreen（所有者）]
    DF["useDeleteFlow + orphanStrategy [NEW]"]
    ESC["escSuspended = deleteFlow.isOpen || isUpperModalOpen"]
  end
  subgraph PS [PropertiesSidebar（presentational）]
    BTN["削除ボタン → deleteFlow.requestDelete"]
    DLG["ConfirmDialog（deleteFlow.isOpen で描画）"]
  end
  DF -- props --> PS
  DF --> ESC
  style DF fill:#dff0d8
```

## 関連 Issue

Closes #311

## テスト

- `pnpm test:run`: 241 files / 2074 tests passed
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- `pnpm biome check src/features/detail`: クリーン

## ドキュメント

純粋な内部リファクタリングであり、公開 API・データ形式・画面挙動・設定項目に変更がないため `docs/spec-board/` の更新は不要。

## レビューポイント

- `DetailScreen/index.tsx` の `requestDelete` ラップ（`setOrphanStrategy("clear")` を event handler で同期実行）が effect 撤去の代替として妥当か
- `escSuspended` が `deleteFlow.isOpen` 直接参照に変わったことで、Esc 抑止のタイミングが 1 render 早まっている点

🤖 Generated with [Claude Code](https://claude.com/claude-code)