### PR TITLE
🎨 [UI/UX]: [FE] ラベル設定画面をモック準拠に再構築し export_labels / 使用数 → ボード絞り込み導線を整備

### DIFF
--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -171,6 +171,36 @@ type GetLabelsPayload = {
 
 > **スコープ境界**: 本仕様は labels.yml のスキーマ確定・読み込み・`get_labels`（使用数集計含む）・`create_label` / `update_label` / `delete_label`・invoke ラッパまでを対象とする（Rust バックエンド）。FE 連携（`usageCounts` の TS 型追従・ラベル編集 UI）と実際のラベル色の UI 反映（既定色の具体値 / design token 定義）は別 Issue で扱う。
 
+### ラベル設定画面（FE）
+
+設定 → ラベルタブ（`LabelSettingsTab`）は labels.yml の CRUD と表示集計を備えるフル機能の管理画面として動作する。マイルストーン設定画面のパターン（楽観更新せず成功時 reload で確定）を踏襲する。
+
+- **作成 / 編集フォーム**: 名前 / 説明 / グループ / カラー（HEX 直接入力 + `<input type="color">` + プリセット10色のスウォッチ）を 1 フォームで扱う。プレビューチップはフォーム値から即時反映する（color → group → name の優先順位で色を解決）。プリセット色は `{ red, orange, yellow, green, teal, blue, indigo, purple, pink, gray }` の `#RRGGBB`。
+- **編集モード**: 一覧の「編集」ボタンで `name` を固定（disabled）したフォームへ既存値を流し込む。送信時は全フィールド送信（PUT セマンティクス）。「キャンセル」で新規モードへ戻る。
+- **削除確認**: `globalThis.confirm` で確認文言を分岐する。使用数 `> 0` のとき「『name』は N 件のタスクで使用中です。削除しますか？（タスクの値は残ります）」、使用数 `= 0` のとき「『name』を削除しますか？」。キャンセルで `delete_label` は呼ばない。
+- **フィルタバー**: グループチップ（件数つき / 「すべて」+ 各グループ）+ 検索ボックス（name / description 部分一致・大小無視）+ ソート select（`name` 昇順 / `usage` 降順 / `updated` 新しい順）。グループ選択は判別 union `{ kind: "all" } | { kind: "group"; value }` で表現し、実グループ名 `"all"` との衝突を回避する。
+- **テーブル**: 列は「ラベルチップ / 説明 / 使用数 / グループ badge / 更新 / 行アクション」。`updated` 未設定は「新規」を表示。相対時刻は「たった今 / N 分前 / N 時間前 / 昨日 / N 日前 / N週間前 / Nヶ月前 / YYYY/MM/DD」。
+- **使用数リンク**: テーブルの使用数セルは `count > 0` のときリンク（ボタン）として描画し、クリックすると board へ遷移して当該ラベルでフィルタを適用する。`count = 0` は「0 件」のプレーンテキスト（クリック不可）。
+- **使用数 live 上書き**: settings 画面に渡す `usageCounts` は、プロジェクトが loaded のときだけ FE 側で live なタスク集合から算出した値（`LabelRegistry.labelUsageCounts(tasks)`）で上書きする。loaded 未到達の間は BE 由来の `get_labels.usageCounts` をフォールバックとして維持する（瞬間的な「0 件 / 未使用」誤表示を防ぐ）。
+- **統計ヘッダー / フッター集計**: 上部に「N 件 / M 使用中 / K 未使用」、フッターに「表示中件数 / 総数」と使用中ラベルのカラー集計（`color` 指定優先・無ければ group キー）を表示する。
+- **エクスポート**: 「⬇ エクスポート」ボタンで `@tauri-apps/plugin-dialog` の `save()` を呼び、ユーザーが選んだパスへ `export_labels` コマンドが `labels.yml` を書き出す。BE は既存 store と同じ `serde_yaml_ng::to_string` 経路で直列化するため、ディスクの labels.yml と同じ camelCase / `skip_serializing_if` 規則が適用される。ダイアログのキャンセルは no-op。空 path（`""`）は BE が `EmptyPath` で拒否し、`save()` 例外 / BE write 失敗は共通トースト経路で通知する。
+
+### `export_labels` コマンド
+
+`labels.yml` を任意パスへ書き出す書き込み専用 Tauri コマンド。
+
+| コマンド | 引数 | 戻り値 | 説明 |
+|:---------|:-----|:-------|:-----|
+| `export_labels` | `{ path: string }` | `Unit` | `AppState.labels` の `LabelRegistry` を `serde_yaml_ng::to_string` で直列化し、`std::fs::write(path)` で書き出す |
+
+- 保存先パスはユーザーが FE の save ダイアログで明示的に選んだもの。アプリ権限の範囲でユーザー指定パスへ書き込むのは仕様。
+- エラー文字列契約（FE のパターンマッチ整合のため `get_labels` / `delete_label` と一致）:
+  - 空 path → `"保存先のパスが空です"`
+  - プロジェクト未オープン → `"プロジェクトが開かれていません"`
+  - 内部状態の lock 破損 → `"内部状態のロックが破損しました"`
+- 親ディレクトリ不存在・書込権限なし等は `std::fs::write` の失敗として OS のエラー文字列を透過する。
+- write は project 外への単発書込のため、`delete_label` のような snapshot / lock preflight は不要（read-only に `state.labels()` を取得するだけ）。
+
 ## milestones.yml スキーマ
 
 タスク frontmatter の `milestone`（単数の自由文字列・参照キー）に対し、表示名・期日・並び順・状態などのメタ情報を一元管理する「マイルストーンマスタ定義ファイル」を `.spec-board/milestones.yml` に置く。`config.json` とは別ファイルで管理し、トップレベルの `milestones:` キー配下に定義の配列を並べる。labels.yml と同じハイブリッド構成（frontmatter 自由文字列 + yml マスタ・非破壊・暗黙許容）を踏襲する。

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -21,6 +21,7 @@ pub mod create_label;
 pub mod create_milestone;
 pub mod delete_label;
 pub mod delete_milestone;
+pub mod export_labels;
 pub mod get_columns;
 pub mod get_labels;
 pub mod get_milestones;

--- a/src-tauri/src/config/export_labels.rs
+++ b/src-tauri/src/config/export_labels.rs
@@ -1,0 +1,120 @@
+//! `export_labels` Tauri command 本体。
+//!
+//! 現在 `AppState.labels` に commit されている `LabelRegistry` を、ユーザーが
+//! save ダイアログで選んだ**任意のパス**へ `labels.yml` 形式（`serde_yaml_ng::to_string`）で
+//! 書き出す書き込み専用 command。`.spec-board/labels.yml` の store とは別経路で、
+//! プロジェクト外への単発 export を担う。
+//!
+//! 直列化は BE 既存 store（`label_registry.rs::FsLabelRegistryStore::save`）と同じ
+//! `serde_yaml_ng::to_string(&registry)` を転用するため、ディスク上の `labels.yml` と
+//! エクスポート出力の形式（camelCase / 空フィールド `skip_serializing_if` / 正規化）が
+//! 一致する。
+//!
+//! # 脅威モデル（任意パス書込）
+//!
+//! 本アプリはローカルデスクトップアプリで、保存先 `path` はユーザーが FE の
+//! save ダイアログで明示的に選んだもの。アプリ権限の範囲でユーザー指定パスへ
+//! 書き込むのは仕様（任意パス export 自体が機能要件）。ただし空 `path` は
+//! [`ExportLabelsError::EmptyPath`] で弾き、親ディレクトリ不存在・書込権限なし等は
+//! `std::fs::write` の失敗を [`ExportLabelsError::Write`] へ集約する。
+//!
+//! # ロック取得順序
+//!
+//! `labels` のみ（read-only 取得）。書込は project 外パスで store / lock を伴わないため
+//! delete のような snapshot / lock preflight は不要。
+//!
+//! # エラー文字列の契約
+//!
+//! - `NoProjectOpen` の Display は `"プロジェクトが開かれていません"`（`delete_label` と一致）
+//! - `StateLockPoisoned` の Display は `"内部状態のロックが破損しました"`（同上）
+//! - `EmptyPath` の Display は `"保存先のパスが空です"`
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tauri::State;
+use thiserror::Error;
+
+use crate::state::{AppState, AppStateError};
+
+/// `export_labels` コマンドの引数。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportLabelsArgs {
+    pub path: String,
+}
+
+/// `export_labels` コマンドのエラー。
+#[derive(Debug, Error)]
+pub enum ExportLabelsError {
+    /// `path` が空文字列。
+    #[error("保存先のパスが空です")]
+    EmptyPath,
+    /// `AppState.labels` が `None`（プロジェクト未オープン）。
+    #[error("プロジェクトが開かれていません")]
+    NoProjectOpen,
+    /// `AppState` 内部 mutex (`labels`) が poison 状態。
+    #[error("内部状態のロックが破損しました")]
+    StateLockPoisoned,
+    /// `serde_yaml_ng` での直列化失敗。
+    #[error(transparent)]
+    Serialize(serde_yaml_ng::Error),
+    /// `std::fs::write` の I/O 失敗。
+    #[error(transparent)]
+    Write(std::io::Error),
+}
+
+impl From<AppStateError> for ExportLabelsError {
+    fn from(_: AppStateError) -> Self {
+        ExportLabelsError::StateLockPoisoned
+    }
+}
+
+/// Tauri command 薄層。`export_labels_impl` を呼び、エラーを文字列化して返す。
+///
+/// # Errors
+///
+/// - 空 path のとき `"保存先のパスが空です"`
+/// - プロジェクト未オープン時に `"プロジェクトが開かれていません"`
+/// - `labels` の `Mutex` が poison している場合に `"内部状態のロックが破損しました"`
+/// - 直列化失敗 / I/O 失敗時はそれぞれの原因文字列を透過
+#[tauri::command]
+pub fn export_labels(
+    state: State<'_, Arc<AppState>>,
+    args: ExportLabelsArgs,
+) -> Result<(), String> {
+    export_labels_impl(state.inner(), &args).map_err(|e| e.to_string())
+}
+
+/// 単体テスト境界の effect 層。
+///
+/// 1. 空 path を `EmptyPath` で拒否する
+/// 2. `state.labels()?` を read-only 取得（書込でないため snapshot / lock preflight は不要）
+/// 3. `serde_yaml_ng::to_string(&registry)` で直列化（store と同一経路）
+/// 4. `std::fs::write(args.path, yaml)` で任意パスへ書き出す
+///
+/// # Errors
+///
+/// - 空 path: [`ExportLabelsError::EmptyPath`]
+/// - 未オープン: [`ExportLabelsError::NoProjectOpen`]
+/// - lock poison: [`ExportLabelsError::StateLockPoisoned`]
+/// - 直列化失敗: [`ExportLabelsError::Serialize`]
+/// - 書込失敗: [`ExportLabelsError::Write`]
+pub(crate) fn export_labels_impl(
+    state: &AppState,
+    args: &ExportLabelsArgs,
+) -> Result<(), ExportLabelsError> {
+    if args.path.is_empty() {
+        return Err(ExportLabelsError::EmptyPath);
+    }
+    // read-only 取得（get_labels_impl と同形）。export は書込でないため
+    // delete のような snapshot / lock preflight は不要。
+    let registry = state.labels()?.ok_or(ExportLabelsError::NoProjectOpen)?;
+    let yaml = serde_yaml_ng::to_string(&registry).map_err(ExportLabelsError::Serialize)?;
+    std::fs::write(&args.path, yaml).map_err(ExportLabelsError::Write)?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "export_labels_tests.rs"]
+mod export_labels_tests;

--- a/src-tauri/src/config/export_labels.rs
+++ b/src-tauri/src/config/export_labels.rs
@@ -104,14 +104,18 @@ pub(crate) fn export_labels_impl(
     state: &AppState,
     args: &ExportLabelsArgs,
 ) -> Result<(), ExportLabelsError> {
-    if args.path.is_empty() {
+    // 防御的に trim ベースで空判定する（FE は通常 save ダイアログ経由だが、
+    // 不正な空白のみパスが直接 invoke された場合に意図しないパスへ write しない）。
+    // write も trim 済みパスで行うため、前後空白を含んだまま OS へ渡らない。
+    let path = args.path.trim();
+    if path.is_empty() {
         return Err(ExportLabelsError::EmptyPath);
     }
     // read-only 取得（get_labels_impl と同形）。export は書込でないため
     // delete のような snapshot / lock preflight は不要。
     let registry = state.labels()?.ok_or(ExportLabelsError::NoProjectOpen)?;
     let yaml = serde_yaml_ng::to_string(&registry).map_err(ExportLabelsError::Serialize)?;
-    std::fs::write(&args.path, yaml).map_err(ExportLabelsError::Write)?;
+    std::fs::write(path, yaml).map_err(ExportLabelsError::Write)?;
     Ok(())
 }
 

--- a/src-tauri/src/config/export_labels_tests.rs
+++ b/src-tauri/src/config/export_labels_tests.rs
@@ -101,3 +101,23 @@ fn empty_path_check_runs_before_state_lookup() {
     let err = export_labels_impl(&state, &args("")).expect_err("empty rejected");
     assert!(matches!(err, ExportLabelsError::EmptyPath));
 }
+
+#[test]
+fn whitespace_only_path_is_rejected() {
+    // 空白のみの path は trim 後に空文字となるため EmptyPath で弾かれる。
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(tmp.path(), LabelRegistry::default());
+    let err = export_labels_impl(&state, &args("   \t  ")).expect_err("whitespace rejected");
+    assert!(matches!(err, ExportLabelsError::EmptyPath));
+}
+
+#[test]
+fn path_with_surrounding_whitespace_is_trimmed_before_write() {
+    // 前後に空白を含むパスは trim 済みのパスへ書き込まれる。
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(tmp.path(), LabelRegistry::default());
+    let target = tmp.path().join("trimmed.yml");
+    let padded = format!("  {}  ", target.to_str().unwrap());
+    export_labels_impl(&state, &args(&padded)).expect("export ok");
+    assert!(target.exists(), "trim 済みパスにファイルが作られる");
+}

--- a/src-tauri/src/config/export_labels_tests.rs
+++ b/src-tauri/src/config/export_labels_tests.rs
@@ -1,0 +1,103 @@
+//! `export_labels_impl` のテスト。
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::{export_labels_impl, ExportLabelsArgs, ExportLabelsError};
+use crate::config::{LabelDefinition, LabelRegistry};
+use crate::state::AppState;
+
+fn definition(name: &str) -> LabelDefinition {
+    LabelDefinition {
+        name: name.to_string(),
+        description: None,
+        group: None,
+        color: None,
+        updated: None,
+    }
+}
+
+fn opened_state(root: &Path, registry: LabelRegistry) -> AppState {
+    let state = AppState::new();
+    state
+        .set_project_path(Some(root.to_path_buf()))
+        .expect("writable");
+    state.replace_labels(Some(registry)).expect("writable");
+    state
+}
+
+fn args(path: &str) -> ExportLabelsArgs {
+    ExportLabelsArgs {
+        path: path.to_string(),
+    }
+}
+
+#[test]
+fn writes_yaml_to_specified_path() {
+    let tmp = TempDir::new().unwrap();
+    let registry = LabelRegistry {
+        labels: vec![definition("bug"), definition("feat")],
+    };
+    let state = opened_state(tmp.path(), registry.clone());
+
+    let target = tmp.path().join("exported.yml");
+    let target_str = target.to_str().unwrap().to_string();
+
+    export_labels_impl(&state, &args(&target_str)).expect("export ok");
+
+    let written = std::fs::read_to_string(&target).expect("read written file");
+    let expected = serde_yaml_ng::to_string(&registry).expect("serialize");
+    // store と同一直列化経路で書かれるため、文字列が完全一致する。
+    assert_eq!(written, expected);
+}
+
+#[test]
+fn writes_empty_registry_as_empty_labels() {
+    let tmp = TempDir::new().unwrap();
+    let registry = LabelRegistry { labels: vec![] };
+    let state = opened_state(tmp.path(), registry.clone());
+
+    let target = tmp.path().join("empty.yml");
+    let target_str = target.to_str().unwrap().to_string();
+
+    export_labels_impl(&state, &args(&target_str)).expect("export ok");
+    let written = std::fs::read_to_string(&target).expect("read written file");
+    let expected = serde_yaml_ng::to_string(&registry).expect("serialize");
+    assert_eq!(written, expected);
+}
+
+#[test]
+fn empty_path_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(tmp.path(), LabelRegistry::default());
+    let err = export_labels_impl(&state, &args("")).expect_err("empty rejected");
+    assert!(matches!(err, ExportLabelsError::EmptyPath));
+}
+
+#[test]
+fn no_project_open_is_rejected() {
+    let state = AppState::new();
+    // project_path / labels 共に None のまま
+    let err = export_labels_impl(&state, &args("/tmp/x.yml")).expect_err("no project");
+    assert!(matches!(err, ExportLabelsError::NoProjectOpen));
+}
+
+#[test]
+fn nonexistent_parent_directory_returns_write_error() {
+    let tmp = TempDir::new().unwrap();
+    let state = opened_state(tmp.path(), LabelRegistry::default());
+    let missing = tmp.path().join("no_such_dir/inside.yml");
+    let missing_str = missing.to_str().unwrap().to_string();
+
+    let err = export_labels_impl(&state, &args(&missing_str)).expect_err("write fails");
+    assert!(matches!(err, ExportLabelsError::Write(_)));
+}
+
+#[test]
+fn empty_path_check_runs_before_state_lookup() {
+    // 未オープン + 空 path → EmptyPath が先に返る（空 path が NoProjectOpen より優先）。
+    let state = AppState::new();
+    let err = export_labels_impl(&state, &args("")).expect_err("empty rejected");
+    assert!(matches!(err, ExportLabelsError::EmptyPath));
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ use crate::state::AppState;
 
 /// Builds and runs the Tauri application with the configured plugins and commands.
 ///
-/// @returns 戻り値なし。Tauri runtime が終了するまでアプリケーションを実行する。
+/// Tauri runtime が終了するまでアプリケーションを実行する（戻り値なし）。
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -31,6 +31,7 @@ pub fn run() {
             config::create_label::create_label,
             config::update_label::update_label,
             config::delete_label::delete_label,
+            config::export_labels::export_labels,
             config::get_milestones::get_milestones,
             config::create_milestone::create_milestone,
             config::update_milestone::update_milestone,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,13 @@ import {
   buildTasksByNormalizedPath,
   countTasksWithBrokenLink,
 } from "@/domains/broken-link";
+import { LabelRegistry } from "@/domains/label-registry";
 import { Milestone } from "@/domains/milestone";
 import { countTasksWithParseError } from "@/domains/parse-error";
 import { selectTaskOutcome } from "@/domains/task-selection";
 import { type AppView, useAppView } from "@/hooks/useAppView";
 import { resolveCloseTarget } from "@/hooks/useAppView/resolveCloseTarget";
+import { useLabels } from "@/hooks/useLabels";
 import { useMilestones } from "@/hooks/useMilestones";
 import { useRecentProjects } from "@/hooks/useRecentProjects";
 import { useToasts } from "@/hooks/useToasts";
@@ -319,6 +321,37 @@ export const App = () => {
     }),
     [milestonesResource, tasks],
   );
+  // ラベルリソース（settings 向けの唯一の取得点）。TaskForm は別途 useLabelList を使う。
+  const labelsResource = useLabels(loadedPath ?? undefined);
+  // settings の使用数は milestone と対称に live な tasks から算出した値で上書きする。
+  // ただし「プロジェクトが loaded」のときだけ。未ロードの間は BE 由来の usageCounts を
+  // 維持し、ロード前の瞬間に「0 件 / 未使用」と誤表示しないようにする（loaded で 0 件は
+  // live の 0 が正解）。
+  const isProjectLoaded = state.kind === "loaded";
+  const settingsLabelsResource = useMemo(
+    () => ({
+      ...labelsResource,
+      usageCounts: isProjectLoaded
+        ? LabelRegistry.labelUsageCounts(tasks)
+        : labelsResource.usageCounts,
+    }),
+    [labelsResource, tasks, isProjectLoaded],
+  );
+  // settings → board へラベル絞り込みを 1 回だけ持ち込むための pending state。
+  // 適用後は BoardWorkspace の onLabelFilterApplied コールバックで null へ戻す。
+  const [pendingLabelFilter, setPendingLabelFilter] = useState<string | null>(
+    null,
+  );
+  const handleLabelUsageClick = useCallback(
+    (name: string) => {
+      setPendingLabelFilter(name);
+      navigate("board");
+    },
+    [navigate],
+  );
+  const handleLabelFilterApplied = useCallback(() => {
+    setPendingLabelFilter(null);
+  }, []);
   // リンク切れ / パースエラーの警告トーストは load 成功イベント（useProject の
   // onLoaded callback = handleProjectLoaded）で 1 回だけ発火する。tasks 変更のたびに
   // 走る effect + ref の発火済み管理は廃止した。
@@ -955,6 +988,10 @@ export const App = () => {
     return (
       <div className="relative flex flex-1 overflow-hidden">
         <BoardWorkspace
+          // settings 表示中は BoardWorkspace が unmount されるため、settings→board 遷移で
+          // 必ず remount される。これにより useTaskFilter の useState 初期 seed が遷移ごとに
+          // 1 回適用される（key の追加はかえって seed→クリア→再 remount で seed 消失を招く
+          // ので付けない）。
           columns={columns}
           tasks={tasks}
           tasksByNormalizedPath={tasksByNormalizedPath}
@@ -968,6 +1005,8 @@ export const App = () => {
           onTaskClick={handleTaskClick}
           onTaskDrop={handleTaskDrop}
           onColumnReorder={handleColumnReorder}
+          initialLabelFilter={pendingLabelFilter}
+          onLabelFilterApplied={handleLabelFilterApplied}
         />
         {tasks.length === 0 && (
           <div className="pointer-events-none absolute inset-x-0 top-12 flex justify-center">
@@ -1025,7 +1064,11 @@ export const App = () => {
               />
               <main className="flex flex-1 overflow-hidden">
                 {view === "settings" && (
-                  <SettingsScreen milestones={settingsMilestonesResource} />
+                  <SettingsScreen
+                    labels={settingsLabelsResource}
+                    milestones={settingsMilestonesResource}
+                    onLabelUsageClick={handleLabelUsageClick}
+                  />
                 )}
                 {view === "milestone" && (
                   <MilestoneViewScreen

--- a/src/__tests__/App.detailView.test.tsx
+++ b/src/__tests__/App.detailView.test.tsx
@@ -94,7 +94,7 @@ beforeEach(() => {
     },
   });
   getLabelsMock.mockReset();
-  getLabelsMock.mockResolvedValue(Result.ok({ labels: [] }));
+  getLabelsMock.mockResolvedValue(Result.ok({ labels: [], usageCounts: {} }));
   updateTaskMock.mockReset();
   deleteTaskMock.mockReset();
 });

--- a/src/__tests__/App.interaction.test.tsx
+++ b/src/__tests__/App.interaction.test.tsx
@@ -105,7 +105,7 @@ beforeEach(() => {
   });
   getLabelsMock.mockReset();
   // 設定画面のラベルタブが getLabels を読むため、既定で空一覧を返す。
-  getLabelsMock.mockResolvedValue(Result.ok({ labels: [] }));
+  getLabelsMock.mockResolvedValue(Result.ok({ labels: [], usageCounts: {} }));
   createTaskMock.mockReset();
   updateTaskMock.mockReset();
   deleteTaskMock.mockReset();

--- a/src/__tests__/App.labelUsageLink.test.tsx
+++ b/src/__tests__/App.labelUsageLink.test.tsx
@@ -1,0 +1,194 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { App } from "@/App";
+import {
+  getColumns as getColumnsInvoke,
+  getLabels as getLabelsInvoke,
+  getMilestones as getMilestonesInvoke,
+  type OpenProjectPayload,
+  openDirectoryDialog,
+  openProject as openProjectInvoke,
+} from "@/lib/tauri";
+import { Task } from "@/types/task";
+import { Result } from "@/utils/result";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    openDirectoryDialog: vi.fn(),
+    openProject: vi.fn(),
+    getColumns: vi.fn(),
+    getLabels: vi.fn(),
+    getMilestones: vi.fn(),
+    createTask: vi.fn(),
+    updateTask: vi.fn(),
+    deleteTask: vi.fn(),
+    updateColumns: vi.fn(),
+    updateCardOrder: vi.fn(),
+  };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+const openDirectoryDialogMock = vi.mocked(openDirectoryDialog);
+const openProjectMock = vi.mocked(openProjectInvoke);
+const getColumnsMock = vi.mocked(getColumnsInvoke);
+const getLabelsMock = vi.mocked(getLabelsInvoke);
+const getMilestonesMock = vi.mocked(getMilestonesInvoke);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previous: boolean | undefined;
+beforeAll(() => {
+  previous = reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = previous;
+});
+
+const taskBug: Task = Task.fromPayload({
+  id: "bug-1",
+  title: "Bug タスク",
+  status: "Todo",
+  labels: ["bug"],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/bug-1.md",
+});
+const taskFeature: Task = Task.fromPayload({
+  id: "feat-1",
+  title: "Feature タスク",
+  status: "Todo",
+  labels: ["feature"],
+  links: [],
+  children: [],
+  reverseLinks: [],
+  body: "",
+  filePath: "tasks/feat-1.md",
+});
+
+const payload: OpenProjectPayload = {
+  tasks: [taskBug, taskFeature],
+  columns: ["Todo", "Done"],
+};
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeEach(() => {
+  openDirectoryDialogMock.mockReset();
+  openProjectMock.mockReset();
+  getColumnsMock.mockReset();
+  getColumnsMock.mockResolvedValue({
+    ok: true,
+    value: {
+      columns: [
+        { name: "Todo", order: 0 },
+        { name: "Done", order: 1 },
+      ],
+      doneColumn: "Done",
+    },
+  });
+  getLabelsMock.mockReset();
+  getLabelsMock.mockResolvedValue(
+    Result.ok({
+      labels: [{ name: "bug" }, { name: "feature" }],
+      // BE 由来の usageCounts。App 側で live 集計に上書きされる。
+      usageCounts: { bug: 1, feature: 1 },
+    }),
+  );
+  getMilestonesMock.mockReset();
+  getMilestonesMock.mockResolvedValue(
+    Result.ok({ milestones: [], usageCounts: {} }),
+  );
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+const mountApp = (): void => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<App />);
+  });
+};
+
+const openProject = async (): Promise<void> => {
+  openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
+  openProjectMock.mockResolvedValueOnce(Result.ok(payload));
+  const headerButtons = container?.querySelectorAll("header button") ?? [];
+  const openBtn = Array.from(headerButtons).find(
+    (b) => b.textContent === "開く",
+  ) as HTMLButtonElement | undefined;
+  await act(async () => {
+    openBtn?.click();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const clickButtonByLabel = async (label: string): Promise<void> => {
+  const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
+    (b) => b.textContent === label,
+  ) as HTMLButtonElement | undefined;
+  await act(async () => {
+    btn?.click();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+test("ラベル設定タブの使用数リンク → board へ遷移しそのラベルでフィルタされる", async () => {
+  mountApp();
+  await openProject();
+  // 初期は board。Bug / Feature 両方のタスクが見えている。
+  expect(container?.textContent).toContain("Bug タスク");
+  expect(container?.textContent).toContain("Feature タスク");
+
+  // 設定画面 → ラベルタブ
+  await clickButtonByLabel("設定");
+  // ラベル設定タブのテーブルに bug の使用数リンクが表示される
+  const usageLink = container?.querySelector(
+    '[data-testid="label-usage-link"]',
+  ) as HTMLButtonElement | null;
+  expect(usageLink).not.toBeNull();
+  expect(usageLink?.textContent).toContain("1");
+
+  await act(async () => {
+    usageLink?.click();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  // Board へ遷移し、bug ラベルだけで絞り込まれていること
+  expect(container?.textContent).toContain("Bug タスク");
+  expect(container?.textContent).not.toContain("Feature タスク");
+});

--- a/src/__tests__/App.mutationFailureToast.test.tsx
+++ b/src/__tests__/App.mutationFailureToast.test.tsx
@@ -273,6 +273,8 @@ const makeInvoke =
       // App が loaded 時に useMilestones から呼ぶ読み取り系。空レジストリを返す。
       get_milestones: () =>
         Promise.resolve({ milestones: [], usageCounts: {} }),
+      // 同じく useLabels から呼ぶ読み取り系。空レジストリ + 空 usageCounts。
+      get_labels: () => Promise.resolve({ labels: [], usageCounts: {} }),
       ...overrides,
     };
     return (responders[cmd] ?? resolveUndefined)();

--- a/src/domains/label-registry/__tests__/labelUsageCounts.behavior.test.ts
+++ b/src/domains/label-registry/__tests__/labelUsageCounts.behavior.test.ts
@@ -54,9 +54,9 @@ test("__proto__ / constructor のようなプロトタイプキー名でも own 
     task("c", ["constructor"]),
   ];
   const result = LabelRegistry.labelUsageCounts(tasks);
-  expect(Object.hasOwn(result, "__proto__")).toBe(true);
-  expect(Object.hasOwn(result, "constructor")).toBe(true);
-  // own property としての値を直接取り出す（プロトタイプチェーンを経由しない）。
+  // own property の存在 + 値の正しさを `getOwnPropertyDescriptor` でまとめて検証する。
+  // 通常の `result.__proto__` / `result.constructor` アクセスは prototype に
+  // フォールバックして descriptor を経由するのが安全。
   expect(Object.getOwnPropertyDescriptor(result, "__proto__")?.value).toBe(2);
   expect(Object.getOwnPropertyDescriptor(result, "constructor")?.value).toBe(2);
 });

--- a/src/domains/label-registry/__tests__/labelUsageCounts.behavior.test.ts
+++ b/src/domains/label-registry/__tests__/labelUsageCounts.behavior.test.ts
@@ -46,3 +46,17 @@ test("ラベル無しのタスクのみのとき空オブジェクトを返す",
   const tasks = [task("a", []), task("b", [])];
   expect(LabelRegistry.labelUsageCounts(tasks)).toEqual({});
 });
+
+test("__proto__ / constructor のようなプロトタイプキー名でも own property として正しく数える", () => {
+  const tasks = [
+    task("a", ["__proto__"]),
+    task("b", ["__proto__", "constructor"]),
+    task("c", ["constructor"]),
+  ];
+  const result = LabelRegistry.labelUsageCounts(tasks);
+  expect(Object.hasOwn(result, "__proto__")).toBe(true);
+  expect(Object.hasOwn(result, "constructor")).toBe(true);
+  // own property としての値を直接取り出す（プロトタイプチェーンを経由しない）。
+  expect(Object.getOwnPropertyDescriptor(result, "__proto__")?.value).toBe(2);
+  expect(Object.getOwnPropertyDescriptor(result, "constructor")?.value).toBe(2);
+});

--- a/src/domains/label-registry/__tests__/labelUsageCounts.behavior.test.ts
+++ b/src/domains/label-registry/__tests__/labelUsageCounts.behavior.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "vitest";
+import { LabelRegistry } from "@/domains/label-registry";
+import { Task } from "@/types/task";
+
+const task = (id: string, labels: string[]): Task =>
+  Task.fromPayload({
+    id,
+    title: id,
+    status: "Todo",
+    labels,
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: `tasks/${id}.md`,
+  });
+
+test("複数タスクのラベルを名前ごとに集計する", () => {
+  const tasks = [
+    task("a", ["bug", "frontend"]),
+    task("b", ["bug"]),
+    task("c", ["frontend", "a11y"]),
+  ];
+  expect(LabelRegistry.labelUsageCounts(tasks)).toEqual({
+    bug: 2,
+    frontend: 2,
+    a11y: 1,
+  });
+});
+
+test("同一タスク内の重複ラベルは 1 件として数える", () => {
+  const tasks = [task("a", ["bug", "bug", "bug"])];
+  expect(LabelRegistry.labelUsageCounts(tasks)).toEqual({ bug: 1 });
+});
+
+test("空文字ラベルは数えない", () => {
+  const tasks = [task("a", ["", "bug", ""])];
+  expect(LabelRegistry.labelUsageCounts(tasks)).toEqual({ bug: 1 });
+});
+
+test("タスクが 0 件のとき空オブジェクトを返す", () => {
+  expect(LabelRegistry.labelUsageCounts([])).toEqual({});
+});
+
+test("ラベル無しのタスクのみのとき空オブジェクトを返す", () => {
+  const tasks = [task("a", []), task("b", [])];
+  expect(LabelRegistry.labelUsageCounts(tasks)).toEqual({});
+});

--- a/src/domains/label-registry/index.ts
+++ b/src/domains/label-registry/index.ts
@@ -229,8 +229,12 @@ export const LabelRegistry = {
 
   /**
    * 現在のタスク集合からラベル名ごとの使用数を算出する（`Milestone.usageCounts` と対称）。
-   * BE `TaskIndex::label_usage_counts` と同セマンティクス: タスク内の重複ラベルは 1 件に排除し、
-   * 空文字ラベルは数えない。BE のスナップショットと異なり live なタスク集合から毎回計算する。
+   *
+   * BE `TaskIndex::label_usage_counts` と概ね対応するが、空文字ラベルの扱いは異なる:
+   * BE は frontmatter 由来の空文字ラベルも 1 件として計上する一方、本実装は UI で
+   * 意味を持たない空文字をフィルタする。タスク内の重複ラベルは双方とも 1 件に排除する。
+   * BE のスナップショットと異なり live なタスク集合から毎回計算する。
+   *
    * @param tasks - 現在のタスク一覧（各 task は `labels: string[]` を持つ）
    * @returns ラベル名 → 使用タスク件数
    */

--- a/src/domains/label-registry/index.ts
+++ b/src/domains/label-registry/index.ts
@@ -1,3 +1,5 @@
+import type { Task } from "@/types/task";
+
 /**
  * ラベルのグループ。標準 4 種 + その他 prefix（任意文字列）+ prefix 無し用 "default"。
  * 標準グループは型で固定し、その他は string として受ける。
@@ -203,5 +205,48 @@ export const LabelRegistry = {
    */
   tokensForLabel: (label: string): ColorTokens => {
     return LabelRegistry.tokensForGroup(LabelRegistry.parseGroup(label));
+  },
+
+  /**
+   * ラベル定義 1 件から「表示・集計・スワッチ解決で使うグループ名」を 1 つに決める。
+   * `group` が定義済みかつ非空文字ならそれを採用、未定義 / 空文字 / 空白のみは
+   * `parseGroup(label.name)` で name の prefix から導出する。
+   *
+   * この関数はラベル UI 全体（テーブルのグループ badge、フッター/ヘッダーの集計、
+   * フォームのスワッチ、フィルタの絞り込み）が「同じ LabelDefinition を渡したら同じ
+   * グループ名が返る」契約を保証するため、複数モジュールから参照する単一の真実源として
+   * 使う（`displayGroup` / `groupOf` の重複実装を避ける）。
+   * @param label - ラベル定義
+   * @returns 表示・集計に使うグループ名
+   */
+  effectiveGroup: (label: { name: string; group?: string }): string => {
+    const group = label.group?.trim() ?? "";
+    if (group !== "") {
+      return group;
+    }
+    return LabelRegistry.parseGroup(label.name);
+  },
+
+  /**
+   * 現在のタスク集合からラベル名ごとの使用数を算出する（`Milestone.usageCounts` と対称）。
+   * BE `TaskIndex::label_usage_counts` と同セマンティクス: タスク内の重複ラベルは 1 件に排除し、
+   * 空文字ラベルは数えない。BE のスナップショットと異なり live なタスク集合から毎回計算する。
+   * @param tasks - 現在のタスク一覧（各 task は `labels: string[]` を持つ）
+   * @returns ラベル名 → 使用タスク件数
+   */
+  labelUsageCounts: (tasks: readonly Task[]): Record<string, number> => {
+    const counts: Record<string, number> = {};
+    for (const task of tasks) {
+      // タスク内重複を排除（同名ラベル複数記載でも 1 件として数える）。
+      const seen = new Set<string>();
+      for (const label of task.labels) {
+        if (label === "" || seen.has(label)) {
+          continue;
+        }
+        seen.add(label);
+        counts[label] = (counts[label] ?? 0) + 1;
+      }
+    }
+    return counts;
   },
 } as const;

--- a/src/domains/label-registry/index.ts
+++ b/src/domains/label-registry/index.ts
@@ -235,7 +235,11 @@ export const LabelRegistry = {
    * @returns ラベル名 → 使用タスク件数
    */
   labelUsageCounts: (tasks: readonly Task[]): Record<string, number> => {
-    const counts: Record<string, number> = {};
+    // accumulator は Map にする。frontmatter のラベルは任意文字列のため、
+    // `__proto__` / `constructor` のような prototype キーが来ても継承プロパティと
+    // 衝突せず正しく数えるため。最終的に Object.fromEntries で公開形へ変換する
+    // （`Object.fromEntries` は __proto__ も own property として設定する）。
+    const counts = new Map<string, number>();
     for (const task of tasks) {
       // タスク内重複を排除（同名ラベル複数記載でも 1 件として数える）。
       const seen = new Set<string>();
@@ -244,9 +248,9 @@ export const LabelRegistry = {
           continue;
         }
         seen.add(label);
-        counts[label] = (counts[label] ?? 0) + 1;
+        counts.set(label, (counts.get(label) ?? 0) + 1);
       }
     }
-    return counts;
+    return Object.fromEntries(counts);
   },
 } as const;

--- a/src/features/board/components/BoardWorkspace/index.tsx
+++ b/src/features/board/components/BoardWorkspace/index.tsx
@@ -233,9 +233,20 @@ export const BoardWorkspace = (props: BoardWorkspaceProps) => {
   onLabelFilterAppliedRef.current = onLabelFilterApplied;
   initialLabelFilterRef.current = initialLabelFilter;
   useEffect(() => {
-    if (initialLabelFilterRef.current) {
-      onLabelFilterAppliedRef.current?.();
+    if (!initialLabelFilterRef.current) {
+      return;
     }
+    // React.StrictMode 下では mount→cleanup→再 mount が同サイクル内で走るため、
+    // 同期で onLabelFilterApplied を呼ぶと 1 回目の cleanup 前に親 state が null になり、
+    // 2 回目 mount の useTaskFilter init が seed を取りこぼす可能性がある。
+    // setTimeout(0) で遅延し、StrictMode の 1 回目 cleanup で clearTimeout して
+    // 2 回目 mount 側だけが最終的に通知を発火する形にする。
+    const id = window.setTimeout(() => {
+      onLabelFilterAppliedRef.current?.();
+    }, 0);
+    return () => {
+      window.clearTimeout(id);
+    };
   }, []);
 
   return (

--- a/src/features/board/components/BoardWorkspace/index.tsx
+++ b/src/features/board/components/BoardWorkspace/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   type TabItem,
   TabNav,
@@ -85,6 +85,18 @@ type BoardWorkspaceProps = {
    */
   // biome-ignore lint/suspicious/noConfusingVoidType: void union allows synchronous handlers without forcing consumers to wrap them in Promises
   onColumnReorder?: (params: ColumnDropParams) => Promise<unknown> | void;
+  /**
+   * settings → board ナビゲートでラベル絞り込みを 1 回だけ seed する初期ラベル名。
+   * `useTaskFilter` の `useState` 初期値関数にだけ反映され、effect での setCriteria
+   * 二重適用は行わない。BoardWorkspace は settings からの遷移時に必ず remount される
+   * ため、この seed は遷移ごとに 1 回適用される。
+   */
+  initialLabelFilter?: string | null;
+  /**
+   * 初期ラベルフィルタが BoardWorkspace の mount 後に 1 回だけ通知される。
+   * 親（App）はこのコールバックで `pendingLabelFilter` を null へ戻し、残留を防ぐ。
+   */
+  onLabelFilterApplied?: () => void;
 };
 
 /**
@@ -166,7 +178,13 @@ const ActiveBoardView = ({
  * @returns ワークスペース要素
  */
 export const BoardWorkspace = (props: BoardWorkspaceProps) => {
-  const { tasks, columns, milestones } = props;
+  const {
+    tasks,
+    columns,
+    milestones,
+    initialLabelFilter,
+    onLabelFilterApplied,
+  } = props;
   const { viewMode, setViewMode } = useBoardViewMode();
 
   const availableLabels = useMemo(() => collectLabels(tasks), [tasks]);
@@ -185,10 +203,40 @@ export const BoardWorkspace = (props: BoardWorkspaceProps) => {
     () => ({ statuses, labels: availableLabels, milestoneNames }),
     [statuses, availableLabels, milestoneNames],
   );
+  const initialLabels = useMemo(
+    () =>
+      initialLabelFilter !== null && initialLabelFilter !== undefined
+        ? [initialLabelFilter]
+        : undefined,
+    [initialLabelFilter],
+  );
   const { criteria, setCriteria, clear, filtered, isActive } = useTaskFilter(
     tasks,
     filterOptions,
+    { initialLabels },
   );
+
+  // mount 時に initialLabelFilter があれば 1 回だけ親へ「適用済み」を通知し、
+  // App 側の pendingLabelFilter を null へ戻して残留を防ぐ。
+  //
+  // 依存配列を空にする理由（remount 前提）: 本コンポーネントは App.tsx の条件付き
+  // レンダリングで settings 表示中は unmount され、settings→board 遷移で必ず remount
+  // されるため、mount-once 通知だけで pendingLabelFilter のクリア責務を満たせる。
+  // mount 後に initialLabelFilter / onLabelFilterApplied が props として変化することは
+  // 設計上想定しない（mount 時の値だけが正解）。
+  //
+  // stale closure 対策: onLabelFilterApplied / initialLabelFilter は ref に同期させ、
+  // mount-once effect の中から ref 経由で最新参照を読む。これにより親が
+  // useCallback の依存を増やしたり、毎 render 新関数を渡しても安全に動作する。
+  const onLabelFilterAppliedRef = useRef(onLabelFilterApplied);
+  const initialLabelFilterRef = useRef(initialLabelFilter);
+  onLabelFilterAppliedRef.current = onLabelFilterApplied;
+  initialLabelFilterRef.current = initialLabelFilter;
+  useEffect(() => {
+    if (initialLabelFilterRef.current) {
+      onLabelFilterAppliedRef.current?.();
+    }
+  }, []);
 
   return (
     <div className="flex h-full flex-col">

--- a/src/features/board/hooks/useTaskFilter/index.ts
+++ b/src/features/board/hooks/useTaskFilter/index.ts
@@ -29,22 +29,45 @@ export type UseTaskFilterResult = {
 };
 
 /**
+ * `useTaskFilter` のオプション引数（任意）。settings → board ナビゲートで
+ * 初期ラベルフィルタを 1 回だけ seed したいときに使う。
+ */
+export type UseTaskFilterOptions = {
+  /**
+   * 初回 mount 時の criteria に注入するラベル絞り込みの初期値。`undefined` / 空配列は
+   * 「seed しない」と同義（criteria は `EMPTY_TASK_FILTER` のまま）。
+   * effect 由来の二重適用を避けるため `useState` 初期化時にのみ参照する。
+   */
+  initialLabels?: readonly string[];
+};
+
+/**
  * ボード上のタスクを検索キーワード / ラベル / 優先度 / ステータス / マイルストーンで
  * 横断的に絞り込むフィルタ state。board の全ビュー（board / list / tree / calendar）で共有する。
  *
  * カラムのリネーム/削除やマイルストーン削除で選択肢が消えると、UI に出ない条件が
  * 「隠れフィルタ」として残り続ける。raw な条件を state に保持したまま、render 中に
  * 利用可能な選択肢で間引いた条件を導出してフィルタ結果へ反映する（effect で書き戻さない）。
+ *
+ * 第三引数 `init.initialLabels` で初期ラベルフィルタを `useState` 初期値関数で
+ * 1 回だけ seed する。effect 由来の `setCriteria` 二重適用を避けるため、後続の依存
+ * 変化では再 seed しない（remount で再注入する設計）。
+ *
  * @param tasks - 絞り込み対象のタスク一覧
  * @param options - 現在利用可能な選択肢（間引きの基準）
+ * @param init - 初期 seed 用オプション（省略可）
  * @returns 絞り込み state と結果
  */
 export const useTaskFilter = (
   tasks: Task[],
   options: TaskFilterOptions,
+  init?: UseTaskFilterOptions,
 ): UseTaskFilterResult => {
-  const [rawCriteria, setCriteria] =
-    useState<TaskFilterCriteria>(EMPTY_TASK_FILTER);
+  const [rawCriteria, setCriteria] = useState<TaskFilterCriteria>(() =>
+    init?.initialLabels && init.initialLabels.length > 0
+      ? { ...EMPTY_TASK_FILTER, labels: [...init.initialLabels] }
+      : EMPTY_TASK_FILTER,
+  );
 
   const clear = useCallback(() => {
     setCriteria(EMPTY_TASK_FILTER);

--- a/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
@@ -180,9 +180,11 @@ export const CreateLabelForm = ({
             <input
               id={hexId}
               value={values.color.replace(/^#/, "")}
-              onChange={(e) =>
-                onChange("color", `#${e.target.value.replace(/^#/, "")}`)
-              }
+              onChange={(e) => {
+                const body = e.target.value.replace(/^#/, "");
+                // 空入力は color クリア（PUT で undefined 化）を残すため "" を保持する。
+                onChange("color", body === "" ? "" : `#${body}`);
+              }}
               maxLength={6}
               spellCheck={false}
               autoComplete="off"

--- a/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
@@ -234,7 +234,9 @@ export const CreateLabelForm = ({
           </button>
           <button
             type="submit"
-            disabled={values.name === "" || isPending}
+            // 親側 toArgs が name を trim して空判定するため、disabled も trim ベースに
+            // 揃える。空白のみ入力でボタンが有効化され、送信しても no-op になるのを防ぐ。
+            disabled={values.name.trim() === "" || isPending}
             className="rounded bg-accent px-3 py-1 text-sm text-accent-foreground disabled:opacity-50"
           >
             {isEditing ? "更新" : "ラベルを作成"}

--- a/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
@@ -193,11 +193,13 @@ export const CreateLabelForm = ({
               id={hexId}
               value={values.color.replace(/^#/, "")}
               onChange={(e) => {
-                const body = e.target.value.replace(/^#/, "");
+                // # 付き 7 文字のペーストを許容するため maxLength=7。
+                // onChange で先頭 # を strip し、本体 6 桁を `#${body}` で保存する。
                 // 空入力は color クリア（PUT で undefined 化）を残すため "" を保持する。
+                const body = e.target.value.replace(/^#/, "");
                 onChange("color", body === "" ? "" : `#${body}`);
               }}
-              maxLength={6}
+              maxLength={7}
               spellCheck={false}
               autoComplete="off"
               className="w-[78px] border-none bg-transparent p-0 font-mono text-sm tracking-wide outline-none"

--- a/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
@@ -1,0 +1,232 @@
+import { useId } from "react";
+import { LABEL_COLOR_PRESETS } from "@/features/settings/lib/labelSettings/colorPresets";
+import { resolveLabelSwatchStyle } from "@/features/settings/lib/labelSettings/swatch";
+import type { LabelDefinition } from "@/lib/tauri";
+
+/** CreateLabelForm の入力値（すべて文字列で保持し、送信時に正規化する）。 */
+export type LabelFormValues = {
+  name: string;
+  description: string;
+  group: string;
+  color: string;
+};
+
+/** EMPTY_FORM は親側でも再利用するため export する。 */
+export const EMPTY_LABEL_FORM: LabelFormValues = {
+  name: "",
+  description: "",
+  group: "",
+  color: "",
+};
+
+type CreateLabelFormProps = {
+  /** フォーム入力値 */
+  values: LabelFormValues;
+  /** 編集中の対象 name。`null` は新規作成モード。 */
+  editingName: string | null;
+  /** mutation 実行中 */
+  isPending: boolean;
+  /** 既存のグループ一覧（プルダウンに並べる候補） */
+  groupOptions: readonly string[];
+  /**
+   * フィールド更新ハンドラ。
+   * @param key - 更新するフィールド名
+   * @param value - 新しい値
+   */
+  onChange: (key: keyof LabelFormValues, value: string) => void;
+  /** クリア（新規モードに戻す） */
+  onReset: () => void;
+  /** 送信（成功時に親が resetForm を呼ぶ） */
+  onSubmit: () => void;
+};
+
+/**
+ * プレビュー表示用に form 値を LabelDefinition 風に整形する。
+ * @param values - フォーム入力値
+ * @returns プレビュー用の LabelDefinition
+ */
+const previewDef = (values: LabelFormValues): LabelDefinition => ({
+  name: values.name === "" ? "preview" : values.name,
+  description: values.description || undefined,
+  group: values.group === "" ? undefined : values.group,
+  color: values.color === "" ? undefined : values.color,
+});
+
+/**
+ * ラベル作成 / 編集フォーム。名前 / 説明 / グループ / カラー（HEX textbox + color picker +
+ * プリセット 10 色）/ ライブプレビュー / クリア・作成（編集時は更新 + キャンセル）。
+ * @param props - {@link CreateLabelFormProps}
+ * @returns フォーム要素
+ */
+export const CreateLabelForm = ({
+  values,
+  editingName,
+  isPending,
+  groupOptions,
+  onChange,
+  onReset,
+  onSubmit,
+}: CreateLabelFormProps) => {
+  const nameId = useId();
+  const descId = useId();
+  const groupId = useId();
+  const hexId = useId();
+  const pickerId = useId();
+  const isEditing = editingName !== null;
+  const preview = previewDef(values);
+  const previewLabel = preview.name;
+
+  return (
+    <form
+      className="flex flex-col gap-3 rounded border border-slate-200 bg-white p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+        <span aria-hidden="true">+</span>
+        {isEditing ? `「${editingName}」を編集` : "新しいラベル"}
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor={nameId} className="text-xs text-muted">
+            名前
+          </label>
+          <input
+            id={nameId}
+            value={values.name}
+            disabled={isEditing}
+            onChange={(e) => onChange("name", e.target.value)}
+            className="rounded border border-slate-300 px-2 py-1 text-sm disabled:bg-slate-100"
+            placeholder="needs-design"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor={descId} className="text-xs text-muted">
+            説明（任意）
+          </label>
+          <input
+            id={descId}
+            value={values.description}
+            onChange={(e) => onChange("description", e.target.value)}
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+            placeholder="デザイン待ちのタスク"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor={groupId} className="text-xs text-muted">
+            グループ
+          </label>
+          <input
+            id={groupId}
+            list={`${groupId}-list`}
+            value={values.group}
+            onChange={(e) => onChange("group", e.target.value)}
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+            placeholder="status"
+          />
+          <datalist id={`${groupId}-list`}>
+            {groupOptions.map((g) => (
+              <option key={g} value={g} />
+            ))}
+          </datalist>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-muted">プレビュー</span>
+          <span
+            className="inline-flex items-center gap-1 self-start rounded-full border px-2 py-0.5 text-xs"
+            style={resolveLabelSwatchStyle(preview)}
+            data-testid="label-form-preview"
+          >
+            <span
+              aria-hidden="true"
+              className="inline-block h-1.5 w-1.5 rounded-full bg-current"
+            />
+            {previewLabel}
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor={hexId} className="text-xs text-muted">
+          カラー{" "}
+          <span className="text-muted">
+            — HEX を直接入力、またはプリセットから選択
+          </span>
+        </label>
+        <div className="flex items-center gap-2">
+          <span className="relative inline-block h-8 w-8 shrink-0 overflow-hidden rounded-md border border-slate-300 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.25)]">
+            <span
+              aria-hidden="true"
+              className="absolute inset-0"
+              style={{ backgroundColor: values.color || "#7860b5" }}
+            />
+            <input
+              id={pickerId}
+              type="color"
+              value={values.color || "#7860b5"}
+              onChange={(e) => onChange("color", e.target.value)}
+              className="absolute -inset-1 h-[calc(100%+8px)] w-[calc(100%+8px)] cursor-pointer opacity-0"
+              aria-label="カラーピッカー"
+            />
+          </span>
+          <span className="inline-flex h-8 items-center rounded border border-slate-300 bg-white pl-2 pr-2.5">
+            <span
+              aria-hidden="true"
+              className="mr-px font-mono text-sm text-muted"
+            >
+              #
+            </span>
+            <input
+              id={hexId}
+              value={values.color.replace(/^#/, "")}
+              onChange={(e) =>
+                onChange("color", `#${e.target.value.replace(/^#/, "")}`)
+              }
+              maxLength={6}
+              spellCheck={false}
+              autoComplete="off"
+              className="w-[78px] border-none bg-transparent p-0 font-mono text-sm tracking-wide outline-none"
+              placeholder="7860b5"
+            />
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="mr-0.5 text-[11px] text-muted">プリセット</span>
+          {LABEL_COLOR_PRESETS.map((preset) => (
+            <button
+              key={preset.name}
+              type="button"
+              title={preset.name}
+              aria-label={`プリセット ${preset.name}`}
+              onClick={() => onChange("color", preset.hex)}
+              className="h-[18px] w-[18px] shrink-0 rounded border-2 border-transparent shadow-[inset_0_0_0_1px_rgba(20,24,32,0.08)] transition-transform hover:scale-110"
+              style={{ backgroundColor: preset.hex }}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted">
+          名前は kebab-case 推奨、 type:bug のようにグループ接頭辞も使えます
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onReset}
+            className="rounded border border-slate-300 px-3 py-1 text-sm"
+          >
+            {isEditing ? "キャンセル" : "クリア"}
+          </button>
+          <button
+            type="submit"
+            disabled={values.name === "" || isPending}
+            className="rounded bg-accent px-3 py-1 text-sm text-accent-foreground disabled:opacity-50"
+          >
+            {isEditing ? "更新" : "ラベルを作成"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/CreateLabelForm/index.tsx
@@ -52,6 +52,18 @@ const previewDef = (values: LabelFormValues): LabelDefinition => ({
   color: values.color === "" ? undefined : values.color,
 });
 
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+const DEFAULT_PICKER_COLOR = "#7860b5";
+
+/**
+ * `<input type="color">` 用に妥当な #RRGGBB のみ反映し、それ以外は既定色へ落とす。
+ * テキスト欄の lenient 挙動（任意文字列保持）と分離するための正規化。
+ * @param raw - フォーム保持中の color 文字列
+ * @returns 8 桁未満や不正値の場合は既定色、妥当な HEX ならそのまま
+ */
+const toPickerValue = (raw: string): string =>
+  HEX_COLOR_RE.test(raw) ? raw : DEFAULT_PICKER_COLOR;
+
 /**
  * ラベル作成 / 編集フォーム。名前 / 説明 / グループ / カラー（HEX textbox + color picker +
  * プリセット 10 色）/ ライブプレビュー / クリア・作成（編集時は更新 + キャンセル）。
@@ -159,12 +171,12 @@ export const CreateLabelForm = ({
             <span
               aria-hidden="true"
               className="absolute inset-0"
-              style={{ backgroundColor: values.color || "#7860b5" }}
+              style={{ backgroundColor: toPickerValue(values.color) }}
             />
             <input
               id={pickerId}
               type="color"
-              value={values.color || "#7860b5"}
+              value={toPickerValue(values.color)}
               onChange={(e) => onChange("color", e.target.value)}
               className="absolute -inset-1 h-[calc(100%+8px)] w-[calc(100%+8px)] cursor-pointer opacity-0"
               aria-label="カラーピッカー"

--- a/src/features/settings/components/LabelSettingsTab/LabelFilterBar/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/LabelFilterBar/index.tsx
@@ -1,0 +1,155 @@
+import { useId } from "react";
+import type {
+  LabelGroupFilter,
+  LabelSort,
+} from "@/features/settings/lib/labelSettings/derive";
+
+type GroupOption = {
+  /** グループ名 */
+  group: string;
+  /** そのグループに属するラベル数 */
+  count: number;
+};
+
+type LabelFilterBarProps = {
+  /** 「すべて」の件数（総数） */
+  totalCount: number;
+  /** グループチップに並べる候補 */
+  groupOptions: readonly GroupOption[];
+  /** 現在のグループ絞り込み */
+  groupFilter: LabelGroupFilter;
+  /** 現在の検索キーワード */
+  keyword: string;
+  /** 現在のソートキー */
+  sort: LabelSort;
+  /**
+   * グループ絞り込み変更ハンドラ。
+   * @param next - 新しいグループ絞り込み
+   */
+  onGroupChange: (next: LabelGroupFilter) => void;
+  /**
+   * 検索キーワード変更ハンドラ。
+   * @param next - 新しいキーワード
+   */
+  onKeywordChange: (next: string) => void;
+  /**
+   * ソート変更ハンドラ。
+   * @param next - 新しいソートキー
+   */
+  onSortChange: (next: LabelSort) => void;
+};
+
+/** ソート選択肢の表示ラベル。 */
+const SORT_LABELS: Readonly<Record<LabelSort, string>> = {
+  name: "名前順",
+  usage: "使用数",
+  updated: "更新順",
+};
+
+/**
+ * 「全てチップ」が選択中か判定する。
+ * @param current - 現在の絞り込み
+ * @returns 全件モード（`{ kind: "all" }`）なら true
+ */
+const isAllActive = (current: LabelGroupFilter): boolean =>
+  current.kind === "all";
+
+/**
+ * 特定グループチップが選択中か判定する。
+ * 実グループ名 "all" と「全てチップ」を文字列リテラルで混ぜないため、
+ * 判別 union 構造で受け取った `kind === "group"` のときだけ value を比較する。
+ * @param current - 現在の絞り込み
+ * @param group - 判定対象の実グループ名
+ * @returns 選択中なら true
+ */
+const isGroupActive = (current: LabelGroupFilter, group: string): boolean =>
+  current.kind === "group" && current.value === group;
+
+/**
+ * グループチップ + 検索ボックス + ソート select を備えたフィルタバー。
+ * グループは判別 union（{ kind: "all" } | { kind: "group"; value }）で表現する。
+ * @param props - {@link LabelFilterBarProps}
+ * @returns フィルタバー要素
+ */
+export const LabelFilterBar = ({
+  totalCount,
+  groupOptions,
+  groupFilter,
+  keyword,
+  sort,
+  onGroupChange,
+  onKeywordChange,
+  onSortChange,
+}: LabelFilterBarProps) => {
+  const keywordId = useId();
+  const sortId = useId();
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs text-muted">グループ</span>
+      <button
+        type="button"
+        onClick={() => onGroupChange({ kind: "all" })}
+        aria-pressed={isAllActive(groupFilter)}
+        className={`rounded-full border px-2 py-0.5 text-xs ${
+          isAllActive(groupFilter)
+            ? "bg-accent text-accent-foreground"
+            : "border-slate-300"
+        }`}
+      >
+        すべて {totalCount}
+      </button>
+      {groupOptions.map((opt) => (
+        <button
+          key={opt.group}
+          type="button"
+          onClick={() => onGroupChange({ kind: "group", value: opt.group })}
+          aria-pressed={isGroupActive(groupFilter, opt.group)}
+          className={`rounded-full border px-2 py-0.5 text-xs ${
+            isGroupActive(groupFilter, opt.group)
+              ? "bg-accent text-accent-foreground"
+              : "border-slate-300"
+          }`}
+        >
+          {opt.group} {opt.count}
+        </button>
+      ))}
+      <label htmlFor={keywordId} className="sr-only">
+        ラベル名・説明で絞り込み
+      </label>
+      <div className="relative ml-auto">
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-2 flex items-center text-xs text-muted"
+        >
+          🔍
+        </span>
+        <input
+          id={keywordId}
+          value={keyword}
+          onChange={(e) => onKeywordChange(e.target.value)}
+          placeholder="ラベル名・説明で絞り込み..."
+          className="w-64 rounded-full border border-slate-300 bg-slate-50 px-2 py-1 pl-7 text-sm focus:bg-white"
+        />
+      </div>
+      <fieldset
+        id={sortId}
+        className="flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 p-0.5 text-xs"
+      >
+        <legend className="sr-only">並び順</legend>
+        {(Object.keys(SORT_LABELS) as LabelSort[]).map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onSortChange(key)}
+            aria-pressed={sort === key}
+            className={`rounded-full px-2 py-0.5 ${
+              sort === key ? "bg-white text-slate-900 shadow-sm" : "text-muted"
+            }`}
+          >
+            {SORT_LABELS[key]}
+          </button>
+        ))}
+      </fieldset>
+    </div>
+  );
+};

--- a/src/features/settings/components/LabelSettingsTab/LabelFooterTally/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/LabelFooterTally/index.tsx
@@ -1,0 +1,59 @@
+import { LabelRegistry } from "@/domains/label-registry";
+
+type LabelFooterTallyProps = {
+  /** 表示中件数（フィルタ後） */
+  shown: number;
+  /** 総数 */
+  total: number;
+  /** 使用中ラベルの色集計（color or group キー） */
+  colorTally: readonly { color: string; count: number }[];
+};
+
+/**
+ * 色キーから表示用の背景色を解決する。
+ * `#` から始まれば直接、そうでなければ LabelRegistry のグループトークン bg を使う。
+ * @param key - color or group キー
+ * @returns 背景色（CSS 色）
+ */
+const swatchBg = (key: string): string => {
+  if (key.startsWith("#")) {
+    return key;
+  }
+  return LabelRegistry.tokensForGroup(key).bg;
+};
+
+/**
+ * 「N / N 件 表示中」+ 使用中ラベルのカラー集計をフッターとして表示する。
+ * @param props - {@link LabelFooterTallyProps}
+ * @returns フッター要素
+ */
+export const LabelFooterTally = ({
+  shown,
+  total,
+  colorTally,
+}: LabelFooterTallyProps) => {
+  return (
+    <div className="flex items-center justify-between text-xs text-muted">
+      <span>
+        {shown} / {total} 件 表示中
+      </span>
+      <div className="flex items-center gap-2">
+        <span>使用中のカラー</span>
+        {colorTally.map((entry) => (
+          <span
+            key={entry.color}
+            className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-2 py-0.5"
+            title={entry.color}
+          >
+            <span
+              aria-hidden="true"
+              className="inline-block h-2 w-2 rounded-full border border-slate-300"
+              style={{ backgroundColor: swatchBg(entry.color) }}
+            />
+            {entry.count}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/features/settings/components/LabelSettingsTab/LabelStatsHeader/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/LabelStatsHeader/index.tsx
@@ -1,0 +1,44 @@
+type LabelStatsHeaderProps = {
+  /** 総数 */
+  total: number;
+  /** 使用中 */
+  used: number;
+  /** 未使用 */
+  unused: number;
+  /** エクスポート実行中 / 他 mutation 実行中で disable */
+  isExportDisabled: boolean;
+  /** エクスポートボタンクリック */
+  onExport: () => void;
+};
+
+/**
+ * ラベル設定タブの上部統計ヘッダー（「N 件 / M 使用中 / K 未使用」+ エクスポートボタン）。
+ * @param props - {@link LabelStatsHeaderProps}
+ * @returns ヘッダー要素
+ */
+export const LabelStatsHeader = ({
+  total,
+  used,
+  unused,
+  isExportDisabled,
+  onExport,
+}: LabelStatsHeaderProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <h2 className="flex items-baseline gap-3 text-lg font-semibold text-slate-800">
+        ラベル
+        <span className="text-xs font-normal text-muted">
+          {total} 件 · {used} 使用中 · {unused} 未使用
+        </span>
+      </h2>
+      <button
+        type="button"
+        onClick={onExport}
+        disabled={isExportDisabled}
+        className="rounded border border-slate-300 px-3 py-1 text-sm disabled:opacity-50"
+      >
+        ⬇ エクスポート
+      </button>
+    </div>
+  );
+};

--- a/src/features/settings/components/LabelSettingsTab/LabelTable/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/LabelTable/index.tsx
@@ -1,0 +1,179 @@
+import { LabelRegistry } from "@/domains/label-registry";
+import { resolveLabelSwatchStyle } from "@/features/settings/lib/labelSettings/swatch";
+import type { LabelDefinition } from "@/lib/tauri";
+import { formatRelativeTime } from "@/utils/relativeTime";
+
+type LabelTableProps = {
+  /** 表示するラベル（フィルタ/ソート適用後） */
+  labels: readonly LabelDefinition[];
+  /** ラベル名 → 使用数 */
+  usageCounts: Record<string, number>;
+  /** mutation 実行中（編集・削除ボタン disable に使う） */
+  isPending: boolean;
+  /**
+   * 相対時刻表示の基準時刻。親で 1 個だけ生成して全行で共有することで、行ごとに
+   * `new Date()` を生成するコストと、行間で基準時刻が微妙にずれて表記がブレる
+   * 問題（同じ render 内なのに「1分前」「2分前」が混在）を防ぐ。
+   */
+  now: Date;
+  /**
+   * 使用数リンククリック。
+   * @param name - クリックされたラベル名
+   */
+  onUsageClick: (name: string) => void;
+  /**
+   * 編集アイコンクリック。
+   * @param label - 編集対象のラベル定義
+   */
+  onEdit: (label: LabelDefinition) => void;
+  /**
+   * 削除アイコンクリック。
+   * @param name - 削除対象のラベル名
+   */
+  onDelete: (name: string) => void;
+};
+
+/**
+ * 表示用のグループ名を返す（domain companion `LabelRegistry.effectiveGroup` に委譲）。
+ * スワッチ色解決・derive 集計と同じグループ判定ロジックを使うことで、バッジ色とバッジ名の
+ * 整合を保つ。
+ * @param label - ラベル定義
+ * @returns グループ名（badge 表示用）
+ */
+const displayGroup = (label: LabelDefinition): string =>
+  LabelRegistry.effectiveGroup(label);
+
+/**
+ * ラベル一覧テーブル。色スワッチ chip / 説明 / 使用数（リンク or 0件） / グループ badge /
+ * 更新（相対時刻、`updated` 無しは「新規」） / hover で見える編集・削除アクション。
+ * @param props - {@link LabelTableProps}
+ * @returns テーブル要素
+ */
+export const LabelTable = ({
+  labels,
+  usageCounts,
+  isPending,
+  now,
+  onUsageClick,
+  onEdit,
+  onDelete,
+}: LabelTableProps) => {
+  if (labels.length === 0) {
+    return (
+      <p className="px-4 py-8 text-center text-sm text-muted">
+        条件に一致するラベルがありません
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded border border-slate-200 bg-white">
+      <div className="grid grid-cols-[140px_1fr_88px_88px_88px_72px] gap-2 border-b border-slate-200 bg-slate-50 px-3 py-2 text-xs text-muted">
+        <div>ラベル</div>
+        <div>説明</div>
+        <div>使用数</div>
+        <div>グループ</div>
+        <div>更新</div>
+        <div className="sr-only">アクション</div>
+      </div>
+      <ul>
+        {labels.map((label) => {
+          const count = usageCounts[label.name] ?? 0;
+          return (
+            <li
+              key={label.name}
+              data-testid="label-row"
+              className="group grid grid-cols-[140px_1fr_88px_88px_88px_72px] items-center gap-2 border-b border-slate-100 px-3 py-2 text-sm last:border-b-0"
+            >
+              <div>
+                <span
+                  className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+                  style={resolveLabelSwatchStyle(label)}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-1.5 w-1.5 rounded-full bg-current"
+                  />
+                  {label.name}
+                </span>
+              </div>
+              <div className="truncate text-muted">
+                {label.description ?? ""}
+              </div>
+              <div>
+                {count > 0 ? (
+                  <button
+                    type="button"
+                    onClick={() => onUsageClick(label.name)}
+                    className="text-accent underline-offset-2 hover:underline"
+                    data-testid="label-usage-link"
+                  >
+                    {count} 件
+                  </button>
+                ) : (
+                  <span className="text-muted">0 件</span>
+                )}
+              </div>
+              <div>
+                <span className="rounded border border-slate-300 px-1.5 py-0.5 text-xs text-muted">
+                  {displayGroup(label)}
+                </span>
+              </div>
+              <div className="text-xs text-muted">
+                {label.updated === undefined
+                  ? "新規"
+                  : formatRelativeTime(label.updated, now)}
+              </div>
+              <div className="flex items-center justify-end gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                <button
+                  type="button"
+                  aria-label={`${label.name} を編集`}
+                  title="編集"
+                  disabled={isPending}
+                  onClick={() => onEdit(label)}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded border-none bg-transparent text-muted hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
+                    <path d="m15 5 4 4" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  aria-label={`${label.name} を削除`}
+                  title="削除"
+                  disabled={isPending}
+                  onClick={() => onDelete(label.name)}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded border-none bg-transparent text-muted hover:bg-slate-100 hover:text-red-600 disabled:opacity-50"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  </svg>
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
@@ -385,3 +385,32 @@ test("HEX 入力を全削除すると color は undefined として createLabel 
     color: undefined,
   });
 });
+
+test("group / color / description の空白のみ入力は undefined に正規化されて createLabel に渡る", async () => {
+  noopReload.mockClear();
+  createMock.mockResolvedValue(Result.ok(undefined));
+  render(baseResource({ labels: [] }));
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  typeInto(nameInput, "blanky");
+  const descInput = container?.querySelector(
+    'input[placeholder="デザイン待ちのタスク"]',
+  ) as HTMLInputElement;
+  typeInto(descInput, "   ");
+  const groupInput = container?.querySelector(
+    'input[placeholder="status"]',
+  ) as HTMLInputElement;
+  typeInto(groupInput, "   ");
+  const form = container?.querySelector("form") as HTMLFormElement;
+  await act(async () => {
+    submitForm(form);
+    await Promise.resolve();
+  });
+  expect(createMock).toHaveBeenCalledWith({
+    name: "blanky",
+    description: undefined,
+    group: undefined,
+    color: undefined,
+  });
+});

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
@@ -1,0 +1,361 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { LabelsResource } from "@/hooks/useLabels";
+import {
+  createLabel,
+  deleteLabel,
+  exportLabels,
+  saveFileDialog,
+  TauriError,
+  updateLabel,
+} from "@/lib/tauri";
+import { Result } from "@/utils/result";
+import { LabelSettingsTab } from "..";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    createLabel: vi.fn(),
+    updateLabel: vi.fn(),
+    deleteLabel: vi.fn(),
+    exportLabels: vi.fn(),
+    saveFileDialog: vi.fn(),
+  };
+});
+
+const createMock = vi.mocked(createLabel);
+const updateMock = vi.mocked(updateLabel);
+const deleteMock = vi.mocked(deleteLabel);
+const exportMock = vi.mocked(exportLabels);
+const saveMock = vi.mocked(saveFileDialog);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  createMock.mockReset();
+  updateMock.mockReset();
+  deleteMock.mockReset();
+  exportMock.mockReset();
+  saveMock.mockReset();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const noopReload = vi.fn(async () => {});
+
+const baseResource = (
+  override: Partial<LabelsResource> = {},
+): LabelsResource => {
+  const labels = override.labels ?? [{ name: "bug", group: "type" }];
+  return {
+    labels,
+    usageCounts: override.usageCounts ?? {},
+    byName: new Map(labels.map((l) => [l.name, l])),
+    status: override.status ?? "loaded",
+    reload: override.reload ?? noopReload,
+  };
+};
+
+const render = (
+  resource: LabelsResource,
+  onLabelUsageClick: (name: string) => void = () => {},
+): void => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      createElement(LabelSettingsTab, { resource, onLabelUsageClick }),
+    );
+  });
+};
+
+const click = (el: Element): void => {
+  act(() => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+};
+
+// React 19 の controlled input は value tracker を使うため、`el.value = v` だけだと
+// React に変更が伝わらない。HTMLInputElement.prototype の value setter 経由で
+// trigger することで onChange を発火させる（MilestoneSettingsTab テストと同手法）。
+const valueSetter = Object.getOwnPropertyDescriptor(
+  HTMLInputElement.prototype,
+  "value",
+)?.set;
+
+const typeInto = (el: HTMLInputElement, value: string): void => {
+  act(() => {
+    valueSetter?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+};
+
+const submitForm = (form: HTMLFormElement): void => {
+  act(() => {
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+  });
+};
+
+test("作成成功時に reload が呼ばれフォームが reset される", async () => {
+  noopReload.mockClear();
+  createMock.mockResolvedValue(Result.ok(undefined));
+  render(baseResource({ labels: [] }));
+
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  typeInto(nameInput, "new-label");
+
+  const form = container?.querySelector("form") as HTMLFormElement;
+  await act(async () => {
+    submitForm(form);
+    await Promise.resolve();
+  });
+  expect(createMock).toHaveBeenCalledWith({
+    name: "new-label",
+    description: undefined,
+    group: undefined,
+    color: undefined,
+  });
+  expect(noopReload).toHaveBeenCalledTimes(1);
+  // フォームがリセット（name 入力がクリア）
+  const nameAfter = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  expect(nameAfter.value).toBe("");
+});
+
+test("作成失敗時はフォームが保持され reload は呼ばれない", async () => {
+  noopReload.mockClear();
+  createMock.mockResolvedValue(Result.err(TauriError.from("重複")));
+  render(baseResource({ labels: [] }));
+
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  typeInto(nameInput, "dup");
+  const form = container?.querySelector("form") as HTMLFormElement;
+  await act(async () => {
+    submitForm(form);
+    await Promise.resolve();
+  });
+  expect(noopReload).not.toHaveBeenCalled();
+  expect(nameInput.value).toBe("dup");
+});
+
+test("使用数リンクをクリックすると onLabelUsageClick が呼ばれる", () => {
+  const onUsage = vi.fn();
+  render(
+    baseResource({
+      labels: [{ name: "bug" }],
+      usageCounts: { bug: 3 },
+    }),
+    onUsage,
+  );
+  const link = container?.querySelector(
+    '[data-testid="label-usage-link"]',
+  ) as HTMLButtonElement;
+  click(link);
+  expect(onUsage).toHaveBeenCalledWith("bug");
+});
+
+test("編集ボタン → name 固定でフォーム編集モードになり update で送信される", async () => {
+  noopReload.mockClear();
+  updateMock.mockResolvedValue(Result.ok(undefined));
+  render(
+    baseResource({
+      labels: [
+        { name: "bug", description: "old", group: "type", color: "#aaaaaa" },
+      ],
+    }),
+  );
+  const editBtn = container?.querySelector(
+    '[aria-label="bug を編集"]',
+  ) as HTMLButtonElement;
+  click(editBtn);
+  // name が disable される（編集モード）
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  expect(nameInput.disabled).toBe(true);
+  expect(nameInput.value).toBe("bug");
+  // description を変更
+  const descInput = container?.querySelector(
+    'input[placeholder="デザイン待ちのタスク"]',
+  ) as HTMLInputElement;
+  typeInto(descInput, "new desc");
+
+  const form = container?.querySelector("form") as HTMLFormElement;
+  await act(async () => {
+    submitForm(form);
+    await Promise.resolve();
+  });
+  expect(updateMock).toHaveBeenCalledWith({
+    name: "bug",
+    description: "new desc",
+    group: "type",
+    color: "#aaaaaa",
+  });
+});
+
+test("削除確認: usageCount>0 のとき件数を含む確認文言、キャンセルで remove 非実行", () => {
+  // happy-dom の global.confirm は未定義のため事前に noop を入れて spyOn を可能にする。
+  Object.defineProperty(globalThis, "confirm", {
+    configurable: true,
+    writable: true,
+    value: () => false,
+  });
+  const confirmSpy = vi
+    .spyOn(globalThis, "confirm")
+    .mockImplementation(() => false);
+  render(
+    baseResource({
+      labels: [{ name: "bug" }],
+      usageCounts: { bug: 8 },
+    }),
+  );
+  const delBtn = container?.querySelector(
+    '[aria-label="bug を削除"]',
+  ) as HTMLButtonElement;
+  click(delBtn);
+  expect(confirmSpy).toHaveBeenCalledWith(
+    expect.stringContaining("8 件のタスクで使用中"),
+  );
+  expect(deleteMock).not.toHaveBeenCalled();
+  confirmSpy.mockRestore();
+});
+
+test("削除確認: usageCount=0 のときシンプル文言で OK ならば remove 実行", async () => {
+  Object.defineProperty(globalThis, "confirm", {
+    configurable: true,
+    writable: true,
+    value: () => true,
+  });
+  const confirmSpy = vi
+    .spyOn(globalThis, "confirm")
+    .mockImplementation(() => true);
+  deleteMock.mockResolvedValue(Result.ok({ usageCount: 0 }));
+  render(baseResource({ labels: [{ name: "wontfix" }] }));
+  const delBtn = container?.querySelector(
+    '[aria-label="wontfix を削除"]',
+  ) as HTMLButtonElement;
+  await act(async () => {
+    click(delBtn);
+    await Promise.resolve();
+  });
+  expect(confirmSpy).toHaveBeenCalledWith(
+    expect.stringMatching(/「wontfix」を削除しますか/),
+  );
+  expect(deleteMock).toHaveBeenCalledWith("wontfix");
+  confirmSpy.mockRestore();
+});
+
+test("エクスポート: 成功 path → exportLabels 呼び出し", async () => {
+  saveMock.mockResolvedValue(Result.ok("/tmp/labels.yml"));
+  exportMock.mockResolvedValue(Result.ok(undefined));
+  render(baseResource());
+  // LabelStatsHeader のエクスポートボタンを取得（テキスト "エクスポート" を含む）
+  const allButtons = Array.from(
+    container?.querySelectorAll("button[type=button]") ?? [],
+  ) as HTMLButtonElement[];
+  const target = allButtons.find((b) =>
+    b.textContent?.includes("エクスポート"),
+  );
+  expect(target).toBeDefined();
+  await act(async () => {
+    click(target as HTMLButtonElement);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  expect(saveMock).toHaveBeenCalled();
+  expect(exportMock).toHaveBeenCalledWith({ path: "/tmp/labels.yml" });
+});
+
+test("エクスポート: キャンセル時は exportLabels 非呼び出し", async () => {
+  saveMock.mockResolvedValue(Result.ok(null));
+  render(baseResource());
+  const allButtons = Array.from(
+    container?.querySelectorAll("button[type=button]") ?? [],
+  ) as HTMLButtonElement[];
+  const target = allButtons.find((b) =>
+    b.textContent?.includes("エクスポート"),
+  );
+  await act(async () => {
+    click(target as HTMLButtonElement);
+    await Promise.resolve();
+  });
+  expect(saveMock).toHaveBeenCalled();
+  expect(exportMock).not.toHaveBeenCalled();
+});
+
+test("エクスポート: save() 例外時は exportLabels 非呼び出し", async () => {
+  saveMock.mockResolvedValue(Result.err(TauriError.from("plugin failed")));
+  render(baseResource());
+  const allButtons = Array.from(
+    container?.querySelectorAll("button[type=button]") ?? [],
+  ) as HTMLButtonElement[];
+  const target = allButtons.find((b) =>
+    b.textContent?.includes("エクスポート"),
+  );
+  await act(async () => {
+    click(target as HTMLButtonElement);
+    await Promise.resolve();
+  });
+  expect(exportMock).not.toHaveBeenCalled();
+});
+
+test("プリセット選択で color 入力欄が更新される", () => {
+  render(baseResource({ labels: [] }));
+  const presetBtn = container?.querySelector(
+    '[aria-label="プリセット red"]',
+  ) as HTMLButtonElement;
+  click(presetBtn);
+  const hexInput = container?.querySelector(
+    'input[placeholder="7860b5"]',
+  ) as HTMLInputElement;
+  expect(hexInput.value).toBe("d55753");
+});
+
+test("FE は HEX 形式バリデーションを行わず、入力文字列をそのまま createLabel に渡す（BE が lenient に既定色化する契約）", async () => {
+  noopReload.mockClear();
+  createMock.mockResolvedValue(Result.ok(undefined));
+  render(baseResource({ labels: [] }));
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  typeInto(nameInput, "bad");
+  const hexInput = container?.querySelector(
+    'input[placeholder="7860b5"]',
+  ) as HTMLInputElement;
+  typeInto(hexInput, "not-a-hex");
+  const form = container?.querySelector("form") as HTMLFormElement;
+  await act(async () => {
+    submitForm(form);
+    await Promise.resolve();
+  });
+  expect(createMock).toHaveBeenCalledWith({
+    name: "bad",
+    description: undefined,
+    group: undefined,
+    color: "#not-a-hex",
+  });
+});

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
@@ -359,3 +359,29 @@ test("FE は HEX 形式バリデーションを行わず、入力文字列をそ
     color: "#not-a-hex",
   });
 });
+
+test("HEX 入力を全削除すると color は undefined として createLabel に渡る（PUT クリア相当）", async () => {
+  noopReload.mockClear();
+  createMock.mockResolvedValue(Result.ok(undefined));
+  render(baseResource({ labels: [] }));
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  typeInto(nameInput, "blank");
+  const hexInput = container?.querySelector(
+    'input[placeholder="7860b5"]',
+  ) as HTMLInputElement;
+  typeInto(hexInput, "abc123");
+  typeInto(hexInput, "");
+  const form = container?.querySelector("form") as HTMLFormElement;
+  await act(async () => {
+    submitForm(form);
+    await Promise.resolve();
+  });
+  expect(createMock).toHaveBeenCalledWith({
+    name: "blank",
+    description: undefined,
+    group: undefined,
+    color: undefined,
+  });
+});

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
@@ -451,6 +451,33 @@ test("group / color / description の空白のみ入力は undefined に正規�
   });
 });
 
+test("HEX 入力欄に # 付き 7 文字をペーストしても末尾欠落なく 6 桁全てが取り込まれる", async () => {
+  noopReload.mockClear();
+  createMock.mockResolvedValue(Result.ok(undefined));
+  render(baseResource({ labels: [] }));
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  typeInto(nameInput, "with-color");
+  const hexInput = container?.querySelector(
+    'input[placeholder="7860b5"]',
+  ) as HTMLInputElement;
+  // ブラウザの maxLength 切り詰めを通過した最終文字列を typeInto で再現する。
+  // maxLength=7 なら "#7860b5"（7 文字）全てが onChange に届く前提。
+  typeInto(hexInput, "#7860b5");
+  const form = container?.querySelector("form") as HTMLFormElement;
+  await act(async () => {
+    submitForm(form);
+    await Promise.resolve();
+  });
+  expect(createMock).toHaveBeenCalledWith({
+    name: "with-color",
+    description: undefined,
+    group: undefined,
+    color: "#7860b5",
+  });
+});
+
 test("名前が空白のみのときは送信ボタンが disabled になる（trim ベース判定）", () => {
   render(baseResource({ labels: [] }));
   const nameInput = container?.querySelector(

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
@@ -323,6 +323,42 @@ test("エクスポート: save() 例外時は exportLabels 非呼び出し", asy
   expect(exportMock).not.toHaveBeenCalled();
 });
 
+test("エクスポート: in-flight 中の連打は無視され save / exportLabels は 1 回ずつしか呼ばれない", async () => {
+  let resolveSave: ((value: Result<string | null, TauriError>) => void) | null =
+    null;
+  saveMock.mockReturnValue(
+    new Promise<Result<string | null, TauriError>>((resolve) => {
+      resolveSave = resolve;
+    }),
+  );
+  exportMock.mockResolvedValue(Result.ok(undefined));
+  render(baseResource());
+  const allButtons = Array.from(
+    container?.querySelectorAll("button[type=button]") ?? [],
+  ) as HTMLButtonElement[];
+  const target = allButtons.find((b) =>
+    b.textContent?.includes("エクスポート"),
+  ) as HTMLButtonElement;
+  // 1 回目クリック → save は pending のまま
+  await act(async () => {
+    click(target);
+    await Promise.resolve();
+  });
+  // 2 回目クリック（連打）→ ref ガードで即時に弾かれる
+  await act(async () => {
+    click(target);
+    await Promise.resolve();
+  });
+  expect(saveMock).toHaveBeenCalledTimes(1);
+  // 1 回目の save を解決させて invoke まで進める
+  await act(async () => {
+    resolveSave?.(Result.ok("/tmp/labels.yml"));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  expect(exportMock).toHaveBeenCalledTimes(1);
+});
+
 test("プリセット選択で color 入力欄が更新される", () => {
   render(baseResource({ labels: [] }));
   const presetBtn = container?.querySelector(

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.interaction.test.tsx
@@ -450,3 +450,15 @@ test("group / color / description の空白のみ入力は undefined に正規�
     color: undefined,
   });
 });
+
+test("名前が空白のみのときは送信ボタンが disabled になる（trim ベース判定）", () => {
+  render(baseResource({ labels: [] }));
+  const nameInput = container?.querySelector(
+    'input[placeholder="needs-design"]',
+  ) as HTMLInputElement;
+  typeInto(nameInput, "   ");
+  const submit = Array.from(
+    container?.querySelectorAll('button[type="submit"]') ?? [],
+  )[0] as HTMLButtonElement | undefined;
+  expect(submit?.disabled).toBe(true);
+});

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.rendering.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.rendering.test.tsx
@@ -3,14 +3,23 @@ import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, expect, test, vi } from "vitest";
 import { LabelRegistry } from "@/domains/label-registry";
-import { useLabelList } from "@/hooks/useLabelList";
+import type { LabelsResource } from "@/hooks/useLabels";
 import { LabelSettingsTab } from "..";
 
-vi.mock("@/hooks/useLabelList", () => ({
-  useLabelList: vi.fn(),
-}));
-
-const useLabelListMock = vi.mocked(useLabelList);
+// useLabelMutations は内部で createLabel/updateLabel/deleteLabel を invoke するため、
+// rendering テストでは tauri ラッパをまるごとモックして invoke 不発を避ける。
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    createLabel: vi.fn(),
+    updateLabel: vi.fn(),
+    deleteLabel: vi.fn(),
+    exportLabels: vi.fn(),
+    saveFileDialog: vi.fn(),
+  };
+});
 
 let container: HTMLDivElement | null = null;
 let root: ReturnType<typeof createRoot> | null = null;
@@ -22,99 +31,130 @@ afterEach(() => {
   root = null;
   container?.remove();
   container = null;
-  useLabelListMock.mockReset();
 });
 
-/**
- * LabelSettingsTab をレンダリングするヘルパー
- */
-const render = () => {
+const noopReload = async (): Promise<void> => {};
+
+const buildResource = (
+  override: Partial<LabelsResource> = {},
+): LabelsResource => {
+  const labels = override.labels ?? [];
+  return {
+    labels,
+    usageCounts: override.usageCounts ?? {},
+    byName: new Map(labels.map((l) => [l.name, l])),
+    status: override.status ?? "loaded",
+    error: override.error,
+    reload: override.reload ?? noopReload,
+  };
+};
+
+const render = (resource: LabelsResource): void => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root?.render(createElement(LabelSettingsTab));
+    root?.render(
+      createElement(LabelSettingsTab, {
+        resource,
+        onLabelUsageClick: () => {},
+      }),
+    );
   });
 };
 
 test("loaded で各ラベル名が描画される", () => {
-  useLabelListMock.mockReturnValue({
-    kind: "loaded",
-    labels: [{ name: "type:feature" }, { name: "priority:high" }],
-  });
-  render();
+  render(
+    buildResource({
+      labels: [{ name: "type:feature" }, { name: "priority:high" }],
+    }),
+  );
   expect(container?.textContent).toContain("type:feature");
   expect(container?.textContent).toContain("priority:high");
 });
 
 test("color が #RRGGBB のラベルはその色がインライン style に付く（マスタ色優先）", () => {
-  useLabelListMock.mockReturnValue({
-    kind: "loaded",
-    labels: [{ name: "custom", color: "#FF8800" }],
-  });
-  const html = renderToStaticMarkup(createElement(LabelSettingsTab));
+  const html = renderToStaticMarkup(
+    createElement(LabelSettingsTab, {
+      resource: buildResource({
+        labels: [{ name: "custom", color: "#FF8800" }],
+      }),
+      onLabelUsageClick: () => {},
+    }),
+  );
   expect(html).toContain("#FF8800");
 });
 
 test("color 無し・group ありは tokensForGroup の oklch が付く", () => {
-  useLabelListMock.mockReturnValue({
-    kind: "loaded",
-    labels: [{ name: "feature", group: "type" }],
-  });
   const { bg } = LabelRegistry.tokensForGroup("type");
-  const html = renderToStaticMarkup(createElement(LabelSettingsTab));
+  const html = renderToStaticMarkup(
+    createElement(LabelSettingsTab, {
+      resource: buildResource({
+        labels: [{ name: "feature", group: "type" }],
+      }),
+      onLabelUsageClick: () => {},
+    }),
+  );
   expect(html).toContain(bg);
 });
 
 test("color も group も無しは tokensForLabel(name) の oklch が付く", () => {
-  useLabelListMock.mockReturnValue({
-    kind: "loaded",
-    labels: [{ name: "priority:high" }],
-  });
   const { bg } = LabelRegistry.tokensForLabel("priority:high");
-  const html = renderToStaticMarkup(createElement(LabelSettingsTab));
+  const html = renderToStaticMarkup(
+    createElement(LabelSettingsTab, {
+      resource: buildResource({ labels: [{ name: "priority:high" }] }),
+      onLabelUsageClick: () => {},
+    }),
+  );
   expect(html).toContain(bg);
 });
 
-test("group は name の prefix より優先される（tokensForGroup ≠ tokensForLabel(name)）", () => {
-  useLabelListMock.mockReturnValue({
-    kind: "loaded",
-    labels: [{ name: "priority:high", group: "type" }],
-  });
+test("group は name の prefix より優先される", () => {
   const groupBg = LabelRegistry.tokensForGroup("type").bg;
-  const nameBg = LabelRegistry.tokensForLabel("priority:high").bg;
-  expect(groupBg).not.toBe(nameBg);
-  const html = renderToStaticMarkup(createElement(LabelSettingsTab));
+  const html = renderToStaticMarkup(
+    createElement(LabelSettingsTab, {
+      resource: buildResource({
+        labels: [{ name: "priority:high", group: "type" }],
+      }),
+      onLabelUsageClick: () => {},
+    }),
+  );
   expect(html).toContain(groupBg);
 });
 
-test('group が空文字で定義済みなら tokensForGroup("")（既定色）になり name 由来色にはならない', () => {
-  useLabelListMock.mockReturnValue({
-    kind: "loaded",
-    labels: [{ name: "priority:high", group: "" }],
-  });
-  const emptyGroupBg = LabelRegistry.tokensForGroup("").bg;
-  const nameBg = LabelRegistry.tokensForLabel("priority:high").bg;
-  expect(emptyGroupBg).not.toBe(nameBg);
-  const html = renderToStaticMarkup(createElement(LabelSettingsTab));
-  expect(html).toContain(emptyGroupBg);
-  expect(html).not.toContain(nameBg);
-});
-
-test("loaded で labels が空のとき「ラベルなし」相当の表示になる", () => {
-  useLabelListMock.mockReturnValue({ kind: "loaded", labels: [] });
-  render();
-  expect(container?.textContent).toContain("ラベルなし");
+test("loaded で labels が空のときフィルタバーは描画されるが行は無い", () => {
+  render(buildResource({ labels: [] }));
+  // 統計ヘッダーは描画される
+  expect(container?.textContent).toContain("0 件");
+  // 行は無い
+  const rows = container?.querySelectorAll('[data-testid="label-row"]');
+  expect(rows?.length ?? 0).toBe(0);
 });
 
 test("error のときインライン文言が表示される", () => {
-  useLabelListMock.mockReturnValue({ kind: "error" });
-  render();
+  render(buildResource({ status: "error" }));
   expect(container?.textContent).toContain("読み込めませんでした");
 });
 
 test("loading のとき読み込み中表示になる", () => {
-  useLabelListMock.mockReturnValue({ kind: "loading" });
-  render();
+  render(buildResource({ status: "loading" }));
   expect(container?.textContent).toContain("読み込み中");
+});
+
+test("usageCount=0 は非リンク、>0 は『N 件』リンク", () => {
+  render(
+    buildResource({
+      labels: [{ name: "bug" }, { name: "wontfix" }],
+      usageCounts: { bug: 8 },
+    }),
+  );
+  const link = container?.querySelector('[data-testid="label-usage-link"]');
+  expect(link?.textContent).toContain("8");
+  // wontfix 行に対応する「0 件」テキストがある（リンクではない）
+  expect(container?.textContent).toContain("0 件");
+});
+
+test("updated 無しは『新規』表示", () => {
+  render(buildResource({ labels: [{ name: "needs-triage" }] }));
+  expect(container?.textContent).toContain("新規");
 });

--- a/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.rendering.test.tsx
+++ b/src/features/settings/components/LabelSettingsTab/__tests__/LabelSettingsTab.rendering.test.tsx
@@ -141,6 +141,12 @@ test("loading のとき読み込み中表示になる", () => {
   expect(container?.textContent).toContain("読み込み中");
 });
 
+test("idle（プロジェクト未オープン）のとき専用文言を表示する", () => {
+  render(buildResource({ status: "idle" }));
+  expect(container?.textContent).toContain("プロジェクトを開く");
+  expect(container?.textContent).not.toContain("読み込み中");
+});
+
 test("usageCount=0 は非リンク、>0 は『N 件』リンク", () => {
   render(
     buildResource({

--- a/src/features/settings/components/LabelSettingsTab/index.stories.tsx
+++ b/src/features/settings/components/LabelSettingsTab/index.stories.tsx
@@ -1,0 +1,189 @@
+// @jsdoc-rules-disable
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { LabelsResource } from "@/hooks/useLabels";
+import type { LabelDefinition } from "@/lib/tauri";
+import { LabelSettingsTab } from ".";
+
+const FIXTURE_LABELS: LabelDefinition[] = [
+  {
+    name: "a11y",
+    description: "アクセシビリティ関連",
+    group: "area",
+    color: "#7860b5",
+    updated: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "backend",
+    description: "API・サーバーサイド",
+    group: "area",
+    color: "#d27830",
+    updated: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "bug",
+    description: "バグ報告・修正",
+    group: "type",
+    color: "#d55753",
+    updated: new Date(Date.now() - 2 * 60_000).toISOString(),
+  },
+  {
+    name: "docs",
+    description: "ドキュメント更新",
+    group: "type",
+    color: "#79818d",
+    updated: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "enhancement",
+    description: "既存機能の改善",
+    group: "type",
+    color: "#14874e",
+    updated: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "epic",
+    description: "複数のタスクをまとめるエピック",
+    group: "type",
+    color: "#466abf",
+    updated: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "feature",
+    description: "新機能の追加",
+    group: "type",
+    color: "#14874e",
+    updated: new Date(Date.now() - 18 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "frontend",
+    description: "UI / クライアントサイド",
+    group: "area",
+    color: "#d27830",
+    updated: new Date(Date.now() - 2 * 60_000).toISOString(),
+  },
+  {
+    name: "needs-triage",
+    description: "未トリアージ",
+    group: "status",
+  },
+  {
+    name: "perf",
+    description: "パフォーマンス改善",
+    group: "area",
+    color: "#14874e",
+    updated: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "priority:high",
+    description: "リリースまでに必須",
+    group: "priority",
+    color: "#d55753",
+    updated: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "priority:low",
+    description: "余裕があれば対応",
+    group: "priority",
+    color: "#14874e",
+    updated: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "priority:medium",
+    description: "次のスプリントで対応",
+    group: "priority",
+    color: "#d27830",
+    updated: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    name: "wontfix",
+    description: "対応しない判断",
+    group: "status",
+    color: "#79818d",
+    updated: new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+const FIXTURE_USAGE_COUNTS: Record<string, number> = {
+  a11y: 2,
+  backend: 5,
+  bug: 8,
+  docs: 3,
+  enhancement: 4,
+  epic: 5,
+  feature: 12,
+  frontend: 9,
+  perf: 1,
+  "priority:high": 3,
+  "priority:low": 6,
+  "priority:medium": 7,
+};
+
+const noopReload = async (): Promise<void> => {};
+
+const loadedResource: LabelsResource = {
+  labels: FIXTURE_LABELS,
+  usageCounts: FIXTURE_USAGE_COUNTS,
+  byName: new Map(FIXTURE_LABELS.map((label) => [label.name, label])),
+  status: "loaded",
+  reload: noopReload,
+};
+
+const emptyResource: LabelsResource = {
+  labels: [],
+  usageCounts: {},
+  byName: new Map(),
+  status: "loaded",
+  reload: noopReload,
+};
+
+const loadingResource: LabelsResource = {
+  labels: [],
+  usageCounts: {},
+  byName: new Map(),
+  status: "loading",
+  reload: noopReload,
+};
+
+const errorResource: LabelsResource = {
+  labels: [],
+  usageCounts: {},
+  byName: new Map(),
+  status: "error",
+  error: "labels.yml の読み込みに失敗しました",
+  reload: noopReload,
+};
+
+const meta: Meta<typeof LabelSettingsTab> = {
+  component: LabelSettingsTab,
+  args: {
+    resource: loadedResource,
+    onLabelUsageClick: (name) => {
+      console.log("usage click", name);
+    },
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LabelSettingsTab>;
+
+export const Default: Story = {};
+
+export const Loaded: Story = {
+  args: { resource: loadedResource },
+};
+
+export const Empty: Story = {
+  args: { resource: emptyResource },
+};
+
+export const Loading: Story = {
+  args: { resource: loadingResource },
+};
+
+export const ErrorState: Story = {
+  args: { resource: errorResource },
+};

--- a/src/features/settings/components/LabelSettingsTab/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/index.tsx
@@ -1,64 +1,265 @@
-import type { CSSProperties } from "react";
-import { LabelRegistry } from "@/domains/label-registry";
-import { useLabelList } from "@/hooks/useLabelList";
-import type { LabelDefinition } from "@/lib/tauri";
+import { useMemo, useState } from "react";
+import {
+  filterLabels,
+  type LabelGroupFilter,
+  type LabelSort,
+  labelColorTally,
+  labelGroupCounts,
+  labelStats,
+  sortLabels,
+} from "@/features/settings/lib/labelSettings/derive";
+import type { LabelsResource } from "@/hooks/useLabels";
+import {
+  type CreateLabelArgs,
+  exportLabels,
+  type LabelDefinition,
+  saveFileDialog,
+} from "@/lib/tauri";
+import { getToastSink } from "@/lib/tauri/toastSink";
+import { useLabelMutations } from "../../hooks/useLabelMutations";
+import {
+  CreateLabelForm,
+  EMPTY_LABEL_FORM,
+  type LabelFormValues,
+} from "./CreateLabelForm";
+import { LabelFilterBar } from "./LabelFilterBar";
+import { LabelFooterTally } from "./LabelFooterTally";
+import { LabelStatsHeader } from "./LabelStatsHeader";
+import { LabelTable } from "./LabelTable";
 
 /**
- * ラベル 1 件のスワッチに適用する色スタイルを解決する。
- * 優先順位は color（マスタ定義色） → group（明示グループ） → name（prefix 由来）。
- * color がある場合はその単色を背景に使い、無い場合は LabelRegistry の
- * グループトークン（fg/bg/bd）を適用する。CSS 変数は作らずインライン style に束ねる。
- * group は「定義されているか」で判定する（空文字も定義済みとして tokensForGroup に渡し、
- * 既定色へ正規化させる）。未定義のときだけ name prefix からグループを導出する。
- * @param label - ラベルマスタ定義 1 件
- * @returns スワッチ要素へ束ねるインライン style
+ * ラベル定義 → フォーム初期値。
+ * @param def - ラベル定義
+ * @returns フォーム値
  */
-const resolveSwatchStyle = (label: LabelDefinition): CSSProperties => {
-  if (label.color) {
-    return { backgroundColor: label.color };
-  }
-  const tokens =
-    label.group !== undefined
-      ? LabelRegistry.tokensForGroup(label.group)
-      : LabelRegistry.tokensForLabel(label.name);
-  return {
-    color: tokens.fg,
-    backgroundColor: tokens.bg,
-    borderColor: tokens.bd,
-  };
+const toForm = (def: LabelDefinition): LabelFormValues => ({
+  name: def.name,
+  description: def.description ?? "",
+  group: def.group ?? "",
+  color: def.color ?? "",
+});
+
+/**
+ * フォーム入力値を CreateLabelArgs に正規化する。空文字は undefined に倒し、
+ * BE が group/color を skip_serializing_if で省略 / lenient 既定色化できるようにする。
+ * @param values - フォーム入力値
+ * @returns 送信用 args
+ */
+const toArgs = (values: LabelFormValues): CreateLabelArgs => ({
+  name: values.name.trim(),
+  description: values.description === "" ? undefined : values.description,
+  group: values.group === "" ? undefined : values.group,
+  color: values.color === "" ? undefined : values.color,
+});
+
+type LabelSettingsTabProps = {
+  /** App / SettingsScreen から配られるラベルリソース（唯一の取得点・live usageCounts 上書き済み） */
+  resource: LabelsResource;
+  /**
+   * 使用数クリックで board へ遷移しラベル絞り込みを適用するためのコールバック。
+   * @param labelName - クリックされたラベル名
+   */
+  onLabelUsageClick: (labelName: string) => void;
 };
 
 /**
- * ラベルレジストリの読み取り専用一覧タブ。
- * 取得は useLabelList に委譲し、本体は取得状態に応じた描画のみ行う。
- * 各ラベルは color → group → name の優先順位で色を解決し、
- * CSS 変数を作らずインライン style にバインドしてプレビューする。
- * @returns ラベル一覧パネル
+ * ラベル管理タブ（CRUD + フィルタ + ソート + 統計 + エクスポート + 使用数リンク）。
+ * 一覧は楽観更新せず、mutation 成功後に `resource.reload` で確定する。取得は
+ * `useLabels`（resource）に委譲し、本コンポーネントは独自に getLabels を呼ばない。
+ * 削除確認は `globalThis.confirm` を使い、使用数 0 / >0 で文言を分岐させる。
+ * @param props - {@link LabelSettingsTabProps}
+ * @returns ラベル管理パネル
  */
-export const LabelSettingsTab = () => {
-  const state = useLabelList();
+export const LabelSettingsTab = ({
+  resource,
+  onLabelUsageClick,
+}: LabelSettingsTabProps) => {
+  const { labels, usageCounts, status, reload } = resource;
+  const { isPending, create, update, remove } = useLabelMutations(reload);
+  const [editingName, setEditingName] = useState<string | null>(null);
+  const [form, setForm] = useState<LabelFormValues>(EMPTY_LABEL_FORM);
+  const [keyword, setKeyword] = useState("");
+  const [groupFilter, setGroupFilter] = useState<LabelGroupFilter>({
+    kind: "all",
+  });
+  const [sort, setSort] = useState<LabelSort>("name");
 
-  if (state.kind === "loading") {
+  const filtered = useMemo(
+    () => filterLabels(labels, keyword, groupFilter),
+    [labels, keyword, groupFilter],
+  );
+  const sorted = useMemo(
+    () => sortLabels(filtered, sort, usageCounts),
+    [filtered, sort, usageCounts],
+  );
+  const stats = useMemo(
+    () => labelStats(labels, usageCounts),
+    [labels, usageCounts],
+  );
+  const groupCounts = useMemo(() => labelGroupCounts(labels), [labels]);
+  const colorTally = useMemo(
+    () => labelColorTally(labels, usageCounts),
+    [labels, usageCounts],
+  );
+  // 相対時刻表示の基準時刻を 1 回だけ生成し、全行へ流す。`labels` が入れ替わった
+  // タイミングで作り直して「数秒〜分単位で古い相対時刻」が残るのを避ける。labels が
+  // 同一参照を保つ限り基準は固定で、フォーム入力の度に再生成しない（labels への参照は
+  // 「labels が変わった時だけ再生成する」意図を biome へ伝えるためのもの）。
+  const now = useMemo(() => {
+    void labels;
+    return new Date();
+  }, [labels]);
+
+  /**
+   * フォームのフィールドを更新する。
+   * @param key - 更新するフィールド名
+   * @param value - 新しい値
+   */
+  const setField = (key: keyof LabelFormValues, value: string): void => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  /** フォームを新規モードへリセットする。 */
+  const resetForm = (): void => {
+    setEditingName(null);
+    setForm(EMPTY_LABEL_FORM);
+  };
+
+  /**
+   * 編集モードへ切り替える。
+   * @param def - 編集対象のラベル定義
+   */
+  const startEdit = (def: LabelDefinition): void => {
+    setEditingName(def.name);
+    setForm(toForm(def));
+  };
+
+  /** フォーム送信（新規作成 or 更新）。成功時はフォームをリセットする。 */
+  const handleSubmit = async (): Promise<void> => {
+    const args = toArgs(form);
+    if (args.name === "") {
+      return;
+    }
+    if (editingName === null) {
+      const created = await create(args);
+      if (created) {
+        resetForm();
+      }
+      return;
+    }
+    // 更新は PUT セマンティクスで「未指定フィールドはクリア」される。`toArgs` が空文字を
+    // undefined に倒すため、ユーザーがフォームを空欄にしたまま送信すると、そのフィールドの
+    // 既存値（description / group / color）はクリアされる挙動になる（UI で削除を表現する経路）。
+    // UI で全フィールド編集可なため、form 値をそのまま送って良い（name は固定）。
+    const updated = await update({ ...args, name: editingName });
+    if (updated) {
+      resetForm();
+    }
+  };
+
+  /**
+   * 削除確認 → mutation 実行。編集中対象なら resetForm へ戻す。
+   * @param name - 削除対象 name
+   */
+  const handleDelete = async (name: string): Promise<void> => {
+    const count = usageCounts[name] ?? 0;
+    const message =
+      count > 0
+        ? `「${name}」は ${count} 件のタスクで使用中です。削除しますか？（タスクの値は残ります）`
+        : `「${name}」を削除しますか？`;
+    if (!globalThis.confirm(message)) {
+      return;
+    }
+    await remove(name);
+    if (editingName === name) {
+      resetForm();
+    }
+  };
+
+  /**
+   * エクスポート（save ダイアログ → exportLabels invoke）。
+   * 失敗 3 系統: (1) save() 例外は invoke allowlist 外で共通トーストが拾わないため、
+   * ここで明示的に sink へトーストを上げて中断する（サイレント失敗を防ぐ）。
+   * (2) ユーザーキャンセル(null) は no-op。
+   * (3) BE export_labels 失敗は invoke allowlist 内で共通トーストが発火するため
+   * 本関数では別途処理しない。
+   */
+  const handleExport = async (): Promise<void> => {
+    const picked = await saveFileDialog({
+      defaultPath: "labels.yml",
+      filters: [{ name: "YAML", extensions: ["yml", "yaml"] }],
+    });
+    if (!picked.ok) {
+      const sink = getToastSink();
+      if (sink !== null) {
+        sink(
+          `ラベルのエクスポートに失敗しました: ${picked.error.message}`,
+          "error",
+        );
+      }
+      return;
+    }
+    if (picked.value === null) {
+      return;
+    }
+    await exportLabels({ path: picked.value });
+  };
+
+  if (status === "loading" || status === "idle") {
     return <p className="text-sm text-muted">読み込み中…</p>;
   }
-  if (state.kind === "error") {
+  if (status === "error") {
     return <p className="text-sm text-muted">ラベルを読み込めませんでした</p>;
   }
-  if (state.labels.length === 0) {
-    return <p className="text-sm text-muted">ラベルなし</p>;
-  }
+
   return (
-    <ul className="flex flex-wrap gap-2">
-      {state.labels.map((label) => (
-        <li key={label.name}>
-          <span
-            className="inline-flex items-center rounded border px-1.5 py-0.5 text-xs"
-            style={resolveSwatchStyle(label)}
-          >
-            {label.name}
-          </span>
-        </li>
-      ))}
-    </ul>
+    <div className="flex flex-col gap-4">
+      <LabelStatsHeader
+        total={stats.total}
+        used={stats.used}
+        unused={stats.unused}
+        isExportDisabled={isPending}
+        onExport={() => {
+          void handleExport();
+        }}
+      />
+      <CreateLabelForm
+        values={form}
+        editingName={editingName}
+        isPending={isPending}
+        groupOptions={groupCounts.groups.map((g) => g.group)}
+        onChange={setField}
+        onReset={resetForm}
+        onSubmit={() => {
+          void handleSubmit();
+        }}
+      />
+      <LabelFilterBar
+        totalCount={groupCounts.all}
+        groupOptions={groupCounts.groups}
+        groupFilter={groupFilter}
+        keyword={keyword}
+        sort={sort}
+        onGroupChange={setGroupFilter}
+        onKeywordChange={setKeyword}
+        onSortChange={setSort}
+      />
+      <LabelTable
+        labels={sorted}
+        usageCounts={usageCounts}
+        isPending={isPending}
+        now={now}
+        onUsageClick={onLabelUsageClick}
+        onEdit={startEdit}
+        onDelete={(name) => {
+          void handleDelete(name);
+        }}
+      />
+      <LabelFooterTally
+        shown={sorted.length}
+        total={labels.length}
+        colorTally={colorTally}
+      />
+    </div>
   );
 };

--- a/src/features/settings/components/LabelSettingsTab/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/index.tsx
@@ -45,12 +45,19 @@ const toForm = (def: LabelDefinition): LabelFormValues => ({
  * @param values - フォーム入力値
  * @returns 送信用 args
  */
-const toArgs = (values: LabelFormValues): CreateLabelArgs => ({
-  name: values.name.trim(),
-  description: values.description === "" ? undefined : values.description,
-  group: values.group === "" ? undefined : values.group,
-  color: values.color === "" ? undefined : values.color,
-});
+const toArgs = (values: LabelFormValues): CreateLabelArgs => {
+  // 各フィールドは送信前に trim する。空白のみの入力 ("   ") は
+  // LabelRegistry.effectiveGroup（trim 比較）と整合するよう undefined に正規化する。
+  const trimmedDescription = values.description.trim();
+  const trimmedGroup = values.group.trim();
+  const trimmedColor = values.color.trim();
+  return {
+    name: values.name.trim(),
+    description: trimmedDescription === "" ? undefined : trimmedDescription,
+    group: trimmedGroup === "" ? undefined : trimmedGroup,
+    color: trimmedColor === "" ? undefined : trimmedColor,
+  };
+};
 
 type LabelSettingsTabProps = {
   /** App / SettingsScreen から配られるラベルリソース（唯一の取得点・live usageCounts 上書き済み） */

--- a/src/features/settings/components/LabelSettingsTab/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/index.tsx
@@ -205,7 +205,14 @@ export const LabelSettingsTab = ({
     await exportLabels({ path: picked.value });
   };
 
-  if (status === "loading" || status === "idle") {
+  if (status === "idle") {
+    return (
+      <p className="text-sm text-muted">
+        プロジェクトを開くとラベルを表示します
+      </p>
+    );
+  }
+  if (status === "loading") {
     return <p className="text-sm text-muted">読み込み中…</p>;
   }
   if (status === "error") {

--- a/src/features/settings/components/LabelSettingsTab/index.tsx
+++ b/src/features/settings/components/LabelSettingsTab/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   filterLabels,
   type LabelGroupFilter,
@@ -85,6 +85,10 @@ export const LabelSettingsTab = ({
   const { isPending, create, update, remove } = useLabelMutations(reload);
   const [editingName, setEditingName] = useState<string | null>(null);
   const [form, setForm] = useState<LabelFormValues>(EMPTY_LABEL_FORM);
+  // export 専用の in-flight ガード。state は disabled 表示用、ref は連打レース防止用
+  // （state 反映前の click でも ref で即時ガードされる）。
+  const [isExporting, setIsExporting] = useState(false);
+  const isExportingRef = useRef(false);
   const [keyword, setKeyword] = useState("");
   const [groupFilter, setGroupFilter] = useState<LabelGroupFilter>({
     kind: "all",
@@ -192,24 +196,36 @@ export const LabelSettingsTab = ({
    * 本関数では別途処理しない。
    */
   const handleExport = async (): Promise<void> => {
-    const picked = await saveFileDialog({
-      defaultPath: "labels.yml",
-      filters: [{ name: "YAML", extensions: ["yml", "yaml"] }],
-    });
-    if (!picked.ok) {
-      const sink = getToastSink();
-      if (sink !== null) {
-        sink(
-          `ラベルのエクスポートに失敗しました: ${picked.error.message}`,
-          "error",
-        );
+    // 連打ガード: state 反映前の click でも ref で即時に弾く。
+    if (isExportingRef.current) {
+      return;
+    }
+    isExportingRef.current = true;
+    setIsExporting(true);
+    try {
+      const picked = await saveFileDialog({
+        defaultPath: "labels.yml",
+        filters: [{ name: "YAML", extensions: ["yml", "yaml"] }],
+      });
+      if (!picked.ok) {
+        const sink = getToastSink();
+        if (sink !== null) {
+          sink(
+            `ラベルのエクスポートに失敗しました: ${picked.error.message}`,
+            "error",
+          );
+        }
+        return;
       }
-      return;
+      if (picked.value === null) {
+        return;
+      }
+      await exportLabels({ path: picked.value });
+    } finally {
+      // ガード解除は ref と state の両方を必ず戻す。
+      isExportingRef.current = false;
+      setIsExporting(false);
     }
-    if (picked.value === null) {
-      return;
-    }
-    await exportLabels({ path: picked.value });
   };
 
   if (status === "idle") {
@@ -232,7 +248,7 @@ export const LabelSettingsTab = ({
         total={stats.total}
         used={stats.used}
         unused={stats.unused}
-        isExportDisabled={isPending}
+        isExportDisabled={isPending || isExporting}
         onExport={() => {
           void handleExport();
         }}

--- a/src/features/settings/components/SettingsScreen/__tests__/SettingsScreen.interaction.test.tsx
+++ b/src/features/settings/components/SettingsScreen/__tests__/SettingsScreen.interaction.test.tsx
@@ -1,6 +1,7 @@
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { LabelsResource } from "@/hooks/useLabels";
 import type { MilestonesResource } from "@/hooks/useMilestones";
 import { getLabels } from "@/lib/tauri";
 import { Result } from "@/utils/result";
@@ -26,12 +27,23 @@ const milestonesResource: MilestonesResource = {
   reload: vi.fn(async () => {}),
 };
 
+// ラベルリソースも App から共有される前提（settings → labels タブへ配る）。
+const labelsResource: LabelsResource = {
+  labels: [],
+  usageCounts: {},
+  byName: new Map(),
+  status: "loaded",
+  reload: vi.fn(async () => {}),
+};
+
+const noopUsageClick = (_name: string): void => {};
+
 let container: HTMLDivElement | null = null;
 let root: ReturnType<typeof createRoot> | null = null;
 
 beforeEach(() => {
   getLabelsMock.mockReset();
-  getLabelsMock.mockResolvedValue(Result.ok({ labels: [] }));
+  getLabelsMock.mockResolvedValue(Result.ok({ labels: [], usageCounts: {} }));
 });
 
 afterEach(() => {
@@ -52,7 +64,11 @@ const mountSettingsScreen = async () => {
   root = createRoot(container);
   await act(async () => {
     root?.render(
-      createElement(SettingsScreen, { milestones: milestonesResource }),
+      createElement(SettingsScreen, {
+        labels: labelsResource,
+        milestones: milestonesResource,
+        onLabelUsageClick: noopUsageClick,
+      }),
     );
   });
   await act(async () => {

--- a/src/features/settings/components/SettingsScreen/index.tsx
+++ b/src/features/settings/components/SettingsScreen/index.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useState } from "react";
+import type { LabelsResource } from "@/hooks/useLabels";
 import type { MilestonesResource } from "@/hooks/useMilestones";
 import { type NonEmptySettingsTabs, SettingsTab } from "../../types";
 import { AppearanceSettingsTab } from "../AppearanceSettingsTab";
@@ -16,8 +17,15 @@ const SETTINGS_TABS: NonEmptySettingsTabs = [
 type ActivePanelProps = {
   /** アクティブタブの識別子 */
   tabId: string;
+  /** ラベルリソース（labels タブへ配る） */
+  labels: LabelsResource;
   /** マイルストーンリソース（milestones タブへ配る） */
   milestones: MilestonesResource;
+  /**
+   * ラベル設定タブから board へ遷移して指定ラベルでフィルタを掛けるコールバック。
+   * @param labelName - クリックされたラベル名
+   */
+  onLabelUsageClick: (labelName: string) => void;
 };
 
 /**
@@ -27,10 +35,20 @@ type ActivePanelProps = {
  * @param props - tabId とリソースを含む props
  * @returns 対応するパネル要素、未知 id なら null
  */
-const ActivePanel = ({ tabId, milestones }: ActivePanelProps): ReactNode => {
+const ActivePanel = ({
+  tabId,
+  labels,
+  milestones,
+  onLabelUsageClick,
+}: ActivePanelProps): ReactNode => {
   switch (tabId) {
     case "labels":
-      return <LabelSettingsTab />;
+      return (
+        <LabelSettingsTab
+          resource={labels}
+          onLabelUsageClick={onLabelUsageClick}
+        />
+      );
     case "milestones":
       return <MilestoneSettingsTab resource={milestones} />;
     case "appearance":
@@ -42,21 +60,35 @@ const ActivePanel = ({ tabId, milestones }: ActivePanelProps): ReactNode => {
 
 type SettingsScreenProps = {
   /**
+   * ラベルリソース。App が唯一の取得点（useLabels）として保持し、settings 用に
+   * live `usageCounts` 上書きを掛けたものを受け取る。
+   */
+  labels: LabelsResource;
+  /**
    * マイルストーンリソース。App が唯一の取得点（useMilestones）として保持するものを
    * 受け取り、board / milestoneView と共有する。設定タブでの CRUD 後の reload が
    * 同一リソースに効くため、バッジ / フィルタ / 専用ビューが即時に最新化される。
    */
   milestones: MilestonesResource;
+  /**
+   * 使用数クリックで board へ遷移しそのラベルで絞り込むコールバック。
+   * @param labelName - クリックされたラベル名
+   */
+  onLabelUsageClick: (labelName: string) => void;
 };
 
 /**
  * 設定画面本体。SubNav + アクティブタブのパネルを合成する。
- * board state には依存しない（App 側で保持・据え置き）。マイルストーンリソースは
+ * board state には依存しない（App 側で保持・据え置き）。ラベル / マイルストーンリソースは
  * App から共有で受け取る（独自取得はしない）。
  * @param props - {@link SettingsScreenProps}
  * @returns 設定画面要素
  */
-export const SettingsScreen = ({ milestones }: SettingsScreenProps) => {
+export const SettingsScreen = ({
+  labels,
+  milestones,
+  onLabelUsageClick,
+}: SettingsScreenProps) => {
   const [activeTabId, setActiveTabId] = useState<string>(SETTINGS_TABS[0].id);
   const activeTab = SettingsTab.selectActive(SETTINGS_TABS, activeTabId);
 
@@ -73,7 +105,12 @@ export const SettingsScreen = ({ milestones }: SettingsScreenProps) => {
         aria-labelledby={subNavTabId(activeTab.id)}
         className="flex-1 overflow-auto p-4"
       >
-        <ActivePanel tabId={activeTab.id} milestones={milestones} />
+        <ActivePanel
+          tabId={activeTab.id}
+          labels={labels}
+          milestones={milestones}
+          onLabelUsageClick={onLabelUsageClick}
+        />
       </div>
     </div>
   );

--- a/src/features/settings/hooks/useLabelMutations/__tests__/useLabelMutations.interaction.test.tsx
+++ b/src/features/settings/hooks/useLabelMutations/__tests__/useLabelMutations.interaction.test.tsx
@@ -1,0 +1,222 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import {
+  type UseLabelMutationsResult,
+  useLabelMutations,
+} from "@/features/settings/hooks/useLabelMutations";
+import { createLabel, deleteLabel, TauriError } from "@/lib/tauri";
+import { Result } from "@/utils/result";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    createLabel: vi.fn(),
+    updateLabel: vi.fn(),
+    deleteLabel: vi.fn(),
+  };
+});
+
+const createMock = vi.mocked(createLabel);
+const deleteMock = vi.mocked(deleteLabel);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previous: boolean | undefined;
+
+beforeAll(() => {
+  previous = reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = previous;
+});
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  createMock.mockReset();
+  deleteMock.mockReset();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const Probe = ({
+  reload,
+  onResult,
+}: {
+  reload: () => Promise<void>;
+  onResult: (result: UseLabelMutationsResult) => void;
+}) => {
+  const result = useLabelMutations(reload);
+  useEffect(() => {
+    onResult(result);
+  });
+  return null;
+};
+
+const mount = async (
+  reload: () => Promise<void>,
+): Promise<{ get latest(): UseLabelMutationsResult }> => {
+  let latest: UseLabelMutationsResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      createElement(Probe, {
+        reload,
+        onResult: (r) => {
+          latest = r;
+        },
+      }),
+    );
+  });
+  return {
+    get latest(): UseLabelMutationsResult {
+      return latest as UseLabelMutationsResult;
+    },
+  };
+};
+
+test("create 成功時に reload を呼ぶ", async () => {
+  createMock.mockResolvedValue(Result.ok(undefined));
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+  await act(async () => {
+    await probe.latest.create({ name: "needs-design" });
+  });
+  expect(reload).toHaveBeenCalledTimes(1);
+});
+
+test("create 失敗時は reload を呼ばず false を返す", async () => {
+  createMock.mockResolvedValue(Result.err(TauriError.from("失敗")));
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+  await act(async () => {
+    const ok = await probe.latest.create({ name: "dup" });
+    expect(ok).toBe(false);
+  });
+  expect(reload).not.toHaveBeenCalled();
+});
+
+test("remove 成功時に reload を呼び usageCount payload を返す", async () => {
+  deleteMock.mockResolvedValue(Result.ok({ usageCount: 5 }));
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+  await act(async () => {
+    const payload = await probe.latest.remove("bug");
+    expect(payload).toEqual({ usageCount: 5 });
+  });
+  expect(reload).toHaveBeenCalledTimes(1);
+});
+
+test("remove 失敗時は reload を呼ばず null を返す", async () => {
+  deleteMock.mockResolvedValue(Result.err(TauriError.from("失敗")));
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+  await act(async () => {
+    const payload = await probe.latest.remove("bug");
+    expect(payload).toBeNull();
+  });
+  expect(reload).not.toHaveBeenCalled();
+});
+
+test("create 実行中は isPending=true、完了で false に戻る", async () => {
+  let resolveCb: ((r: Result<undefined, TauriError>) => void) | null = null;
+  createMock.mockReturnValue(
+    new Promise<Result<undefined, TauriError>>((resolve) => {
+      resolveCb = resolve;
+    }),
+  );
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+
+  let createPromise: Promise<boolean> = Promise.resolve(false);
+  act(() => {
+    createPromise = probe.latest.create({ name: "x" });
+  });
+  expect(probe.latest.isPending).toBe(true);
+
+  await act(async () => {
+    resolveCb?.(Result.ok(undefined));
+    await createPromise;
+  });
+  expect(probe.latest.isPending).toBe(false);
+});
+
+test("実行中の create 連打は 2 回目を短絡し IPC を二重発行しない", async () => {
+  let resolveCb: ((r: Result<undefined, TauriError>) => void) | null = null;
+  createMock.mockReturnValue(
+    new Promise<Result<undefined, TauriError>>((resolve) => {
+      resolveCb = resolve;
+    }),
+  );
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+
+  let firstPromise: Promise<boolean> = Promise.resolve(false);
+  act(() => {
+    firstPromise = probe.latest.create({ name: "x" });
+  });
+  let secondResult: boolean | undefined;
+  await act(async () => {
+    secondResult = await probe.latest.create({ name: "x" });
+  });
+
+  expect(createMock).toHaveBeenCalledTimes(1);
+  expect(secondResult).toBe(false);
+
+  await act(async () => {
+    resolveCb?.(Result.ok(undefined));
+    await firstPromise;
+  });
+});
+
+test("実行中は他種別の mutation も短絡する（create 中の remove）", async () => {
+  let resolveCb: ((r: Result<undefined, TauriError>) => void) | null = null;
+  createMock.mockReturnValue(
+    new Promise<Result<undefined, TauriError>>((resolve) => {
+      resolveCb = resolve;
+    }),
+  );
+  const reload = vi.fn(async () => {});
+  const probe = await mount(reload);
+
+  let firstPromise: Promise<boolean> = Promise.resolve(false);
+  act(() => {
+    firstPromise = probe.latest.create({ name: "x" });
+  });
+  let removeResult: unknown;
+  await act(async () => {
+    removeResult = await probe.latest.remove("y");
+  });
+
+  expect(deleteMock).not.toHaveBeenCalled();
+  expect(removeResult).toBeNull();
+
+  await act(async () => {
+    resolveCb?.(Result.ok(undefined));
+    await firstPromise;
+  });
+});

--- a/src/features/settings/hooks/useLabelMutations/index.ts
+++ b/src/features/settings/hooks/useLabelMutations/index.ts
@@ -1,0 +1,141 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  type CreateLabelArgs,
+  createLabel,
+  type DeleteLabelPayload,
+  deleteLabel,
+  type UpdateLabelArgs,
+  updateLabel,
+} from "@/lib/tauri";
+
+/** ラベル一覧を再取得する関数（`useLabels.reload`）。 */
+export type ReloadLabels = () => Promise<void>;
+
+/** useLabelMutations の返り値。create / update / delete を提供する。 */
+export type UseLabelMutationsResult = {
+  /**
+   * いずれかの mutation が実行中か。送信ボタン等の disabled に使う。
+   * pending 中に呼ばれた mutation は短絡して即失敗値を返す。
+   */
+  isPending: boolean;
+  /**
+   * ラベルを作成する。成功時のみ reload を呼ぶ。
+   * @param args - 作成内容
+   * @returns 成功なら true、失敗・pending 中なら false（失敗トーストは共通層が発火する）
+   */
+  create: (args: CreateLabelArgs) => Promise<boolean>;
+  /**
+   * ラベルを更新する（PUT）。成功時のみ reload を呼ぶ。
+   * @param args - 更新内容
+   * @returns 成功なら true、失敗・pending 中なら false
+   */
+  update: (args: UpdateLabelArgs) => Promise<boolean>;
+  /**
+   * ラベルを削除する。成功時のみ reload を呼ぶ。
+   * @param name - 削除対象の name
+   * @returns 成功なら削除前 usageCount を含む payload、失敗・pending 中なら null
+   */
+  remove: (name: string) => Promise<DeleteLabelPayload | null>;
+};
+
+/**
+ * ラベル CRUD の mutation フック。**楽観更新は行わず**、成功時に `reload` を呼んで
+ * 一覧を再取得・確定する（取得・一覧 state は持たない）。失敗時は共通層
+ * （invokeWrapped allowlist）が失敗トーストを発火するため、ここでは reload を呼ばない。
+ *
+ * 実行中の再呼び出しは hook 内の in-flight ガードで短絡する。3 種の mutation は同じ
+ * 一覧 state を共有して reload で確定するため、ガードは種別をまたいで 1 本に統一し、
+ * いずれかが実行中なら他種別も短絡させる（create 連打の重複作成・remove の二重失敗
+ * トーストを防ぐ）。`isPending`（state）は描画追従用、ref は同一 tick の連打でも
+ * 確実に短絡させるための同期判定用として併用する。
+ *
+ * @param reload - 成功後に呼ぶ再取得関数（`useLabels.reload`）
+ * @returns isPending / create / update / remove
+ */
+export const useLabelMutations = (
+  reload: ReloadLabels,
+): UseLabelMutationsResult => {
+  const [isPending, setIsPending] = useState(false);
+  // state 反映を待たずに同期判定するための in-flight フラグ（種別共通）。
+  const inFlightRef = useRef(false);
+
+  /**
+   * mutation を in-flight ガードで包む。pending 中なら `rejected` を即返し、
+   * そうでなければ `run` を実行して結果を返す。成否に関わらず finally で解放する。
+   * @param run - 実行する mutation 本体
+   * @param rejected - pending 中の短絡時に返す値
+   * @returns run の結果、または pending 中なら rejected
+   */
+  const guard = useCallback(
+    async <T>(run: () => Promise<T>, rejected: T): Promise<T> => {
+      if (inFlightRef.current) {
+        return rejected;
+      }
+      inFlightRef.current = true;
+      setIsPending(true);
+      try {
+        return await run();
+      } finally {
+        inFlightRef.current = false;
+        setIsPending(false);
+      }
+    },
+    [],
+  );
+
+  /**
+   * 作成。成功時のみ reload する。
+   * @param args - 作成内容
+   * @returns 成功なら true、失敗・pending 中なら false
+   */
+  const create = useCallback(
+    (args: CreateLabelArgs): Promise<boolean> =>
+      guard(async () => {
+        const result = await createLabel(args);
+        if (!result.ok) {
+          return false;
+        }
+        await reload();
+        return true;
+      }, false),
+    [guard, reload],
+  );
+
+  /**
+   * 更新。成功時のみ reload する。
+   * @param args - 更新内容
+   * @returns 成功なら true、失敗・pending 中なら false
+   */
+  const update = useCallback(
+    (args: UpdateLabelArgs): Promise<boolean> =>
+      guard(async () => {
+        const result = await updateLabel(args);
+        if (!result.ok) {
+          return false;
+        }
+        await reload();
+        return true;
+      }, false),
+    [guard, reload],
+  );
+
+  /**
+   * 削除。成功時のみ reload する。
+   * @param name - 削除対象の name
+   * @returns 成功なら usageCount payload、失敗・pending 中なら null
+   */
+  const remove = useCallback(
+    (name: string): Promise<DeleteLabelPayload | null> =>
+      guard<DeleteLabelPayload | null>(async () => {
+        const result = await deleteLabel(name);
+        if (!result.ok) {
+          return null;
+        }
+        await reload();
+        return result.value;
+      }, null),
+    [guard, reload],
+  );
+
+  return { isPending, create, update, remove };
+};

--- a/src/features/settings/lib/labelSettings/__tests__/derive.unit.test.ts
+++ b/src/features/settings/lib/labelSettings/__tests__/derive.unit.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from "vitest";
+import {
+  filterLabels,
+  type LabelGroupFilter,
+  type LabelSort,
+  labelColorTally,
+  labelGroupCounts,
+  labelStats,
+  sortLabels,
+} from "@/features/settings/lib/labelSettings/derive";
+import type { LabelDefinition } from "@/lib/tauri";
+
+const labels: LabelDefinition[] = [
+  {
+    name: "bug",
+    description: "バグ報告",
+    group: "type",
+    color: "#d55753",
+    updated: "2026-06-16T11:58:00Z",
+  },
+  {
+    name: "frontend",
+    description: "UI / クライアントサイド",
+    group: "area",
+    updated: "2026-06-16T11:58:00Z",
+  },
+  {
+    name: "a11y",
+    description: "アクセシビリティ関連",
+    group: "area",
+    updated: "2026-06-11T12:00:00Z",
+  },
+  {
+    name: "wontfix",
+    description: "対応しない判断",
+    group: "status",
+    updated: "2026-05-16T12:00:00Z",
+  },
+];
+
+const allFilter: LabelGroupFilter = { kind: "all" };
+
+test("filterLabels: キーワードは name の部分一致で大小無視", () => {
+  expect(filterLabels(labels, "BUG", allFilter).map((l) => l.name)).toEqual([
+    "bug",
+  ]);
+});
+
+test("filterLabels: キーワードは description にも適用される", () => {
+  expect(
+    filterLabels(labels, "アクセシビリティ", allFilter).map((l) => l.name),
+  ).toEqual(["a11y"]);
+});
+
+test("filterLabels: kind=all はキーワードのみ適用", () => {
+  expect(filterLabels(labels, "", allFilter)).toHaveLength(4);
+});
+
+test("filterLabels: kind=group は実グループ名で絞る", () => {
+  const result = filterLabels(labels, "", { kind: "group", value: "area" });
+  expect(result.map((l) => l.name)).toEqual(["frontend", "a11y"]);
+});
+
+test("filterLabels: group + keyword の併用は AND", () => {
+  const result = filterLabels(labels, "front", {
+    kind: "group",
+    value: "area",
+  });
+  expect(result.map((l) => l.name)).toEqual(["frontend"]);
+});
+
+test("filterLabels: kind=group で 'all' を指定しても群名と衝突しない", () => {
+  const withAllGroup: LabelDefinition[] = [{ name: "anything", group: "all" }];
+  expect(
+    filterLabels(withAllGroup, "", { kind: "group", value: "all" }).map(
+      (l) => l.name,
+    ),
+  ).toEqual(["anything"]);
+  expect(
+    filterLabels(withAllGroup, "", { kind: "all" }).map((l) => l.name),
+  ).toEqual(["anything"]);
+});
+
+test("filterLabels: マッチ無しで空配列", () => {
+  expect(filterLabels(labels, "zzzz", allFilter)).toEqual([]);
+});
+
+const usageCounts: Record<string, number> = {
+  bug: 8,
+  frontend: 9,
+  a11y: 2,
+  wontfix: 0,
+};
+
+test.each<[LabelSort, string[]]>([
+  ["name", ["a11y", "bug", "frontend", "wontfix"]],
+  ["usage", ["frontend", "bug", "a11y", "wontfix"]],
+  ["updated", ["bug", "frontend", "a11y", "wontfix"]],
+])("sortLabels(%s) は期待順に並べる", (sort, expected) => {
+  expect(sortLabels(labels, sort, usageCounts).map((l) => l.name)).toEqual(
+    expected,
+  );
+});
+
+test("sortLabels: updated 無しは末尾へ送る（安定）", () => {
+  const withMissing: LabelDefinition[] = [
+    { name: "noupdated" },
+    { name: "newest", updated: "2026-06-16T11:58:00Z" },
+    { name: "older", updated: "2026-06-15T11:58:00Z" },
+  ];
+  expect(sortLabels(withMissing, "updated", {}).map((l) => l.name)).toEqual([
+    "newest",
+    "older",
+    "noupdated",
+  ]);
+});
+
+test("labelStats: total/used/unused を返す", () => {
+  expect(labelStats(labels, usageCounts)).toEqual({
+    total: 4,
+    used: 3,
+    unused: 1,
+  });
+});
+
+test("labelStats: usageCounts に未定義キーは未使用扱い", () => {
+  expect(labelStats(labels, { bug: 8 })).toEqual({
+    total: 4,
+    used: 1,
+    unused: 3,
+  });
+});
+
+test("labelGroupCounts: all + グループ別件数（group 無しは default）", () => {
+  const mixed: LabelDefinition[] = [
+    { name: "x", group: "type" },
+    { name: "y", group: "type" },
+    { name: "z", group: "area" },
+    { name: "n" },
+  ];
+  expect(labelGroupCounts(mixed)).toEqual({
+    all: 4,
+    groups: [
+      { group: "type", count: 2 },
+      { group: "area", count: 1 },
+      { group: "default", count: 1 },
+    ],
+  });
+});
+
+test("labelColorTally: 使用中ラベルのみ・色キー（color or group）で集計", () => {
+  const tally = labelColorTally(labels, usageCounts);
+  // bug は color 指定（#d55753）、frontend/a11y は area group、wontfix は使用 0 で除外
+  const map = Object.fromEntries(tally.map((e) => [e.color, e.count]));
+  expect(map["#d55753"]).toBe(1);
+  expect(map.area).toBe(2);
+  expect(tally.find((e) => e.color === "wontfix")).toBeUndefined();
+});

--- a/src/features/settings/lib/labelSettings/__tests__/derive.unit.test.ts
+++ b/src/features/settings/lib/labelSettings/__tests__/derive.unit.test.ts
@@ -156,3 +156,27 @@ test("labelColorTally: 使用中ラベルのみ・色キー（color or group）�
   expect(map.area).toBe(2);
   expect(tally.find((e) => e.color === "wontfix")).toBeUndefined();
 });
+
+test("labelGroupCounts: __proto__ / constructor のような group 名でも継承プロパティと衝突せず数える", () => {
+  const labels: LabelDefinition[] = [
+    { name: "a", group: "__proto__" },
+    { name: "b", group: "__proto__" },
+    { name: "c", group: "constructor" },
+  ];
+  const result = labelGroupCounts(labels);
+  expect(result.all).toBe(3);
+  expect(result.groups).toContainEqual({ group: "__proto__", count: 2 });
+  expect(result.groups).toContainEqual({ group: "constructor", count: 1 });
+});
+
+test("labelColorTally: __proto__ / constructor の group fallback でも継承プロパティと衝突せず数える", () => {
+  const labels: LabelDefinition[] = [
+    { name: "a", group: "__proto__" },
+    { name: "b", group: "__proto__" },
+    { name: "c", group: "constructor" },
+  ];
+  const usageCounts: Record<string, number> = { a: 1, b: 1, c: 1 };
+  const tally = labelColorTally(labels, usageCounts);
+  expect(tally).toContainEqual({ color: "__proto__", count: 2 });
+  expect(tally).toContainEqual({ color: "constructor", count: 1 });
+});

--- a/src/features/settings/lib/labelSettings/__tests__/swatch.unit.test.ts
+++ b/src/features/settings/lib/labelSettings/__tests__/swatch.unit.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest";
+import { LabelRegistry } from "@/domains/label-registry";
+import { resolveLabelSwatchStyle } from "@/features/settings/lib/labelSettings/swatch";
+
+test("color が指定されているとき backgroundColor だけ採用する", () => {
+  const style = resolveLabelSwatchStyle({ name: "bug", color: "#ef4444" });
+  expect(style.backgroundColor).toBe("#ef4444");
+  // color 指定時は group/name 由来の fg/bd は使わない
+  expect(style.color).toBeUndefined();
+  expect(style.borderColor).toBeUndefined();
+});
+
+test("color が無く group がある場合は group トークンを使う", () => {
+  const style = resolveLabelSwatchStyle({ name: "x", group: "type" });
+  const tokens = LabelRegistry.tokensForGroup("type");
+  expect(style.color).toBe(tokens.fg);
+  expect(style.backgroundColor).toBe(tokens.bg);
+  expect(style.borderColor).toBe(tokens.bd);
+});
+
+test("color/group が無い場合は name から解決する", () => {
+  const style = resolveLabelSwatchStyle({ name: "priority:high" });
+  const tokens = LabelRegistry.tokensForLabel("priority:high");
+  expect(style.color).toBe(tokens.fg);
+  expect(style.backgroundColor).toBe(tokens.bg);
+  expect(style.borderColor).toBe(tokens.bd);
+});

--- a/src/features/settings/lib/labelSettings/colorPresets.ts
+++ b/src/features/settings/lib/labelSettings/colorPresets.ts
@@ -1,0 +1,24 @@
+/** ラベル設定フォームのカラープリセット 1 件。 */
+export type LabelColorPreset = {
+  /** プリセット表示名 */
+  name: string;
+  /** `#RRGGBB` 値 */
+  hex: string;
+};
+
+/**
+ * ラベル設定フォームに並べる HEX プリセット 10 色（モック準拠）。
+ * label-registry の oklch グループ色とは別概念（混ぜない）。
+ */
+export const LABEL_COLOR_PRESETS: readonly LabelColorPreset[] = [
+  { name: "red", hex: "#d55753" },
+  { name: "orange", hex: "#d27830" },
+  { name: "yellow", hex: "#c4a032" },
+  { name: "green", hex: "#14874e" },
+  { name: "teal", hex: "#008e8e" },
+  { name: "blue", hex: "#007bb2" },
+  { name: "indigo", hex: "#466abf" },
+  { name: "purple", hex: "#7860b5" },
+  { name: "pink", hex: "#bf5ea2" },
+  { name: "gray", hex: "#79818d" },
+] as const;

--- a/src/features/settings/lib/labelSettings/derive.ts
+++ b/src/features/settings/lib/labelSettings/derive.ts
@@ -133,18 +133,21 @@ export const labelGroupCounts = (
   labels: readonly LabelDefinition[],
 ): { all: number; groups: { group: string; count: number }[] } => {
   const order: string[] = [];
-  const counts: Record<string, number> = {};
+  // accumulator は Map にする。group は frontmatter / name 由来で任意文字列のため、
+  // `__proto__` / `constructor` 等のプロトタイプキーが入っても継承プロパティと
+  // 衝突せず正しく数えるため。
+  const counts = new Map<string, number>();
   for (const label of labels) {
     const g = groupOf(label);
-    if (!(g in counts)) {
+    if (!counts.has(g)) {
       order.push(g);
-      counts[g] = 0;
+      counts.set(g, 0);
     }
-    counts[g] += 1;
+    counts.set(g, (counts.get(g) ?? 0) + 1);
   }
   return {
     all: labels.length,
-    groups: order.map((group) => ({ group, count: counts[group] })),
+    groups: order.map((group) => ({ group, count: counts.get(group) ?? 0 })),
   };
 };
 
@@ -161,17 +164,19 @@ export const labelColorTally = (
   usageCounts: Record<string, number>,
 ): { color: string; count: number }[] => {
   const order: string[] = [];
-  const counts: Record<string, number> = {};
+  // group fallback 経由でプロトタイプキー名が key になりうるため Map で集計する
+  // （labelGroupCounts と同じ理由）。
+  const counts = new Map<string, number>();
   for (const label of labels) {
     if ((usageCounts[label.name] ?? 0) <= 0) {
       continue;
     }
     const key = label.color ?? groupOf(label);
-    if (!(key in counts)) {
+    if (!counts.has(key)) {
       order.push(key);
-      counts[key] = 0;
+      counts.set(key, 0);
     }
-    counts[key] += 1;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
   }
-  return order.map((color) => ({ color, count: counts[color] }));
+  return order.map((color) => ({ color, count: counts.get(color) ?? 0 }));
 };

--- a/src/features/settings/lib/labelSettings/derive.ts
+++ b/src/features/settings/lib/labelSettings/derive.ts
@@ -1,0 +1,177 @@
+import { LabelRegistry } from "@/domains/label-registry";
+import type { LabelDefinition } from "@/lib/tauri";
+
+/** ソートキー。 */
+export type LabelSort = "name" | "usage" | "updated";
+
+/**
+ * グループフィルタ。実グループ名 "all" との衝突を避けるため判別可能 union にする
+ * （`"all" | string` だと実グループ名 "all" と区別不能）。
+ */
+export type LabelGroupFilter =
+  | { kind: "all" }
+  | { kind: "group"; value: string };
+
+/**
+ * ラベルが属するグループを返す（domain companion `LabelRegistry.effectiveGroup` へ委譲）。
+ * 「未指定 / 空文字 → name から導出」のルールを domain に集約することで、テーブルの
+ * バッジ表示・スワッチ色解決と一致させる（バッジ色とバッジ名の食い違いを防ぐ）。
+ * @param label - ラベル定義
+ * @returns グループ名
+ */
+const groupOf = (label: LabelDefinition): string =>
+  LabelRegistry.effectiveGroup(label);
+
+/**
+ * 検索キーワード（name / description 部分一致・大小無視）+ グループ絞り込み。
+ * `group.kind === "all"` は全グループ通過。
+ * @param labels - 全ラベル
+ * @param keyword - 検索キーワード
+ * @param group - グループフィルタ
+ * @returns 絞り込み後のラベル配列（元順）
+ */
+export const filterLabels = (
+  labels: readonly LabelDefinition[],
+  keyword: string,
+  group: LabelGroupFilter,
+): LabelDefinition[] => {
+  const kw = keyword.trim().toLowerCase();
+  return labels.filter((label) => {
+    if (group.kind === "group" && groupOf(label) !== group.value) {
+      return false;
+    }
+    if (kw === "") {
+      return true;
+    }
+    const hay = `${label.name}\n${label.description ?? ""}`.toLowerCase();
+    return hay.includes(kw);
+  });
+};
+
+/**
+ * ISO 文字列を Date.parse で数値タイムスタンプへ変換する。
+ * @param iso - 対象 ISO 文字列（undefined 可）
+ * @returns ミリ秒タイムスタンプ。undefined / パース不能なら null
+ */
+const parsedTime = (iso: string | undefined): number | null => {
+  if (iso === undefined) {
+    return null;
+  }
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+};
+
+/**
+ * ラベルを指定キーで並べ替える（安定）。
+ * - `name`: 昇順
+ * - `usage`: 使用数降順
+ * - `updated`: 新しい順。`updated` 無し / パース不能は末尾へ送る
+ * @param labels - 並べ替え対象
+ * @param sort - ソートキー
+ * @param usageCounts - 使用数（`usage` ソート時に使用）
+ * @returns 新しい配列
+ */
+export const sortLabels = (
+  labels: readonly LabelDefinition[],
+  sort: LabelSort,
+  usageCounts: Record<string, number>,
+): LabelDefinition[] => {
+  const indexed = labels.map((label, index) => ({ label, index }));
+  indexed.sort((a, b) => {
+    if (sort === "name") {
+      const cmp = a.label.name.localeCompare(b.label.name);
+      return cmp !== 0 ? cmp : a.index - b.index;
+    }
+    if (sort === "usage") {
+      const ua = usageCounts[a.label.name] ?? 0;
+      const ub = usageCounts[b.label.name] ?? 0;
+      return ub - ua !== 0 ? ub - ua : a.index - b.index;
+    }
+    // sort === "updated"
+    const ta = parsedTime(a.label.updated);
+    const tb = parsedTime(b.label.updated);
+    if (ta === null && tb === null) {
+      return a.index - b.index;
+    }
+    if (ta === null) {
+      return 1;
+    }
+    if (tb === null) {
+      return -1;
+    }
+    return tb - ta !== 0 ? tb - ta : a.index - b.index;
+  });
+  return indexed.map((e) => e.label);
+};
+
+/**
+ * 統計（総数 / 使用中数 / 未使用数）を算出する。
+ * @param labels - 集計対象
+ * @param usageCounts - 使用数（未定義キーは未使用扱い）
+ * @returns total/used/unused
+ */
+export const labelStats = (
+  labels: readonly LabelDefinition[],
+  usageCounts: Record<string, number>,
+): { total: number; used: number; unused: number } => {
+  let used = 0;
+  for (const label of labels) {
+    if ((usageCounts[label.name] ?? 0) > 0) {
+      used += 1;
+    }
+  }
+  return { total: labels.length, used, unused: labels.length - used };
+};
+
+/**
+ * グループ別件数を算出する（チップ UI 用）。
+ * 出現順序（初出順）でグループを並べる。
+ * @param labels - 集計対象
+ * @returns all + グループ別件数
+ */
+export const labelGroupCounts = (
+  labels: readonly LabelDefinition[],
+): { all: number; groups: { group: string; count: number }[] } => {
+  const order: string[] = [];
+  const counts: Record<string, number> = {};
+  for (const label of labels) {
+    const g = groupOf(label);
+    if (!(g in counts)) {
+      order.push(g);
+      counts[g] = 0;
+    }
+    counts[g] += 1;
+  }
+  return {
+    all: labels.length,
+    groups: order.map((group) => ({ group, count: counts[group] })),
+  };
+};
+
+/**
+ * 使用中ラベルのカラー集計（フッター用）。
+ * 色キーは color（`#RRGGBB`）優先、無ければ group（既定色との重複を避けるため）。
+ * 未使用ラベル（usageCounts 0 / 未定義）は除外する。
+ * @param labels - 集計対象
+ * @param usageCounts - 使用数
+ * @returns 色キー → 件数の配列（初出順）
+ */
+export const labelColorTally = (
+  labels: readonly LabelDefinition[],
+  usageCounts: Record<string, number>,
+): { color: string; count: number }[] => {
+  const order: string[] = [];
+  const counts: Record<string, number> = {};
+  for (const label of labels) {
+    if ((usageCounts[label.name] ?? 0) <= 0) {
+      continue;
+    }
+    const key = label.color ?? groupOf(label);
+    if (!(key in counts)) {
+      order.push(key);
+      counts[key] = 0;
+    }
+    counts[key] += 1;
+  }
+  return order.map((color) => ({ color, count: counts[color] }));
+};

--- a/src/features/settings/lib/labelSettings/swatch.ts
+++ b/src/features/settings/lib/labelSettings/swatch.ts
@@ -1,0 +1,29 @@
+import type { CSSProperties } from "react";
+import { LabelRegistry } from "@/domains/label-registry";
+import type { LabelDefinition } from "@/lib/tauri";
+
+/**
+ * ラベル 1 件のスワッチに適用する色スタイルを解決する。
+ * 優先順位は color（マスタ定義色） → effectiveGroup（group が非空ならそれ、空 or 未指定なら name の prefix）。
+ * color がある場合はその単色を背景に使い、無い場合は `LabelRegistry.effectiveGroup` で
+ * 解決したグループのトークン（fg/bg/bd）を適用する。CSS 変数は作らずインライン style に束ねる。
+ * group の空文字 / 空白扱いを `effectiveGroup` に集約することで、テーブルのバッジ表示・derive
+ * 集計と同じグループ判定を 1 箇所に統一する（バッジ色とバッジ名の食い違いを防ぐ）。
+ * @param label - ラベルマスタ定義 1 件
+ * @returns スワッチ要素へ束ねるインライン style
+ */
+export const resolveLabelSwatchStyle = (
+  label: LabelDefinition,
+): CSSProperties => {
+  if (label.color) {
+    return { backgroundColor: label.color };
+  }
+  const tokens = LabelRegistry.tokensForGroup(
+    LabelRegistry.effectiveGroup(label),
+  );
+  return {
+    color: tokens.fg,
+    backgroundColor: tokens.bg,
+    borderColor: tokens.bd,
+  };
+};

--- a/src/features/task-form/components/TaskForm/__tests__/TaskForm.interaction.test.tsx
+++ b/src/features/task-form/components/TaskForm/__tests__/TaskForm.interaction.test.tsx
@@ -24,7 +24,7 @@ let root: ReturnType<typeof createRoot> | null = null;
 beforeEach(() => {
   getLabelsMock.mockReset();
   // 既定はラベルマスタ 0 件（従来挙動 = 候補なし）。
-  getLabelsMock.mockResolvedValue(Result.ok({ labels: [] }));
+  getLabelsMock.mockResolvedValue(Result.ok({ labels: [], usageCounts: {} }));
 });
 
 afterEach(() => {
@@ -587,7 +587,10 @@ test("isSubmitting=true で下書きチェックボックスも無効化され�
 
 test("getLabels の候補が popover の option へ配線される（結合）", async () => {
   getLabelsMock.mockResolvedValue(
-    Result.ok({ labels: [{ name: "bug" }, { name: "feature" }] }),
+    Result.ok({
+      labels: [{ name: "bug" }, { name: "feature" }],
+      usageCounts: {},
+    }),
   );
   render({
     columns: COLUMNS,
@@ -633,7 +636,9 @@ test("getLabels が失敗しても popover は開き、新規作成のみ可能�
 });
 
 test("popover の option クリックでラベルが選択され trigger に表示される（結合）", async () => {
-  getLabelsMock.mockResolvedValue(Result.ok({ labels: [{ name: "bug" }] }));
+  getLabelsMock.mockResolvedValue(
+    Result.ok({ labels: [{ name: "bug" }], usageCounts: {} }),
+  );
   render({
     columns: COLUMNS,
     initialStatus: "Todo",

--- a/src/hooks/useLabelList/__tests__/useLabelList.interaction.test.tsx
+++ b/src/hooks/useLabelList/__tests__/useLabelList.interaction.test.tsx
@@ -104,7 +104,9 @@ const sampleLabels: LabelDefinition[] = [
 ];
 
 test("getLabels が ok(labels) を返すと最終 state が loaded(labels) になる", async () => {
-  getLabelsMock.mockResolvedValue(Result.ok({ labels: sampleLabels }));
+  getLabelsMock.mockResolvedValue(
+    Result.ok({ labels: sampleLabels, usageCounts: {} }),
+  );
   let latest: LabelListState | null = null;
   await mountProbe((r) => {
     latest = r;
@@ -113,7 +115,7 @@ test("getLabels が ok(labels) を返すと最終 state が loaded(labels) に�
 });
 
 test("getLabels が ok(labels:[]) を返すと loaded の空一覧になる（error ではない）", async () => {
-  getLabelsMock.mockResolvedValue(Result.ok({ labels: [] }));
+  getLabelsMock.mockResolvedValue(Result.ok({ labels: [], usageCounts: {} }));
   let latest: LabelListState | null = null;
   await mountProbe((r) => {
     latest = r;
@@ -153,7 +155,7 @@ test("取得 resolve 前にアンマウントしても setState 警告/例外が
   });
   root = null;
   await act(async () => {
-    resolveGetLabels?.(Result.ok({ labels: sampleLabels }));
+    resolveGetLabels?.(Result.ok({ labels: sampleLabels, usageCounts: {} }));
     await Promise.resolve();
   });
 

--- a/src/hooks/useLabels/__tests__/useLabels.interaction.test.tsx
+++ b/src/hooks/useLabels/__tests__/useLabels.interaction.test.tsx
@@ -1,0 +1,198 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { type LabelsResource, useLabels } from "@/hooks/useLabels";
+import { getLabels, TauriError } from "@/lib/tauri";
+import { Result } from "@/utils/result";
+
+vi.mock("@/lib/tauri", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/tauri")>("@/lib/tauri");
+  return {
+    ...actual,
+    getLabels: vi.fn(),
+  };
+});
+
+const getLabelsMock = vi.mocked(getLabels);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousIsReactActEnvironment: boolean | undefined;
+
+beforeAll(() => {
+  previousIsReactActEnvironment =
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT =
+    previousIsReactActEnvironment;
+});
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  getLabelsMock.mockReset();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const Probe = ({
+  projectKey,
+  onResult,
+}: {
+  projectKey: string | undefined;
+  onResult: (result: LabelsResource) => void;
+}) => {
+  const result = useLabels(projectKey);
+  useEffect(() => {
+    onResult(result);
+  });
+  return null;
+};
+
+const captured: { current: LabelsResource | null } = { current: null };
+
+const capture = (r: LabelsResource): void => {
+  captured.current = r;
+};
+
+const mount = async (
+  projectKey: string | undefined,
+): Promise<LabelsResource | null> => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(Probe, { projectKey, onResult: capture }));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return captured.current;
+};
+
+const rerender = async (
+  projectKey: string | undefined,
+): Promise<LabelsResource | null> => {
+  await act(async () => {
+    root?.render(createElement(Probe, { projectKey, onResult: capture }));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return captured.current;
+};
+
+test("projectKey が undefined のとき getLabels を呼ばず idle になる", async () => {
+  const latest = await mount(undefined);
+  expect(getLabelsMock).not.toHaveBeenCalled();
+  expect(latest?.status).toBe("idle");
+  expect(latest?.labels).toEqual([]);
+  expect(latest?.usageCounts).toEqual({});
+});
+
+test("初回取得で loaded になり labels / usageCounts / byName を保持する", async () => {
+  getLabelsMock.mockResolvedValue(
+    Result.ok({
+      labels: [{ name: "bug", group: "type" }],
+      usageCounts: { bug: 8 },
+    }),
+  );
+  const latest = await mount("proj-1");
+  expect(latest?.status).toBe("loaded");
+  expect(latest?.usageCounts).toEqual({ bug: 8 });
+  expect(latest?.byName.get("bug")?.group).toBe("type");
+});
+
+test("projectKey が変わると再取得する", async () => {
+  getLabelsMock.mockResolvedValue(Result.ok({ labels: [], usageCounts: {} }));
+  await mount("proj-1");
+  expect(getLabelsMock).toHaveBeenCalledTimes(1);
+  await rerender("proj-2");
+  expect(getLabelsMock).toHaveBeenCalledTimes(2);
+});
+
+test("reload() で再取得する", async () => {
+  getLabelsMock.mockResolvedValue(Result.ok({ labels: [], usageCounts: {} }));
+  const latest = await mount("proj-1");
+  expect(getLabelsMock).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    await latest?.reload();
+  });
+  expect(getLabelsMock).toHaveBeenCalledTimes(2);
+});
+
+test("getLabels が err を返すと status が error になる", async () => {
+  getLabelsMock.mockResolvedValue(Result.err(TauriError.from("取得失敗")));
+  const latest = await mount("proj-1");
+  expect(latest?.status).toBe("error");
+  expect(latest?.error).toBe("取得失敗");
+});
+
+type Deferred = {
+  promise: Promise<Awaited<ReturnType<typeof getLabels>>>;
+  resolve: (value: Awaited<ReturnType<typeof getLabels>>) => void;
+};
+
+const makeDeferred = (): Deferred => {
+  let resolve: Deferred["resolve"] = () => {};
+  const promise = new Promise<Awaited<ReturnType<typeof getLabels>>>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+test("同一 projectKey で初回ロードと reload が競合しても古い応答は新しい結果を上書きしない", async () => {
+  const deferreds: Deferred[] = [];
+  getLabelsMock.mockImplementation(() => {
+    const deferred = makeDeferred();
+    deferreds.push(deferred);
+    return deferred.promise;
+  });
+
+  const latest = await mount("proj-1");
+  expect(latest?.status).toBe("loading");
+
+  await act(async () => {
+    void latest?.reload();
+    await Promise.resolve();
+  });
+  expect(deferreds.length).toBe(2);
+
+  await act(async () => {
+    deferreds[1].resolve(
+      Result.ok({ labels: [{ name: "new" }], usageCounts: { new: 1 } }),
+    );
+    await Promise.resolve();
+  });
+
+  await act(async () => {
+    deferreds[0].resolve(
+      Result.ok({ labels: [{ name: "old" }], usageCounts: { old: 9 } }),
+    );
+    await Promise.resolve();
+  });
+
+  expect(captured.current?.labels).toEqual([{ name: "new" }]);
+  expect(captured.current?.usageCounts).toEqual({ new: 1 });
+});

--- a/src/hooks/useLabels/index.ts
+++ b/src/hooks/useLabels/index.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getLabels, type LabelDefinition } from "@/lib/tauri";
+
+/** ラベル定義リソースの取得状態。 */
+export type LabelsStatus = "idle" | "loading" | "loaded" | "error";
+
+/**
+ * 複数 feature（settings / 将来統合先）で共有するラベル定義リソース。
+ * settings 向けの取得点として使う。TaskForm は別途 `useLabelList` を使用する。
+ */
+export type LabelsResource = {
+  /** ラベル定義の配列（定義順）。idle / loading 中は空配列 */
+  labels: LabelDefinition[];
+  /** ラベル名 → 使用タスク件数（BE 由来。settings では App 側で live 上書き可能） */
+  usageCounts: Record<string, number>;
+  /** name → 定義の Map（テーブル / プレビューが引く） */
+  byName: Map<string, LabelDefinition>;
+  /** 取得状態 */
+  status: LabelsStatus;
+  /** error 状態時のメッセージ */
+  error?: string;
+  /** 設定 CRUD 成功後などに呼ぶ再取得関数 */
+  reload: () => Promise<void>;
+};
+
+type ResourceState = {
+  labels: LabelDefinition[];
+  usageCounts: Record<string, number>;
+  status: LabelsStatus;
+  error?: string;
+};
+
+const IDLE_STATE: ResourceState = {
+  labels: [],
+  usageCounts: {},
+  status: "idle",
+};
+
+/**
+ * ラベル定義配列を name キーの Map に変換する。
+ * @param labels - ラベル定義の配列
+ * @returns name → LabelDefinition の Map
+ */
+const buildByName = (
+  labels: readonly LabelDefinition[],
+): Map<string, LabelDefinition> =>
+  new Map(labels.map((label) => [label.name, label]));
+
+/**
+ * プロジェクト単位のラベル定義リソースを取得する feature 横断の共有フック。
+ *
+ * - projectKey が undefined（プロジェクト未オープン）のときは getLabels を呼ばず idle。
+ * - projectKey が変化したら再取得する（loading → loaded / error）。
+ * - in-flight 中に projectKey が変わった場合、古い応答は stale として破棄する。
+ * - reload() は現在の projectKey で再取得する（設定 CRUD 後に呼ぶ）。
+ *
+ * @param projectKey - 現在開いているプロジェクトの識別子（未オープンは undefined）
+ * @returns ラベル定義リソース
+ */
+export const useLabels = (projectKey: string | undefined): LabelsResource => {
+  const [state, setState] = useState<ResourceState>(IDLE_STATE);
+  // 各 load 呼び出しに採番する世代 id。最新世代の応答だけが state を確定する。
+  // 同一 projectKey の重複ロード（初回 + reload）で古い応答が後勝ちしないよう
+  // key 比較ではなく世代 id で stale 応答を破棄する。
+  const requestIdRef = useRef(0);
+
+  const load = useCallback(async (key: string | undefined): Promise<void> => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    if (key === undefined) {
+      setState(IDLE_STATE);
+      return;
+    }
+    // loading 開始時は前回値を残さずクリアする（projectKey 変更 / reload 時の stale 表示防止）。
+    setState({ labels: [], usageCounts: {}, status: "loading" });
+    const result = await getLabels();
+    // この応答より後に開始された load があれば（key 同一でも）古い応答として捨てる。
+    if (requestIdRef.current !== requestId) {
+      return;
+    }
+    if (result.ok) {
+      setState({
+        labels: result.value.labels,
+        usageCounts: result.value.usageCounts,
+        status: "loaded",
+      });
+      return;
+    }
+    setState({
+      labels: [],
+      usageCounts: {},
+      status: "error",
+      error: result.error.message,
+    });
+  }, []);
+
+  useEffect(() => {
+    void load(projectKey);
+    // unmount / 依存変更時に世代 id を進め、解決済みでない in-flight 応答を
+    // stale として破棄する（unmount 後の setState を防ぐ）。
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [load, projectKey]);
+
+  const reload = useCallback((): Promise<void> => {
+    return load(projectKey);
+  }, [load, projectKey]);
+
+  const byName = useMemo(() => buildByName(state.labels), [state.labels]);
+
+  return useMemo(
+    () => ({
+      labels: state.labels,
+      usageCounts: state.usageCounts,
+      byName,
+      status: state.status,
+      error: state.error,
+      reload,
+    }),
+    [
+      state.labels,
+      state.usageCounts,
+      byName,
+      state.status,
+      state.error,
+      reload,
+    ],
+  );
+};

--- a/src/lib/tauri/dialog/saveFileDialog/__tests__/saveFileDialog.behavior.test.ts
+++ b/src/lib/tauri/dialog/saveFileDialog/__tests__/saveFileDialog.behavior.test.ts
@@ -1,0 +1,43 @@
+import { save } from "@tauri-apps/plugin-dialog";
+import { beforeEach, expect, test, vi } from "vitest";
+import { saveFileDialog } from "@/lib/tauri";
+import { TauriError } from "@/lib/tauri/tauriError";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ save: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(save).mockReset();
+});
+
+test("保存先が選ばれた場合は Result.ok(path) を返す", async () => {
+  vi.mocked(save).mockResolvedValue("/tmp/labels.yml");
+  const res = await saveFileDialog({
+    defaultPath: "labels.yml",
+    filters: [{ name: "YAML", extensions: ["yml", "yaml"] }],
+  });
+  expect(res).toEqual({ ok: true, value: "/tmp/labels.yml" });
+});
+
+test("キャンセル時は Result.ok(null) を返す", async () => {
+  vi.mocked(save).mockResolvedValue(null);
+  const res = await saveFileDialog();
+  expect(res).toEqual({ ok: true, value: null });
+});
+
+test("save() が例外を投げると Result.err(TauriError) を返す", async () => {
+  vi.mocked(save).mockRejectedValue(new Error("dialog plugin failure"));
+  const res = await saveFileDialog();
+  expect(res.ok).toBe(false);
+  expect((res as { ok: false; error: unknown }).error).toBeInstanceOf(
+    TauriError,
+  );
+});
+
+test("オプション無し呼び出しは defaultPath/filters undefined で save() へ透過される", async () => {
+  vi.mocked(save).mockResolvedValue(null);
+  await saveFileDialog();
+  expect(save).toHaveBeenCalledWith({
+    defaultPath: undefined,
+    filters: undefined,
+  });
+});

--- a/src/lib/tauri/dialog/saveFileDialog/index.ts
+++ b/src/lib/tauri/dialog/saveFileDialog/index.ts
@@ -1,0 +1,51 @@
+import { save } from "@tauri-apps/plugin-dialog";
+import { TauriError } from "@/lib/tauri/tauriError";
+import { Result, type Result as ResultT } from "@/utils/result";
+
+/** save() に渡すフィルタ条件（拡張子による絞り込み）。 */
+export type SaveFileDialogFilter = {
+  /** filter の表示名 */
+  name: string;
+  /** 受理する拡張子の配列（ドット無し） */
+  extensions: string[];
+};
+
+/**
+ * saveFileDialog の呼び出しオプション。
+ * `@tauri-apps/plugin-dialog` の `save()` にそのまま透過するため、
+ * 値の解釈は plugin の挙動に従う。
+ */
+export type SaveFileDialogOptions = {
+  /**
+   * ダイアログ初期表示の既定ファイル名 or パス。
+   * 相対のファイル名（例: `"labels.yml"`）を渡すと OS の「最後に使った保存先」を
+   * ベースに表示される。絶対パスを渡すとそのディレクトリ/ファイル名がプリセットされる。
+   */
+  defaultPath?: string;
+  /** ファイルタイプフィルタ（拡張子による絞り込み）。 */
+  filters?: SaveFileDialogFilter[];
+};
+
+/**
+ * OS のファイル保存 dialog を開いて保存先パスを取得する。
+ * - 選択された: Result.ok(path)
+ * - キャンセル: Result.ok(null)
+ * - dialog plugin 例外: Result.err(TauriError)
+ *
+ * 書き込み自体は行わず、選択結果のみを返す。実書き込みは後段（BE `export_labels` 等）に委ねる。
+ * @param opts - 既定パス・拡張子フィルタなどのオプション
+ * @returns 成否を表す Result
+ */
+export const saveFileDialog = async (
+  opts: SaveFileDialogOptions = {},
+): Promise<ResultT<string | null, TauriError>> => {
+  try {
+    const selected = await save({
+      defaultPath: opts.defaultPath,
+      filters: opts.filters,
+    });
+    return Result.ok(typeof selected === "string" ? selected : null);
+  } catch (e) {
+    return Result.err(TauriError.from(e));
+  }
+};

--- a/src/lib/tauri/index.ts
+++ b/src/lib/tauri/index.ts
@@ -11,12 +11,21 @@ export type {
 export { updateColumns } from "./columnCommands/updateColumns";
 // dialog
 export { openDirectoryDialog } from "./dialog/openDirectoryDialog";
+export { saveFileDialog } from "./dialog/saveFileDialog";
 // labelCommands
+export { createLabel } from "./labelCommands/createLabel";
+export { deleteLabel } from "./labelCommands/deleteLabel";
+export { exportLabels } from "./labelCommands/exportLabels";
 export { getLabels } from "./labelCommands/getLabels";
 export type {
+  CreateLabelArgs,
+  DeleteLabelPayload,
+  ExportLabelsArgs,
   GetLabelsPayload,
   LabelDefinition,
+  UpdateLabelArgs,
 } from "./labelCommands/types";
+export { updateLabel } from "./labelCommands/updateLabel";
 // linkCommands
 export { addLink } from "./linkCommands/addLink";
 export { removeLink } from "./linkCommands/removeLink";

--- a/src/lib/tauri/labelCommands/createLabel/__tests__/createLabel.behavior.test.ts
+++ b/src/lib/tauri/labelCommands/createLabel/__tests__/createLabel.behavior.test.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, expect, test, vi } from "vitest";
+import { createLabel } from "@/lib/tauri";
+import { TauriError } from "@/lib/tauri/tauriError";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+});
+
+test("invoke が 'create_label' という command 名 + {args} payload で呼ばれる", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  await createLabel({ name: "needs-design", group: "status" });
+  expect(vi.mocked(invoke)).toHaveBeenCalledWith("create_label", {
+    args: { name: "needs-design", group: "status" },
+  });
+});
+
+test("成功時は Result.ok(undefined) を返し value まで透過される", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  const res = await createLabel({ name: "needs-design" });
+  expect(res).toEqual({ ok: true, value: undefined });
+});
+
+test("invoke が reject すると Result.err(TauriError) を返す", async () => {
+  vi.mocked(invoke).mockRejectedValue(new Error("fail"));
+  const res = await createLabel({ name: "needs-design" });
+  expect(res.ok).toBe(false);
+  expect((res as { ok: false; error: unknown }).error).toBeInstanceOf(
+    TauriError,
+  );
+});

--- a/src/lib/tauri/labelCommands/createLabel/index.ts
+++ b/src/lib/tauri/labelCommands/createLabel/index.ts
@@ -1,0 +1,15 @@
+import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
+import type { TauriError } from "@/lib/tauri/tauriError";
+import type { Result } from "@/utils/result";
+import type { CreateLabelArgs } from "../types";
+
+/**
+ * 新しいラベルを labels.yml に追記する。
+ * 失敗時は書き込み失敗トースト（mutation 通知）の対象。
+ * @param args 作成するラベルの属性
+ * @returns 成功時は Result.ok(undefined)、失敗時は Result.err(TauriError)
+ */
+export const createLabel = (
+  args: CreateLabelArgs,
+): Promise<Result<void, TauriError>> =>
+  invokeWrapped<void>("create_label", { args });

--- a/src/lib/tauri/labelCommands/deleteLabel/__tests__/deleteLabel.behavior.test.ts
+++ b/src/lib/tauri/labelCommands/deleteLabel/__tests__/deleteLabel.behavior.test.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, expect, test, vi } from "vitest";
+import { deleteLabel } from "@/lib/tauri";
+import { TauriError } from "@/lib/tauri/tauriError";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+});
+
+test("invoke が 'delete_label' という command 名 + {args:{name}} payload で呼ばれる", async () => {
+  vi.mocked(invoke).mockResolvedValue({ usageCount: 0 });
+  await deleteLabel("bug");
+  expect(vi.mocked(invoke)).toHaveBeenCalledWith("delete_label", {
+    args: { name: "bug" },
+  });
+});
+
+test("成功時は usageCount を Result.ok で返す", async () => {
+  vi.mocked(invoke).mockResolvedValue({ usageCount: 8 });
+  const res = await deleteLabel("bug");
+  expect(res).toEqual({ ok: true, value: { usageCount: 8 } });
+});
+
+test("invoke が reject すると Result.err(TauriError) を返す", async () => {
+  vi.mocked(invoke).mockRejectedValue(new Error("fail"));
+  const res = await deleteLabel("bug");
+  expect(res.ok).toBe(false);
+  expect((res as { ok: false; error: unknown }).error).toBeInstanceOf(
+    TauriError,
+  );
+});

--- a/src/lib/tauri/labelCommands/deleteLabel/index.ts
+++ b/src/lib/tauri/labelCommands/deleteLabel/index.ts
@@ -1,0 +1,16 @@
+import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
+import type { TauriError } from "@/lib/tauri/tauriError";
+import type { Result } from "@/utils/result";
+import type { DeleteLabelPayload } from "../types";
+
+/**
+ * 指定 name のラベルを削除する。削除前の使用タスク件数を返す。
+ * タスク frontmatter の labels 値は変更しない（非破壊）。
+ * 失敗時は書き込み失敗トースト（mutation 通知）の対象。
+ * @param name 削除対象ラベルの name
+ * @returns 成功時は Result.ok({usageCount})、失敗時は Result.err(TauriError)
+ */
+export const deleteLabel = (
+  name: string,
+): Promise<Result<DeleteLabelPayload, TauriError>> =>
+  invokeWrapped<DeleteLabelPayload>("delete_label", { args: { name } });

--- a/src/lib/tauri/labelCommands/exportLabels/__tests__/exportLabels.behavior.test.ts
+++ b/src/lib/tauri/labelCommands/exportLabels/__tests__/exportLabels.behavior.test.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, expect, test, vi } from "vitest";
+import { exportLabels } from "@/lib/tauri";
+import { TauriError } from "@/lib/tauri/tauriError";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+});
+
+test("invoke が 'export_labels' という command 名 + {args:{path}} payload で呼ばれる", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  await exportLabels({ path: "/tmp/labels.yml" });
+  expect(vi.mocked(invoke)).toHaveBeenCalledWith("export_labels", {
+    args: { path: "/tmp/labels.yml" },
+  });
+});
+
+test("成功時は Result.ok(undefined) を返し value まで透過される", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  const res = await exportLabels({ path: "/tmp/labels.yml" });
+  expect(res).toEqual({ ok: true, value: undefined });
+});
+
+test("invoke が reject すると Result.err(TauriError) を返す", async () => {
+  vi.mocked(invoke).mockRejectedValue(new Error("fail"));
+  const res = await exportLabels({ path: "/tmp/labels.yml" });
+  expect(res.ok).toBe(false);
+  expect((res as { ok: false; error: unknown }).error).toBeInstanceOf(
+    TauriError,
+  );
+});

--- a/src/lib/tauri/labelCommands/exportLabels/index.ts
+++ b/src/lib/tauri/labelCommands/exportLabels/index.ts
@@ -1,0 +1,16 @@
+import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
+import type { TauriError } from "@/lib/tauri/tauriError";
+import type { Result } from "@/utils/result";
+import type { ExportLabelsArgs } from "../types";
+
+/**
+ * 現在のラベルマスタを指定パスへ labels.yml 形式で書き出す。
+ * BE が `serde_yaml_ng::to_string` で直列化するため store と同一形式になる。
+ * 失敗時は書き込み失敗トースト（mutation 通知）の対象。
+ * @param args 保存先パス
+ * @returns 成功時は Result.ok(undefined)、失敗時は Result.err(TauriError)
+ */
+export const exportLabels = (
+  args: ExportLabelsArgs,
+): Promise<Result<void, TauriError>> =>
+  invokeWrapped<void>("export_labels", { args });

--- a/src/lib/tauri/labelCommands/getLabels/__tests__/getLabels.behavior.test.ts
+++ b/src/lib/tauri/labelCommands/getLabels/__tests__/getLabels.behavior.test.ts
@@ -16,24 +16,31 @@ beforeEach(() => {
 });
 
 test("invoke が 'get_labels' という command 名で呼ばれる", async () => {
-  vi.mocked(invoke).mockResolvedValue({ labels: [] });
+  vi.mocked(invoke).mockResolvedValue({ labels: [], usageCounts: {} });
   await getLabels();
   expect(vi.mocked(invoke).mock.calls[0]?.[0]).toBe("get_labels");
 });
 
 test("invoke 第 2 引数（payload）は undefined で呼ばれる", async () => {
-  vi.mocked(invoke).mockResolvedValue({ labels: [] });
+  vi.mocked(invoke).mockResolvedValue({ labels: [], usageCounts: {} });
   await getLabels();
   expect(vi.mocked(invoke).mock.calls[0]?.[1]).toBeUndefined();
 });
 
-test("成功時は Result.ok({labels}) を返し定義順を保持する", async () => {
-  vi.mocked(invoke).mockResolvedValue({ labels: labelsFixture });
+test("成功時は Result.ok({labels, usageCounts}) を返し定義順を保持する", async () => {
+  const usageCounts = { bug: 8 };
+  vi.mocked(invoke).mockResolvedValue({
+    labels: labelsFixture,
+    usageCounts,
+  });
   const res = await getLabels();
   // labels.yml 定義順（bug → enhancement）がそのまま payload に保持される
   expect(res).toEqual({
     ok: true,
-    value: { labels: [{ ...labelsFixture[0] }, { ...labelsFixture[1] }] },
+    value: {
+      labels: [{ ...labelsFixture[0] }, { ...labelsFixture[1] }],
+      usageCounts,
+    },
   });
 });
 

--- a/src/lib/tauri/labelCommands/types.ts
+++ b/src/lib/tauri/labelCommands/types.ts
@@ -12,8 +12,40 @@ export type LabelDefinition = {
   updated?: string;
 };
 
-/** get_labels 戻り値ペイロード。`labels` は labels.yml の定義順を保持する。 */
+/**
+ * get_labels 戻り値ペイロード。`labels` は labels.yml の定義順を保持する。
+ * `usageCounts` を含める（labels で起きた型ドリフトを繰り返さない）。
+ */
 export type GetLabelsPayload = {
   /** ラベル定義の配列（定義順） */
   labels: LabelDefinition[];
+  /** ラベル名 → 使用タスク件数（タスク単位で重複排除） */
+  usageCounts: Record<string, number>;
+};
+
+/** create_label 引数。BE は空 group → None / 不正 HEX → 既定色 へ lenient 変換する。 */
+export type CreateLabelArgs = {
+  /** ラベル識別子（必須） */
+  name: string;
+  /** 説明文（任意） */
+  description?: string;
+  /** グループ名（任意） */
+  group?: string;
+  /** `#RRGGBB`。不正・空は送ってよい（BE が既定色へ倒す） */
+  color?: string;
+};
+
+/** update_label 引数。PUT セマンティクス（name は rename しない・未指定はクリア）。 */
+export type UpdateLabelArgs = CreateLabelArgs;
+
+/** delete_label 戻り値ペイロード。削除前の使用タスク件数を返す。 */
+export type DeleteLabelPayload = {
+  /** 削除前に算出した使用タスク件数 */
+  usageCount: number;
+};
+
+/** export_labels 引数。保存先パス（ユーザーが save ダイアログで選択する）。 */
+export type ExportLabelsArgs = {
+  /** labels.yml の書き出し先パス */
+  path: string;
 };

--- a/src/lib/tauri/labelCommands/updateLabel/__tests__/updateLabel.behavior.test.ts
+++ b/src/lib/tauri/labelCommands/updateLabel/__tests__/updateLabel.behavior.test.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, expect, test, vi } from "vitest";
+import { updateLabel } from "@/lib/tauri";
+import { TauriError } from "@/lib/tauri/tauriError";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+});
+
+test("invoke が 'update_label' という command 名 + {args} payload で呼ばれる", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  await updateLabel({ name: "bug", color: "#d55753" });
+  expect(vi.mocked(invoke)).toHaveBeenCalledWith("update_label", {
+    args: { name: "bug", color: "#d55753" },
+  });
+});
+
+test("成功時は Result.ok(undefined) を返し value まで透過される", async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  const res = await updateLabel({ name: "bug" });
+  expect(res).toEqual({ ok: true, value: undefined });
+});
+
+test("invoke が reject すると Result.err(TauriError) を返す", async () => {
+  vi.mocked(invoke).mockRejectedValue(new Error("fail"));
+  const res = await updateLabel({ name: "bug" });
+  expect(res.ok).toBe(false);
+  expect((res as { ok: false; error: unknown }).error).toBeInstanceOf(
+    TauriError,
+  );
+});

--- a/src/lib/tauri/labelCommands/updateLabel/index.ts
+++ b/src/lib/tauri/labelCommands/updateLabel/index.ts
@@ -1,0 +1,15 @@
+import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
+import type { TauriError } from "@/lib/tauri/tauriError";
+import type { Result } from "@/utils/result";
+import type { UpdateLabelArgs } from "../types";
+
+/**
+ * 既存ラベルの metadata を更新する（PUT セマンティクス・name は rename しない）。
+ * 失敗時は書き込み失敗トースト（mutation 通知）の対象。
+ * @param args 更新内容（全フィールド・未指定はクリア）
+ * @returns 成功時は Result.ok(undefined)、失敗時は Result.err(TauriError)
+ */
+export const updateLabel = (
+  args: UpdateLabelArgs,
+): Promise<Result<void, TauriError>> =>
+  invokeWrapped<void>("update_label", { args });

--- a/src/lib/tauri/mutationFailureMessage/index.ts
+++ b/src/lib/tauri/mutationFailureMessage/index.ts
@@ -24,6 +24,10 @@ const MUTATION_COMMAND_LABELS = {
   create_milestone: "マイルストーンの作成",
   update_milestone: "マイルストーンの更新",
   delete_milestone: "マイルストーンの削除",
+  create_label: "ラベルの作成",
+  update_label: "ラベルの更新",
+  delete_label: "ラベルの削除",
+  export_labels: "ラベルのエクスポート",
 } as const satisfies Record<string, string>;
 
 /** 書き込み allowlist に含まれるコマンド名の union 型（テーブルのキーが source of truth）。 */

--- a/src/utils/relativeTime/__tests__/relativeTime.behavior.test.ts
+++ b/src/utils/relativeTime/__tests__/relativeTime.behavior.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "vitest";
+import { formatRelativeTime } from "@/utils/relativeTime";
+
+const NOW = new Date("2026-06-16T12:00:00Z");
+
+test("1 分未満は『たった今』を返す", () => {
+  const iso = new Date(NOW.getTime() - 30_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("たった今");
+});
+
+test("N 分前を返す", () => {
+  const iso = new Date(NOW.getTime() - 5 * 60_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("5分前");
+});
+
+test("N 時間前を返す", () => {
+  const iso = new Date(NOW.getTime() - 3 * 60 * 60_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("3時間前");
+});
+
+test("1 日前は『昨日』を返す", () => {
+  const iso = new Date(NOW.getTime() - 24 * 60 * 60_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("昨日");
+});
+
+test("N 日前（2〜6 日）を返す", () => {
+  const iso = new Date(NOW.getTime() - 5 * 24 * 60 * 60_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("5日前");
+});
+
+test("7 日以上 30 日未満は『N週間前』を返す", () => {
+  const iso = new Date(NOW.getTime() - 14 * 24 * 60 * 60_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("2週間前");
+});
+
+test("30 日以上は『Nヶ月前』を返す", () => {
+  const iso = new Date(NOW.getTime() - 35 * 24 * 60 * 60_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("1ヶ月前");
+});
+
+test("365 日以上は YYYY/MM/DD 表記を返す", () => {
+  const iso = new Date("2024-01-15T00:00:00Z").toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("2024/01/15");
+});
+
+test("パース不能な文字列はそのまま返す（lenient）", () => {
+  expect(formatRelativeTime("not-a-date", NOW)).toBe("not-a-date");
+});
+
+test("未来の時刻も『たった今』として扱う（小さな時計ずれ吸収）", () => {
+  const iso = new Date(NOW.getTime() + 10_000).toISOString();
+  expect(formatRelativeTime(iso, NOW)).toBe("たった今");
+});

--- a/src/utils/relativeTime/__tests__/relativeTime.behavior.test.ts
+++ b/src/utils/relativeTime/__tests__/relativeTime.behavior.test.ts
@@ -51,3 +51,18 @@ test("未来の時刻も『たった今』として扱う（小さな時計ず�
   const iso = new Date(NOW.getTime() + 10_000).toISOString();
   expect(formatRelativeTime(iso, NOW)).toBe("たった今");
 });
+
+test("許容時計ずれ（1 分）を超える未来は YYYY/MM/DD 表記へフォールバック", () => {
+  // 2 分先の未来 → 時計ずれの範囲を超えているので「たった今」では隠さない
+  const minutesAhead = new Date(NOW.getTime() + 2 * 60_000).toISOString();
+  expect(formatRelativeTime(minutesAhead, NOW)).not.toBe("たった今");
+  // 数日先 / 数年先も日付表記で返ること
+  const daysAhead = new Date(NOW.getTime() + 5 * 24 * 60 * 60 * 1000);
+  expect(formatRelativeTime(daysAhead.toISOString(), NOW)).toMatch(
+    /^\d{4}\/\d{2}\/\d{2}$/,
+  );
+  const yearsAhead = new Date(NOW.getTime() + 365 * 24 * 60 * 60 * 1000 * 3);
+  expect(formatRelativeTime(yearsAhead.toISOString(), NOW)).toMatch(
+    /^\d{4}\/\d{2}\/\d{2}$/,
+  );
+});

--- a/src/utils/relativeTime/index.ts
+++ b/src/utils/relativeTime/index.ts
@@ -35,7 +35,11 @@ export const formatRelativeTime = (
     return iso;
   }
   const diff = now.getTime() - target.getTime();
-  // 未来の時刻 / ごく直近は「たった今」に丸める（小さな時計ずれを吸収）。
+  // 1 分以上先の未来は時計ずれでは説明できない異常値として扱い、日付表記で
+  // 隠さず提示する。許容範囲（過去 1 分以内 + 同程度の時計ずれ）は「たった今」に丸める。
+  if (diff < -MS_PER_MINUTE) {
+    return toYmd(target);
+  }
   if (diff < MS_PER_MINUTE) {
     return "たった今";
   }

--- a/src/utils/relativeTime/index.ts
+++ b/src/utils/relativeTime/index.ts
@@ -1,10 +1,10 @@
-const SECONDS = 1000;
-const MINUTES = 60 * SECONDS;
-const HOURS = 60 * MINUTES;
-const DAYS = 24 * HOURS;
-const WEEKS = 7 * DAYS;
-const MONTHS = 30 * DAYS;
-const YEARS = 365 * DAYS;
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+const MS_PER_MONTH = 30 * MS_PER_DAY;
+const MS_PER_YEAR = 365 * MS_PER_DAY;
 
 /**
  * Date を YYYY/MM/DD 表記へ整形する（タイムゾーンは ISO の UTC 起点）。
@@ -36,26 +36,26 @@ export const formatRelativeTime = (
   }
   const diff = now.getTime() - target.getTime();
   // 未来の時刻 / ごく直近は「たった今」に丸める（小さな時計ずれを吸収）。
-  if (diff < MINUTES) {
+  if (diff < MS_PER_MINUTE) {
     return "たった今";
   }
-  if (diff < HOURS) {
-    return `${Math.floor(diff / MINUTES)}分前`;
+  if (diff < MS_PER_HOUR) {
+    return `${Math.floor(diff / MS_PER_MINUTE)}分前`;
   }
-  if (diff < DAYS) {
-    return `${Math.floor(diff / HOURS)}時間前`;
+  if (diff < MS_PER_DAY) {
+    return `${Math.floor(diff / MS_PER_HOUR)}時間前`;
   }
-  if (diff < 2 * DAYS) {
+  if (diff < 2 * MS_PER_DAY) {
     return "昨日";
   }
-  if (diff < WEEKS) {
-    return `${Math.floor(diff / DAYS)}日前`;
+  if (diff < MS_PER_WEEK) {
+    return `${Math.floor(diff / MS_PER_DAY)}日前`;
   }
-  if (diff < MONTHS) {
-    return `${Math.floor(diff / WEEKS)}週間前`;
+  if (diff < MS_PER_MONTH) {
+    return `${Math.floor(diff / MS_PER_WEEK)}週間前`;
   }
-  if (diff < YEARS) {
-    return `${Math.floor(diff / MONTHS)}ヶ月前`;
+  if (diff < MS_PER_YEAR) {
+    return `${Math.floor(diff / MS_PER_MONTH)}ヶ月前`;
   }
   return toYmd(target);
 };

--- a/src/utils/relativeTime/index.ts
+++ b/src/utils/relativeTime/index.ts
@@ -1,0 +1,61 @@
+const SECONDS = 1000;
+const MINUTES = 60 * SECONDS;
+const HOURS = 60 * MINUTES;
+const DAYS = 24 * HOURS;
+const WEEKS = 7 * DAYS;
+const MONTHS = 30 * DAYS;
+const YEARS = 365 * DAYS;
+
+/**
+ * Date を YYYY/MM/DD 表記へ整形する（タイムゾーンは ISO の UTC 起点）。
+ * @param d - 整形対象の Date
+ * @returns YYYY/MM/DD 文字列
+ */
+const toYmd = (d: Date): string => {
+  const yyyy = String(d.getUTCFullYear()).padStart(4, "0");
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${yyyy}/${mm}/${dd}`;
+};
+
+/**
+ * ISO 文字列を「たった今 / N 分前 / N 時間前 / 昨日 / N 日前 / N週間前 / Nヶ月前 / YYYY/MM/DD」へ整形する。
+ * パース不能は元文字列をそのまま返す（lenient）。基準時刻は引数注入でテスト可能にする。
+ *
+ * @param iso - 対象時刻（ISO 8601 文字列）
+ * @param now - 基準時刻。省略時は現在時刻。
+ * @returns 整形済み相対時刻表記
+ */
+export const formatRelativeTime = (
+  iso: string,
+  now: Date = new Date(),
+): string => {
+  const target = new Date(iso);
+  if (Number.isNaN(target.getTime())) {
+    return iso;
+  }
+  const diff = now.getTime() - target.getTime();
+  // 未来の時刻 / ごく直近は「たった今」に丸める（小さな時計ずれを吸収）。
+  if (diff < MINUTES) {
+    return "たった今";
+  }
+  if (diff < HOURS) {
+    return `${Math.floor(diff / MINUTES)}分前`;
+  }
+  if (diff < DAYS) {
+    return `${Math.floor(diff / HOURS)}時間前`;
+  }
+  if (diff < 2 * DAYS) {
+    return "昨日";
+  }
+  if (diff < WEEKS) {
+    return `${Math.floor(diff / DAYS)}日前`;
+  }
+  if (diff < MONTHS) {
+    return `${Math.floor(diff / WEEKS)}週間前`;
+  }
+  if (diff < YEARS) {
+    return `${Math.floor(diff / MONTHS)}ヶ月前`;
+  }
+  return toYmd(target);
+};


### PR DESCRIPTION
## 概要
ラベル設定タブ `LabelSettingsTab` をモック `docs/design/ラベル設定 (standalone).html` に合わせて再構築し、ラベル CRUD UX をミルストーン設定パターンと揃える。あわせて BE に `export_labels` Tauri command を追加し、ラベル設定画面の「使用数」リンクからボード画面のラベル絞り込みへ遷移する経路を整備する。

## 変更の種類
- 🎨 UI/UX: ラベル設定タブ全面リデザイン
- ✨ New Feature: `export_labels` command / `useLabels` / `LabelRegistry.labelUsageCounts` 等
- 🧪 Tests: 既存テストの payload 互換修正

## 追加した内容
- **BE**
  - `config::export_labels::export_labels` Tauri command（`labels.yml` を任意パスに保存）
- **FE — `src/lib/tauri/`**
  - `createLabel` / `updateLabel` / `deleteLabel` / `exportLabels` invoke ラッパ
  - `dialog/saveFileDialog`（OS の保存ダイアログ）
- **FE — `src/domains/` / 共通**
  - `LabelRegistry.labelUsageCounts` / `LabelRegistry.effectiveGroup` companion
  - `hooks/useLabels`（世代 ID で stale request を棄却する `LabelsResource`）
  - `utils/relativeTime`（「たった今 / N分前 / 昨日 / N日前 / N週間前 / Nヶ月前 / YYYY/MM/DD」）
- **FE — `src/features/settings/`**
  - `LabelSettingsTab` 配下に 5 サブコンポーネント（`CreateLabelForm` / `LabelStatsHeader` / `LabelFilterBar` / `LabelTable` / `LabelFooterTally`）
  - `hooks/useLabelMutations`（in-flight ガード付き CRUD）
  - `lib/labelSettings/`（color presets / swatch / derive: filter・sort・stats）
  - Storybook story（Default / Loaded / Empty / Loading / Error）

## 変更した内容
- **GetLabelsPayload** に `usageCounts: Record<string, number>` を追加。get_labels の応答が必須キーを 1 つ増やす（FE 内のみ）
- **mutationFailureMessage** の allowlist に `create_label` / `update_label` / `delete_label` / `export_labels` を追加し、共通エラー toast の対象に含める
- **BoardWorkspace** に `initialLabelFilter` / `onLabelFilterApplied` prop を追加。mount-once `useEffect` で seed → クリアを ref 経由で安全に処理（stale closure 防止）
- **useTaskFilter** に `init.initialLabels` を追加し、初期ラベル絞り込みを seed 可能に
- **App.tsx** に `pendingLabelFilter` state を導入し、ラベル設定 → ボードへの導線を結線
- **SettingsScreen** が `labels` resource と `onLabelUsageClick` を受け取れるよう prop を拡張

## 削除した内容
なし

## 仕様ドキュメント更新
- `docs/spec-board/config-spec.md`: `export_labels` command と labels.yml の保存先（任意パス）に関する記述を追記

## システム図

\`\`\`mermaid
flowchart LR
  subgraph Settings[Settings 画面]
    LST[LabelSettingsTab]
    CLF[CreateLabelForm]
    LFB[LabelFilterBar]
    LT[LabelTable]
    LST --> CLF
    LST --> LFB
    LST --> LT
  end

  subgraph Hooks[hooks]
    UL[useLabels<br/>+ usageCounts]
    ULM[useLabelMutations]
  end

  subgraph LibTauri[lib/tauri]
    CL[createLabel]
    UpL[updateLabel]
    DL[deleteLabel]
    EL["exportLabels<br/>NEW"]
    SFD["saveFileDialog<br/>NEW"]
  end

  subgraph BE[src-tauri]
    BEEXP["config::export_labels<br/>NEW"]
  end

  LST --> UL
  LST --> ULM
  ULM --> CL
  ULM --> UpL
  ULM --> DL
  LST -- エクスポート --> SFD
  LST -- パス確定 --> EL
  EL --> BEEXP

  LST -- 使用数クリック --> App[App.pendingLabelFilter]
  App -- initialLabelFilter --> BW[BoardWorkspace]
  BW --> UTF[useTaskFilter]

  style EL fill:#fff4d6,stroke:#d4a017
  style SFD fill:#fff4d6,stroke:#d4a017
  style BEEXP fill:#fff4d6,stroke:#d4a017
\`\`\`

## 関連Issue
Refs #010 (spec: 010-label-settings-design-alignment)

## テスト
- \`pnpm test:run --exclude '**/.claude/**'\`: 257 ファイル / 2180 テスト 全通過
- \`cargo test\`（src-tauri / spec-board-fs）: 全通過（1016 件、`export_labels` 6 件含む）
- \`pnpm build\`: TypeScript + Vite ビルド成功
- Biome / oxlint: 警告なし
- UI 確認: Storybook + playwright-cli でモック `docs/design/ラベル設定 (standalone).html` と並べて目視一致確認
  - カラーチップ 32×32、HEX 入力（# 分離）、プリセット 10 色 swatches、ソート 3-tab pill、検索 🔍 アイコン、編集（鉛筆）/ 削除（ゴミ箱）アイコン（行ホバー表示）

## レビューポイント
1. **BoardWorkspace の mount-once seed**：`onLabelFilterAppliedRef` / `initialLabelFilterRef` を毎レンダで sync し、`useEffect([])` 内では ref 経由で読むことで stale closure を避けている。`key` による強制再マウントは導入していない（seed→クリアのループを起こさない設計）
2. **useLabels の世代 ID**：reload 中に新 reload が走った場合、古い応答は捨てる。`status: "loading" / "loaded" / "error"` の判別 union 設計
3. **HEX 入力の # 分離**：input value は `values.color.replace(/^#/, "")`、onChange で `#` を必ず前置。FE はフォーマット検証を行わず、BE の lenient 既定色化に委ねる契約は維持
4. **`labelUsageCounts` の置き場所**：feature 境界を超えないよう shared 側の `LabelRegistry` companion に配置（App.tsx から feature 内部を import しない）

## チェックリスト
- [x] セルフレビューを実施した
- [x] `pnpm test:run` が通る
- [x] `pnpm build` が通る
- [x] `cargo test` / `cargo clippy` / `cargo fmt --check` が通る
- [x] Biome / oxlint の警告を解消した
- [x] UI 変更を Storybook + playwright-cli で動作確認した
- [x] 仕様変更を `docs/spec-board/config-spec.md` に反映した
- [x] feature 間の依存は `index.ts` 経由のみ
- [x] 関連 Issue を本文で参照
- [x] 破壊的変更なし