### PR TITLE
♻️ [Refactoring]: #316 [FE] mutation 系フックの連打競合制御（useMilestoneMutations / useAddLink / useRemoveLink）

### DIFF
--- a/src/features/detail/hooks/useAddLink/__tests__/useAddLink.flow.test.ts
+++ b/src/features/detail/hooks/useAddLink/__tests__/useAddLink.flow.test.ts
@@ -136,3 +136,47 @@ test("onAddLink が throw しても finally で isBusy=false に戻る", async (
 
   expect(probe.latest.isBusy).toBe(false);
 });
+
+test("実行中に再度呼んでも 2 回目は onAddLink を発行せず短絡する", async () => {
+  let resolveCb: ((r: Result<Task, unknown>) => void) | null = null;
+  const onAddLink = vi.fn(
+    () =>
+      new Promise<Result<Task, unknown>>((resolve) => {
+        resolveCb = resolve;
+      }),
+  );
+  const probe = renderHook({ onAddLink });
+
+  let firstPromise: Promise<void> = Promise.resolve();
+  act(() => {
+    firstPromise = probe.latest.addLink("tasks/b.md");
+  });
+  // 1 回目が in-flight のまま 2 回目を呼ぶ。
+  await act(async () => {
+    await probe.latest.addLink("tasks/c.md");
+  });
+
+  expect(onAddLink).toHaveBeenCalledTimes(1);
+  expect(probe.latest.isBusy).toBe(true);
+
+  await act(async () => {
+    resolveCb?.(Result.ok(stubTask()));
+    await firstPromise;
+  });
+  expect(probe.latest.isBusy).toBe(false);
+});
+
+test("1 回目完了後は再度 addLink を発行できる", async () => {
+  const onAddLink = vi.fn(async () => Result.ok(stubTask()));
+  const probe = renderHook({ onAddLink });
+
+  await act(async () => {
+    await probe.latest.addLink("tasks/b.md");
+  });
+  await act(async () => {
+    await probe.latest.addLink("tasks/c.md");
+  });
+
+  expect(onAddLink).toHaveBeenCalledTimes(2);
+  expect(probe.latest.isBusy).toBe(false);
+});

--- a/src/features/detail/hooks/useAddLink/index.ts
+++ b/src/features/detail/hooks/useAddLink/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { Task } from "@/types/task";
 import type { Result } from "@/utils/result";
 
@@ -29,27 +29,36 @@ export type UseAddLinkResult = {
 };
 
 /**
- * DetailScreen の関連タスク追加 UI 用フック。`isBusy` を管理するだけの薄い wrapper。
+ * DetailScreen の関連タスク追加 UI 用フック。`isBusy` を管理する薄い wrapper。
  *
- * 連続発火の防止は呼び出し側に委ねる:
- * - LinksSection は候補選択で `setIsOpen(false)` し popover を unmount するため
- *   候補ボタンが消える
- * - `+ リンク追加` ボタンは `disabled={isBusy}` で再オープンを抑止する
- * - 万一同時呼出が起きても downstream `addLinkAction` は `enqueueProjectCommand`
- *   で直列化され、`TaskLinks.appendLinkedFilePath` の重複ガードで no-op になる
+ * 実行中の再呼び出しは hook 内の in-flight ガードで短絡する。`isBusy`（state）は
+ * 描画に追従するが反映が非同期なため、同一 tick の連打では `isBusy` を見ても
+ * 二重発行を防げない。同期的に判定できる ref を真の競合制御として併用し、
+ * in-flight 中の 2 回目以降は `onAddLink` を発行せず即 return する。
+ *
+ * 呼び出し側の disabled（LinksSection の popover unmount / `disabled={isBusy}`）や
+ * downstream の `enqueueProjectCommand` 直列化も従来どおり働くが、最後の砦は
+ * この hook 内ガードが担う。
  *
  * @param args - {@link UseAddLinkArgs}
  * @returns {@link UseAddLinkResult}
  */
 export const useAddLink = (args: UseAddLinkArgs): UseAddLinkResult => {
   const [isBusy, setIsBusy] = useState(false);
+  // state 反映を待たずに同期判定するための in-flight フラグ。
+  const inFlightRef = useRef(false);
 
   const addLink = useCallback(
     async (targetFilePath: string) => {
+      if (inFlightRef.current) {
+        return;
+      }
+      inFlightRef.current = true;
       setIsBusy(true);
       try {
         await args.onAddLink(targetFilePath);
       } finally {
+        inFlightRef.current = false;
         setIsBusy(false);
       }
     },

--- a/src/features/detail/hooks/useRemoveLink/__tests__/useRemoveLink.flow.test.ts
+++ b/src/features/detail/hooks/useRemoveLink/__tests__/useRemoveLink.flow.test.ts
@@ -153,3 +153,47 @@ test("onRemoveLink が throw しても finally で isBusy=false に戻る", asyn
 
   expect(probe.latest.isBusy).toBe(false);
 });
+
+test("実行中に再度呼んでも 2 回目は onRemoveLink を発行せず短絡する", async () => {
+  let resolveCb: ((r: Result<Task, unknown>) => void) | null = null;
+  const onRemoveLink = vi.fn(
+    () =>
+      new Promise<Result<Task, unknown>>((resolve) => {
+        resolveCb = resolve;
+      }),
+  );
+  const probe = renderHook({ onRemoveLink });
+
+  let firstPromise: Promise<void> = Promise.resolve();
+  act(() => {
+    firstPromise = probe.latest.removeLink("tasks/b.md");
+  });
+  // 1 回目が in-flight のまま 2 回目を呼ぶ。
+  await act(async () => {
+    await probe.latest.removeLink("tasks/c.md");
+  });
+
+  expect(onRemoveLink).toHaveBeenCalledTimes(1);
+  expect(probe.latest.isBusy).toBe(true);
+
+  await act(async () => {
+    resolveCb?.(Result.ok(stubTask()));
+    await firstPromise;
+  });
+  expect(probe.latest.isBusy).toBe(false);
+});
+
+test("1 回目完了後は再度 removeLink を発行できる", async () => {
+  const onRemoveLink = vi.fn(async () => Result.ok(stubTask()));
+  const probe = renderHook({ onRemoveLink });
+
+  await act(async () => {
+    await probe.latest.removeLink("tasks/b.md");
+  });
+  await act(async () => {
+    await probe.latest.removeLink("tasks/c.md");
+  });
+
+  expect(onRemoveLink).toHaveBeenCalledTimes(2);
+  expect(probe.latest.isBusy).toBe(false);
+});

--- a/src/features/detail/hooks/useRemoveLink/index.ts
+++ b/src/features/detail/hooks/useRemoveLink/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { Task } from "@/types/task";
 import type { Result } from "@/utils/result";
 
@@ -28,24 +28,35 @@ export type UseRemoveLinkResult = {
 };
 
 /**
- * DetailScreen の関連タスク削除 UI 用フック。`isBusy` を管理するだけの薄い wrapper。
+ * DetailScreen の関連タスク削除 UI 用フック。`isBusy` を管理する薄い wrapper。
  *
- * 連続発火の防止は呼び出し側の LinksSection が button disabled で行う。
- * 万一同時呼出が起きても downstream `removeLinkAction` は `enqueueProjectCommand`
- * で直列化され、整合性は保たれる。
+ * 実行中の再呼び出しは hook 内の in-flight ガードで短絡する。`isBusy`（state）は
+ * 描画に追従するが反映が非同期なため、同一 tick の連打では二重発行を防げない。
+ * 同期的に判定できる ref を真の競合制御として併用し、in-flight 中の 2 回目以降は
+ * `onRemoveLink` を発行せず即 return する。
+ *
+ * 呼び出し側 LinksSection の button disabled や downstream `enqueueProjectCommand`
+ * 直列化も従来どおり働くが、最後の砦はこの hook 内ガードが担う。
  *
  * @param args - {@link UseRemoveLinkArgs}
  * @returns {@link UseRemoveLinkResult}
  */
 export const useRemoveLink = (args: UseRemoveLinkArgs): UseRemoveLinkResult => {
   const [isBusy, setIsBusy] = useState(false);
+  // state 反映を待たずに同期判定するための in-flight フラグ。
+  const inFlightRef = useRef(false);
 
   const removeLink = useCallback(
     async (targetFilePath: string) => {
+      if (inFlightRef.current) {
+        return;
+      }
+      inFlightRef.current = true;
       setIsBusy(true);
       try {
         await args.onRemoveLink(targetFilePath);
       } finally {
+        inFlightRef.current = false;
         setIsBusy(false);
       }
     },

--- a/src/features/settings/components/MilestoneSettingsTab/index.tsx
+++ b/src/features/settings/components/MilestoneSettingsTab/index.tsx
@@ -83,7 +83,7 @@ export const MilestoneSettingsTab = ({
   resource,
 }: MilestoneSettingsTabProps) => {
   const { milestones, usageCounts, status, reload } = resource;
-  const { create, update, remove } = useMilestoneMutations(reload);
+  const { isPending, create, update, remove } = useMilestoneMutations(reload);
   // 編集対象の name（null は新規作成モード）。
   const [editingName, setEditingName] = useState<string | null>(null);
   const [form, setForm] = useState<FormValues>(EMPTY_FORM);
@@ -192,7 +192,8 @@ export const MilestoneSettingsTab = ({
               </button>
               <button
                 type="button"
-                className="text-red-600"
+                className="text-red-600 disabled:opacity-50"
+                disabled={isPending}
                 onClick={() => {
                   void handleDelete(def.name);
                 }}
@@ -253,7 +254,7 @@ export const MilestoneSettingsTab = ({
         <div className="flex gap-2">
           <button
             type="submit"
-            disabled={form.name === ""}
+            disabled={form.name === "" || isPending}
             className="rounded bg-accent px-3 py-1 text-sm text-accent-foreground disabled:opacity-50"
           >
             {editingName === null ? "作成" : "更新"}

--- a/src/features/settings/hooks/useMilestoneMutations/__tests__/useMilestoneMutations.interaction.test.tsx
+++ b/src/features/settings/hooks/useMilestoneMutations/__tests__/useMilestoneMutations.interaction.test.tsx
@@ -77,7 +77,7 @@ const Probe = ({
 
 const mount = async (
   reload: () => Promise<void>,
-): Promise<UseMilestoneMutationsResult | null> => {
+): Promise<{ get latest(): UseMilestoneMutationsResult }> => {
   let latest: UseMilestoneMutationsResult | null = null;
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -92,15 +92,19 @@ const mount = async (
       }),
     );
   });
-  return latest;
+  return {
+    get latest(): UseMilestoneMutationsResult {
+      return latest as UseMilestoneMutationsResult;
+    },
+  };
 };
 
 test("create 成功時に reload を呼ぶ", async () => {
   createMock.mockResolvedValue(Result.ok(undefined));
   const reload = vi.fn(async () => {});
-  const mutations = await mount(reload);
+  const probe = await mount(reload);
   await act(async () => {
-    await mutations?.create({ name: "v0.3" });
+    await probe.latest.create({ name: "v0.3" });
   });
   expect(reload).toHaveBeenCalledTimes(1);
 });
@@ -108,9 +112,9 @@ test("create 成功時に reload を呼ぶ", async () => {
 test("create 失敗時は reload を呼ばない", async () => {
   createMock.mockResolvedValue(Result.err(TauriError.from("失敗")));
   const reload = vi.fn(async () => {});
-  const mutations = await mount(reload);
+  const probe = await mount(reload);
   await act(async () => {
-    const ok = await mutations?.create({ name: "v0.3" });
+    const ok = await probe.latest.create({ name: "v0.3" });
     expect(ok).toBe(false);
   });
   expect(reload).not.toHaveBeenCalled();
@@ -119,10 +123,106 @@ test("create 失敗時は reload を呼ばない", async () => {
 test("remove 成功時に reload を呼び usageCount payload を返す", async () => {
   deleteMock.mockResolvedValue(Result.ok({ usageCount: 2 }));
   const reload = vi.fn(async () => {});
-  const mutations = await mount(reload);
+  const probe = await mount(reload);
   await act(async () => {
-    const payload = await mutations?.remove("v0.3");
+    const payload = await probe.latest.remove("v0.3");
     expect(payload).toEqual({ usageCount: 2 });
   });
   expect(reload).toHaveBeenCalledTimes(1);
+});
+
+test("create 実行中は isPending=true、完了で false に戻る", async () => {
+  let resolveCb: ((r: Result<undefined, TauriError>) => void) | null = null;
+  createMock.mockReturnValue(
+    new Promise<Result<undefined, TauriError>>((resolve) => {
+      resolveCb = resolve;
+    }),
+  );
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+
+  let createPromise: Promise<boolean> = Promise.resolve(false);
+  act(() => {
+    createPromise = probe.latest.create({ name: "v0.3" });
+  });
+  expect(probe.latest.isPending).toBe(true);
+
+  await act(async () => {
+    resolveCb?.(Result.ok(undefined));
+    await createPromise;
+  });
+  expect(probe.latest.isPending).toBe(false);
+});
+
+test("実行中の create 連打は 2 回目を短絡し IPC を二重発行しない", async () => {
+  let resolveCb: ((r: Result<undefined, TauriError>) => void) | null = null;
+  createMock.mockReturnValue(
+    new Promise<Result<undefined, TauriError>>((resolve) => {
+      resolveCb = resolve;
+    }),
+  );
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+
+  let firstPromise: Promise<boolean> = Promise.resolve(false);
+  act(() => {
+    firstPromise = probe.latest.create({ name: "v0.3" });
+  });
+  let secondResult: boolean | undefined;
+  await act(async () => {
+    secondResult = await probe.latest.create({ name: "v0.3" });
+  });
+
+  expect(createMock).toHaveBeenCalledTimes(1);
+  expect(secondResult).toBe(false);
+
+  await act(async () => {
+    resolveCb?.(Result.ok(undefined));
+    await firstPromise;
+  });
+  expect(probe.latest.isPending).toBe(false);
+});
+
+test("実行中は他種別の mutation も短絡する（create 中の remove）", async () => {
+  let resolveCb: ((r: Result<undefined, TauriError>) => void) | null = null;
+  createMock.mockReturnValue(
+    new Promise<Result<undefined, TauriError>>((resolve) => {
+      resolveCb = resolve;
+    }),
+  );
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+
+  let firstPromise: Promise<boolean> = Promise.resolve(false);
+  act(() => {
+    firstPromise = probe.latest.create({ name: "v0.3" });
+  });
+  let removeResult: unknown;
+  await act(async () => {
+    removeResult = await probe.latest.remove("v0.3");
+  });
+
+  expect(deleteMock).not.toHaveBeenCalled();
+  expect(removeResult).toBeNull();
+
+  await act(async () => {
+    resolveCb?.(Result.ok(undefined));
+    await firstPromise;
+  });
+});
+
+test("create 完了後は再度 create を発行できる", async () => {
+  createMock.mockResolvedValue(Result.ok(undefined));
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+
+  await act(async () => {
+    await probe.latest.create({ name: "v0.3" });
+  });
+  await act(async () => {
+    await probe.latest.create({ name: "v0.4" });
+  });
+
+  expect(createMock).toHaveBeenCalledTimes(2);
+  expect(probe.latest.isPending).toBe(false);
 });

--- a/src/features/settings/hooks/useMilestoneMutations/index.ts
+++ b/src/features/settings/hooks/useMilestoneMutations/index.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   type CreateMilestoneArgs,
   createMilestone,
@@ -14,21 +14,26 @@ export type ReloadMilestones = () => Promise<void>;
 /** useMilestoneMutations の返り値。create / update / delete を提供する。 */
 export type UseMilestoneMutationsResult = {
   /**
+   * いずれかの mutation が実行中か。送信ボタン等の disabled に使う。
+   * pending 中に呼ばれた mutation は短絡して即失敗値を返す。
+   */
+  isPending: boolean;
+  /**
    * マイルストーンを作成する。成功時のみ reload を呼ぶ。
    * @param args - 作成内容
-   * @returns 成功なら true、失敗なら false（失敗トーストは共通層が発火する）
+   * @returns 成功なら true、失敗・pending 中なら false（失敗トーストは共通層が発火する）
    */
   create: (args: CreateMilestoneArgs) => Promise<boolean>;
   /**
    * マイルストーンを更新する（PUT）。成功時のみ reload を呼ぶ。
    * @param args - 更新内容
-   * @returns 成功なら true、失敗なら false
+   * @returns 成功なら true、失敗・pending 中なら false
    */
   update: (args: UpdateMilestoneArgs) => Promise<boolean>;
   /**
    * マイルストーンを削除する。成功時のみ reload を呼ぶ。
    * @param name - 削除対象の name
-   * @returns 成功なら削除前 usageCount を含む payload、失敗なら null
+   * @returns 成功なら削除前 usageCount を含む payload、失敗・pending 中なら null
    */
   remove: (name: string) => Promise<DeleteMilestonePayload | null>;
 };
@@ -38,62 +43,99 @@ export type UseMilestoneMutationsResult = {
  * 呼んで一覧を再取得・確定する（取得・一覧 state は持たない）。失敗時は共通層
  * （invokeWrapped allowlist）が失敗トーストを発火するため、ここでは reload を呼ばない。
  *
+ * 実行中の再呼び出しは hook 内の in-flight ガードで短絡する。3 種の mutation は同じ
+ * 一覧 state を共有して reload で確定するため、ガードは種別をまたいで 1 本に統一し、
+ * いずれかが実行中なら他種別も短絡させる（create 連打の重複作成・remove の二重失敗
+ * トーストを防ぐ）。`isPending`（state）は描画追従用、ref は同一 tick の連打でも
+ * 確実に短絡させるための同期判定用として併用する。
+ *
  * @param reload - 成功後に呼ぶ再取得関数（`useMilestones.reload`）
- * @returns create / update / remove
+ * @returns isPending / create / update / remove
  */
 export const useMilestoneMutations = (
   reload: ReloadMilestones,
 ): UseMilestoneMutationsResult => {
+  const [isPending, setIsPending] = useState(false);
+  // state 反映を待たずに同期判定するための in-flight フラグ（種別共通）。
+  const inFlightRef = useRef(false);
+
+  /**
+   * mutation を in-flight ガードで包む。pending 中なら `rejected` を即返し、
+   * そうでなければ `run` を実行して結果を返す。成否に関わらず finally で解放する。
+   * @param run - 実行する mutation 本体
+   * @param rejected - pending 中の短絡時に返す値
+   * @returns run の結果、または pending 中なら rejected
+   */
+  const guard = useCallback(
+    async <T>(run: () => Promise<T>, rejected: T): Promise<T> => {
+      if (inFlightRef.current) {
+        return rejected;
+      }
+      inFlightRef.current = true;
+      setIsPending(true);
+      try {
+        return await run();
+      } finally {
+        inFlightRef.current = false;
+        setIsPending(false);
+      }
+    },
+    [],
+  );
+
   /**
    * 作成。成功時のみ reload する。
    * @param args - 作成内容
-   * @returns 成功なら true
+   * @returns 成功なら true、失敗・pending 中なら false
    */
   const create = useCallback(
-    async (args: CreateMilestoneArgs): Promise<boolean> => {
-      const result = await createMilestone(args);
-      if (!result.ok) {
-        return false;
-      }
-      await reload();
-      return true;
-    },
-    [reload],
+    (args: CreateMilestoneArgs): Promise<boolean> =>
+      guard(async () => {
+        const result = await createMilestone(args);
+        if (!result.ok) {
+          return false;
+        }
+        await reload();
+        return true;
+      }, false),
+    [guard, reload],
   );
 
   /**
    * 更新。成功時のみ reload する。
    * @param args - 更新内容
-   * @returns 成功なら true
+   * @returns 成功なら true、失敗・pending 中なら false
    */
   const update = useCallback(
-    async (args: UpdateMilestoneArgs): Promise<boolean> => {
-      const result = await updateMilestone(args);
-      if (!result.ok) {
-        return false;
-      }
-      await reload();
-      return true;
-    },
-    [reload],
+    (args: UpdateMilestoneArgs): Promise<boolean> =>
+      guard(async () => {
+        const result = await updateMilestone(args);
+        if (!result.ok) {
+          return false;
+        }
+        await reload();
+        return true;
+      }, false),
+    [guard, reload],
   );
 
   /**
    * 削除。成功時のみ reload する。
    * @param name - 削除対象の name
-   * @returns 成功なら usageCount payload、失敗なら null
+   * @returns 成功なら usageCount payload、失敗・pending 中なら null
    */
   const remove = useCallback(
-    async (name: string): Promise<DeleteMilestonePayload | null> => {
-      const result = await deleteMilestone(name);
-      if (!result.ok) {
-        return null;
-      }
-      await reload();
-      return result.value;
-    },
-    [reload],
+    (name: string): Promise<DeleteMilestonePayload | null> =>
+      guard<DeleteMilestonePayload | null>(async () => {
+        const result = await deleteMilestone(name);
+        if (!result.ok) {
+          return null;
+        }
+        await reload();
+        return result.value;
+      }, null),
+    [guard, reload],
   );
 
-  return { create, update, remove };
+  return { isPending, create, update, remove };
 };


### PR DESCRIPTION
## 概要

- mutation 系フック（`useMilestoneMutations` / `useAddLink` / `useRemoveLink`）に実行中ガード（in-flight 競合制御）を追加し、連打時の二重 IPC 発行と `isBusy` の壊れを防ぐ。
- 正常系の外部挙動は不変。連打時のみ安全側（短絡）に変わる。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 変更した内容

- **`useAddLink` / `useRemoveLink`**: `inFlightRef`（同期判定用の boolean ref）を追加。実行中の再呼び出しは `onAddLink` / `onRemoveLink` を発行せず即 return する。`isBusy`(state) は反映が非同期で、1 回目の `finally` の `setIsBusy(false)` が 2 回目の実行中に走ると in-flight なのに UI が enabled に戻る不具合があったため、同期判定できる ref を真の競合制御として併用する。
- **`useMilestoneMutations`**: 返り値に `isPending` を追加し、種別共通の `inFlightRef` ガードを導入。3 種（create/update/remove）は同じ一覧 state を `reload` で確定するため、いずれかが実行中なら他種別も短絡させる。pending 中の呼び出しは即失敗値（`false` / `null`）を返す。
- **`MilestoneSettingsTab`**: `isPending` を受けて作成/更新の submit ボタンと各行の削除ボタンを pending 中 disabled にし、UI 側でも連打を抑止（hook 内ガードと二重の防御）。従来は送信ボタンが `name === ""` 以外で disabled にならなかった。

## システム図

```mermaid
flowchart TD
    A[addLink / removeLink / create / update / remove 呼び出し] --> B{inFlightRef.current?}
    B -- true（実行中） --> C[即 return / 失敗値を返す<br>IPC を発行しない]
    B -- false --> D[inFlightRef = true<br>setIsBusy/isPending true]
    D --> E[await IPC]
    E --> F[finally: inFlightRef = false<br>setIsBusy/isPending false]
    style B fill:#fde68a
    style C fill:#fecaca
```

## 仕様ドキュメント更新

- 不要（純粋な内部競合制御の追加。公開 API のうち `useMilestoneMutations` に `isPending` を足したが、これは FE 内部 hook の戻り値であり、`docs/spec-board/` が扱うタスク形式・画面挙動・設定項目・データ形式の仕様変更には該当しない。連打抑止以外の外部挙動は不変）。

## 関連Issue

Closes #316

## テスト

- `pnpm test:run`: 241 ファイル / 2081 テスト 全 pass
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- `biome check src`: クリーン
- 追加テスト: 各 hook に「実行中の再呼び出しが 2 回目を短絡し IPC を二重発行しない」「1 回目完了後は再発行できる」、`useMilestoneMutations` に `isPending` 遷移・種別跨ぎ短絡のテストを追加。

## レビューポイント

- in-flight ガードを `useState` ではなく `useRef` で同期判定している点（同一 tick の連打を確実に短絡するため）。
- `useMilestoneMutations` のガードを種別共通の 1 本にした判断（3 種が同じ一覧 state を共有するため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)