### PR TITLE
🐛 [Bug Fix]: [FE] update_task/add_link/remove_link の invoke 引数を args キーでラップ

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
       "package.json",
       "tsconfig*.json",
       "biome.json",
-      ".devcontainer/**/*.json"
+      ".devcontainer/**/*.json",
+      "!**/.claude"
     ]
   },
   "formatter": {

--- a/src/lib/tauri/linkCommands/addLink/__tests__/addLink.behavior.test.ts
+++ b/src/lib/tauri/linkCommands/addLink/__tests__/addLink.behavior.test.ts
@@ -35,15 +35,17 @@ test("invoke が 'add_link' という command 名で呼ばれる", async () => {
   expect(vi.mocked(invoke).mock.calls[0]?.[0]).toBe("add_link");
 });
 
-test("引数 { sourceFilePath, targetFilePath } が camelCase のまま invoke に渡る", async () => {
+test("引数 { sourceFilePath, targetFilePath } が args キー配下に camelCase のまま invoke に渡る", async () => {
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await addLink({
     sourceFilePath: "tasks/a.md",
     targetFilePath: "tasks/b.md",
   });
   expect(vi.mocked(invoke)).toHaveBeenCalledWith("add_link", {
-    sourceFilePath: "tasks/a.md",
-    targetFilePath: "tasks/b.md",
+    args: {
+      sourceFilePath: "tasks/a.md",
+      targetFilePath: "tasks/b.md",
+    },
   });
 });
 

--- a/src/lib/tauri/linkCommands/addLink/index.ts
+++ b/src/lib/tauri/linkCommands/addLink/index.ts
@@ -12,6 +12,6 @@ import type { LinkParams } from "../types";
 export const addLink = (
   params: LinkParams,
 ): Promise<ResultT<Task, TauriError>> =>
-  invokeWrapped<TaskPayload>("add_link", params).then((result) =>
+  invokeWrapped<TaskPayload>("add_link", { args: params }).then((result) =>
     Result.map(result, Task.fromPayload),
   );

--- a/src/lib/tauri/linkCommands/removeLink/__tests__/removeLink.behavior.test.ts
+++ b/src/lib/tauri/linkCommands/removeLink/__tests__/removeLink.behavior.test.ts
@@ -35,15 +35,17 @@ test("invoke が 'remove_link' という command 名で呼ばれる", async () =
   expect(vi.mocked(invoke).mock.calls[0]?.[0]).toBe("remove_link");
 });
 
-test("引数 { sourceFilePath, targetFilePath } が camelCase のまま invoke に渡る", async () => {
+test("引数 { sourceFilePath, targetFilePath } が args キー配下に camelCase のまま invoke に渡る", async () => {
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await removeLink({
     sourceFilePath: "tasks/a.md",
     targetFilePath: "tasks/b.md",
   });
   expect(vi.mocked(invoke)).toHaveBeenCalledWith("remove_link", {
-    sourceFilePath: "tasks/a.md",
-    targetFilePath: "tasks/b.md",
+    args: {
+      sourceFilePath: "tasks/a.md",
+      targetFilePath: "tasks/b.md",
+    },
   });
 });
 

--- a/src/lib/tauri/linkCommands/removeLink/index.ts
+++ b/src/lib/tauri/linkCommands/removeLink/index.ts
@@ -13,6 +13,6 @@ import type { LinkParams } from "../types";
 export const removeLink = (
   params: LinkParams,
 ): Promise<ResultT<Task, TauriError>> =>
-  invokeWrapped<TaskPayload>("remove_link", params).then((result) =>
+  invokeWrapped<TaskPayload>("remove_link", { args: params }).then((result) =>
     Result.map(result, Task.fromPayload),
   );

--- a/src/lib/tauri/taskCommands/updateTask/__tests__/updateTask.behavior.test.ts
+++ b/src/lib/tauri/taskCommands/updateTask/__tests__/updateTask.behavior.test.ts
@@ -32,35 +32,43 @@ test("invoke が 'update_task' という command 名で呼ばれる", async () =
   expect(vi.mocked(invoke).mock.calls[0]?.[0]).toBe("update_task");
 });
 
-test("filePath を含む引数が camelCase のまま渡る", async () => {
+test("filePath を含む引数が args キー配下に camelCase のまま渡る", async () => {
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await updateTask({ filePath: "tasks/x.md", title: "new" });
   expect(vi.mocked(invoke)).toHaveBeenCalledWith("update_task", {
-    filePath: "tasks/x.md",
-    title: "new",
+    args: {
+      filePath: "tasks/x.md",
+      title: "new",
+    },
   });
 });
 
 test("optional 未指定（キー省略）の場合、そのキーは invoke 引数に含まれない", async () => {
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await updateTask({ filePath: "tasks/x.md" });
-  const args = vi.mocked(invoke).mock.calls[0]?.[1] as Record<string, unknown>;
-  expect(Object.keys(args)).toEqual(["filePath"]);
+  const payload = vi.mocked(invoke).mock.calls[0]?.[1] as {
+    args: Record<string, unknown>;
+  };
+  expect(Object.keys(payload.args)).toEqual(["filePath"]);
 });
 
 test("optional に undefined を明示指定した場合 undefined のまま渡る（ラッパで削らない）", async () => {
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await updateTask({ filePath: "tasks/x.md", title: undefined });
-  const args = vi.mocked(invoke).mock.calls[0]?.[1] as Record<string, unknown>;
-  expect("title" in args).toBe(true);
-  expect(args.title).toBeUndefined();
+  const payload = vi.mocked(invoke).mock.calls[0]?.[1] as {
+    args: Record<string, unknown>;
+  };
+  expect("title" in payload.args).toBe(true);
+  expect(payload.args.title).toBeUndefined();
 });
 
 test("parent: '' （親解除）はそのまま空文字で渡る", async () => {
   vi.mocked(invoke).mockResolvedValue(taskPayloadFixture);
   await updateTask({ filePath: "tasks/x.md", parent: "" });
-  const args = vi.mocked(invoke).mock.calls[0]?.[1] as Record<string, unknown>;
-  expect(args.parent).toBe("");
+  const payload = vi.mocked(invoke).mock.calls[0]?.[1] as {
+    args: Record<string, unknown>;
+  };
+  expect(payload.args.parent).toBe("");
 });
 
 test("成功時は Result.ok(Task) を返す", async () => {

--- a/src/lib/tauri/taskCommands/updateTask/index.ts
+++ b/src/lib/tauri/taskCommands/updateTask/index.ts
@@ -12,6 +12,6 @@ import type { UpdateTaskParams } from "../types";
 export const updateTask = (
   params: UpdateTaskParams,
 ): Promise<ResultT<Task, TauriError>> =>
-  invokeWrapped<TaskPayload>("update_task", params).then((result) =>
+  invokeWrapped<TaskPayload>("update_task", { args: params }).then((result) =>
     Result.map(result, Task.fromPayload),
   );


### PR DESCRIPTION
## 概要
- `update_task` 実行時の `invalid args 'args' for command 'update_task': command update_task missing required key args` を修正。
- Tauri コマンドが `args: XxxArgs` で受ける契約に対し、フロントのラッパが params をフラット送出していたのが原因。`{ args: params }` でラップして契約に合わせた。

## 変更の種類
- 🐛 Bug Fix（[FE]）
- 🔧 Config（biome 走査設定）

## 変更した内容
- `src/lib/tauri/taskCommands/updateTask/index.ts` — invoke 第2引数を `params` → `{ args: params }`
- `src/lib/tauri/linkCommands/addLink/index.ts` — 同型バグを同時修正（`{ args: params }`）
- `src/lib/tauri/linkCommands/removeLink/index.ts` — 同型バグを同時修正（`{ args: params }`）
- 各 `__tests__/*.behavior.test.ts` — 期待値を `args` キー配下へ修正
- `biome.json` — `files.includes` に `!**/.claude/**` を追加（後述）

報告は `update_task` だが、同じ `args: XxxArgs` 契約を持つ `add_link` / `remove_link` も同型の潜在バグ（フラット送出）を抱えていたため、3コマンドまとめて修正した。`create_task` のみ元から `{ args: params }` で正しくラップされていた。

## システム図

```mermaid
flowchart LR
    subgraph FE["フロント invoke ラッパ"]
      P["params (UpdateTaskParams 等)"]
    end
    subgraph IPC["Tauri IPC"]
      W["{ args: {...} } 形状を要求"]
    end
    subgraph BE["Rust command"]
      R["update_task(args: UpdateTaskArgs)"]
    end

    P -- "修正前: params をフラット送出" --> X["❌ missing required key args"]
    P -- "修正後: { args: params }" --> W --> R

    style X fill:#fdd,stroke:#c00
    style W fill:#dfd,stroke:#0a0
```

## 仕様ドキュメント更新
- 不要。IPC 引数の `{ args }` ラップは Tauri のシリアライズ詳細であり、`docs/spec-board/` が定める公開仕様（データ形式・画面挙動・設定項目）の変更には当たらない。コードを既存の Rust 契約に追従させた純粋なバグ修正。

## テスト
- 対象3コマンド: 15 tests passed（Red→Green を確認）
- 実コード全体（worktree 除外）: **243 files / 2075 tests 全合格・回帰ゼロ**
  - `node_modules/.bin/vitest run --exclude '**/.claude/**'`
- 型チェック `tsc -b`: エラー 0
- lint `oxlint` / `biome check .`: エラー 0

## レビューポイント
- **biome.json の `!**/.claude/**` 追加について**: `.claude/worktrees/agent-*` の stale worktree が持つ `biome.json` を biome 2.x が「nested root configuration」と判定し、`biome check .` が設定エラーで異常終了 → pre-push lint フックが push をブロックしていた。`files.includes` の許可リストは走査抑止に効かないため明示除外が必要。各 worktree は自身の `biome.json` を root に使うので、worktree 内の lint/push はこの除外の影響を受けないことを実機確認済み（root/worktree 双方で `biome check .` が EXIT 0）。
- バグ修正本体は3コマンドで同一パターン。`create_task` の既存実装に揃えている。

## 関連Issue
- 対応する GitHub Issue なし（branch の `008` はローカル採番）。