### PR TITLE
♻️ [Refactoring]: #314 [FE] App.tsx の警告トースト発火を effect + ref 管理から useProject の onLoaded callback へ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   type MoveTaskParams,
   PROJECT_SWITCHED_MESSAGE,
   type ProjectError,
+  type ProjectLoadedEvent,
   type ProjectState,
   projectErrorMessage,
   type ReorderColumnsEvent,
@@ -122,6 +123,33 @@ const resolveSelectedTask = (
 export const App = () => {
   const { toasts, showToast, dismissToast } = useToasts();
   const { view, navigate } = useAppView();
+  const { projects: recentProjects, add: addRecentProject } =
+    useRecentProjects();
+
+  // project の load 成功イベントで実行する副作用。useProject の onLoaded callback に
+  // 注入することで、effect + ref による「発火済み管理」を排し、load 完了という
+  // 1 回のイベントで「最近一覧記録」と「警告トースト発火」をまとめて実行する。
+  // close → reopen / 別 project 切替のたびに改めて 1 回ずつ呼ばれる。
+  const handleProjectLoaded = useCallback(
+    ({ path, data }: ProjectLoadedEvent): void => {
+      // 最近開いた一覧へ記録する（サイドバーからの再オープン用）。
+      addRecentProject(path);
+      // リンク切れ / パースエラーは判定ドメイン・文言が別なので個別に集計して通知する。
+      const brokenLinkCount = countTasksWithBrokenLink(
+        data.tasks,
+        buildTasksByNormalizedPath(data.tasks),
+      );
+      if (brokenLinkCount >= 1) {
+        showToast(`リンク切れが ${brokenLinkCount} 件あります`, "warning");
+      }
+      const parseErrorCount = countTasksWithParseError(data.tasks);
+      if (parseErrorCount >= 1) {
+        showToast(`パースエラーが ${parseErrorCount} 件あります`, "warning");
+      }
+    },
+    [addRecentProject, showToast],
+  );
+
   const {
     state,
     openProject,
@@ -144,6 +172,7 @@ export const App = () => {
       }
       showToast(projectErrorMessage(err), "error");
     },
+    onLoaded: handleProjectLoaded,
   });
   const { submit: submitCreateTask } = useTaskCreate({ createTask });
 
@@ -172,9 +201,6 @@ export const App = () => {
     navigate("board");
     openProject();
   }, [navigate, openProject]);
-
-  const { projects: recentProjects, add: addRecentProject } =
-    useRecentProjects();
 
   // サイドバーの最近一覧から指定パスを直接開く（ダイアログを経由しない）。
   const handleOpenProjectPath = useCallback(
@@ -264,13 +290,6 @@ export const App = () => {
     }
   }
 
-  // プロジェクトを読み込めたら最近開いた一覧へ記録する（サイドバーからの再オープン用）。
-  useEffect(() => {
-    if (loadedPath !== null) {
-      addRecentProject(loadedPath);
-    }
-  }, [loadedPath, addRecentProject]);
-
   const tasks = tasksOf(state);
   const columns = columnsOf(state);
   const doneColumn = doneColumnOf(state);
@@ -292,46 +311,9 @@ export const App = () => {
     }),
     [milestonesResource, tasks],
   );
-  // Toast 発火管理用 ref。`prevLoadedPath` (UI リセット用、render-phase 更新) と
-  // 役割を分離するため別 ref を持つ。
-  // 「loaded セッション内で 1 回だけ発火」をルールとし、state.kind が "loaded" から
-  // 離れた時点で ref をクリアすることで、close → reopen 同一 path のような再ロードでも
-  // 改めて発火するようにする。
-  const toastFiredForLoadedPathRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (state.kind !== "loaded") {
-      toastFiredForLoadedPathRef.current = null;
-      return;
-    }
-    if (toastFiredForLoadedPathRef.current === loadedPath) {
-      return;
-    }
-    toastFiredForLoadedPathRef.current = loadedPath;
-    const n = countTasksWithBrokenLink(tasks, tasksByNormalizedPath);
-    if (n >= 1) {
-      showToast(`リンク切れが ${n} 件あります`, "warning");
-    }
-  }, [state.kind, loadedPath, tasks, tasksByNormalizedPath, showToast]);
-
-  // パースエラー Toast 発火管理用 ref。リンク切れ Toast (toastFiredForLoadedPathRef) とは
-  // 判定ドメイン・文言が別なので発火管理を分離する。ルールは同じく「loaded セッション内
-  // 1 回発火」。state.kind が "loaded" を離れた時点で ref をクリアし、close → reopen /
-  // 別 project 切替後 N >= 1 なら改めて 1 回発火する。
-  const parseErrorToastFiredRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (state.kind !== "loaded") {
-      parseErrorToastFiredRef.current = null;
-      return;
-    }
-    if (parseErrorToastFiredRef.current === loadedPath) {
-      return;
-    }
-    parseErrorToastFiredRef.current = loadedPath;
-    const n = countTasksWithParseError(tasks);
-    if (n >= 1) {
-      showToast(`パースエラーが ${n} 件あります`, "warning");
-    }
-  }, [state.kind, loadedPath, tasks, showToast]);
+  // リンク切れ / パースエラーの警告トーストは load 成功イベント（useProject の
+  // onLoaded callback = handleProjectLoaded）で 1 回だけ発火する。tasks 変更のたびに
+  // 走る effect + ref の発火済み管理は廃止した。
   // サブIssue モード中は親候補を 1 件に絞り、ユーザに「親が自動セットされた」ことを示す。
   // tasks から親が消えると filter 結果が [] になり、ParentTaskSelect の filePath fallback が起動する。
   const parentCandidates = useMemo(() => {

--- a/src/features/board/hooks/useProject/__tests__/useProject.interaction.test.tsx
+++ b/src/features/board/hooks/useProject/__tests__/useProject.interaction.test.tsx
@@ -308,6 +308,94 @@ test("openProject dialog cancel (null) → state 不変", async () => {
   expect(onError).not.toHaveBeenCalled();
 });
 
+test("openProject 成功 → onLoaded が path / data 付きで 1 回だけ発火する", async () => {
+  const onLoaded = vi.fn();
+  const probe = renderHook({ onLoaded });
+  await openLoaded(probe);
+  expect(onLoaded).toHaveBeenCalledTimes(1);
+  expect(onLoaded).toHaveBeenCalledWith({
+    path: "/p",
+    data: {
+      tasks: [taskA],
+      columns: [
+        { name: "Todo", order: 0 },
+        { name: "Done", order: 1 },
+      ],
+      doneColumn: "Done",
+    },
+  });
+});
+
+test("openProject invoke 失敗 → onLoaded は発火しない", async () => {
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  openProjectMock.mockResolvedValueOnce(
+    Result.err(new TauriError("NOT_FOUND", "no")),
+  );
+  const onLoaded = vi.fn();
+  const probe = renderHook({ onLoaded });
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProject();
+  });
+  await act(async () => {
+    await pending;
+  });
+  expect(onLoaded).not.toHaveBeenCalled();
+});
+
+test("openProject invoke 中 unmount → onLoaded は発火しない", async () => {
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  let resolveInvoke!: (r: ResultT<OpenProjectPayload, TauriError>) => void;
+  openProjectMock.mockReturnValueOnce(
+    new Promise<ResultT<OpenProjectPayload, TauriError>>((res) => {
+      resolveInvoke = res;
+    }),
+  );
+  const onLoaded = vi.fn();
+  const probe = renderHook({ onLoaded });
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProject();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  act(() => {
+    root?.unmount();
+    root = null;
+  });
+  await act(async () => {
+    resolveInvoke(Result.ok(payload));
+    await pending;
+  });
+  expect(onLoaded).not.toHaveBeenCalled();
+});
+
+test("openProjectByPath 成功 → onLoaded が path / data 付きで発火する", async () => {
+  openProjectMock.mockResolvedValueOnce(Result.ok(payload));
+  const onLoaded = vi.fn();
+  const probe = renderHook({ onLoaded });
+  let pending!: Promise<void>;
+  act(() => {
+    pending = probe.latest.openProjectByPath("/p");
+  });
+  await act(async () => {
+    await pending;
+  });
+  expect(onLoaded).toHaveBeenCalledTimes(1);
+  expect(onLoaded).toHaveBeenCalledWith({
+    path: "/p",
+    data: {
+      tasks: [taskA],
+      columns: [
+        { name: "Todo", order: 0 },
+        { name: "Done", order: 1 },
+      ],
+      doneColumn: "Done",
+    },
+  });
+});
+
 test("openProject dialog 例外 → state 不変、onError 発火", async () => {
   const dialogErr = new TauriError("UNKNOWN", "dialog boom");
   openDirectoryDialogMock.mockResolvedValueOnce(Result.err(dialogErr));

--- a/src/features/board/hooks/useProject/actions/openProject.ts
+++ b/src/features/board/hooks/useProject/actions/openProject.ts
@@ -95,6 +95,11 @@ export type OpenProjectActionDeps = {
    * @param error 通知する ProjectError
    */
   onError?: (error: ProjectError) => void;
+  /**
+   * load 成功で state を loaded へ遷移させた直後に呼ばれる任意のコールバック。
+   * @param event 開いた path と読み込んだ ProjectData
+   */
+  onLoaded?: (event: { path: string; data: ProjectData }) => void;
 };
 
 /**
@@ -110,6 +115,7 @@ export const openProjectAction = async ({
   path: explicitPath,
   dispatchSync,
   onError,
+  onLoaded,
 }: OpenProjectActionDeps): Promise<void> => {
   const path = await resolveProjectPath({
     explicitPath,
@@ -173,5 +179,8 @@ export const openProjectAction = async ({
     };
     invalidateProject(projectVersion);
     dispatchSync({ type: "open-succeed", path, data });
+    // load 成功イベントの場所。警告トースト発火 / 最近一覧記録など「開けた帰結」の
+    // 副作用を呼び出し側へ 1 回だけ通知する（effect + ref 管理の代替）。
+    onLoaded?.({ path, data });
   });
 };

--- a/src/features/board/hooks/useProject/index.ts
+++ b/src/features/board/hooks/useProject/index.ts
@@ -57,6 +57,7 @@ export type {
   ColumnsCommandBuilder,
   MoveTaskCallbacks,
   MoveTaskParams,
+  ProjectLoadedEvent,
   ReorderColumnsCallbacks,
   ReorderColumnsEvent,
   ReorderColumnsParams,
@@ -75,7 +76,7 @@ export type {
 export const useProject = (
   options: UseProjectOptions = {},
 ): UseProjectResult => {
-  const { onError } = options;
+  const { onError, onLoaded } = options;
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const latestStateRef = useRef<ProjectState>(state);
@@ -231,8 +232,9 @@ export const useProject = (
         dialogOpening: dialogOpeningRef,
         dispatchSync,
         onError,
+        onLoaded,
       }),
-    [dispatchSync, onError],
+    [dispatchSync, onError, onLoaded],
   );
 
   const openProjectByPath = useCallback(
@@ -244,8 +246,9 @@ export const useProject = (
         path,
         dispatchSync,
         onError,
+        onLoaded,
       }),
-    [dispatchSync, onError],
+    [dispatchSync, onError, onLoaded],
   );
 
   const actionDeps = useCallback(

--- a/src/features/board/hooks/useProject/types.ts
+++ b/src/features/board/hooks/useProject/types.ts
@@ -16,6 +16,7 @@ import type {
   ReorderColumnsResult,
 } from "./actions/reorderColumns";
 import type { ProjectError } from "./errors";
+import type { ProjectData } from "./reducer";
 import type { ProjectSessionState } from "./state/projectSessionState";
 
 export type {
@@ -32,8 +33,29 @@ export type {
 
 export type UpdateColumnsInput = ColumnsCommand | ColumnsCommandBuilder;
 
+/**
+ * project の load 成功イベントの payload。
+ * 開いた path と読み込んだ ProjectData を併せて渡す。
+ */
+export type ProjectLoadedEvent = {
+  /** 開いたプロジェクトの絶対パス。 */
+  path: string;
+  /** 読み込んだ ProjectData（tasks / columns / doneColumn）。 */
+  data: ProjectData;
+};
+
 export type UseProjectOptions = {
+  /**
+   * openProject / openProjectByPath 系の失敗時に呼ばれる callback。
+   * @param error 通知する ProjectError
+   */
   onError?: (error: ProjectError) => void;
+  /**
+   * project の load が成功し state が loaded へ遷移した直後に 1 回だけ呼ばれる callback。
+   * close → reopen / 別 project 切替のたびに、その都度 1 回ずつ発火する。
+   * @param event 開いた path と読み込んだ ProjectData
+   */
+  onLoaded?: (event: ProjectLoadedEvent) => void;
 };
 
 export type UseProjectResult = {

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -8,6 +8,7 @@ export type {
   MoveTaskCallbacks,
   MoveTaskParams,
   ProjectData,
+  ProjectLoadedEvent,
   ProjectState,
   ReorderColumnsCallbacks,
   ReorderColumnsEvent,


### PR DESCRIPTION
## 概要

App.tsx でリンク切れ / パースエラーの警告トーストを発火していた「effect + ref による発火済み管理」を、`useProject` が公開する `onLoaded` callback（load 成功イベント）へ置き換えるリファクタリング。あわせて `addRecentProject` の `loadedPath` 監視 effect も同じ通知経路に集約した。外部挙動は不変。

Closes #314

## 変更の種類

- ♻️ リファクタリング（外部仕様の変更なし）

## 詳細な変更内容

### useProject に `onLoaded` callback を追加
- `UseProjectOptions` に `onLoaded?: (event: ProjectLoadedEvent) => void` を追加（`ProjectLoadedEvent = { path; data }`）。
- `openProjectAction` の `open-succeed` dispatch 直後に `onLoaded?.({ path, data })` を 1 回発火。invoke 失敗 / unmount などで loaded に到達しない経路では発火しない。
- `useProject` 本体で `openProject` / `openProjectByPath` 両方の依存に `onLoaded` を配線。
- board barrel から `ProjectLoadedEvent` を re-export。

### App.tsx の effect/ref を削除し callback へ集約
- リンク切れ警告 effect + `toastFiredForLoadedPathRef` を削除。
- パースエラー警告 effect + `parseErrorToastFiredRef` を削除。
- `addRecentProject` の `loadedPath` 監視 effect を削除。
- 上記 3 つの副作用を `handleProjectLoaded`（`useProject({ onLoaded })` に注入）へまとめ、load 完了という 1 イベントで実行する。

## システム図

```mermaid
flowchart LR
  subgraph Before
    A1[open-succeed dispatch] --> B1[state=loaded]
    B1 --> C1[effect: tasks 変更ごとに走る]
    C1 --> D1{ref で発火済み?}
    D1 -- no --> E1[showToast / addRecentProject]
  end
  subgraph After
    A2[open-succeed dispatch] --> F2[onLoaded path,data]
    F2 --> E2[handleProjectLoaded:\naddRecentProject + 警告トースト]
    A2 --> B2[state=loaded]
  end
  style F2 fill:#d4f7d4
  style E2 fill:#d4f7d4
```

## テスト

- `pnpm test:run`: 241 files / 2077 tests 全 pass（`useProject` に onLoaded の発火条件テストを 4 件追加。既存の `App.brokenLinkToast` / `App.parseErrorToast`（初回発火 / N===0 非発火 / project 切替再発火 / 同一 path 再 open 再発火）も全 pass で外部挙動の不変を担保）。
- `pnpm build`（tsc -b + vite build）: 成功。
- `pnpm lint`（oxlint）: 0 warnings / 0 errors。
- biome check（変更領域）: クリーン。

## レビューポイント

- `onLoaded` は loaded 到達時のみ 1 回発火する設計（unmount / invoke 失敗では非発火）。従来 effect が担保していた「loaded セッション内 1 回 / close→reopen で再発火」と同等の挙動になっていること。

## 仕様ドキュメント

純粋なリファクタリングで公開仕様・画面挙動の変更はないため `docs/spec-board/` の更新は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)