### PR TITLE
♻️ [Refactoring]: #320 [FE] hooks 公開 API の規約整合（handleXxx 命名 / 内部 state 公開 / options object / DOM ref 公開）

### DIFF
--- a/src/features/detail/components/LabelEditor/index.tsx
+++ b/src/features/detail/components/LabelEditor/index.tsx
@@ -44,7 +44,7 @@ export const LabelEditor = ({ labels, onAdd, onRemove }: LabelEditorProps) => {
    */
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     justClosedByKeyRef.current = e.key === "Enter" || e.key === "Escape";
-    input.handleKeyDown(e);
+    input.commitOrCancelOnKey(e);
   };
 
   /**

--- a/src/features/detail/components/MarkdownBody/index.tsx
+++ b/src/features/detail/components/MarkdownBody/index.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { renderBlock } from "@/components/MarkdownContent/renderBlock";
 import { Markdown } from "@/domains/markdown";
 import {
@@ -37,6 +38,18 @@ const PLACEHOLDER_CLASS_NAME = "text-sm text-muted";
 export const MarkdownBody = ({ body, onConfirm }: MarkdownBodyProps) => {
   const edit = useMarkdownBodyEdit({ body, onConfirm });
 
+  // textarea mount 時に focus + 末尾カーソル設定を行う callback ref。DOM 操作は
+  // コンポーネント側の責務とし、hook の公開 API には DOM 参照を含めない。
+  const focusTextareaAtEnd = useCallback((el: HTMLTextAreaElement | null) => {
+    if (el === null) {
+      return;
+    }
+    el.focus();
+    const end = el.value.length;
+    el.selectionStart = end;
+    el.selectionEnd = end;
+  }, []);
+
   const handleToggle = (sourceLine: number) => {
     if (onConfirm === undefined) {
       return;
@@ -54,11 +67,11 @@ export const MarkdownBody = ({ body, onConfirm }: MarkdownBodyProps) => {
   if (edit.mode === MarkdownBodyEditMode.Edit) {
     return (
       <textarea
-        ref={edit.textareaRef}
+        ref={focusTextareaAtEnd}
         className={TEXTAREA_CLASS_NAME}
         value={edit.editValue}
         onChange={(e) => edit.setEditValue(e.target.value)}
-        onKeyDown={edit.handleTextareaKeyDown}
+        onKeyDown={edit.submitOrCancelOnKey}
         data-testid="markdown-body-textarea"
         aria-label="本文を編集"
       />
@@ -87,8 +100,8 @@ export const MarkdownBody = ({ body, onConfirm }: MarkdownBodyProps) => {
       role="button"
       tabIndex={0}
       className={DISPLAY_EDITABLE_WRAPPER_CLASS_NAME}
-      onClick={edit.handleDisplayClick}
-      onKeyDown={edit.handleDisplayKeyDown}
+      onClick={edit.enterEditOnClick}
+      onKeyDown={edit.enterEditOnKey}
       data-testid="markdown-body"
       aria-label="本文を編集する"
     >

--- a/src/features/detail/hooks/useChildTasks/index.ts
+++ b/src/features/detail/hooks/useChildTasks/index.ts
@@ -35,6 +35,12 @@ const EMPTY_TASKS: readonly Task[] = [];
  * `childTasks` / `descendantTasks` / `effectiveDoneColumn` は独立した useMemo で
  * メモ化しており、`columns` / `doneColumn` の変更だけでは `descendantTasks` の
  * 再計算は走らない。
+ *
+ * hook 化を維持する理由: 戻り値 `UseChildTasksResult` を `PropertiesSidebar` の
+ * prop 型として共有し、3 つの派生値（直下子 / 全子孫 / 完了カラム）と各々の
+ * メモ化境界を 1 つの公開 API にまとめて component 境界をまたいで渡している。
+ * 単一コンポーネント内の useMemo へ展開すると、この共有 ViewModel と独立した
+ * メモ化境界が分散するため hook に残す。
  * @param args - 親ファイルパス・全タスク・カラム・doneColumn
  * @returns 直下子・全子孫・完了カラム名
  */

--- a/src/features/detail/hooks/useDeleteFlow/__tests__/useDeleteFlow.interaction.test.tsx
+++ b/src/features/detail/hooks/useDeleteFlow/__tests__/useDeleteFlow.interaction.test.tsx
@@ -93,12 +93,7 @@ const renderHook = (args: UseDeleteFlowArgs) => {
   };
 };
 
-test("初期 state は { kind: 'idle' }", () => {
-  const probe = renderHook({ onDelete: vi.fn() });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
-});
-
-test("idle では isOpen=false / isBusy=false", () => {
+test("初期状態は閉じている（isOpen=false / isBusy=false）", () => {
   const probe = renderHook({ onDelete: vi.fn() });
   expect(probe.latest.isOpen).toBe(false);
   expect(probe.latest.isBusy).toBe(false);
@@ -150,15 +145,16 @@ test("error では isOpen=true / isBusy=false", async () => {
   expect(probe.latest.isBusy).toBe(false);
 });
 
-test("requestDelete() で confirming に遷移", () => {
+test("requestDelete() で確認ダイアログが開く（isOpen=true）", () => {
   const probe = renderHook({ onDelete: vi.fn() });
   act(() => {
     probe.latest.requestDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "confirming" });
+  expect(probe.latest.isOpen).toBe(true);
+  expect(probe.latest.isBusy).toBe(false);
 });
 
-test("cancelDelete() で idle に戻る", () => {
+test("cancelDelete() で閉じる（isOpen=false）", () => {
   const probe = renderHook({ onDelete: vi.fn() });
   act(() => {
     probe.latest.requestDelete();
@@ -166,10 +162,10 @@ test("cancelDelete() で idle に戻る", () => {
   act(() => {
     probe.latest.cancelDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isOpen).toBe(false);
 });
 
-test("confirmDelete() 成功で deleting → idle、onDelete が呼ばれる", async () => {
+test("confirmDelete() 成功で閉じる（isOpen=false）、onDelete が呼ばれる", async () => {
   const onDelete = vi.fn().mockResolvedValue(undefined);
   const probe = renderHook({ onDelete });
   act(() => {
@@ -179,12 +175,11 @@ test("confirmDelete() 成功で deleting → idle、onDelete が呼ばれる", a
     await probe.latest.confirmDelete();
   });
   expect(onDelete).toHaveBeenCalledTimes(1);
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isOpen).toBe(false);
 });
 
-test("confirmDelete() 失敗で error 状態へ遷移（reason 保持）", async () => {
-  const reason = new Error("boom");
-  const onDelete = vi.fn().mockRejectedValue(reason);
+test("confirmDelete() 失敗でダイアログは開いたまま（isOpen=true / isBusy=false）", async () => {
+  const onDelete = vi.fn().mockRejectedValue(new Error("boom"));
   const probe = renderHook({ onDelete });
   act(() => {
     probe.latest.requestDelete();
@@ -192,7 +187,8 @@ test("confirmDelete() 失敗で error 状態へ遷移（reason 保持）", async
   await act(async () => {
     await probe.latest.confirmDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "error", reason });
+  expect(probe.latest.isOpen).toBe(true);
+  expect(probe.latest.isBusy).toBe(false);
 });
 
 test("削除失敗時に console.error / warn / log が呼ばれない", async () => {
@@ -212,7 +208,7 @@ test("削除失敗時に console.error / warn / log が呼ばれない", async (
   expect(logSpy).not.toHaveBeenCalled();
 });
 
-test("deleting 中の cancelDelete は machine no-op で吸収（state そのまま）", async () => {
+test("deleting 中の cancelDelete は machine no-op で吸収（busy のまま）", async () => {
   vi.spyOn(console, "warn").mockImplementation(() => {});
   let resolve!: () => void;
   const onDelete = vi.fn(
@@ -229,16 +225,16 @@ test("deleting 中の cancelDelete は machine no-op で吸収（state そのま
   act(() => {
     pending = probe.latest.confirmDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "deleting" });
+  expect(probe.latest.isBusy).toBe(true);
   act(() => {
     probe.latest.cancelDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "deleting" });
+  expect(probe.latest.isBusy).toBe(true);
   await act(async () => {
     resolve();
     await pending;
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isOpen).toBe(false);
 });
 
 test("deleting 中の confirmDelete 再呼び出しは machine no-op で吸収", async () => {
@@ -258,12 +254,12 @@ test("deleting 中の confirmDelete 再呼び出しは machine no-op で吸収",
   act(() => {
     pending = probe.latest.confirmDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "deleting" });
+  expect(probe.latest.isBusy).toBe(true);
   let pending2: Promise<void> | undefined;
   act(() => {
     pending2 = probe.latest.confirmDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "deleting" });
+  expect(probe.latest.isBusy).toBe(true);
   await act(async () => {
     for (const r of resolvers) {
       r();
@@ -273,14 +269,14 @@ test("deleting 中の confirmDelete 再呼び出しは machine no-op で吸収",
   });
 });
 
-test("idle 中の confirmDelete 再呼び出しは machine no-op で吸収", async () => {
+test("閉じている状態での confirmDelete 再呼び出しは machine no-op で吸収", async () => {
   vi.spyOn(console, "warn").mockImplementation(() => {});
   const onDelete = vi.fn().mockResolvedValue(undefined);
   const probe = renderHook({ onDelete });
   await act(async () => {
     await probe.latest.confirmDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isOpen).toBe(false);
 });
 
 test("同期的な onDelete でも動作する", async () => {
@@ -293,10 +289,10 @@ test("同期的な onDelete でも動作する", async () => {
     await probe.latest.confirmDelete();
   });
   expect(onDelete).toHaveBeenCalledTimes(1);
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isOpen).toBe(false);
 });
 
-test("error 状態から cancelDelete で idle に戻る", async () => {
+test("error 状態から cancelDelete で閉じる（isOpen=false）", async () => {
   const onDelete = vi.fn().mockRejectedValue(new Error("x"));
   const probe = renderHook({ onDelete });
   act(() => {
@@ -305,9 +301,9 @@ test("error 状態から cancelDelete で idle に戻る", async () => {
   await act(async () => {
     await probe.latest.confirmDelete();
   });
-  expect(probe.latest.state.kind).toBe("error");
+  expect(probe.latest.isOpen).toBe(true);
   act(() => {
     probe.latest.cancelDelete();
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isOpen).toBe(false);
 });

--- a/src/features/detail/hooks/useDeleteFlow/index.ts
+++ b/src/features/detail/hooks/useDeleteFlow/index.ts
@@ -15,8 +15,6 @@ export type UseDeleteFlowArgs = {
 
 /** useDeleteFlow の戻り値 */
 export type UseDeleteFlowResult = {
-  /** 現在の state（kind で UI 表示分岐する） */
-  state: DeleteFlowState;
   /** 確認ダイアログを表示すべきか（idle 以外なら true） */
   isOpen: boolean;
   /** 削除実行中か（deleting なら true、UI の disabled / ラベル切替に使う） */
@@ -66,7 +64,6 @@ export const useDeleteFlow = (args: UseDeleteFlowArgs): UseDeleteFlowResult => {
   }, [state, onDelete]);
 
   return {
-    state,
     isOpen: !DeleteFlow.canRequest(state),
     isBusy: state.kind === "deleting",
     requestDelete,

--- a/src/features/detail/hooks/useLabelInput/__tests__/useLabelInput.interaction.test.tsx
+++ b/src/features/detail/hooks/useLabelInput/__tests__/useLabelInput.interaction.test.tsx
@@ -77,22 +77,24 @@ const renderHook = (args: UseLabelInputArgs) => {
   };
 };
 
-test("初期 state は { kind: 'idle' }", () => {
+test("初期状態は非追加（isAdding=false / inputValue=''）", () => {
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: [], onCommit });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
+  expect(probe.latest.inputValue).toBe("");
 });
 
-test("startAdding() で adding に遷移", () => {
+test("startAdding() で追加中（isAdding=true / inputValue=''）に遷移", () => {
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: [], onCommit });
   act(() => {
     probe.latest.startAdding();
   });
-  expect(probe.latest.state).toEqual({ kind: "adding", input: "" });
+  expect(probe.latest.isAdding).toBe(true);
+  expect(probe.latest.inputValue).toBe("");
 });
 
-test("setInput で input が更新される（連続）", () => {
+test("setInput で inputValue が更新される（連続）", () => {
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: [], onCommit });
   act(() => {
@@ -101,14 +103,14 @@ test("setInput で input が更新される（連続）", () => {
   act(() => {
     probe.latest.setInput("foo");
   });
-  expect(probe.latest.state).toEqual({ kind: "adding", input: "foo" });
+  expect(probe.latest.inputValue).toBe("foo");
   act(() => {
     probe.latest.setInput("bar");
   });
-  expect(probe.latest.state).toEqual({ kind: "adding", input: "bar" });
+  expect(probe.latest.inputValue).toBe("bar");
 });
 
-test("cancelAdding() で idle に戻る", () => {
+test("cancelAdding() で非追加（isAdding=false）に戻る", () => {
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: [], onCommit });
   act(() => {
@@ -120,10 +122,10 @@ test("cancelAdding() で idle に戻る", () => {
   act(() => {
     probe.latest.cancelAdding();
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });
 
-test("confirmAdding() 成功で onCommit が trim 値で 1 回呼ばれて idle に戻る", () => {
+test("confirmAdding() 成功で onCommit が trim 値で 1 回呼ばれて非追加に戻る", () => {
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: ["a"], onCommit });
   act(() => {
@@ -137,10 +139,10 @@ test("confirmAdding() 成功で onCommit が trim 値で 1 回呼ばれて idle 
   });
   expect(onCommit).toHaveBeenCalledTimes(1);
   expect(onCommit).toHaveBeenCalledWith("foo");
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });
 
-test("confirmAdding() 重複時は onCommit 呼ばれず idle に戻る", () => {
+test("confirmAdding() 重複時は onCommit 呼ばれず非追加に戻る", () => {
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: ["a"], onCommit });
   act(() => {
@@ -153,10 +155,10 @@ test("confirmAdding() 重複時は onCommit 呼ばれず idle に戻る", () => 
     probe.latest.confirmAdding();
   });
   expect(onCommit).not.toHaveBeenCalled();
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });
 
-test("confirmAdding() 空文字時は onCommit 呼ばれず idle に戻る", () => {
+test("confirmAdding() 空文字時は onCommit 呼ばれず非追加に戻る", () => {
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: [], onCommit });
   act(() => {
@@ -169,7 +171,7 @@ test("confirmAdding() 空文字時は onCommit 呼ばれず idle に戻る", () 
     probe.latest.confirmAdding();
   });
   expect(onCommit).not.toHaveBeenCalled();
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });
 
 test("Enter キーで confirmAdding が走る", () => {
@@ -184,7 +186,7 @@ test("Enter キーで confirmAdding が走る", () => {
   const preventDefault = vi.fn();
   const stopPropagation = vi.fn();
   act(() => {
-    probe.latest.handleKeyDown({
+    probe.latest.commitOrCancelOnKey({
       key: "Enter",
       preventDefault,
       stopPropagation,
@@ -192,7 +194,7 @@ test("Enter キーで confirmAdding が走る", () => {
   });
   expect(preventDefault).toHaveBeenCalled();
   expect(onCommit).toHaveBeenCalledWith("x");
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });
 
 test("Enter 後の confirmAdding 再呼び出しは早期 return（onCommit 1 回のみ）", () => {
@@ -205,7 +207,7 @@ test("Enter 後の confirmAdding 再呼び出しは早期 return（onCommit 1 �
     probe.latest.setInput("x");
   });
   act(() => {
-    probe.latest.handleKeyDown({
+    probe.latest.commitOrCancelOnKey({
       key: "Enter",
       preventDefault: () => {},
       stopPropagation: () => {},
@@ -228,7 +230,7 @@ test("Enter 後の cancelAdding は machine no-op で副作用なし", () => {
     probe.latest.setInput("x");
   });
   act(() => {
-    probe.latest.handleKeyDown({
+    probe.latest.commitOrCancelOnKey({
       key: "Enter",
       preventDefault: () => {},
       stopPropagation: () => {},
@@ -238,7 +240,7 @@ test("Enter 後の cancelAdding は machine no-op で副作用なし", () => {
     probe.latest.cancelAdding();
   });
   expect(onCommit).toHaveBeenCalledTimes(1);
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });
 
 test("Escape キーで cancelAdding が走る（onCommit 呼ばれない）", () => {
@@ -252,7 +254,7 @@ test("Escape キーで cancelAdding が走る（onCommit 呼ばれない）", ()
   });
   const preventDefault = vi.fn();
   act(() => {
-    probe.latest.handleKeyDown({
+    probe.latest.commitOrCancelOnKey({
       key: "Escape",
       preventDefault,
       stopPropagation: () => {},
@@ -260,24 +262,24 @@ test("Escape キーで cancelAdding が走る（onCommit 呼ばれない）", ()
   });
   expect(preventDefault).toHaveBeenCalled();
   expect(onCommit).not.toHaveBeenCalled();
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });
 
-test("idle 中の setInput / confirmAdding / cancelAdding は hook を壊さない", () => {
+test("非追加中の setInput / confirmAdding / cancelAdding は hook を壊さない", () => {
   vi.spyOn(console, "warn").mockImplementation(() => {});
   const onCommit = vi.fn();
   const probe = renderHook({ existingLabels: [], onCommit });
   act(() => {
     probe.latest.setInput("foo");
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
   act(() => {
     probe.latest.confirmAdding();
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
   expect(onCommit).not.toHaveBeenCalled();
   act(() => {
     probe.latest.cancelAdding();
   });
-  expect(probe.latest.state).toEqual({ kind: "idle" });
+  expect(probe.latest.isAdding).toBe(false);
 });

--- a/src/features/detail/hooks/useLabelInput/index.ts
+++ b/src/features/detail/hooks/useLabelInput/index.ts
@@ -19,8 +19,6 @@ export type UseLabelInputArgs = {
 
 /** useLabelInput の戻り値 */
 export type UseLabelInputResult = {
-  /** 現在の state（テスト等で参照する。UI は isAdding / inputValue を使う） */
-  state: LabelInputState;
   /** 入力 input 要素を表示すべきか（adding なら true） */
   isAdding: boolean;
   /** 入力中の値（adding 以外は ""） */
@@ -37,10 +35,10 @@ export type UseLabelInputResult = {
   /** adding 中の入力を確定する（成功時 onCommit + idle 復帰） */
   confirmAdding: () => void;
   /**
-   * input 要素に渡す Enter/Escape ハンドラ。
+   * input 要素の onKeyDown に渡すハンドラ。Enter で確定、Escape でキャンセルする。
    * @param e - keydown イベント
    */
-  handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  commitOrCancelOnKey: (e: KeyboardEvent<HTMLInputElement>) => void;
 };
 
 /**
@@ -80,7 +78,7 @@ export const useLabelInput = (args: UseLabelInputArgs): UseLabelInputResult => {
     setState((s) => LabelInput.confirm(s));
   }, [state, existingLabels, onCommit]);
 
-  const handleKeyDown = useCallback(
+  const commitOrCancelOnKey = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
@@ -96,13 +94,12 @@ export const useLabelInput = (args: UseLabelInputArgs): UseLabelInputResult => {
   );
 
   return {
-    state,
     isAdding: LabelInput.isAdding(state),
     inputValue: LabelInput.inputOf(state) ?? "",
     startAdding,
     setInput,
     cancelAdding,
     confirmAdding,
-    handleKeyDown,
+    commitOrCancelOnKey,
   };
 };

--- a/src/features/detail/hooks/useMarkdownBodyEdit/__tests__/useMarkdownBodyEdit.behavior.test.tsx
+++ b/src/features/detail/hooks/useMarkdownBodyEdit/__tests__/useMarkdownBodyEdit.behavior.test.tsx
@@ -92,82 +92,59 @@ test("onConfirm 指定なら isEditable=true", () => {
   expect(captured?.isEditable).toBe(true);
 });
 
-test("handleDisplayClick で mode が edit に切り替わり editValue が body にリセットされる", () => {
+test("enterEditOnClick で mode が edit に切り替わり editValue が body にリセットされる", () => {
   mount({ body: "abc", onConfirm: vi.fn() });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Edit);
   expect(captured?.editValue).toBe("abc");
 });
 
-test("handleDisplayClick は isEditable=false のとき no-op", () => {
+test("enterEditOnClick は isEditable=false のとき no-op", () => {
   mount({ body: "abc" });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Display);
 });
 
-test("handleDisplayKeyDown(Enter) で edit モードに入る", () => {
+test("enterEditOnKey(Enter) で edit モードに入る", () => {
   mount({ body: "abc", onConfirm: vi.fn() });
   const e = makeFakeKey({ key: "Enter" });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleDisplayKeyDown(e as any);
+    captured?.enterEditOnKey(e as any);
   });
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Edit);
   expect(e.preventDefault).toHaveBeenCalled();
 });
 
-test("handleDisplayKeyDown(Space) で edit モードに入る", () => {
+test("enterEditOnKey(Space) で edit モードに入る", () => {
   mount({ body: "abc", onConfirm: vi.fn() });
   const e = makeFakeKey({ key: " " });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleDisplayKeyDown(e as any);
+    captured?.enterEditOnKey(e as any);
   });
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Edit);
 });
 
-test("handleDisplayKeyDown(他キー) では mode が変わらない", () => {
+test("enterEditOnKey(他キー) では mode が変わらない", () => {
   mount({ body: "abc", onConfirm: vi.fn() });
   const e = makeFakeKey({ key: "a" });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleDisplayKeyDown(e as any);
+    captured?.enterEditOnKey(e as any);
   });
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Display);
-});
-
-test("textareaRef(element) で focus + 末尾カーソル設定が行われる", () => {
-  mount({ body: "abcdef", onConfirm: vi.fn() });
-  const textarea = document.createElement("textarea");
-  textarea.value = "abcdef";
-  document.body.appendChild(textarea);
-  act(() => {
-    captured?.textareaRef(textarea);
-  });
-  expect(document.activeElement).toBe(textarea);
-  expect(textarea.selectionStart).toBe(6);
-  expect(textarea.selectionEnd).toBe(6);
-  textarea.remove();
-});
-
-test("textareaRef(null) は no-op", () => {
-  mount({ body: "abc", onConfirm: vi.fn() });
-  expect(() => {
-    act(() => {
-      captured?.textareaRef(null);
-    });
-  }).not.toThrow();
 });
 
 test("Cmd+Enter で変更ありなら onConfirm(editValue) 発火 + display に戻る", () => {
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("xyz");
@@ -175,7 +152,7 @@ test("Cmd+Enter で変更ありなら onConfirm(editValue) 発火 + display に�
   const e = makeFakeKey({ key: "Enter", metaKey: true });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).toHaveBeenCalledWith("xyz");
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Display);
@@ -187,7 +164,7 @@ test("Ctrl+Enter でも同様に commit する", () => {
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("xyz");
@@ -195,7 +172,7 @@ test("Ctrl+Enter でも同様に commit する", () => {
   const e = makeFakeKey({ key: "Enter", ctrlKey: true });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).toHaveBeenCalledWith("xyz");
 });
@@ -204,12 +181,12 @@ test("Cmd+Enter で editValue===body の場合 onConfirm 未発火 + display へ
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   const e = makeFakeKey({ key: "Enter", metaKey: true });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).not.toHaveBeenCalled();
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Display);
@@ -219,7 +196,7 @@ test("先頭/末尾の空白だけ追加した編集の Cmd+Enter は onConfirm 
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("abc\n  ");
@@ -227,7 +204,7 @@ test("先頭/末尾の空白だけ追加した編集の Cmd+Enter は onConfirm 
   const e = makeFakeKey({ key: "Enter", metaKey: true });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).toHaveBeenCalledWith("abc\n  ");
 });
@@ -236,7 +213,7 @@ test("空文字に編集した Cmd+Enter は onConfirm('') を呼ぶ", () => {
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("");
@@ -244,7 +221,7 @@ test("空文字に編集した Cmd+Enter は onConfirm('') を呼ぶ", () => {
   const e = makeFakeKey({ key: "Enter", metaKey: true });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).toHaveBeenCalledWith("");
 });
@@ -253,7 +230,7 @@ test("IME 変換中(isComposing=true)の Cmd+Enter は onConfirm 未発火、pre
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("xyz");
@@ -261,7 +238,7 @@ test("IME 変換中(isComposing=true)の Cmd+Enter は onConfirm 未発火、pre
   const e = makeFakeKey({ key: "Enter", metaKey: true, isComposing: true });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).not.toHaveBeenCalled();
   expect(e.preventDefault).toHaveBeenCalled();
@@ -273,7 +250,7 @@ test("IME 変換中(isComposing=true)の Esc は cancel を呼ばず mode/editVa
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("draft");
@@ -281,7 +258,7 @@ test("IME 変換中(isComposing=true)の Esc は cancel を呼ばず mode/editVa
   const e = makeFakeKey({ key: "Escape", isComposing: true });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Edit);
   expect(captured?.editValue).toBe("draft");
@@ -293,7 +270,7 @@ test("Esc で onConfirm 未発火 + editValue が body に戻り display へ遷�
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("draft");
@@ -301,7 +278,7 @@ test("Esc で onConfirm 未発火 + editValue が body に戻り display へ遷�
   const e = makeFakeKey({ key: "Escape" });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).not.toHaveBeenCalled();
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Display);
@@ -314,12 +291,12 @@ test("Enter (修飾なし) は textarea ハンドラで何もしない（改行�
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   const e = makeFakeKey({ key: "Enter" });
   act(() => {
     // biome-ignore lint/suspicious/noExplicitAny: harness 用の最小限の型整合
-    captured?.handleTextareaKeyDown(e as any);
+    captured?.submitOrCancelOnKey(e as any);
   });
   expect(onConfirm).not.toHaveBeenCalled();
   expect(captured?.mode).toBe(MarkdownBodyEditMode.Edit);
@@ -330,7 +307,7 @@ test("body が rerender で変わっても hook 内 state は維持される（�
   const onConfirm = vi.fn();
   mount({ body: "abc", onConfirm });
   act(() => {
-    captured?.handleDisplayClick();
+    captured?.enterEditOnClick();
   });
   act(() => {
     captured?.setEditValue("draft");

--- a/src/features/detail/hooks/useMarkdownBodyEdit/index.ts
+++ b/src/features/detail/hooks/useMarkdownBodyEdit/index.ts
@@ -34,27 +34,22 @@ export type UseMarkdownBodyEditResult = {
   setEditValue: (value: string) => void;
   /** `onConfirm` が指定されているか */
   isEditable: boolean;
-  /**
-   * textarea mount 時に focus + 末尾カーソル設定を行う callback ref
-   * @param el - mount された textarea 要素（unmount 時は null）
-   */
-  textareaRef: (el: HTMLTextAreaElement | null) => void;
-  /** display エリアの click ハンドラ */
-  handleDisplayClick: () => void;
+  /** display エリアの click で edit モードへ入る */
+  enterEditOnClick: () => void;
   /**
    * display エリアの keydown ハンドラ（Enter / Space で edit 起動）
    * @param e - React の keyboard イベント
    */
-  handleDisplayKeyDown: (e: KeyboardEvent<HTMLDivElement>) => void;
+  enterEditOnKey: (e: KeyboardEvent<HTMLDivElement>) => void;
   /**
-   * textarea の keydown ハンドラ（Cmd/Ctrl+Enter / Esc / IME 抑止）
+   * textarea の keydown ハンドラ（Cmd/Ctrl+Enter で確定 / Esc でキャンセル / IME 抑止）
    * @param e - React の keyboard イベント
    */
-  handleTextareaKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+  submitOrCancelOnKey: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
 };
 
 /**
- * MarkdownBody の display↔edit モード切替・キーバインド・focus 制御をまとめたフック。
+ * MarkdownBody の display↔edit モード切替・キーバインドをまとめたフック。
  *
  * - body が変わっても hook 内 state は自動リセットしない。呼び出し側で
  *   `<MarkdownBody key={task.id} ... />` のように key で再マウントする契約。
@@ -63,6 +58,8 @@ export type UseMarkdownBodyEditResult = {
  * - IME 変換中（`nativeEvent.isComposing`）の Cmd/Ctrl+Enter は commit を
  *   呼ばないが、preventDefault + stopPropagation は先行して実行する
  *   （親に Esc-like なキー経路を漏らさない）。
+ * - textarea mount 時の focus + 末尾カーソル設定は DOM 操作のため呼び出し側
+ *   （MarkdownBody）に閉じ込め、hook は DOM 参照を公開 API に含めない。
  *
  * @param args - body / onConfirm
  * @returns mode / editValue / handlers
@@ -78,16 +75,6 @@ export const useMarkdownBodyEdit = (
   const [editValue, setEditValue] = useState(body);
 
   const isEditable = onConfirm !== undefined;
-
-  const textareaRef = useCallback((el: HTMLTextAreaElement | null) => {
-    if (el === null) {
-      return;
-    }
-    el.focus();
-    const end = el.value.length;
-    el.selectionStart = end;
-    el.selectionEnd = end;
-  }, []);
 
   const enterEditMode = useCallback(() => {
     setEditValue(body);
@@ -111,14 +98,14 @@ export const useMarkdownBodyEdit = (
     setMode(MarkdownBodyEditMode.Display);
   }, [body]);
 
-  const handleDisplayClick = useCallback(() => {
+  const enterEditOnClick = useCallback(() => {
     if (!isEditable) {
       return;
     }
     enterEditMode();
   }, [isEditable, enterEditMode]);
 
-  const handleDisplayKeyDown = useCallback(
+  const enterEditOnKey = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
       if (!isEditable) {
         return;
@@ -131,7 +118,7 @@ export const useMarkdownBodyEdit = (
     [isEditable, enterEditMode],
   );
 
-  const handleTextareaKeyDown = useCallback(
+  const submitOrCancelOnKey = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
@@ -161,9 +148,8 @@ export const useMarkdownBodyEdit = (
     editValue,
     setEditValue,
     isEditable,
-    textareaRef,
-    handleDisplayClick,
-    handleDisplayKeyDown,
-    handleTextareaKeyDown,
+    enterEditOnClick,
+    enterEditOnKey,
+    submitOrCancelOnKey,
   };
 };

--- a/src/features/detail/hooks/useParentTask/index.ts
+++ b/src/features/detail/hooks/useParentTask/index.ts
@@ -19,6 +19,10 @@ export type UseParentTaskResult = {
 /**
  * 現在のタスクの親タスクを allTasks から lookup する hook。
  * path 比較は parentReferencesTaskPath に委譲し、表記揺れを吸収する。
+ *
+ * hook 化を維持する理由: 親解決には allTasks の線形探索 + path 表記揺れの吸収が
+ * 絡むため、戻り値 `UseParentTaskResult` として component から切り離し、
+ * useChildTasks と並ぶ「詳細パネルの派生 ViewModel 取得」の一貫した形を保つ。
  * @param args - 現在タスクと全タスク
  * @returns 親タスク（無ければ null）
  */

--- a/src/features/milestoneView/components/MilestoneViewScreen/index.tsx
+++ b/src/features/milestoneView/components/MilestoneViewScreen/index.tsx
@@ -52,7 +52,11 @@ export const MilestoneViewScreen = ({
 }: MilestoneViewScreenProps) => {
   const sorted = sortByOrder(resource.milestones);
   const names = sorted.map((m) => m.name);
-  const progress = useMilestoneProgress(names, tasks, doneColumn);
+  const progress = useMilestoneProgress({
+    milestoneNames: names,
+    tasks,
+    doneColumn,
+  });
 
   if (resource.status === "loading" || resource.status === "idle") {
     return <p className="text-sm text-muted">読み込み中…</p>;

--- a/src/features/milestoneView/hooks/useMilestoneProgress/index.ts
+++ b/src/features/milestoneView/hooks/useMilestoneProgress/index.ts
@@ -64,19 +64,27 @@ export const computeMilestoneProgress = (
   return progress;
 };
 
+/** useMilestoneProgress の引数 */
+export type UseMilestoneProgressArgs = {
+  /** 進捗を出すマイルストーン名一覧（registry 由来） */
+  milestoneNames: readonly string[];
+  /** 全タスク */
+  tasks: Task[];
+  /** done とみなすカラム名（既存 ProjectData.doneColumn 由来・未解決は undefined） */
+  doneColumn: string | undefined;
+};
+
 /**
  * マイルストーン名ごとの進捗（done 件数 / 所属件数 / 進捗率）を算出するフック。
- * @param milestoneNames - 進捗を出すマイルストーン名一覧（registry 由来）
- * @param tasks - 全タスク
- * @param doneColumn - done とみなすカラム名（既存 ProjectData.doneColumn 由来・未解決は undefined）
+ * @param args - {@link UseMilestoneProgressArgs}
  * @returns マイルストーン名 → 進捗 の Map
  */
 export const useMilestoneProgress = (
-  milestoneNames: readonly string[],
-  tasks: Task[],
-  doneColumn: string | undefined,
-): Map<string, MilestoneProgress> =>
-  useMemo(
+  args: UseMilestoneProgressArgs,
+): Map<string, MilestoneProgress> => {
+  const { milestoneNames, tasks, doneColumn } = args;
+  return useMemo(
     () => computeMilestoneProgress(milestoneNames, tasks, doneColumn),
     [milestoneNames, tasks, doneColumn],
   );
+};

--- a/src/features/milestoneView/index.ts
+++ b/src/features/milestoneView/index.ts
@@ -2,5 +2,6 @@ export { MilestoneViewScreen } from "./components/MilestoneViewScreen";
 export {
   computeMilestoneProgress,
   type MilestoneProgress,
+  type UseMilestoneProgressArgs,
   useMilestoneProgress,
 } from "./hooks/useMilestoneProgress";

--- a/src/features/task-form/components/TaskForm/index.tsx
+++ b/src/features/task-form/components/TaskForm/index.tsx
@@ -232,7 +232,7 @@ export const TaskForm = ({
       className="flex flex-col gap-4"
       data-testid="task-form"
       noValidate
-      onSubmit={fields.handleSubmit}
+      onSubmit={fields.submit}
     >
       <TaskFormTitle
         value={fields.state.values.title}
@@ -281,7 +281,7 @@ export const TaskForm = ({
           id={labelsInputId}
           value={labels.state.labelInput}
           onChange={(value) => labels.dispatch({ type: "setInput", value })}
-          onKeyDown={labels.handleKeyDown}
+          onKeyDown={labels.commitOnEnter}
           onBlur={() => labels.dispatch({ type: "commit" })}
           disabled={isSubmitting}
           candidates={labelSuggestions}

--- a/src/features/task-form/hooks/useLabelsInput/__tests__/useLabelsInput.interaction.test.tsx
+++ b/src/features/task-form/hooks/useLabelsInput/__tests__/useLabelsInput.interaction.test.tsx
@@ -110,14 +110,14 @@ test("dispatch remove で指定ラベルが除外される", () => {
   expect(get().state.labels).toEqual(["b"]);
 });
 
-test("handleKeyDown: Enter で commit + preventDefault", () => {
+test("commitOnEnter: Enter で commit + preventDefault", () => {
   const get = render();
   act(() => {
     get().dispatch({ type: "setInput", value: "x" });
   });
   const prevent = vi.fn();
   act(() => {
-    get().handleKeyDown({
+    get().commitOnEnter({
       key: "Enter",
       nativeEvent: { isComposing: false },
       preventDefault: prevent,
@@ -127,7 +127,7 @@ test("handleKeyDown: Enter で commit + preventDefault", () => {
   expect(get().state).toEqual({ labels: ["x"], labelInput: "" });
 });
 
-test("handleKeyDown: IME 変換中（isComposing=true）の Enter は preventDefault するが commit しない", () => {
+test("commitOnEnter: IME 変換中（isComposing=true）の Enter は preventDefault するが commit しない", () => {
   const get = render();
   act(() => {
     get().dispatch({ type: "setInput", value: "日本語" });
@@ -135,7 +135,7 @@ test("handleKeyDown: IME 変換中（isComposing=true）の Enter は preventDef
   const prevent = vi.fn();
   const before = get().state;
   act(() => {
-    get().handleKeyDown({
+    get().commitOnEnter({
       key: "Enter",
       nativeEvent: { isComposing: true },
       preventDefault: prevent,
@@ -146,7 +146,7 @@ test("handleKeyDown: IME 変換中（isComposing=true）の Enter は preventDef
   expect(get().state).toBe(before);
 });
 
-test("handleKeyDown: Enter 以外では何もしない", () => {
+test("commitOnEnter: Enter 以外では何もしない", () => {
   const get = render();
   act(() => {
     get().dispatch({ type: "setInput", value: "x" });
@@ -154,7 +154,7 @@ test("handleKeyDown: Enter 以外では何もしない", () => {
   const prevent = vi.fn();
   const before = get().state;
   act(() => {
-    get().handleKeyDown({
+    get().commitOnEnter({
       key: "Tab",
       preventDefault: prevent,
     } as unknown as React.KeyboardEvent<HTMLInputElement>);

--- a/src/features/task-form/hooks/useLabelsInput/index.ts
+++ b/src/features/task-form/hooks/useLabelsInput/index.ts
@@ -45,7 +45,7 @@ export type UseLabelsInputResult = {
    * input の onKeyDown に渡すハンドラ。Enter で commit を dispatch する。
    * @param e - キーボードイベント
    */
-  handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  commitOnEnter: (e: KeyboardEvent<HTMLInputElement>) => void;
   /**
    * submit 用に pending labelInput を取り込んだ最終 labels を同期で返す。
    * 併せて UI 整合のために `commit` を dispatch するが、返り値は dispatch の
@@ -58,7 +58,7 @@ export type UseLabelsInputResult = {
 /**
  * ラベル入力用の state を `useReducer` で管理するカスタムフック。
  * 状態遷移のドメインロジックは `LabelsField` の pure ops に委譲し、ここでは
- * React の reducer 配線と handleKeyDown / finalizeLabels のユーティリティだけを担う。
+ * React の reducer 配線と commitOnEnter / finalizeLabels のユーティリティだけを担う。
  * @param initialLabels - 初期ラベル配列
  * @returns ラベル入力フック結果
  */
@@ -71,7 +71,7 @@ export const useLabelsInput = (
     LabelsField.initial,
   );
 
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+  const commitOnEnter = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       // Enter では常に preventDefault する。`<form>` 内の input のため、
       // IME 変換確定の Enter であっても抑止しないとフォーム submit が発火する。
@@ -92,5 +92,5 @@ export const useLabelsInput = (
     return labels;
   }, [state]);
 
-  return { state, dispatch, handleKeyDown, finalizeLabels };
+  return { state, dispatch, commitOnEnter, finalizeLabels };
 };

--- a/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
+++ b/src/features/task-form/hooks/useTaskFormFields/__tests__/useTaskFormFields.interaction.test.tsx
@@ -109,7 +109,7 @@ test("dispatch title: 入力時は errors.title をクリアするのみ（再 v
 test("dispatch title: エラー表示中に値を変えると errors.title が undefined になる", () => {
   const { get } = render(defaultArgs());
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(get().state.errors.title?.code).toBe("EMPTY");
   act(() => {
@@ -166,7 +166,7 @@ test("dispatch fileName: 入力値は生のまま保持される（スペース�
   expect(get().state.values.fileName).toBe("my task.md ");
 });
 
-test("handleSubmit: trim + 末尾 .md 剥がしは submit 時に適用される", () => {
+test("submit: trim + 末尾 .md 剥がしは submit 時に適用される", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -176,36 +176,36 @@ test("handleSubmit: trim + 末尾 .md 剥がしは submit 時に適用される"
     get().dispatch({ type: "fileName", value: "  custom.MD  " });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect(values.fileName).toBe("custom.md");
 });
 
-test("handleSubmit: 空タイトルでは onSubmit を呼ばず errors.title.code = EMPTY", () => {
+test("submit: 空タイトルでは onSubmit を呼ばず errors.title.code = EMPTY", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
   expect(get().state.errors.title?.code).toBe("EMPTY");
 });
 
-test("handleSubmit: 空白のみタイトルでも EMPTY エラー", () => {
+test("submit: 空白のみタイトルでも EMPTY エラー", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
     get().dispatch({ type: "title", value: "   " });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
   expect(get().state.errors.title?.code).toBe("EMPTY");
 });
 
-test("handleSubmit: TOO_LONG（TITLE_MAX_LENGTH + 1 文字）", () => {
+test("submit: TOO_LONG（TITLE_MAX_LENGTH + 1 文字）", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -215,52 +215,52 @@ test("handleSubmit: TOO_LONG（TITLE_MAX_LENGTH + 1 文字）", () => {
     });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
   expect(get().state.errors.title?.code).toBe("TOO_LONG");
 });
 
-test("handleSubmit: FORBIDDEN_CHAR", () => {
+test("submit: FORBIDDEN_CHAR", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
     get().dispatch({ type: "title", value: "a<b" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
   expect(get().state.errors.title?.code).toBe("FORBIDDEN_CHAR");
 });
 
-test("handleSubmit: 既存タスクと重複しうるタイトルでも onSubmit が呼ばれる（DUPLICATE 撤廃）", () => {
+test("submit: 既存タスクと重複しうるタイトルでも onSubmit が呼ばれる（DUPLICATE 撤廃）", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
     get().dispatch({ type: "title", value: "Fix Login Bug" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).toHaveBeenCalledTimes(1);
   expect(get().state.errors.title).toBeUndefined();
 });
 
-test("handleSubmit: 自動追従中（手動未編集）は submit 値に fileName キーが含まれない", () => {
+test("submit: 自動追従中（手動未編集）は submit 値に fileName キーが含まれない", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
     get().dispatch({ type: "title", value: "Fix Bug" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect("fileName" in values).toBe(false);
 });
 
-test("handleSubmit: 手動編集後は base に .md を付与した完全名が fileName として送信される", () => {
+test("submit: 手動編集後は base に .md を付与した完全名が fileName として送信される", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -270,13 +270,13 @@ test("handleSubmit: 手動編集後は base に .md を付与した完全名が 
     get().dispatch({ type: "fileName", value: "custom-name" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect(values.fileName).toBe("custom-name.md");
 });
 
-test("handleSubmit: fileName 予約文字では onSubmit を呼ばず errors.fileName が設定される", () => {
+test("submit: fileName 予約文字では onSubmit を呼ばず errors.fileName が設定される", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -286,7 +286,7 @@ test("handleSubmit: fileName 予約文字では onSubmit を呼ばず errors.fil
     get().dispatch({ type: "fileName", value: "a:b" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
   expect(get().state.errors.fileName).toEqual({
@@ -305,7 +305,7 @@ test("dispatch fileName: エラー表示中に再入力すると errors.fileName
     get().dispatch({ type: "fileName", value: "a:b" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(get().state.errors.fileName?.code).toBe("FORBIDDEN_CHAR");
   act(() => {
@@ -314,7 +314,7 @@ test("dispatch fileName: エラー表示中に再入力すると errors.fileName
   expect(get().state.errors.fileName).toBeUndefined();
 });
 
-test("handleSubmit: fileName エラー解消後の再 submit でエラーがクリアされ送信される", () => {
+test("submit: fileName エラー解消後の再 submit でエラーがクリアされ送信される", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -324,32 +324,32 @@ test("handleSubmit: fileName エラー解消後の再 submit でエラーがク�
     get().dispatch({ type: "fileName", value: "a:b" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
   act(() => {
     get().dispatch({ type: "fileName", value: "fixed-name" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).toHaveBeenCalledTimes(1);
   expect(get().state.errors.fileName).toBeUndefined();
 });
 
-test("handleSubmit: isSubmitting=true では何もしない", () => {
+test("submit: isSubmitting=true では何もしない", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), isSubmitting: true, onSubmit });
   act(() => {
     get().dispatch({ type: "title", value: "abc" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
 });
 
-test("handleSubmit 正常系: 正規化された値が onSubmit に渡る（自動追従中は fileName なし）", () => {
+test("submit 正常系: 正規化された値が onSubmit に渡る（自動追従中は fileName なし）", () => {
   const onSubmit = vi.fn();
   const commit = vi.fn(() => [] as string[]);
   const { get } = render({
@@ -370,7 +370,7 @@ test("handleSubmit 正常系: 正規化された値が onSubmit に渡る（自�
     get().dispatch({ type: "body", value: "b" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).toHaveBeenCalledTimes(1);
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
@@ -387,20 +387,20 @@ test("handleSubmit 正常系: 正規化された値が onSubmit に渡る（自�
   });
 });
 
-test('handleSubmit: priority="" は undefined に正規化される', () => {
+test('submit: priority="" は undefined に正規化される', () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
     get().dispatch({ type: "title", value: "t" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect(values.priority).toBeUndefined();
 });
 
-test("handleSubmit: labels は finalizeLabels の戻り値が使われる", () => {
+test("submit: labels は finalizeLabels の戻り値が使われる", () => {
   const onSubmit = vi.fn();
   const commit = vi.fn(() => ["a", "b"]);
   const { get } = render({
@@ -412,14 +412,14 @@ test("handleSubmit: labels は finalizeLabels の戻り値が使われる", () =
     get().dispatch({ type: "title", value: "t" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(commit).toHaveBeenCalledTimes(1);
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect(values.labels).toEqual(["a", "b"]);
 });
 
-test("handleSubmit: links は finalizeLinks の戻り値が使われる", () => {
+test("submit: links は finalizeLinks の戻り値が使われる", () => {
   const onSubmit = vi.fn();
   const finalize = vi.fn(() => ["tasks/a.md", "tasks/b.md"]);
   const { get } = render({
@@ -431,7 +431,7 @@ test("handleSubmit: links は finalizeLinks の戻り値が使われる", () => 
     get().dispatch({ type: "title", value: "t" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(finalize).toHaveBeenCalledTimes(1);
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
@@ -451,7 +451,7 @@ test("dispatch due: 値が更新され他 field に影響しない", () => {
   expect(get().state.values.fileName).toBe("t");
 });
 
-test("handleSubmit: due 入力ありのとき submit 値に due が入る", () => {
+test("submit: due 入力ありのとき submit 値に due が入る", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -461,20 +461,20 @@ test("handleSubmit: due 入力ありのとき submit 値に due が入る", () =
     get().dispatch({ type: "due", value: "2026-07-01" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect(values.due).toBe("2026-07-01");
 });
 
-test("handleSubmit: due 未入力（空文字）のとき submit 値に due キーが含まれない", () => {
+test("submit: due 未入力（空文字）のとき submit 値に due キーが含まれない", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
     get().dispatch({ type: "title", value: "T" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect("due" in values).toBe(false);
@@ -489,7 +489,7 @@ test("dispatch subIssues: 値が更新され他 field に影響しない", () =>
   expect(get().state.values.title).toBe("");
 });
 
-test("handleSubmit: submit 値に正規化済み subIssueTitles が入る（空行無視・trim）", () => {
+test("submit: submit 値に正規化済み subIssueTitles が入る（空行無視・trim）", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -499,13 +499,13 @@ test("handleSubmit: submit 値に正規化済み subIssueTitles が入る（空�
     get().dispatch({ type: "subIssues", value: "子1\n\n 子2 " });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect(values.subIssueTitles).toEqual(["子1", "子2"]);
 });
 
-test("handleSubmit: サブIssue 違反行では onSubmit を呼ばず errors.subIssues に行番号が入る", () => {
+test("submit: サブIssue 違反行では onSubmit を呼ばず errors.subIssues に行番号が入る", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -515,7 +515,7 @@ test("handleSubmit: サブIssue 違反行では onSubmit を呼ばず errors.sub
     get().dispatch({ type: "subIssues", value: "ok\nbad:title" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(onSubmit).not.toHaveBeenCalled();
   expect(get().state.errors.subIssues).toEqual({
@@ -534,7 +534,7 @@ test("dispatch subIssues: エラー表示中に再入力すると errors.subIssu
     get().dispatch({ type: "subIssues", value: "bad:title" });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   expect(get().state.errors.subIssues?.line).toBe(1);
   act(() => {
@@ -552,7 +552,7 @@ test("dispatch draft: 値が更新され他 field に影響しない", () => {
   expect(get().state.values.title).toBe("");
 });
 
-test("handleSubmit: draft の現在値が submit 値に入る", () => {
+test("submit: draft の現在値が submit 値に入る", () => {
   const onSubmit = vi.fn();
   const { get } = render({ ...defaultArgs(), onSubmit });
   act(() => {
@@ -562,7 +562,7 @@ test("handleSubmit: draft の現在値が submit 値に入る", () => {
     get().dispatch({ type: "draft", value: true });
   });
   act(() => {
-    get().handleSubmit(makeFormEvent());
+    get().submit(makeFormEvent());
   });
   const values = onSubmit.mock.calls[0][0] as TaskFormValues;
   expect(values.draft).toBe(true);

--- a/src/features/task-form/hooks/useTaskFormFields/index.ts
+++ b/src/features/task-form/hooks/useTaskFormFields/index.ts
@@ -101,15 +101,15 @@ export type UseTaskFormFieldsResult = {
   /** state 変更用 dispatch */
   dispatch: Dispatch<FieldsAction>;
   /**
-   * form の onSubmit に渡すハンドラ。
+   * form の onSubmit に渡すハンドラ。バリデーション通過時に onSubmit を呼ぶ。
    * @param e - FormEvent
    */
-  handleSubmit: (e: FormEvent<HTMLFormElement>) => void;
+  submit: (e: FormEvent<HTMLFormElement>) => void;
 };
 
 /**
  * TaskForm の field 値・エラー遷移を計算する pure reducer。
- * title / fileName 入力時はエラーをクリアするだけにし、再 validate は handleSubmit 側で行う。
+ * title / fileName 入力時はエラーをクリアするだけにし、再 validate は submit 側で行う。
  * @param state - 現在の state
  * @param action - アクション
  * @returns 新しい state
@@ -215,7 +215,7 @@ const reducer = (state: FieldsState, action: FieldsAction): FieldsState => {
 /**
  * TaskForm の全 field 値・エラー・送信処理をまとめて管理するカスタムフック。
  * バリデーション / 初期値 / 正規化は各 Field モジュール（TitleField / FileNameField /
- * PriorityField / ParentField）に委譲し、ここでは reducer の配線と handleSubmit のみを担う。
+ * PriorityField / ParentField）に委譲し、ここでは reducer の配線と submit のみを担う。
  *
  * **前提**: `parentFieldVisible` / `initialParent` は mount 後に変化しないこと。これらの値は
  * useReducer の初期化関数でのみ参照され、mount 後の変化に追従する useEffect は持たない。
@@ -225,7 +225,7 @@ const reducer = (state: FieldsState, action: FieldsAction): FieldsState => {
  * 長寿命な親コンポーネントから props を動的に変える用途で再利用する場合は、
  * 呼び出し側で `key` を切り替えて remount するか、本 hook に sync ロジックを再追加すること。
  * @param args - フックの引数
- * @returns state / dispatch / handleSubmit
+ * @returns state / dispatch / submit
  */
 export const useTaskFormFields = (
   args: UseTaskFormFieldsArgs,
@@ -251,7 +251,7 @@ export const useTaskFormFields = (
   );
 
   const { isSubmitting, onSubmit, finalizeLabels, finalizeLinks } = args;
-  const handleSubmit = useCallback(
+  const submit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       if (isSubmitting) {
@@ -319,5 +319,5 @@ export const useTaskFormFields = (
     ],
   );
 
-  return { state, dispatch, handleSubmit };
+  return { state, dispatch, submit };
 };


### PR DESCRIPTION
## 概要

カスタムフック規約への軽微な違反を是正する純粋なリファクタリング。戻り値ハンドラの `handleXxx` 命名・テスト都合の内部 state 公開・位置引数 3 つ以上の hook・公開 API への DOM 参照、の 4 観点を規約整合させる。**外部挙動は不変**で、呼び出し側も追従済み。

Closes #320

## 変更の種類

- ♻️ リファクタリング

## 詳細な変更内容

### 戻り値ハンドラ名の handleXxx → 動詞ベースへ改名（4 件）

| hook | 旧 | 新 |
|:--|:--|:--|
| `useLabelInput` | `handleKeyDown` | `commitOrCancelOnKey` |
| `useMarkdownBodyEdit` | `handleDisplayClick` / `handleDisplayKeyDown` / `handleTextareaKeyDown` | `enterEditOnClick` / `enterEditOnKey` / `submitOrCancelOnKey` |
| `useLabelsInput` | `handleKeyDown` | `commitOnEnter` |
| `useTaskFormFields` | `handleSubmit` | `submit` |

`handle` は component 内部向け、という規約に合わせる。LabelEditor / MarkdownBody / TaskForm 呼び出し側と各 hook テスト（記述・テスト名）も追従。

### テスト都合の内部 state 公開を撤廃（2 件）

- `useLabelInput`: 戻り値から `state` を外し、テストを公開 API（`isAdding` / `inputValue`）で検証する形へ書き換え。
- `useDeleteFlow`: UI は `isOpen` / `isBusy` しか使っていないため `state` を外し、テストを `isOpen` / `isBusy` ベースへ書き換え（error 後はダイアログ開存続、cancel で閉じる等を公開 API で検証）。

### options object 化

- `useMilestoneProgress`: 位置引数 3 つ（任意の `doneColumn` 含む）を `UseMilestoneProgressArgs` の options object に変更。`MilestoneViewScreen` 呼び出し側・barrel の型公開も追従。pure util の `computeMilestoneProgress` は distinct 型 3 引数のため据え置き。

### DOM ref 公開方式の整合（グレー）

- `useMarkdownBodyEdit`: focus + 末尾カーソル設定の callback ref（`textareaRef`）を DOM 操作の責務として `MarkdownBody` 側へ移設し、hook の公開 API から DOM 参照を外す。focus 挙動は MarkdownBody の既存コンポーネントテスト（`edit 進入時の textarea が focus され、カーソルが末尾にある`）で担保されるため、hook テストの該当 2 件は移譲。

### グレー 2 件（現状維持 + 理由明示）

- `useChildTasks` / `useParentTask`: 戻り値型を component 境界をまたぐ共有 ViewModel として使い、独立したメモ化境界を 1 つの公開 API にまとめている点を理由に hook 維持とし、その根拠を doc コメントへ明記。

## システム図

\`\`\`mermaid
flowchart LR
  subgraph hook[hook 公開 API]
    A[handleKeyDown 等] -->|改名| A2[commitOrCancelOnKey 等]
    S[内部 state] -->|非公開化| X[（撤去）]
    P[位置引数 3つ] -->|options 化| O[UseMilestoneProgressArgs]
    R[textareaRef DOM 参照] -->|移設| C[MarkdownBody の callback ref]
  end
  style A2 fill:#cdeac0
  style X fill:#f4cccc
  style O fill:#cdeac0
  style C fill:#cdeac0
\`\`\`

## テスト

- `pnpm test:run`: 241 ファイル / **2070 件 全 pass**
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- `pnpm exec biome check src`: クリーン（fixes なし）

## レビューポイント

- 外部挙動は不変（リネーム・内部 state 非公開化・引数の options 化・DOM ref 移設のみ）。
- 内部 state 公開撤廃に伴い、該当テストは `state` 直接アサートから公開 API ベースのアサートへ書き換えている。
- ドキュメント更新は不要（公開アプリ API / データ形式 / 画面挙動 / 設定項目の変更なし、feature 内部 hook の純粋リファクタリング）。`docs/impl/task-create-screen.md` は `useTaskFormFields` / `finalizeLabels` 等の不変名のみ参照しており追従不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)