### PR TITLE
🧹 [Chore]: #321 [FE] effect の細部整理（useTheme 同期対象分離 / useProject ref ミラー除去 / useMilestones cleanup）

### DIFF
--- a/src/features/board/hooks/useProject/index.ts
+++ b/src/features/board/hooks/useProject/index.ts
@@ -86,10 +86,6 @@ export const useProject = (
   const dialogOpeningRef = useRef(false);
 
   useEffect(() => {
-    latestStateRef.current = state;
-  }, [state]);
-
-  useEffect(() => {
     return () => {
       deactivateProject(projectVersionRef.current);
     };
@@ -97,6 +93,9 @@ export const useProject = (
 
   const getState = useCallback((): ProjectState => latestStateRef.current, []);
 
+  // 全 dispatch 経路がこの dispatchSync を通り、reducer 適用と同時に
+  // latestStateRef を即時更新する。これにより effect での state ミラーは不要になり、
+  // commit〜effect 実行の間に Tauri イベントが ref を古い state へ巻き戻す窓も生じない。
   const dispatchSync = useCallback((action: ProjectAction): void => {
     latestStateRef.current = reducer(latestStateRef.current, action);
     dispatch(action);

--- a/src/features/shell/hooks/useTheme/__tests__/useTheme.interaction.test.tsx
+++ b/src/features/shell/hooks/useTheme/__tests__/useTheme.interaction.test.tsx
@@ -1,0 +1,139 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { ThemeProvider } from "@/features/shell/hooks/useTheme";
+import { saveAppearance } from "@/features/shell/lib/appearanceStorage";
+import { applyAppearanceDataset } from "@/features/shell/lib/applyAppearance";
+import type { Appearance } from "@/features/shell/types";
+
+vi.mock("@/features/shell/lib/appearanceStorage", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/shell/lib/appearanceStorage")
+  >("@/features/shell/lib/appearanceStorage");
+  return {
+    ...actual,
+    saveAppearance: vi.fn(),
+    loadAppearance: vi.fn(),
+  };
+});
+
+vi.mock("@/features/shell/lib/applyAppearance", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/shell/lib/applyAppearance")
+  >("@/features/shell/lib/applyAppearance");
+  return {
+    ...actual,
+    applyAppearanceDataset: vi.fn(),
+  };
+});
+
+const saveAppearanceMock = vi.mocked(saveAppearance);
+const applyAppearanceDatasetMock = vi.mocked(applyAppearanceDataset);
+const loadAppearanceMock = vi.mocked(
+  // 同一モジュール内でモック化した loadAppearance を取得する。
+  (await import("@/features/shell/lib/appearanceStorage")).loadAppearance,
+);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+
+beforeAll(() => {
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+});
+
+type MediaQueryListener = (event: { matches: boolean }) => void;
+
+let matches = false;
+const listeners = new Set<MediaQueryListener>();
+
+const emitSystemColorChange = (nextMatches: boolean): void => {
+  matches = nextMatches;
+  for (const listener of listeners) {
+    listener({ matches: nextMatches });
+  }
+};
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  matches = false;
+  listeners.clear();
+  saveAppearanceMock.mockReset();
+  applyAppearanceDatasetMock.mockReset();
+  loadAppearanceMock.mockReset();
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    get matches() {
+      return matches;
+    },
+    addEventListener: (_type: string, listener: MediaQueryListener) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_type: string, listener: MediaQueryListener) => {
+      listeners.delete(listener);
+    },
+  }));
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const mountProvider = async (appearance: Appearance): Promise<void> => {
+  loadAppearanceMock.mockReturnValue(appearance);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(ThemeProvider, null, null));
+  });
+};
+
+test("OS 配色が変わると dataset は再適用されるが saveAppearance は再呼び出しされない", async () => {
+  await mountProvider({
+    theme: "system",
+    density: "comfortable",
+    accent: "blue",
+  });
+
+  // マウント時に保存と dataset 適用が 1 回ずつ走る。
+  expect(saveAppearanceMock).toHaveBeenCalledTimes(1);
+  const datasetCallsAfterMount = applyAppearanceDatasetMock.mock.calls.length;
+
+  // OS の配色をダークへ切り替える。
+  await act(async () => {
+    emitSystemColorChange(true);
+  });
+
+  // 保存内容は appearance に依存し OS 配色では変わらないため再保存されない。
+  expect(saveAppearanceMock).toHaveBeenCalledTimes(1);
+  // dataset 反映は OS 配色にも追従するため再適用される。
+  expect(applyAppearanceDatasetMock.mock.calls.length).toBeGreaterThan(
+    datasetCallsAfterMount,
+  );
+  expect(applyAppearanceDatasetMock).toHaveBeenLastCalledWith(
+    expect.objectContaining({ theme: "dark" }),
+  );
+});

--- a/src/features/shell/hooks/useTheme/index.tsx
+++ b/src/features/shell/hooks/useTheme/index.tsx
@@ -109,11 +109,16 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   // OS 配色変更で context 値が変わり、実効配色に依存する consumer も再描画される。
   const [systemDark, setSystemDark] = useState<boolean>(prefersDark);
 
-  // 外観設定 / OS 配色が変わるたびに永続化と documentElement への反映を行う。
-  // 初回ペイント前に dataset を適用して FOUC（一瞬ライト表示）を抑えるため
-  // useLayoutEffect を使う（保存は副作用として同居させる）。
-  useLayoutEffect(() => {
+  // 外観設定の永続化は appearance のみに依存する。OS 配色（systemDark）が変化しても
+  // 保存内容は変わらないため、同期対象を分離して無駄な書き込みを避ける。
+  useEffect(() => {
     saveAppearance(appearance);
+  }, [appearance]);
+
+  // documentElement への dataset 反映は appearance と OS 配色の両方に追従する。
+  // 初回ペイント前に dataset を適用して FOUC（一瞬ライト表示）を抑えるため
+  // useLayoutEffect を使う。
+  useLayoutEffect(() => {
     applyAppearanceDataset(resolveAppearanceDataset(appearance, systemDark));
   }, [appearance, systemDark]);
 


### PR DESCRIPTION
## 概要

hooks / useEffect レビューで見つかった effect まわりの細かい問題のうち、Issue #321 の非グレー項目（1〜3）を React effect 規約に沿って整理する。外部挙動は不変。

Closes #321

## 変更内容

### 1. useTheme の同期対象分離（`src/features/shell/hooks/useTheme/index.tsx`）
- 1 つの `useLayoutEffect` に同居していた「localStorage 永続化」と「documentElement への dataset 反映」を分離。
- 保存 effect は依存 `[appearance]`、dataset 反映 effect は依存 `[appearance, systemDark]`。
- これにより OS 配色変化（`systemDark`）では `saveAppearance` が再実行されなくなり、無駄な書き込みを排除。dataset 反映は FOUC 抑止のため引き続き `useLayoutEffect`。

### 2. useProject の冗長な ref ミラー effect 除去（`src/features/board/hooks/useProject/index.ts`）
- `useEffect(() => { latestStateRef.current = state }, [state])` を削除。
- 全 dispatch 経路が `dispatchSync`（reducer 即時適用 + ref 更新）を通るため当該 effect は冗長。さらに paint 後に走るため commit〜effect 実行の間に Tauri イベントが `dispatchSync` すると ref を古い state へ巻き戻す窓があった。ref 更新を `dispatchSync` に一本化して解消。

### 3. useMilestones の load effect に cleanup 追加（`src/hooks/useMilestones/index.ts`）
- load effect に cleanup が無く、unmount 後に in-flight の `getMilestones` が解決すると setState が走っていた。
- cleanup で `requestIdRef.current += 1` し、in-flight 応答を世代チェックで stale 破棄するようにした。

## グレー項目（4〜9）の方針

Issue でグレー（単独 Issue にするほどではない / 実害ほぼ無し）とされた 4〜9 は、本 PR のスコープ「effect の細部整理」を超える component / hook の設計変更（callback ref 化・`useOptimistic` 置換・リソース hook の reload 設計統一など）を含み、外部挙動への影響リスクがあるため**現状維持**とした。別 Issue 化が適切と判断。

## テスト証跡

- `pnpm test:run`: 242 ファイル / **2074 件 全 pass**（useTheme の同期対象分離を検証する新規テスト 1 件を追加。fix 前は saveAppearance 二重呼び出しで Red になることを確認済み）
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- biome check（変更ファイル）: クリーン

## ドキュメント

公開 API・データ形式・画面挙動・設定項目のいずれも変わらない純粋な effect リファクタのため、`docs/spec-board/` の更新は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)