### PR TITLE
♻️ [Refactoring]: #318 [FE] タスク作成の送信中 state 三重管理を整理（dead な isSubmitting API を除去）

### DIFF
--- a/src/features/task-form/hooks/useTaskCreate/__tests__/useTaskCreate.behavior.test.tsx
+++ b/src/features/task-form/hooks/useTaskCreate/__tests__/useTaskCreate.behavior.test.tsx
@@ -118,84 +118,31 @@ const renderHook = (args: UseTaskCreateOptions) => {
   };
 };
 
-test("T1: 初期 state は isSubmitting=false で submit が関数である", () => {
+test("T1: submit が関数である", () => {
   const probe = renderHook({ createTask: vi.fn() });
-  expect(probe.latest.isSubmitting).toBe(false);
   expect(typeof probe.latest.submit).toBe("function");
 });
 
-test("T2: 成功時に Result.ok が pass-through され、isSubmitting が true→false で遷移する", async () => {
-  let resolveCreate!: (
-    r: Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>,
-  ) => void;
-  const createTask = vi.fn(
-    () =>
-      new Promise<Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>>(
-        (r) => {
-          resolveCreate = r;
-        },
-      ),
-  );
+test("T2: 成功時に Result.ok が pass-through される", async () => {
+  const createTask = vi.fn().mockResolvedValue(Result.ok(taskFixture));
   const probe = renderHook({ createTask });
 
-  let pending!: ReturnType<UseTaskCreateResult["submit"]>;
-  act(() => {
-    pending = probe.latest.submit(valuesFixture);
-  });
-  expect(probe.latest.isSubmitting).toBe(true);
-
+  let result!: Awaited<ReturnType<UseTaskCreateResult["submit"]>>;
   await act(async () => {
-    resolveCreate(Result.ok(taskFixture));
-    await pending;
+    result = await probe.latest.submit(valuesFixture);
   });
-  expect(probe.latest.isSubmitting).toBe(false);
-  const result = await pending;
   expect(result).toEqual(
     Result.ok({ parent: taskFixture, failedSubIssues: [] }),
   );
 });
 
-test("T5: 送信中の再 submit は invalid-state で短絡し、createTask は 1 回しか呼ばれない", async () => {
-  let resolveCreate!: (
-    r: Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>,
-  ) => void;
-  const createTask = vi.fn(
-    () =>
-      new Promise<Awaited<ReturnType<UseTaskCreateOptions["createTask"]>>>(
-        (r) => {
-          resolveCreate = r;
-        },
-      ),
-  );
-  const probe = renderHook({ createTask });
-
-  let first!: ReturnType<UseTaskCreateResult["submit"]>;
-  act(() => {
-    first = probe.latest.submit(valuesFixture);
-  });
-  expect(probe.latest.isSubmitting).toBe(true);
-
-  let second!: Awaited<ReturnType<UseTaskCreateResult["submit"]>>;
-  await act(async () => {
-    second = await probe.latest.submit(valuesFixture);
-  });
-  expect(second).toEqual(Result.err(ProjectError.invalidState("送信中です")));
-  expect(createTask).toHaveBeenCalledTimes(1);
-
-  await act(async () => {
-    resolveCreate(Result.ok(taskFixture));
-    await first;
-  });
-});
-
-test("T6: 1 回目完了後の再 submit は再度 createTask を呼んで Result.ok を返す", async () => {
+test("T6: 連続 submit はそのつど createTask を呼んで Result.ok を返す", async () => {
   const createTask = vi.fn().mockResolvedValue(Result.ok(taskFixture));
   const probe = renderHook({ createTask });
 
   await act(async () => {
     await probe.latest.submit(valuesFixture);
   });
-  expect(probe.latest.isSubmitting).toBe(false);
 
   let second!: Awaited<ReturnType<UseTaskCreateResult["submit"]>>;
   await act(async () => {
@@ -207,7 +154,7 @@ test("T6: 1 回目完了後の再 submit は再度 createTask を呼んで Resul
   expect(createTask).toHaveBeenCalledTimes(2);
 });
 
-test("T4: 失敗時に Result.err が pass-through され、finally で isSubmitting が false に戻る", async () => {
+test("T4: 失敗時に Result.err が pass-through される", async () => {
   const tauriErrorFixture = TauriError.from("見つかりません");
   const projectErrorFixture = ProjectError.tauri(tauriErrorFixture);
   const createTask = vi.fn().mockResolvedValue(Result.err(projectErrorFixture));
@@ -218,10 +165,9 @@ test("T4: 失敗時に Result.err が pass-through され、finally で isSubmit
     result = await probe.latest.submit(valuesFixture);
   });
   expect(result).toEqual(Result.err(projectErrorFixture));
-  expect(probe.latest.isSubmitting).toBe(false);
 });
 
-test("T7: injected createTask が reject すると submit も reject し、isSubmitting が false に戻る", async () => {
+test("T7: injected createTask が reject すると submit も reject する", async () => {
   const boom = new Error("boom");
   const createTask = vi.fn().mockRejectedValueOnce(boom);
   const probe = renderHook({ createTask });
@@ -229,7 +175,6 @@ test("T7: injected createTask が reject すると submit も reject し、isSub
   await act(async () => {
     await expect(probe.latest.submit(valuesFixture)).rejects.toThrow("boom");
   });
-  expect(probe.latest.isSubmitting).toBe(false);
 });
 
 test("T3: priority / parent が undefined のとき CreateTaskParams から key 自体を含めない", async () => {

--- a/src/features/task-form/hooks/useTaskCreate/index.ts
+++ b/src/features/task-form/hooks/useTaskCreate/index.ts
@@ -1,5 +1,5 @@
-import { useCallback, useState } from "react";
-import { ProjectError } from "@/features/board";
+import { useCallback } from "react";
+import type { ProjectError } from "@/features/board";
 import type { TaskFormValues } from "@/features/task-form/types";
 import type { CreateTaskParams } from "@/lib/tauri";
 import type { Task } from "@/types/task";
@@ -29,18 +29,18 @@ export type UseTaskCreateResult = {
    * 親を作成し、成功時は subIssueTitles を直列ループで子作成する。
    * 親失敗時は Result.err（子は作成しない）。子の部分失敗はロールバックせず
    * failedSubIssues に積んで Result.ok で返す（親は残す方針）。
-   * 送信中は isSubmitting=true。
    * injected createTask が契約通り Result を返す限り throw しない。
-   * 契約違反（reject/throw）時は finally で isSubmitting を戻したうえで再 throw する。
-   * 送信中の再呼び出しは Result.err(invalidState) で短絡する。
+   * 契約違反（reject/throw）時はそのまま再 throw する。
+   *
+   * 送信中フラグ・二重送信ガードはこの hook では持たず、所有者である
+   * モーダル層（TaskCreateScreen）が一元管理する。この hook は
+   * フォーム値の変換と invoke だけに徹する。
    * @param values TaskCreateScreen が submit したフォーム値
    * @returns 成功時 CreateTaskSubmitOutcome、親作成失敗時 ProjectError を含む Result
    */
   submit: (
     values: TaskFormValues,
   ) => Promise<Result<CreateTaskSubmitOutcome, ProjectError>>;
-  /** 送信中フラグ。表示専用。 */
-  isSubmitting: boolean;
 };
 
 /**
@@ -64,51 +64,43 @@ const toCreateTaskParams = (values: TaskFormValues): CreateTaskParams => ({
 
 /**
  * タスク作成 invoke を呼び出すパラメトリックフック。
+ * フォーム値の変換と invoke だけを担い、送信中 state は持たない。
  * @param options createTask を含む依存
- * @returns submit 関数と isSubmitting フラグ
+ * @returns submit 関数
  */
 export const useTaskCreate = (
   options: UseTaskCreateOptions,
 ): UseTaskCreateResult => {
   const { createTask } = options;
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const submit = useCallback(
     async (
       values: TaskFormValues,
     ): Promise<Result<CreateTaskSubmitOutcome, ProjectError>> => {
-      if (isSubmitting) {
-        return Result.err(ProjectError.invalidState("送信中です"));
+      const parentResult = await createTask(toCreateTaskParams(values));
+      if (!parentResult.ok) {
+        // 親の作成に失敗したら子は 1 件も作らない。
+        return Result.err(parentResult.error);
       }
-      setIsSubmitting(true);
-      try {
-        const parentResult = await createTask(toCreateTaskParams(values));
-        if (!parentResult.ok) {
-          // 親の作成に失敗したら子は 1 件も作らない。
-          return Result.err(parentResult.error);
+      const parent = parentResult.value;
+      // サブIssue は直列に作成し、失敗してもループを継続する（ロールバックしない）。
+      // 子の status / draft は親フォームの値を、parent は連番回避後の確定パスを引き継ぐ。
+      const failedSubIssues: { title: string; error: ProjectError }[] = [];
+      for (const title of values.subIssueTitles) {
+        const childResult = await createTask({
+          title,
+          status: values.status,
+          parent: parent.filePath,
+          ...(values.draft === true && { draft: true }),
+        });
+        if (!childResult.ok) {
+          failedSubIssues.push({ title, error: childResult.error });
         }
-        const parent = parentResult.value;
-        // サブIssue は直列に作成し、失敗してもループを継続する（ロールバックしない）。
-        // 子の status / draft は親フォームの値を、parent は連番回避後の確定パスを引き継ぐ。
-        const failedSubIssues: { title: string; error: ProjectError }[] = [];
-        for (const title of values.subIssueTitles) {
-          const childResult = await createTask({
-            title,
-            status: values.status,
-            parent: parent.filePath,
-            ...(values.draft === true && { draft: true }),
-          });
-          if (!childResult.ok) {
-            failedSubIssues.push({ title, error: childResult.error });
-          }
-        }
-        return Result.ok({ parent, failedSubIssues });
-      } finally {
-        setIsSubmitting(false);
       }
+      return Result.ok({ parent, failedSubIssues });
     },
-    [createTask, isSubmitting],
+    [createTask],
   );
 
-  return { submit, isSubmitting };
+  return { submit };
 };


### PR DESCRIPTION
## 概要

タスク作成フローの「送信中ガード」が独立した複数 state にまたがっていた問題を整理し、送信中 state の所有者をモーダル層（`TaskCreateScreen`）に一元化した。`useTaskCreate` が独自に持っていた送信中 state と二重送信ガード、および呼び出し元で未使用だった戻り値 `isSubmitting`（dead API）を除去した。外部挙動は不変。

## 変更の種類

- ♻️ Refactoring（外部仕様の変更なし）

## 変更した内容

- `useTaskCreate` を「フォーム値の変換 + invoke」だけに徹する pure な hook に変更
  - 内部の `useState(isSubmitting)` と二重送信短絡（`Result.err(invalidState("送信中です"))`）を削除
  - `UseTaskCreateResult` から戻り値 `isSubmitting` を削除（呼び出し元 `App.tsx` は `{ submit }` のみ destructure しており未使用だった）
  - `useCallback` 依存配列から `isSubmitting` が外れ、`submit` の参照安定性が向上
- 送信中 state の単一の所有者は `TaskCreateScreen`（`submittingRef` + `isSubmitting`）に確定。`isSubmitting` は単一ソースから prop として下流（`TaskForm` → `useTaskFormFields`）へ流れ、入力欄/ボタンの無効化と submit ガードに使われる

## 削除した内容

- `useTaskCreate` 内の `isSubmitting` state・再入ガード・戻り値 `isSubmitting`
- 上記の hook 単体再入ガードを検証していたテスト（T5）。各テストから `isSubmitting` 観測アサーションを除去

## 仕様ドキュメント更新

不要（純粋な内部リファクタリング。公開 UI 挙動・データ形式・設定は不変。二重送信防止は `TaskCreateScreen` の `submittingRef` ガードが、入力欄/ボタンの無効化は単一ソース由来の `isSubmitting` prop が引き続き担う）。

## システム図

```mermaid
flowchart LR
  subgraph before["変更前: 送信中 state が2つの独立した所有者に分散"]
    A1[TaskCreateScreen<br/>submittingRef + isSubmitting] --> A2[useTaskCreate<br/>独自 isSubmitting state + 再入ガード]
    A2 -.->|戻り値 isSubmitting<br/>未使用 dead API| A3[App.tsx]
  end
  subgraph after["変更後: 所有者を1箇所に一元化"]
    B1["TaskCreateScreen<br/>submittingRef + isSubmitting<br/>★単一の所有者"] --> B2[useTaskCreate<br/>変換 + invoke のみ pure]
    B1 -->|isSubmitting prop| B3[TaskForm / useTaskFormFields<br/>無効化・ガードに利用]
  end
  style A2 fill:#fdd
  style B2 fill:#dfd
  style B1 fill:#dfd
```

## 関連Issue

Closes #318

## テスト

- `pnpm test:run`: 241 files / 2072 tests すべて pass
- `pnpm build`（tsc -b + vite build）: 成功
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- biome check: clean

純粋な内部リファクタリングのため実機操作確認は省略（送信中の UI 挙動・二重送信防止は `TaskCreateScreen` 側で不変）。

## レビューポイント

- `useTaskCreate` から再入ガードを外しても二重送信防止が維持される根拠: `TaskCreateScreen.handleSubmit` の `submittingRef.current` ガードが同期的に作用し、キーボード submit も同 ref で抑止される。送信中はボタン/入力欄も `isSubmitting` prop で disabled。
- `useTaskFormFields.handleSubmit` の `isSubmitting` ガードは単一ソース（`TaskCreateScreen`）から流れる prop を参照する派生ガードであり、独立 state ではないため本 PR では維持している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)