### PR TITLE
💡 [Comment]: #323 [FE] why 未記載箇所への理由コメント追記（dragGuard / blur 遅延 / capture Escape / z-index 階層）

### DIFF
--- a/src/components/ConfirmDialog/index.tsx
+++ b/src/components/ConfirmDialog/index.tsx
@@ -59,6 +59,7 @@ export const ConfirmDialog = ({
 
   return (
     <>
+      {/* z-[60]=overlay（暗幕）/ z-[70]=dialog 本体。z 階層全体の取り決めは src/index.css を参照。 */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: overlay dismisses dialog on click, Escape key handled separately */}
       <div
         role="presentation"

--- a/src/components/TaskSelect/index.tsx
+++ b/src/components/TaskSelect/index.tsx
@@ -97,6 +97,9 @@ export const TaskSelect = ({
         onClose();
       }
     };
+    // capture フェーズ（第 3 引数 true）で Escape を親より先に捕捉し、stopPropagation で
+    // 親の Escape ハンドラ（詳細画面を閉じる処理など）への伝播を止める。これにより Escape は
+    // まず popover だけを閉じ、「Esc で詳細画面ごと閉じてしまう」挙動を防ぐ。
     document.addEventListener("keydown", handleKeyDown, true);
     return () => {
       document.removeEventListener("keydown", handleKeyDown, true);
@@ -211,6 +214,10 @@ export const TaskSelect = ({
             }}
             onFocus={() => setIsOpen(true)}
             onBlur={() => {
+              // 候補ボタンの mousedown→click は input の blur より後に処理されるため、
+              // blur 即時に popover を閉じると候補クリックが選択前に消えてしまう。
+              // 閉じる処理を少し遅延させ、候補クリックの確定を待ってから閉じる。
+              // 100ms は click 確定に十分かつ、ユーザーに閉じ遅れを感じさせない値。
               if (blurTimeoutRef.current !== null) {
                 window.clearTimeout(blurTimeoutRef.current);
               }
@@ -225,6 +232,8 @@ export const TaskSelect = ({
             data-testid={`${prefix}-input`}
           />
           {isOpen && candidates.length > 0 && (
+            // z-10=候補 popover。通常コンテンツの直上に出すだけの最下層。
+            // z 階層全体の取り決めは src/index.css を参照。
             <div
               className="absolute left-0 right-0 z-10 mt-1 max-h-48 overflow-y-auto rounded border border-border bg-surface shadow-lg"
               data-testid={`${prefix}-list`}

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 import type { ToastItem, ToastType } from "@/types/toast";
 
+/**
+ * トーストの既定表示時間（ms）。
+ * 短い通知文を読み切れる程度に長く、かつ次の操作を妨げない程度に短い値として 3 秒を採る。
+ */
 export const TOAST_DEFAULT_DURATION_MS = 3000;
 
 const typeStyles: Record<ToastType, string> = {

--- a/src/components/ToastContainer/index.tsx
+++ b/src/components/ToastContainer/index.tsx
@@ -28,6 +28,8 @@ export const ToastContainer = ({
     return null;
   }
   return (
+    // z-[80]=トースト。z 階層全体で最前面に置き、ダイアログ（z-[70]）表示中でも通知を隠さない。
+    // 取り決めは src/index.css を参照。
     <div
       className="pointer-events-none fixed top-4 right-4 z-[80] flex flex-col gap-2"
       data-testid="toast-container"

--- a/src/features/board/components/ColumnHeader/index.tsx
+++ b/src/features/board/components/ColumnHeader/index.tsx
@@ -74,6 +74,9 @@ export const ColumnHeader = ({
   const [isBusy, setIsBusy] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const isCancelledRef = useRef(false);
+  // カラム dragend 直後の synthetic click を抑止するためのガード。
+  // dragstart で true にし、root の onClick / 名前クリックの編集開始はこのフラグ中は無視する。
+  // click は dragend より後に届くため、handleDragEnd では即解除せず setTimeout で遅延解除する。
   const dragGuardRef = useRef(false);
   const reactId = useId();
   const errorId = `${reactId}-error`;
@@ -163,6 +166,8 @@ export const ColumnHeader = ({
 
   const handleDragEnd = () => {
     onColumnDragEnd?.();
+    // dragend 直後の synthetic click はこのマクロタスクの後に届く。0ms 遅延で解除を
+    // 次のマクロタスクに回し、その click をガードしてから false に戻す。
     setTimeout(() => {
       dragGuardRef.current = false;
     }, 0);

--- a/src/features/board/components/TaskCard/index.tsx
+++ b/src/features/board/components/TaskCard/index.tsx
@@ -171,6 +171,9 @@ export const TaskCard = ({
   onDragStart,
   onDragEnd,
 }: TaskCardProps) => {
+  // ドラッグ終了直後にブラウザが発火する synthetic click を抑止するためのガード。
+  // dragstart で true にし、onClick はこのフラグが立っている間は無視する。
+  // click は dragend より後に届くため、dragend では即解除せず下記 setTimeout で遅延解除する。
   const dragGuardRef = useRef(false);
 
   const handleDragStart = (e: DragEvent<HTMLDivElement>) => {
@@ -185,6 +188,8 @@ export const TaskCard = ({
 
   const handleDragEnd = () => {
     onDragEnd?.();
+    // dragend 直後の synthetic click はこのマクロタスクの後に届く。0ms 遅延で解除を
+    // 次のマクロタスクに回すことで、その click を確実にガードしてから false に戻す。
     setTimeout(() => {
       dragGuardRef.current = false;
     }, 0);

--- a/src/features/board/components/TreeView/index.tsx
+++ b/src/features/board/components/TreeView/index.tsx
@@ -3,7 +3,11 @@ import { DueBadge } from "@/components/DueBadge";
 import type { Task } from "@/types/task";
 import { buildTaskTree, type TaskTreeNode } from "../../lib/buildTaskTree";
 
-/** 1 段あたりのインデント幅（px）。 */
+/**
+ * 1 段あたりのインデント幅（px）。
+ * タスク階層ツリーは各行にバッジやタイトルなど情報量が多く、親子関係を一目で
+ * 追えるよう FileTree（12px）より広い 16px を採る。
+ */
 const INDENT_PER_DEPTH = 16;
 
 type TreeNodeItemProps = {

--- a/src/features/shell/components/FileTree/index.tsx
+++ b/src/features/shell/components/FileTree/index.tsx
@@ -2,7 +2,11 @@ import { memo, useCallback, useMemo, useState } from "react";
 import type { Task } from "@/types/task";
 import { buildFileTree, type FileTreeNode } from "../../lib/buildFileTree";
 
-/** 1 段あたりのインデント幅（px）。 */
+/**
+ * 1 段あたりのインデント幅（px）。
+ * ファイルツリーは深い階層になりやすく横幅が限られるため、TreeView（16px）より
+ * 狭い 12px に抑えて深いネストでも横スクロールしにくくする。
+ */
 const INDENT_PER_DEPTH = 12;
 
 type FileNodeItemProps = {

--- a/src/hooks/useRecentProjects/index.ts
+++ b/src/hooks/useRecentProjects/index.ts
@@ -11,7 +11,10 @@ export type RecentProject = {
 /** 履歴を保存する localStorage キー。 */
 export const RECENT_PROJECTS_STORAGE_KEY = "spec-board:recentProjects";
 
-/** 履歴の最大保持件数。 */
+/**
+ * 履歴の最大保持件数。
+ * 起動時の選択肢として一覧に収まり、かつ古いプロジェクトで埋もれない程度の件数として 8 件に抑える。
+ */
 const MAX_RECENT_PROJECTS = 8;
 
 /**

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+/* z-index 階層契約（Tailwind の z-[NN] 任意値ユーティリティで各所に散在するため、
+   重なり順の取り決めをここに 1 箇所だけ明文化する）:
+     - 候補 popover（TaskSelect の list/empty）: z-10  … 通常コンテンツの直上に出すだけ
+     - ダイアログ overlay（ConfirmDialog の暗幕）: z-[60]
+     - ダイアログ本体（ConfirmDialog）:          z-[70]  … overlay より前面
+     - トースト（ToastContainer）:               z-[80]  … 常に最前面（ダイアログ表示中でも通知を隠さない）
+   値を変える際はこの順序関係（popover < overlay < dialog < toast）を必ず保つこと。 */
+
 @theme {
 	--animate-slide-in: slide-in 0.2s ease-out;
 


### PR DESCRIPTION
## 概要

- コメント品質監査で「一見不自然な実装」「マジックナンバー」に why が無く、将来「不要そうだから消す」リグレッションを誘発しうる FE 箇所へ理由コメントを追記した。
- コメント追記のみで挙動は一切変更していない（#305 の削除系と対になる追記系の対応）。

## 変更の種類

- 💡 コメント追加（挙動不変）

## 変更した内容

### 競合回避ハック（高）
- `TaskSelect` の blur 時 `setTimeout(..., 100)` 遅延 close に、候補ボタン click が input blur より後に処理される競合を回避するためであること、100ms の根拠を追記。
- `TaskCard` の `dragGuardRef` + `setTimeout(..., 0)` に、dragend 直後の synthetic click を抑止するガードであること、click が dragend より後に届くため 0ms 遅延で次マクロタスクに解除を回す理由を追記（従来はテスト側にしか記載なし）。
- `ColumnHeader` の同じ dragGuard パターンに同様の why を追記。
- `TaskSelect` の `addEventListener("keydown", ..., true)` capture + `stopPropagation` に、親（詳細画面を閉じる Escape ハンドラ）より先に Escape を捕捉して popover だけ閉じる event 順序契約を追記（壊すと「Esc で詳細画面ごと閉じる」バグに直結）。

### 階層・定数の規約（中）
- z-index 階層契約（popover z-10 < overlay z-[60] < dialog z-[70] < toast z-[80]）を `src/index.css` に 1 箇所明文化し、`ConfirmDialog` / `ToastContainer` / `TaskSelect` の各 z 指定からそこを参照させる。
  - なお issue 記載の `TaskCreateModal:102,112`（z-[60]/z-[70]）は現行コードに存在せず、当該階層は `ConfirmDialog` に集約されているため、実在する 4 箇所へ反映した。
- `TreeView` の `INDENT_PER_DEPTH = 16` と `FileTree` の `= 12` に、値が異なる理由（タスクツリーは情報量が多く広め / ファイルツリーは深いネストで横幅を抑える）を追記。

### 低優先
- `Toast` の `TOAST_DEFAULT_DURATION_MS = 3000` の根拠を追記。
- `useRecentProjects` の `MAX_RECENT_PROJECTS = 8` の根拠を追記。

## 仕様ドキュメント更新

- 不要（コメント追記のみで公開 API・データ形式・画面挙動・設定項目のいずれも変更していないため）。

## 関連Issue

- Closes #323
- Relates to #305, #321

## テスト

- `pnpm test:run`: 241 files / 2073 tests すべて pass
- `pnpm build`: 成功（tsc -b + vite build）
- `pnpm lint`（oxlint）: 0 warnings / 0 errors
- `biome check src`: No fixes applied（クリーン）
- UI 挙動の変更は無し（コメントのみ）のため実機操作確認は対象外。

## レビューポイント

- z-index 階層契約を `src/index.css` に集約した方針が適切か（Tailwind の z-[NN] 任意値はトークン化できないため、契約コメントを 1 箇所に置き各所から参照させる形にしている）。
- 各 why コメントが自然文で挙動の意図を正確に表しているか（spec ID は記載していない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)