### PR TITLE
♻️ [Refactoring]: [FE] TaskCard を Compound + Context にフォルダ分割

### DIFF
--- a/src/features/board/components/TaskCard/TaskCardContext/__tests__/TaskCardContext.behavior.test.ts
+++ b/src/features/board/components/TaskCard/TaskCardContext/__tests__/TaskCardContext.behavior.test.ts
@@ -54,7 +54,7 @@ test("useTaskCardContext を Provider 外で呼ぶと throw する", () => {
     act(() => {
       root?.render(createElement(Probe));
     });
-  }).toThrow(/TaskCard\.\* は <TaskCard> の子としてのみ使用できます/);
+  }).toThrow(/TaskCard\.\* は <TaskCard\.Root>/);
 });
 
 test("Provider 内で useTaskCardContext は Value を返す", () => {

--- a/src/features/board/components/TaskCard/TaskCardContext/__tests__/TaskCardContext.behavior.test.ts
+++ b/src/features/board/components/TaskCard/TaskCardContext/__tests__/TaskCardContext.behavior.test.ts
@@ -1,0 +1,78 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import {
+  TaskCardContext,
+  type TaskCardContextValue,
+  useTaskCardContext,
+} from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const Probe = () => {
+  const ctx = useTaskCardContext();
+  return createElement("span", { "data-testid": "probe" }, ctx.task.id);
+};
+
+test("useTaskCardContext を Provider 外で呼ぶと throw する", () => {
+  // React は子レンダー中の throw を console.error に出力するため、テストログを汚さないよう抑止する。
+  // afterEach の vi.restoreAllMocks() で自動復元されるため、モジュール変数は持たない。
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  expect(() => {
+    act(() => {
+      root?.render(createElement(Probe));
+    });
+  }).toThrow(/TaskCard\.\* は <TaskCard> の子としてのみ使用できます/);
+});
+
+test("Provider 内で useTaskCardContext は Value を返す", () => {
+  const value: TaskCardContextValue = {
+    task: createTask({ id: "task-42" }),
+    doneColumn: "Done",
+    milestonesByName: undefined,
+    hasBrokenLink: false,
+    hasParseError: false,
+    subIssueCounts: { done: 0, total: 0 },
+    childTasks: [],
+    descendantTasks: [],
+  };
+  act(() => {
+    root?.render(
+      createElement(TaskCardContext.Provider, { value }, createElement(Probe)),
+    );
+  });
+  const probe = container?.querySelector('[data-testid="probe"]');
+  expect(probe?.textContent).toBe("task-42");
+});

--- a/src/features/board/components/TaskCard/TaskCardContext/index.ts
+++ b/src/features/board/components/TaskCard/TaskCardContext/index.ts
@@ -1,0 +1,45 @@
+import { createContext, useContext } from "react";
+import type { MilestoneDefinition } from "@/lib/tauri";
+import type { Task } from "@/types/task";
+
+/** name → マイルストーン定義の Map（バッジ表示用）。 */
+export type MilestonesByName = Map<string, MilestoneDefinition>;
+
+/**
+ * TaskCard 配下のサブコンポーネントが共有する横断データ。
+ * Root（`TaskCardRoot`）が default 値適用と subIssueCounts 計算を済ませて配布する。
+ */
+export type TaskCardContextValue = {
+  /** 表示するタスク */
+  task: Task;
+  /** 完了カラム名（Root で default 適用済み） */
+  doneColumn: string;
+  /** name → マイルストーン定義の Map。未指定は undefined のまま流す */
+  milestonesByName: MilestonesByName | undefined;
+  /** 1 件でもリンク切れ参照を持つかどうか */
+  hasBrokenLink: boolean;
+  /** 1 件でもパースエラー警告を持つかどうか */
+  hasParseError: boolean;
+  /** SubIssue 進捗（Root の useMemo で 1 度だけ計算済み） */
+  subIssueCounts: { done: number; total: number };
+  /** 直下子タスクの配列（Root で [] フォールバック適用済み） */
+  childTasks: readonly Task[];
+  /** 全子孫タスクの配列（Root で childTasks フォールバック適用済み） */
+  descendantTasks: readonly Task[];
+};
+
+export const TaskCardContext = createContext<TaskCardContextValue | null>(null);
+
+/**
+ * TaskCard の context を取得する。Root（{@link TaskCardContext.Provider}）の外で
+ * サブ部品を使うと null になるため、その場合は誤用として throw する。
+ * @returns context 値
+ * @throws Provider の外で呼ばれた場合
+ */
+export const useTaskCardContext = (): TaskCardContextValue => {
+  const ctx = useContext(TaskCardContext);
+  if (ctx === null) {
+    throw new Error("TaskCard.* は <TaskCard> の子としてのみ使用できます");
+  }
+  return ctx;
+};

--- a/src/features/board/components/TaskCard/TaskCardContext/index.ts
+++ b/src/features/board/components/TaskCard/TaskCardContext/index.ts
@@ -39,7 +39,9 @@ export const TaskCardContext = createContext<TaskCardContextValue | null>(null);
 export const useTaskCardContext = (): TaskCardContextValue => {
   const ctx = useContext(TaskCardContext);
   if (ctx === null) {
-    throw new Error("TaskCard.* は <TaskCard> の子としてのみ使用できます");
+    throw new Error(
+      "TaskCard.* は <TaskCard.Root>（旧 API 経路では <TaskCard>）の子としてのみ使用できます",
+    );
   }
   return ctx;
 };

--- a/src/features/board/components/TaskCard/TaskCardFooter/__tests__/TaskCardFooter.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardFooter/__tests__/TaskCardFooter.behavior.test.tsx
@@ -1,0 +1,114 @@
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import {
+  TaskCardContext,
+  type TaskCardContextValue,
+} from "../../TaskCardContext";
+import { TaskCardFooter } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const baseValue = (
+  overrides: Partial<TaskCardContextValue> = {},
+): TaskCardContextValue => ({
+  task: createTask(),
+  doneColumn: "Done",
+  milestonesByName: undefined,
+  hasBrokenLink: false,
+  hasParseError: false,
+  subIssueCounts: { done: 0, total: 0 },
+  childTasks: [],
+  descendantTasks: [],
+  ...overrides,
+});
+
+const renderWithValue = (value: TaskCardContextValue, children: ReactNode) => {
+  act(() => {
+    root?.render(createElement(TaskCardContext.Provider, { value }, children));
+  });
+};
+
+test("task.id がフッターに表示される", () => {
+  renderWithValue(
+    baseValue({ task: createTask({ id: "task-99" }) }),
+    createElement(TaskCardFooter),
+  );
+  const id = container?.querySelector('[data-testid="task-card-id"]');
+  expect(id?.textContent).toBe("task-99");
+});
+
+test("linkCount=2 で 🔗 2 が表示される", () => {
+  renderWithValue(
+    baseValue({
+      task: createTask({ links: ["tasks/a.md", "tasks/b.md"] }),
+    }),
+    createElement(TaskCardFooter),
+  );
+  const linkCount = container?.querySelector(
+    '[data-testid="task-card-link-count"]',
+  );
+  expect(linkCount?.textContent).toContain("2");
+});
+
+test("linkCount=0 で link-count 要素が出ない", () => {
+  renderWithValue(
+    baseValue({ task: createTask({ links: [] }) }),
+    createElement(TaskCardFooter),
+  );
+  expect(
+    container?.querySelector('[data-testid="task-card-link-count"]'),
+  ).toBeNull();
+});
+
+test("subIssueCounts={done:1,total:2} で 1/2 表示", () => {
+  renderWithValue(
+    baseValue({ subIssueCounts: { done: 1, total: 2 } }),
+    createElement(TaskCardFooter),
+  );
+  const count = container?.querySelector(
+    '[data-testid="task-card-subissue-count"]',
+  );
+  expect(count?.textContent).toBe("1/2");
+});
+
+test("subIssueCounts={done:0,total:0} で subissue-count 要素が出ない", () => {
+  renderWithValue(
+    baseValue({ subIssueCounts: { done: 0, total: 0 } }),
+    createElement(TaskCardFooter),
+  );
+  expect(
+    container?.querySelector('[data-testid="task-card-subissue-count"]'),
+  ).toBeNull();
+});

--- a/src/features/board/components/TaskCard/TaskCardFooter/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardFooter/index.tsx
@@ -1,0 +1,28 @@
+import { useTaskCardContext } from "../TaskCardContext";
+
+/**
+ * TaskCard のフッター。task.id 常時表示と、links / subIssue 件数の条件表示を行う。
+ * @returns フッター行
+ */
+export const TaskCardFooter = () => {
+  const { task, subIssueCounts } = useTaskCardContext();
+  const linkCount = task.links.linkedFilePaths.length;
+  const { done, total } = subIssueCounts;
+  return (
+    <footer className="mt-2 flex items-center gap-2 text-xs text-muted">
+      <span className="min-w-0 truncate" data-testid="task-card-id">
+        {task.id}
+      </span>
+      {linkCount > 0 && (
+        <span className="shrink-0" data-testid="task-card-link-count">
+          🔗 {linkCount}
+        </span>
+      )}
+      {total > 0 && (
+        <span className="shrink-0" data-testid="task-card-subissue-count">
+          {done}/{total}
+        </span>
+      )}
+    </footer>
+  );
+};

--- a/src/features/board/components/TaskCard/TaskCardHeader/__tests__/TaskCardHeader.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardHeader/__tests__/TaskCardHeader.behavior.test.tsx
@@ -1,0 +1,134 @@
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import {
+  TaskCardContext,
+  type TaskCardContextValue,
+} from "../../TaskCardContext";
+import { TaskCardHeader } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テストタスク",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const baseValue = (
+  overrides: Partial<TaskCardContextValue> = {},
+): TaskCardContextValue => ({
+  task: createTask(),
+  doneColumn: "Done",
+  milestonesByName: undefined,
+  hasBrokenLink: false,
+  hasParseError: false,
+  subIssueCounts: { done: 0, total: 0 },
+  childTasks: [],
+  descendantTasks: [],
+  ...overrides,
+});
+
+const renderWithValue = (value: TaskCardContextValue, children: ReactNode) => {
+  act(() => {
+    root?.render(createElement(TaskCardContext.Provider, { value }, children));
+  });
+};
+
+test("Draft / Priority / Due / title が描画される", () => {
+  renderWithValue(
+    baseValue({
+      task: createTask({
+        title: "ログイン修正",
+        draft: true,
+        priority: "High",
+        due: "2026-07-01",
+      }),
+    }),
+    createElement(TaskCardHeader),
+  );
+  expect(
+    container?.querySelector('[data-testid="task-card-title"]')?.textContent,
+  ).toBe("ログイン修正");
+  expect(container?.querySelector('[data-testid="draft-badge"]')).toBeTruthy();
+  expect(container?.textContent).toContain("High");
+});
+
+test.each([
+  {
+    label: "hasBrokenLink=true で WarningIcon",
+    hasBrokenLink: true,
+    hasParseError: false,
+    warning: true,
+    parseError: false,
+  },
+  {
+    label: "hasParseError=true で ParseErrorIcon",
+    hasBrokenLink: false,
+    hasParseError: true,
+    warning: false,
+    parseError: true,
+  },
+  {
+    label: "両 true で両アイコン",
+    hasBrokenLink: true,
+    hasParseError: true,
+    warning: true,
+    parseError: true,
+  },
+  {
+    label: "両 false で警告コンテナなし",
+    hasBrokenLink: false,
+    hasParseError: false,
+    warning: false,
+    parseError: false,
+  },
+])("$label", ({ hasBrokenLink, hasParseError, warning, parseError }) => {
+  renderWithValue(
+    baseValue({ hasBrokenLink, hasParseError }),
+    createElement(TaskCardHeader),
+  );
+  expect(!!container?.querySelector('[data-testid="warning-icon"]')).toBe(
+    warning,
+  );
+  expect(!!container?.querySelector('[data-testid="parse-error-icon"]')).toBe(
+    parseError,
+  );
+});
+
+test("title が空のとき filePath がフォールバックで表示される", () => {
+  renderWithValue(
+    baseValue({
+      task: createTask({ title: "", filePath: "tasks/my-task.md" }),
+    }),
+    createElement(TaskCardHeader),
+  );
+  expect(
+    container?.querySelector('[data-testid="task-card-title"]')?.textContent,
+  ).toBe("tasks/my-task.md");
+});

--- a/src/features/board/components/TaskCard/TaskCardHeader/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardHeader/index.tsx
@@ -1,0 +1,32 @@
+import { DueBadge } from "@/components/DueBadge";
+import { ParseErrorIcon } from "@/components/ParseErrorIcon";
+import { WarningIcon } from "@/components/WarningIcon";
+import { DraftBadge } from "../../DraftBadge";
+import { PriorityBadge } from "../../PriorityBadge";
+import { useTaskCardContext } from "../TaskCardContext";
+
+/**
+ * TaskCard のヘッダー行。Draft / Priority / Due バッジとタイトル、
+ * 警告アイコン群（リンク切れ / パースエラー）を描画する。
+ * @returns ヘッダー行
+ */
+export const TaskCardHeader = () => {
+  const { task, hasBrokenLink, hasParseError } = useTaskCardContext();
+  const displayTitle = task.title || task.filePath;
+  return (
+    <div className="flex items-center gap-1.5">
+      <DraftBadge draft={task.draft} />
+      <PriorityBadge priority={task.priority} />
+      <DueBadge due={task.due} />
+      <p data-testid="task-card-title" className="text-sm text-foreground">
+        {displayTitle}
+      </p>
+      {(hasBrokenLink || hasParseError) && (
+        <span className="ml-auto flex shrink-0 gap-1">
+          {hasBrokenLink && <WarningIcon size={14} />}
+          {hasParseError && <ParseErrorIcon size={14} />}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/features/board/components/TaskCard/TaskCardLabels/__tests__/TaskCardLabels.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardLabels/__tests__/TaskCardLabels.behavior.test.tsx
@@ -1,0 +1,94 @@
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import {
+  TaskCardContext,
+  type TaskCardContextValue,
+} from "../../TaskCardContext";
+import { TaskCardLabels } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const baseValue = (
+  overrides: Partial<TaskCardContextValue> = {},
+): TaskCardContextValue => ({
+  task: createTask(),
+  doneColumn: "Done",
+  milestonesByName: undefined,
+  hasBrokenLink: false,
+  hasParseError: false,
+  subIssueCounts: { done: 0, total: 0 },
+  childTasks: [],
+  descendantTasks: [],
+  ...overrides,
+});
+
+const renderWithValue = (value: TaskCardContextValue, children: ReactNode) => {
+  act(() => {
+    root?.render(createElement(TaskCardContext.Provider, { value }, children));
+  });
+};
+
+test("labels=['bug'] で LabelTag が 1 件描画される", () => {
+  renderWithValue(
+    baseValue({ task: createTask({ labels: ["bug"] }) }),
+    createElement(TaskCardLabels),
+  );
+  const tags = container?.querySelectorAll('[data-testid="label-tag"]');
+  expect(tags?.length).toBe(1);
+  expect(tags?.[0]?.textContent).toBe("bug");
+});
+
+test("labels=['bug','urgent','frontend'] で 3 件が順序維持で描画される", () => {
+  renderWithValue(
+    baseValue({
+      task: createTask({ labels: ["bug", "urgent", "frontend"] }),
+    }),
+    createElement(TaskCardLabels),
+  );
+  const tags = container?.querySelectorAll('[data-testid="label-tag"]');
+  expect(tags?.length).toBe(3);
+  expect(tags?.[0]?.textContent).toBe("bug");
+  expect(tags?.[1]?.textContent).toBe("urgent");
+  expect(tags?.[2]?.textContent).toBe("frontend");
+});
+
+test("labels=[] で null（タグ領域なし）", () => {
+  renderWithValue(
+    baseValue({ task: createTask({ labels: [] }) }),
+    createElement(TaskCardLabels),
+  );
+  expect(container?.querySelector('[data-testid="label-tag"]')).toBeNull();
+  expect(container?.querySelector(".flex-wrap")).toBeNull();
+});

--- a/src/features/board/components/TaskCard/TaskCardLabels/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardLabels/index.tsx
@@ -1,0 +1,20 @@
+import { LabelTag } from "../../LabelTag";
+import { useTaskCardContext } from "../TaskCardContext";
+
+/**
+ * TaskCard のラベル行。task.labels が空なら何も描画しない。
+ * @returns ラベル行 or null
+ */
+export const TaskCardLabels = () => {
+  const { task } = useTaskCardContext();
+  if (task.labels.length === 0) {
+    return null;
+  }
+  return (
+    <div className="mt-1.5 flex flex-wrap gap-1">
+      {task.labels.map((label) => (
+        <LabelTag key={label} label={label} />
+      ))}
+    </div>
+  );
+};

--- a/src/features/board/components/TaskCard/TaskCardMilestone/__tests__/TaskCardMilestone.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardMilestone/__tests__/TaskCardMilestone.behavior.test.tsx
@@ -1,0 +1,101 @@
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import type { MilestoneDefinition } from "@/lib/tauri";
+import { Task, type TaskPayload } from "@/types/task";
+import {
+  type MilestonesByName,
+  TaskCardContext,
+  type TaskCardContextValue,
+} from "../../TaskCardContext";
+import { TaskCardMilestone } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const baseValue = (
+  overrides: Partial<TaskCardContextValue> = {},
+): TaskCardContextValue => ({
+  task: createTask(),
+  doneColumn: "Done",
+  milestonesByName: undefined,
+  hasBrokenLink: false,
+  hasParseError: false,
+  subIssueCounts: { done: 0, total: 0 },
+  childTasks: [],
+  descendantTasks: [],
+  ...overrides,
+});
+
+const renderWithValue = (value: TaskCardContextValue, children: ReactNode) => {
+  act(() => {
+    root?.render(createElement(TaskCardContext.Provider, { value }, children));
+  });
+};
+
+test("milestone='v1' + milestonesByName 解決ありで definition 付きバッジが出る", () => {
+  const map: MilestonesByName = new Map<string, MilestoneDefinition>([
+    ["v1", { name: "v1", title: "v1 リリース", due: "2026-08-31" }],
+  ]);
+  renderWithValue(
+    baseValue({
+      task: createTask({ milestone: "v1" }),
+      milestonesByName: map,
+    }),
+    createElement(TaskCardMilestone),
+  );
+  const badge = container?.querySelector('[data-testid="milestone-badge"]');
+  expect(badge?.textContent).toContain("v1 リリース");
+  expect(badge?.textContent).toContain("2026-08-31");
+});
+
+test("milestone='v9' + milestonesByName 未指定で name のみ表示", () => {
+  renderWithValue(
+    baseValue({
+      task: createTask({ milestone: "v9" }),
+      milestonesByName: undefined,
+    }),
+    createElement(TaskCardMilestone),
+  );
+  const badge = container?.querySelector('[data-testid="milestone-badge"]');
+  expect(badge?.textContent).toContain("v9");
+});
+
+test("milestone 未設定で null（バッジ描画なし）", () => {
+  renderWithValue(
+    baseValue({ task: createTask({ milestone: undefined }) }),
+    createElement(TaskCardMilestone),
+  );
+  expect(
+    container?.querySelector('[data-testid="milestone-badge"]'),
+  ).toBeNull();
+});

--- a/src/features/board/components/TaskCard/TaskCardMilestone/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardMilestone/index.tsx
@@ -1,0 +1,21 @@
+import { MilestoneBadge } from "../../MilestoneBadge";
+import { useTaskCardContext } from "../TaskCardContext";
+
+/**
+ * TaskCard のマイルストーン行。task.milestone が無ければ何も描画しない。
+ * @returns マイルストーンバッジ行 or null
+ */
+export const TaskCardMilestone = () => {
+  const { task, milestonesByName } = useTaskCardContext();
+  if (!task.milestone) {
+    return null;
+  }
+  return (
+    <div className="mt-1.5 flex">
+      <MilestoneBadge
+        name={task.milestone}
+        definition={milestonesByName?.get(task.milestone)}
+      />
+    </div>
+  );
+};

--- a/src/features/board/components/TaskCard/TaskCardProgress/__tests__/TaskCardProgress.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardProgress/__tests__/TaskCardProgress.behavior.test.tsx
@@ -1,0 +1,113 @@
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import {
+  TaskCardContext,
+  type TaskCardContextValue,
+} from "../../TaskCardContext";
+import { TaskCardProgress } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const baseValue = (
+  overrides: Partial<TaskCardContextValue> = {},
+): TaskCardContextValue => ({
+  task: createTask(),
+  doneColumn: "Done",
+  milestonesByName: undefined,
+  hasBrokenLink: false,
+  hasParseError: false,
+  subIssueCounts: { done: 0, total: 0 },
+  childTasks: [],
+  descendantTasks: [],
+  ...overrides,
+});
+
+const renderWithValue = (value: TaskCardContextValue, children: ReactNode) => {
+  act(() => {
+    root?.render(createElement(TaskCardContext.Provider, { value }, children));
+  });
+};
+
+test("childTasks 未指定 / Provider が total=0 → SubIssueProgress 自体は null", () => {
+  renderWithValue(
+    baseValue({ subIssueCounts: { done: 0, total: 0 } }),
+    createElement(TaskCardProgress),
+  );
+  expect(container?.querySelector("[role='progressbar']")).toBeNull();
+});
+
+test("Provider の subIssueCounts={done:1,total:3} で進捗バーが 33% 表示", () => {
+  renderWithValue(
+    baseValue({
+      subIssueCounts: { done: 1, total: 3 },
+      childTasks: [createTask({ id: "c1" })],
+    }),
+    createElement(TaskCardProgress),
+  );
+  const bar = container?.querySelector("[role='progressbar']");
+  expect(bar?.getAttribute("aria-valuenow")).toBe("33");
+});
+
+test("props.childTasks override 時は done/total も再集計（Provider の subIssueCounts は使わない）", () => {
+  const overrideChildren = [
+    createTask({ id: "c1", status: "Done" }),
+    createTask({ id: "c2", status: "Todo" }),
+  ];
+  renderWithValue(
+    baseValue({
+      subIssueCounts: { done: 99, total: 99 },
+      childTasks: [],
+    }),
+    <TaskCardProgress childTasks={overrideChildren} />,
+  );
+  const bar = container?.querySelector("[role='progressbar']");
+  expect(bar?.getAttribute("aria-valuenow")).toBe("50");
+});
+
+test("props.childTasks 未指定なら Provider の subIssueCounts={done:2,total:4} がそのまま反映される", () => {
+  // override 経路を踏まないことは aria-valuenow=50% (=2/4) で観察可能。
+  // Provider の {done:2,total:4} を再計算なしに使えば 50% になる。再計算が起きると
+  // Provider 値（done:2,total:4）でなく override 計算結果が出るため値が変わる。
+  renderWithValue(
+    baseValue({
+      subIssueCounts: { done: 2, total: 4 },
+      childTasks: [createTask({ id: "c1" })],
+    }),
+    createElement(TaskCardProgress),
+  );
+  const bar = container?.querySelector("[role='progressbar']");
+  expect(bar?.getAttribute("aria-valuenow")).toBe("50");
+});

--- a/src/features/board/components/TaskCard/TaskCardProgress/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardProgress/index.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { TaskHierarchy } from "@/domains/task-hierarchy";
+import type { Task } from "@/types/task";
+import { SubIssueProgress } from "../../SubIssueProgress";
+import { useTaskCardContext } from "../TaskCardContext";
+
+export type TaskCardProgressProps = {
+  /**
+   * Provider の childTasks / subIssueCounts を上書きするためのデータソース。
+   * 指定時は done/total も再集計するため Provider 値は使わない（論理矛盾防止）。
+   */
+  childTasks?: readonly Task[];
+};
+
+/**
+ * TaskCard の進捗バー行。Provider の `subIssueCounts` を使うが、props.childTasks が
+ * 指定された場合だけはデータソース差し替えとして done/total も再集計する。
+ * @param props - {@link TaskCardProgressProps}
+ * @returns 進捗バー行
+ */
+export const TaskCardProgress = ({
+  childTasks,
+}: TaskCardProgressProps = {}) => {
+  const ctx = useTaskCardContext();
+
+  // override 時のみ countSubIssueProgress を回す。override 無し時は Provider が
+  // すでに計算した subIssueCounts をそのまま流し、二重計算を防ぐ。
+  const overrideCounts = useMemo(() => {
+    if (childTasks === undefined) {
+      return null;
+    }
+    return TaskHierarchy.countSubIssueProgress(childTasks, ctx.doneColumn);
+  }, [childTasks, ctx.doneColumn]);
+
+  const effectiveChildTasks = childTasks ?? ctx.childTasks;
+  const counts = overrideCounts ?? ctx.subIssueCounts;
+
+  return (
+    <SubIssueProgress
+      childTasks={effectiveChildTasks}
+      done={counts.done}
+      total={counts.total}
+      doneColumn={ctx.doneColumn}
+    />
+  );
+};

--- a/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.behavior.test.tsx
@@ -82,8 +82,8 @@ test("Context Value は依存不変なら同一参照（useMemo）", () => {
 });
 
 test("childTasks 未指定でも 2 回連続レンダーで Context Value 参照が安定する", () => {
-  // childTasks ?? [] のリテラル再生成で memo が壊れないか（実コーラ Column が必ず
-  // childTasks を渡すケースとは別に、Compound 直接利用での識別性を担保する）
+  // childTasks ?? [] のリテラル再生成で memo が壊れないか（実呼び出し元 Column が
+  // 必ず childTasks を渡すケースとは別に、Compound 直接利用での識別性を担保する）
   const refs: (TaskCardContextValue | null)[] = [];
   const Probe = () => {
     const ctx = useContext(TaskCardContext);

--- a/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.behavior.test.tsx
@@ -98,6 +98,29 @@ test("childTasks 未指定でも 2 回連続レンダーで Context Value 参照
   expect(refs[0]).toBe(refs[1]);
 });
 
+test("childTasks に都度新規の空配列を渡しても Context Value 参照が安定する", () => {
+  // Column 側が `descendantsByFilePath.get(...) ?? []` のように渡す現実ケース。
+  // length === 0 の正規化が無いと、毎レンダー新しい [] で useMemo が miss する。
+  const refs: (TaskCardContextValue | null)[] = [];
+  const Probe = () => {
+    const ctx = useContext(TaskCardContext);
+    refs.push(ctx);
+    return null;
+  };
+  const task = createTask();
+  renderRoot(
+    { task, childTasks: [], descendantTasks: [] },
+    createElement(Probe),
+  );
+  renderRoot(
+    { task, childTasks: [], descendantTasks: [] },
+    createElement(Probe),
+  );
+  expect(refs.length).toBeGreaterThanOrEqual(2);
+  expect(refs[0]).not.toBeNull();
+  expect(refs[0]).toBe(refs[1]);
+});
+
 test("dragstart で setData / effectAllowed / onDragStart が呼ばれる", () => {
   const onDragStart = vi.fn();
   renderRoot({

--- a/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.behavior.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.behavior.test.tsx
@@ -1,0 +1,232 @@
+import { act, createElement, type ReactNode, useContext } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { createDragEvent } from "@/test-fixtures/createDragEvent";
+import { Task, type TaskPayload } from "@/types/task";
+import { DRAG_MIME_TYPE } from "../../../Board/dragState";
+import {
+  TaskCardContext,
+  type TaskCardContextValue,
+} from "../../TaskCardContext";
+import { TaskCardRoot, type TaskCardRootProps } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+const renderRoot = (
+  props: Partial<TaskCardRootProps> = {},
+  children: ReactNode = null,
+) => {
+  const merged: TaskCardRootProps = {
+    task: createTask(),
+    fromColumn: "Todo",
+    ...props,
+    children,
+  };
+  act(() => {
+    root?.render(createElement(TaskCardRoot, merged));
+  });
+};
+
+const queryCard = (): HTMLElement => {
+  const el = container?.querySelector<HTMLElement>("[data-testid='task-card']");
+  expect(el).not.toBeNull();
+  return el as HTMLElement;
+};
+
+test("Context Value は依存不変なら同一参照（useMemo）", () => {
+  const refs: (TaskCardContextValue | null)[] = [];
+  const Probe = () => {
+    const ctx = useContext(TaskCardContext);
+    refs.push(ctx);
+    return null;
+  };
+  const task = createTask();
+  const childTasks: readonly Task[] = [];
+  renderRoot({ task, childTasks }, createElement(Probe));
+  // 同一 props で再 render（同一 root に再 render するため renderRoot 内の act が走る）
+  renderRoot({ task, childTasks }, createElement(Probe));
+  expect(refs.length).toBeGreaterThanOrEqual(2);
+  expect(refs[0]).not.toBeNull();
+  expect(refs[0]).toBe(refs[1]);
+});
+
+test("childTasks 未指定でも 2 回連続レンダーで Context Value 参照が安定する", () => {
+  // childTasks ?? [] のリテラル再生成で memo が壊れないか（実コーラ Column が必ず
+  // childTasks を渡すケースとは別に、Compound 直接利用での識別性を担保する）
+  const refs: (TaskCardContextValue | null)[] = [];
+  const Probe = () => {
+    const ctx = useContext(TaskCardContext);
+    refs.push(ctx);
+    return null;
+  };
+  const task = createTask();
+  renderRoot({ task }, createElement(Probe));
+  renderRoot({ task }, createElement(Probe));
+  expect(refs.length).toBeGreaterThanOrEqual(2);
+  expect(refs[0]).not.toBeNull();
+  expect(refs[0]).toBe(refs[1]);
+});
+
+test("dragstart で setData / effectAllowed / onDragStart が呼ばれる", () => {
+  const onDragStart = vi.fn();
+  renderRoot({
+    task: createTask({ filePath: "tasks/a.md" }),
+    fromColumn: "Todo",
+    onDragStart,
+  });
+  const card = queryCard();
+  const event = createDragEvent("dragstart");
+  act(() => {
+    card.dispatchEvent(event);
+  });
+  expect(event.dataTransfer.getData(DRAG_MIME_TYPE)).toBe("tasks/a.md");
+  expect(event.dataTransfer.effectAllowed).toBe("move");
+  expect(onDragStart).toHaveBeenCalledWith("tasks/a.md", "Todo");
+});
+
+test("disableDrag=true で onDragStart は呼ばれず draggable=false 属性", () => {
+  const onDragStart = vi.fn();
+  renderRoot({
+    task: createTask({ filePath: "tasks/a.md" }),
+    fromColumn: "Todo",
+    disableDrag: true,
+    onDragStart,
+  });
+  const card = queryCard();
+  expect(card.getAttribute("draggable")).toBe("false");
+  const event = createDragEvent("dragstart");
+  act(() => {
+    card.dispatchEvent(event);
+  });
+  expect(onDragStart).not.toHaveBeenCalled();
+});
+
+test("dragend で onDragEnd + setTimeout(0) 経過後の click は onClick を呼ぶ", () => {
+  vi.useFakeTimers();
+  try {
+    const onClick = vi.fn();
+    const onDragEnd = vi.fn();
+    renderRoot({ task: createTask({ id: "x" }), onClick, onDragEnd });
+    const card = queryCard();
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragstart"));
+    });
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragend"));
+    });
+    expect(onDragEnd).toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    act(() => {
+      card.click();
+    });
+    expect(onClick).toHaveBeenCalledWith("x");
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("dragend 直後（タイマー未進行）の click は onClick を呼ばない", () => {
+  vi.useFakeTimers();
+  try {
+    const onClick = vi.fn();
+    renderRoot({ task: createTask(), onClick });
+    const card = queryCard();
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragstart"));
+    });
+    act(() => {
+      card.dispatchEvent(createDragEvent("dragend"));
+    });
+    act(() => {
+      card.click();
+    });
+    expect(onClick).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("onClick 未指定で role / tabIndex 属性なし", () => {
+  renderRoot({});
+  const card = queryCard();
+  expect(card.getAttribute("role")).toBeNull();
+  expect(card.getAttribute("tabindex")).toBeNull();
+});
+
+test("onClick 指定で role=button + tabIndex=0、Enter / Space で onClick(task.id)", () => {
+  const onClick = vi.fn();
+  renderRoot({ task: createTask({ id: "btn-1" }), onClick });
+  const card = queryCard();
+  expect(card.getAttribute("role")).toBe("button");
+  expect(card.getAttribute("tabindex")).toBe("0");
+  act(() => {
+    card.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+  });
+  expect(onClick).toHaveBeenCalledWith("btn-1");
+  act(() => {
+    card.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+    );
+  });
+  expect(onClick).toHaveBeenCalledTimes(2);
+});
+
+test("isDragging=true で opacity-40 / data-dragging='true' / aria-grabbed", () => {
+  renderRoot({ isDragging: true, onClick: vi.fn() });
+  const card = queryCard();
+  expect(card.className).toContain("opacity-40");
+  expect(card.getAttribute("data-dragging")).toBe("true");
+  expect(card.getAttribute("aria-grabbed")).toBe("true");
+});
+
+test("draft=true で opacity-60", () => {
+  renderRoot({ task: createTask({ draft: true }), onClick: vi.fn() });
+  const card = queryCard();
+  expect(card.className).toContain("opacity-60");
+});
+
+test("isDragging=true は draft より優先（opacity-40 のみ、opacity-60 なし）", () => {
+  renderRoot({
+    task: createTask({ draft: true }),
+    isDragging: true,
+    onClick: vi.fn(),
+  });
+  const card = queryCard();
+  expect(card.className).toContain("opacity-40");
+  expect(card.className).not.toContain("opacity-60");
+});

--- a/src/features/board/components/TaskCard/TaskCardRoot/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardRoot/index.tsx
@@ -1,5 +1,9 @@
-// @lint-suppress-ok
-// 本ファイルの biome-ignore は HTML5 ネイティブ DnD のための a11y 制約に由来する。
+// @lint-suppress-ok — typescript-rules-plugin の block-lint-suppress.sh hook が
+// このマーカーを検出すると、本ファイル内の biome-ignore 行を許可する。
+// 本ファイルで biome-ignore が必要な理由: HTML5 ネイティブ DnD のため
+// draggable ハンドラを <div> に付ける必要があり、`noStaticElementInteractions`
+// が trigger される。子に details/summary 等の interactive descendants が
+// 混ざるため <button> 等のセマンティック要素に置換できず、抑制が必須。
 // 旧 TaskCard/index.tsx から踏襲しており、互換性維持のため削除しない。
 import {
   type DragEvent,

--- a/src/features/board/components/TaskCard/TaskCardRoot/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardRoot/index.tsx
@@ -1,0 +1,194 @@
+// @lint-suppress-ok
+// 本ファイルの biome-ignore は HTML5 ネイティブ DnD のための a11y 制約に由来する。
+// 旧 TaskCard/index.tsx から踏襲しており、互換性維持のため削除しない。
+import {
+  type DragEvent,
+  type KeyboardEvent,
+  type ReactNode,
+  useMemo,
+  useRef,
+} from "react";
+import { DEFAULT_DONE_COLUMN } from "@/domains/project-columns";
+import { TaskHierarchy } from "@/domains/task-hierarchy";
+import type { Task } from "@/types/task";
+import { DRAG_MIME_TYPE } from "../../Board/dragState";
+import {
+  type MilestonesByName,
+  TaskCardContext,
+  type TaskCardContextValue,
+} from "../TaskCardContext";
+
+// childTasks / descendantTasks 未指定時のフォールバック用に参照を固定する。
+// 毎レンダー `[]` リテラルを生成すると useMemo の依存比較が常に miss し、
+// Context Value の memo 化（Column の tasks.map での再描画抑制）が壊れる。
+const EMPTY_TASKS: readonly Task[] = [];
+
+/** TaskCardRoot の Props */
+export type TaskCardRootProps = {
+  /** 表示するタスク */
+  task: Task;
+  /** 子タスクの配列（直下子のみ。<details> 内一覧用） */
+  childTasks?: readonly Task[];
+  /** 全子孫タスク（X/Y サマリ + 進捗バー用、再帰展開済） */
+  descendantTasks?: readonly Task[];
+  /** 完了カラム名 */
+  doneColumn?: string;
+  /** name → マイルストーン定義の Map。未指定は name 表示にフォールバック */
+  milestonesByName?: MilestonesByName;
+  /** 所属カラム名。onDragStart の引数に使う */
+  fromColumn: string;
+  /** ドラッグ中フラグ（Board の DragState から配布） */
+  isDragging?: boolean;
+  /** ドラッグを無効化するか */
+  disableDrag?: boolean;
+  /** 1 件でもリンク切れ参照を持つかどうか */
+  hasBrokenLink?: boolean;
+  /** 1 件でもパースエラー警告を持つかどうか */
+  hasParseError?: boolean;
+  /**
+   * カードクリック時のコールバック
+   * @param taskId クリックされたタスクの id
+   */
+  onClick?: (taskId: string) => void;
+  /**
+   * ドラッグ開始時のコールバック
+   * @param taskFilePath 対象タスクの filePath
+   * @param fromColumn 元カラム名
+   */
+  onDragStart?: (taskFilePath: string, fromColumn: string) => void;
+  /** ドラッグ終了時のコールバック */
+  onDragEnd?: () => void;
+  /** 並べるサブ部品（TaskCard.Header 等） */
+  children: ReactNode;
+};
+
+/**
+ * TaskCard の Container + Context Provider。draggable コンテナとして DnD を司り、
+ * 子サブ部品が利用する横断データを Provider 経由で配布する。
+ * @param props - {@link TaskCardRootProps}
+ * @returns カード要素
+ */
+export const TaskCardRoot = ({
+  task,
+  childTasks,
+  descendantTasks,
+  doneColumn,
+  milestonesByName,
+  fromColumn,
+  isDragging = false,
+  disableDrag = false,
+  hasBrokenLink = false,
+  hasParseError = false,
+  onClick,
+  onDragStart,
+  onDragEnd,
+  children,
+}: TaskCardRootProps) => {
+  // ドラッグ終了直後にブラウザが発火する synthetic click を抑止するためのガード。
+  // dragstart で true にし、onClick はこのフラグが立っている間は無視する。
+  const dragGuardRef = useRef(false);
+
+  const effectiveDoneColumn = doneColumn ?? DEFAULT_DONE_COLUMN;
+  const effectiveChildTasks = childTasks ?? EMPTY_TASKS;
+  const effectiveDescendants = descendantTasks ?? effectiveChildTasks;
+
+  const subIssueCounts = useMemo(
+    () =>
+      TaskHierarchy.countSubIssueProgress(
+        effectiveDescendants,
+        effectiveDoneColumn,
+      ),
+    [effectiveDescendants, effectiveDoneColumn],
+  );
+
+  const contextValue = useMemo<TaskCardContextValue>(
+    () => ({
+      task,
+      doneColumn: effectiveDoneColumn,
+      milestonesByName,
+      hasBrokenLink,
+      hasParseError,
+      subIssueCounts,
+      childTasks: effectiveChildTasks,
+      descendantTasks: effectiveDescendants,
+    }),
+    [
+      task,
+      effectiveDoneColumn,
+      milestonesByName,
+      hasBrokenLink,
+      hasParseError,
+      subIssueCounts,
+      effectiveChildTasks,
+      effectiveDescendants,
+    ],
+  );
+
+  const handleDragStart = (e: DragEvent<HTMLDivElement>) => {
+    if (disableDrag) {
+      return;
+    }
+    e.dataTransfer.setData(DRAG_MIME_TYPE, task.filePath);
+    e.dataTransfer.effectAllowed = "move";
+    dragGuardRef.current = true;
+    onDragStart?.(task.filePath, fromColumn);
+  };
+
+  const handleDragEnd = () => {
+    onDragEnd?.();
+    // dragend 内 setTimeout(0) で解除を次のマクロタスクに回し、synthetic click を確実にガードする。
+    setTimeout(() => {
+      dragGuardRef.current = false;
+    }, 0);
+  };
+
+  const draggingClass = isDragging ? " opacity-40" : "";
+  // ドラッグ中は dragging の減光を優先し draft の opacity を重ねない。
+  const draftClass = !isDragging && task.draft ? " opacity-60" : "";
+  const dataDragging = isDragging ? "true" : undefined;
+  const interactiveClass = onClick
+    ? " cursor-pointer hover:border-accent hover:shadow-md"
+    : "";
+
+  const handleClick = onClick
+    ? () => {
+        if (dragGuardRef.current) {
+          return;
+        }
+        onClick(task.id);
+      }
+    : undefined;
+
+  const handleKeyDown = onClick
+    ? (e: KeyboardEvent<HTMLDivElement>) => {
+        if (e.currentTarget !== e.target) {
+          return;
+        }
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick(task.id);
+        }
+      }
+    : undefined;
+
+  return (
+    <TaskCardContext.Provider value={contextValue}>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: HTML5 native DnD requires draggable handlers on the card container; children may include interactive descendants (e.g. details/summary) so a semantic <button> cannot be used here */}
+      <div
+        draggable={!disableDrag}
+        data-dragging={dataDragging}
+        data-testid="task-card"
+        aria-grabbed={isDragging}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        role={onClick ? "button" : undefined}
+        tabIndex={onClick ? 0 : undefined}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        className={`w-full rounded-lg border border-border bg-surface p-3 text-left shadow-sm${interactiveClass}${draggingClass}${draftClass}`}
+      >
+        {children}
+      </div>
+    </TaskCardContext.Provider>
+  );
+};

--- a/src/features/board/components/TaskCard/TaskCardRoot/index.tsx
+++ b/src/features/board/components/TaskCard/TaskCardRoot/index.tsx
@@ -93,8 +93,17 @@ export const TaskCardRoot = ({
   const dragGuardRef = useRef(false);
 
   const effectiveDoneColumn = doneColumn ?? DEFAULT_DONE_COLUMN;
-  const effectiveChildTasks = childTasks ?? EMPTY_TASKS;
-  const effectiveDescendants = descendantTasks ?? effectiveChildTasks;
+  // childTasks が undefined のときはもちろん、Column 側が `?? []` で都度生成した
+  // 空配列を渡しても useMemo が miss しないよう、length === 0 も EMPTY_TASKS に
+  // 正規化する。子なしタスクが大量に並ぶケース（典型的な Column 描画）で効く。
+  const effectiveChildTasks =
+    childTasks === undefined || childTasks.length === 0
+      ? EMPTY_TASKS
+      : childTasks;
+  const effectiveDescendants =
+    descendantTasks === undefined || descendantTasks.length === 0
+      ? effectiveChildTasks
+      : descendantTasks;
 
   const subIssueCounts = useMemo(
     () =>

--- a/src/features/board/components/TaskCard/__tests__/TaskCard.compound.test.tsx
+++ b/src/features/board/components/TaskCard/__tests__/TaskCard.compound.test.tsx
@@ -1,0 +1,184 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import { TaskCard } from "..";
+
+let containerA: HTMLDivElement | null = null;
+let rootA: ReturnType<typeof createRoot> | null = null;
+let containerB: HTMLDivElement | null = null;
+let rootB: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  containerA = document.createElement("div");
+  document.body.appendChild(containerA);
+  rootA = createRoot(containerA);
+  containerB = document.createElement("div");
+  document.body.appendChild(containerB);
+  rootB = createRoot(containerB);
+});
+
+afterEach(() => {
+  act(() => {
+    rootA?.unmount();
+    rootB?.unmount();
+  });
+  rootA = null;
+  rootB = null;
+  containerA?.remove();
+  containerB?.remove();
+  containerA = null;
+  containerB = null;
+});
+
+const createTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "task-1",
+    title: "テスト",
+    status: "Todo",
+    labels: ["bug"],
+    links: ["tasks/a.md"],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/test.md",
+    ...overrides,
+  });
+
+test("Compound: 5 パーツの実コンテンツ（title / id / label / footer）がすべて描画される", () => {
+  act(() => {
+    rootA?.render(
+      <TaskCard.Root task={createTask()} fromColumn="Todo">
+        <TaskCard.Header />
+        <TaskCard.Milestone />
+        <TaskCard.Labels />
+        <TaskCard.Progress />
+        <TaskCard.Footer />
+      </TaskCard.Root>,
+    );
+  });
+  expect(
+    containerA?.querySelector('[data-testid="task-card-title"]')?.textContent,
+  ).toBe("テスト");
+  expect(
+    containerA?.querySelector('[data-testid="task-card-id"]')?.textContent,
+  ).toBe("task-1");
+  expect(
+    containerA?.querySelector('[data-testid="label-tag"]')?.textContent,
+  ).toBe("bug");
+});
+
+test("旧 API（Legacy）と新 API（Compound）が同じ data-testid と同じ可視内容を描画する", () => {
+  const task = createTask({
+    id: "same-1",
+    title: "同一",
+    labels: ["bug", "urgent"],
+    links: ["tasks/a.md"],
+  });
+  const onClick = vi.fn();
+  act(() => {
+    rootA?.render(
+      <TaskCard
+        task={task}
+        fromColumn="Todo"
+        doneColumn="Done"
+        onClick={onClick}
+      />,
+    );
+  });
+  act(() => {
+    rootB?.render(
+      <TaskCard.Root
+        task={task}
+        fromColumn="Todo"
+        doneColumn="Done"
+        onClick={onClick}
+      >
+        <TaskCard.Header />
+        <TaskCard.Milestone />
+        <TaskCard.Labels />
+        <TaskCard.Progress />
+        <TaskCard.Footer />
+      </TaskCard.Root>,
+    );
+  });
+  // 観察可能な振る舞いの同値性: テキスト・ラベル・role / aria 属性が一致すれば、
+  // Legacy が新 API ラッパとして Compound と同じカードを描いていると判断できる。
+  // className 並びや属性順序は HTML としては観察不能なので比較しない。
+  const cardA = containerA?.querySelector('[data-testid="task-card"]');
+  const cardB = containerB?.querySelector('[data-testid="task-card"]');
+  expect(cardA?.getAttribute("role")).toBe(cardB?.getAttribute("role"));
+  expect(cardA?.getAttribute("draggable")).toBe(
+    cardB?.getAttribute("draggable"),
+  );
+  expect(
+    containerA?.querySelector('[data-testid="task-card-title"]')?.textContent,
+  ).toBe(
+    containerB?.querySelector('[data-testid="task-card-title"]')?.textContent,
+  );
+  expect(
+    containerA?.querySelector('[data-testid="task-card-id"]')?.textContent,
+  ).toBe(
+    containerB?.querySelector('[data-testid="task-card-id"]')?.textContent,
+  );
+  const labelsA = Array.from(
+    containerA?.querySelectorAll('[data-testid="label-tag"]') ?? [],
+  ).map((el) => el.textContent);
+  const labelsB = Array.from(
+    containerB?.querySelectorAll('[data-testid="label-tag"]') ?? [],
+  ).map((el) => el.textContent);
+  expect(labelsA).toEqual(labelsB);
+  expect(labelsA).toEqual(["bug", "urgent"]);
+});
+
+test("doneColumn 省略時に default 'Done' が適用された結果が観察可能な DOM に出る", () => {
+  // doneColumn が context に伝わるか直接観察せず、default が効いた結果として
+  // 「status='Done' の子タスクが done としてカウントされる」ことで間接観察する。
+  const parent = createTask({ id: "parent" });
+  const childDone = createTask({ id: "c1", status: "Done" });
+  const childTodo = createTask({ id: "c2", status: "Todo" });
+  act(() => {
+    rootA?.render(
+      <TaskCard.Root
+        task={parent}
+        fromColumn="Todo"
+        childTasks={[childDone, childTodo]}
+        descendantTasks={[childDone, childTodo]}
+      >
+        <TaskCard.Footer />
+      </TaskCard.Root>,
+    );
+  });
+  // default "Done" が効いていれば 1/2、効かなければ 0/2。
+  expect(
+    containerA?.querySelector('[data-testid="task-card-subissue-count"]')
+      ?.textContent,
+  ).toBe("1/2");
+});
+
+test("Compound 並べ替え（Footer → Header → Labels）で順序とコンテンツが反映される", () => {
+  act(() => {
+    rootA?.render(
+      <TaskCard.Root task={createTask()} fromColumn="Todo">
+        <TaskCard.Footer />
+        <TaskCard.Header />
+        <TaskCard.Labels />
+      </TaskCard.Root>,
+    );
+  });
+  const children = Array.from(
+    containerA?.querySelector('[data-testid="task-card"]')?.children ?? [],
+  );
+  // 並べ替えが反映されていれば footer が先頭になる。
+  expect(children[0]?.tagName.toLowerCase()).toBe("footer");
+  expect(
+    containerA?.querySelector('[data-testid="task-card-id"]')?.textContent,
+  ).toBe("task-1");
+  expect(
+    containerA?.querySelector('[data-testid="task-card-title"]')?.textContent,
+  ).toBe("テスト");
+  const tags = Array.from(
+    containerA?.querySelectorAll('[data-testid="label-tag"]') ?? [],
+  ).map((el) => el.textContent);
+  expect(tags).toEqual(["bug"]);
+});

--- a/src/features/board/components/TaskCard/index.stories.tsx
+++ b/src/features/board/components/TaskCard/index.stories.tsx
@@ -100,3 +100,90 @@ export const Minimal: Story = {
     descendantTasks: [],
   },
 };
+
+// --- Compound 経路（新 API）: render 上書きで TaskCard.Root + 子サブ部品を組み立てる ---
+
+export const HeaderOnly: Story = {
+  render: (args) => (
+    <TaskCard.Root {...args}>
+      <TaskCard.Header />
+    </TaskCard.Root>
+  ),
+};
+
+export const MilestoneOnly: Story = {
+  render: (args) => (
+    <TaskCard.Root {...args}>
+      <TaskCard.Milestone />
+    </TaskCard.Root>
+  ),
+  args: { task: { ...baseTask, milestone: "v1.0" } },
+};
+
+export const LabelsOnly: Story = {
+  render: (args) => (
+    <TaskCard.Root {...args}>
+      <TaskCard.Labels />
+    </TaskCard.Root>
+  ),
+  args: { task: { ...baseTask, labels: ["bug", "urgent"] } },
+};
+
+export const ProgressOnly: Story = {
+  render: (args) => (
+    <TaskCard.Root {...args}>
+      <TaskCard.Progress />
+    </TaskCard.Root>
+  ),
+  args: {
+    task: baseTask,
+    childTasks,
+    descendantTasks: childTasks,
+  },
+};
+
+export const FooterOnly: Story = {
+  render: (args) => (
+    <TaskCard.Root {...args}>
+      <TaskCard.Footer />
+    </TaskCard.Root>
+  ),
+};
+
+export const CompoundFull: Story = {
+  render: (args) => (
+    <TaskCard.Root {...args}>
+      <TaskCard.Header />
+      <TaskCard.Milestone />
+      <TaskCard.Labels />
+      <TaskCard.Progress />
+      <TaskCard.Footer />
+    </TaskCard.Root>
+  ),
+  args: {
+    task: { ...baseTask, milestone: "v1.0", labels: ["bug", "urgent"] },
+    childTasks,
+    descendantTasks: childTasks,
+  },
+};
+
+export const ReorderedFooterFirst: Story = {
+  render: (args) => (
+    <TaskCard.Root {...args}>
+      <TaskCard.Footer />
+      <TaskCard.Header />
+      <TaskCard.Labels />
+    </TaskCard.Root>
+  ),
+  args: { task: { ...baseTask, labels: ["bug", "frontend"] } },
+};
+
+export const WithMilestoneAndLabels: Story = {
+  args: {
+    task: {
+      ...baseTask,
+      milestone: "v1.0",
+      labels: ["bug", "urgent"],
+    },
+  },
+};

--- a/src/features/board/components/TaskCard/index.tsx
+++ b/src/features/board/components/TaskCard/index.tsx
@@ -1,270 +1,86 @@
-import type { DragEvent } from "react";
-import { useRef } from "react";
-import { DueBadge } from "@/components/DueBadge";
-import { ParseErrorIcon } from "@/components/ParseErrorIcon";
-import { WarningIcon } from "@/components/WarningIcon";
-import { DEFAULT_DONE_COLUMN } from "@/domains/project-columns";
-import { TaskHierarchy } from "@/domains/task-hierarchy";
-import type { MilestoneDefinition } from "@/lib/tauri";
-import type { Task } from "@/types/task";
-import { DRAG_MIME_TYPE } from "../Board/dragState";
-import { DraftBadge } from "../DraftBadge";
-import { LabelTag } from "../LabelTag";
-import { MilestoneBadge } from "../MilestoneBadge";
-import { PriorityBadge } from "../PriorityBadge";
-import { SubIssueProgress } from "../SubIssueProgress";
+import type { ReactNode } from "react";
+import { TaskCardFooter } from "./TaskCardFooter";
+import { TaskCardHeader } from "./TaskCardHeader";
+import { TaskCardLabels } from "./TaskCardLabels";
+import { TaskCardMilestone } from "./TaskCardMilestone";
+import { TaskCardProgress } from "./TaskCardProgress";
+import { TaskCardRoot, type TaskCardRootProps } from "./TaskCardRoot";
 
-/** name → マイルストーン定義の Map（バッジ表示用）。 */
-export type MilestonesByName = Map<string, MilestoneDefinition>;
-
-/** タスクカードの Props */
-type TaskCardProps = {
-  /** 表示するタスク */
-  task: Task;
-  /** 子タスクの配列（直下子のみ。<details> 内一覧用） */
-  childTasks?: readonly Task[];
-  /** 全子孫タスク（X/Y サマリ + 進捗バー用、再帰展開済） */
-  descendantTasks?: readonly Task[];
-  /** 完了カラム名 */
-  doneColumn?: string;
-  /** name → マイルストーン定義の Map（バッジの title/due 解決用。未指定は name 表示） */
-  milestonesByName?: MilestonesByName;
-  /** 所属カラム名。onDragStart の引数に使う。 */
-  fromColumn: string;
-  /** ドラッグ中フラグ（Board の DragState から配布） */
-  isDragging?: boolean;
-  /**
-   * ドラッグを無効化するか。フィルタ有効時など、表示集合が全タスクと異なり
-   * 並べ替えが cardOrder を壊しうる状況で true にしてカードのドラッグを止める。
-   */
-  disableDrag?: boolean;
-  /**
-   * 1 件でもリンク切れ参照を持つかどうか。true のときカード隅に警告アイコンのみを表示する。
-   * 詳細はパネルで確認できるためカードはアイコンのみのミニマル表示にする。
-   */
-  hasBrokenLink?: boolean;
-  /**
-   * 1 件でもパースエラー警告（invalid 系コード）を持つかどうか。
-   * true のときカード隅に赤いパースエラーアイコンを表示する（リンク切れアイコンと併存可）。
-   */
-  hasParseError?: boolean;
-  /**
-   * カードクリック時のコールバック
-   * @param taskId - クリックされたタスクのID
-   */
-  onClick?: (taskId: string) => void;
-  /**
-   * ドラッグ開始時のコールバック。
-   * @param taskFilePath - 対象タスクの filePath
-   * @param fromColumn - 元カラム名
-   */
-  onDragStart?: (taskFilePath: string, fromColumn: string) => void;
-  /** ドラッグ終了時のコールバック。 */
-  onDragEnd?: () => void;
-};
-
-type CardContentProps = {
-  task: Task;
-  childTasks?: readonly Task[];
-  descendantTasks?: readonly Task[];
-  doneColumn?: string;
-  milestonesByName?: MilestonesByName;
-  hasBrokenLink?: boolean;
-  hasParseError?: boolean;
-};
+export type { MilestonesByName } from "./TaskCardContext";
 
 /**
- * タスクカード本体の表示。
- * @param props 表示用のタスク情報
- * @returns カード内 markup
+ * 旧 API 互換の props 型。`TaskCardRootProps` から `children` を除いた残り全部を
+ * そのまま受け継ぐ。spread を避け explicit destructure で渡すため、将来
+ * `TaskCardRootProps` に内部用 prop を増やした場合の余剰 prop 漏出を防げる。
  */
-const CardContent = ({
-  task,
-  childTasks = [],
-  descendantTasks,
-  doneColumn = DEFAULT_DONE_COLUMN,
-  milestonesByName,
-  hasBrokenLink = false,
-  hasParseError = false,
-}: CardContentProps) => {
-  // descendantTasks を渡せば全子孫ベースで進捗を集計する。未指定なら childTasks に
-  // フォールバックし、直下子のみで集計する。
-  const effectiveDescendants = descendantTasks ?? childTasks;
-  const displayTitle = task.title || task.filePath;
-  const linkCount = task.links.linkedFilePaths.length;
-  const { done, total } = TaskHierarchy.countSubIssueProgress(
-    effectiveDescendants,
-    doneColumn,
-  );
-
-  return (
-    <>
-      <div className="flex items-center gap-1.5">
-        <DraftBadge draft={task.draft} />
-        <PriorityBadge priority={task.priority} />
-        <DueBadge due={task.due} />
-        <p data-testid="task-card-title" className="text-sm text-foreground">
-          {displayTitle}
-        </p>
-        {(hasBrokenLink || hasParseError) && (
-          <span className="ml-auto flex shrink-0 gap-1">
-            {hasBrokenLink && <WarningIcon size={14} />}
-            {hasParseError && <ParseErrorIcon size={14} />}
-          </span>
-        )}
-      </div>
-      {task.milestone ? (
-        <div className="mt-1.5 flex">
-          <MilestoneBadge
-            name={task.milestone}
-            definition={milestonesByName?.get(task.milestone)}
-          />
-        </div>
-      ) : null}
-      {task.labels.length > 0 && (
-        <div className="mt-1.5 flex flex-wrap gap-1">
-          {task.labels.map((label) => (
-            <LabelTag key={label} label={label} />
-          ))}
-        </div>
-      )}
-      <SubIssueProgress
-        childTasks={childTasks}
-        done={done}
-        total={total}
-        doneColumn={doneColumn}
-      />
-      <footer className="mt-2 flex items-center gap-2 text-xs text-muted">
-        <span className="min-w-0 truncate" data-testid="task-card-id">
-          {task.id}
-        </span>
-        {linkCount > 0 && (
-          <span className="shrink-0" data-testid="task-card-link-count">
-            🔗 {linkCount}
-          </span>
-        )}
-        {total > 0 && (
-          <span className="shrink-0" data-testid="task-card-subissue-count">
-            {done}/{total}
-          </span>
-        )}
-      </footer>
-    </>
-  );
-};
+type TaskCardProps = Omit<TaskCardRootProps, "children">;
 
 /**
- * タスクカードを表示する。onClick の有無に関わらず draggable な div を返す。
+ * 旧 API 互換のタスクカード。13 props を {@link TaskCardRoot} に転送し、
+ * 5 つの子サブ部品（Header / Milestone / Labels / Progress / Footer）を
+ * 既定の順序で並べる。新 API は {@link TaskCard} の `.Root` / `.Header` 等を直接使う。
  * @param props - {@link TaskCardProps}
  * @returns カード要素
  */
-export const TaskCard = ({
+const TaskCardLegacy = ({
   task,
   childTasks,
   descendantTasks,
   doneColumn,
   milestonesByName,
   fromColumn,
-  isDragging = false,
-  disableDrag = false,
-  hasBrokenLink = false,
-  hasParseError = false,
+  isDragging,
+  disableDrag,
+  hasBrokenLink,
+  hasParseError,
   onClick,
   onDragStart,
   onDragEnd,
-}: TaskCardProps) => {
-  // ドラッグ終了直後にブラウザが発火する synthetic click を抑止するためのガード。
-  // dragstart で true にし、onClick はこのフラグが立っている間は無視する。
-  // click は dragend より後に届くため、dragend では即解除せず下記 setTimeout で遅延解除する。
-  const dragGuardRef = useRef(false);
+}: TaskCardProps) => (
+  <TaskCardRoot
+    task={task}
+    childTasks={childTasks}
+    descendantTasks={descendantTasks}
+    doneColumn={doneColumn}
+    milestonesByName={milestonesByName}
+    fromColumn={fromColumn}
+    isDragging={isDragging}
+    disableDrag={disableDrag}
+    hasBrokenLink={hasBrokenLink}
+    hasParseError={hasParseError}
+    onClick={onClick}
+    onDragStart={onDragStart}
+    onDragEnd={onDragEnd}
+  >
+    <TaskCardHeader />
+    <TaskCardMilestone />
+    <TaskCardLabels />
+    <TaskCardProgress />
+    <TaskCardFooter />
+  </TaskCardRoot>
+);
 
-  const handleDragStart = (e: DragEvent<HTMLDivElement>) => {
-    if (disableDrag) {
-      return;
-    }
-    e.dataTransfer.setData(DRAG_MIME_TYPE, task.filePath);
-    e.dataTransfer.effectAllowed = "move";
-    dragGuardRef.current = true;
-    onDragStart?.(task.filePath, fromColumn);
-  };
-
-  const handleDragEnd = () => {
-    onDragEnd?.();
-    // dragend 直後の synthetic click はこのマクロタスクの後に届く。0ms 遅延で解除を
-    // 次のマクロタスクに回すことで、その click を確実にガードしてから false に戻す。
-    setTimeout(() => {
-      dragGuardRef.current = false;
-    }, 0);
-  };
-
-  const draggingClass = isDragging ? " opacity-40" : "";
-  // ドラッグ中は dragging の減光を優先し、draft の opacity は重ねない
-  // （opacity-40 × opacity-60 の重複減光を避ける）。
-  const draftClass = !isDragging && task.draft ? " opacity-60" : "";
-  const dataDragging = isDragging ? "true" : undefined;
-
-  if (!onClick) {
-    return (
-      // biome-ignore lint/a11y/noStaticElementInteractions: HTML5 native DnD requires draggable handlers on the card container; CardContent may include interactive descendants so a semantic element is unsuitable
-      <div
-        draggable={!disableDrag}
-        data-dragging={dataDragging}
-        data-testid="task-card"
-        aria-grabbed={isDragging}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
-        className={`w-full rounded-lg border border-border bg-surface p-3 text-left shadow-sm${draggingClass}${draftClass}`}
-      >
-        <CardContent
-          task={task}
-          childTasks={childTasks}
-          descendantTasks={descendantTasks}
-          doneColumn={doneColumn}
-          milestonesByName={milestonesByName}
-          hasBrokenLink={hasBrokenLink}
-          hasParseError={hasParseError}
-        />
-      </div>
-    );
-  }
-
-  return (
-    // biome-ignore lint/a11y/useSemanticElements: CardContent may include interactive descendants such as details/summary, so a semantic <button> cannot be used as the card container
-    <div
-      draggable={!disableDrag}
-      data-dragging={dataDragging}
-      data-testid="task-card"
-      aria-grabbed={isDragging}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      role="button"
-      tabIndex={0}
-      className={`w-full cursor-pointer rounded-lg border border-border bg-surface p-3 text-left shadow-sm hover:border-accent hover:shadow-md${draggingClass}${draftClass}`}
-      onClick={() => {
-        if (dragGuardRef.current) {
-          return;
-        }
-        onClick(task.id);
-      }}
-      onKeyDown={(e) => {
-        if (e.currentTarget !== e.target) {
-          return;
-        }
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onClick(task.id);
-        }
-      }}
-    >
-      <CardContent
-        task={task}
-        childTasks={childTasks}
-        descendantTasks={descendantTasks}
-        doneColumn={doneColumn}
-        milestonesByName={milestonesByName}
-        hasBrokenLink={hasBrokenLink}
-        hasParseError={hasParseError}
-      />
-    </div>
-  );
+/** Compound コンポーネント本体（Root + 5 サブ部品の名前空間） */
+type TaskCardComponent = ((props: TaskCardProps) => ReactNode) & {
+  Root: typeof TaskCardRoot;
+  Header: typeof TaskCardHeader;
+  Milestone: typeof TaskCardMilestone;
+  Labels: typeof TaskCardLabels;
+  Progress: typeof TaskCardProgress;
+  Footer: typeof TaskCardFooter;
 };
+
+/**
+ * タスクカード（Compound コンポーネント）。
+ * `<TaskCard task ... />` の形は旧 API ラッパで Compound パーツを既定順序で展開する。
+ * `<TaskCard.Root task ...><TaskCard.Header />...</TaskCard.Root>` は新 API として
+ * 並べ替え自由度を提供する。両者は内部で同じ {@link TaskCardRoot} を呼ぶ。
+ */
+export const TaskCard: TaskCardComponent = Object.assign(TaskCardLegacy, {
+  Root: TaskCardRoot,
+  Header: TaskCardHeader,
+  Milestone: TaskCardMilestone,
+  Labels: TaskCardLabels,
+  Progress: TaskCardProgress,
+  Footer: TaskCardFooter,
+});


### PR DESCRIPTION
## 概要
- `src/features/board/components/TaskCard/index.tsx`（270 行・top-level 13 props）を **Compound + Context** パターンで Root + 5 子（Header / Milestone / Labels / Progress / Footer） + Context に分解。
- 旧 API は **Legacy ラッパ**として残置し、`Object.assign` でドット記法（`TaskCard.Root` / `TaskCard.Header` ...）を公開する。Column 等の呼出側は無修正。
- 表示挙動・公開 API は不変の **純粋なリファクタリング**。

## 変更の種類
- ♻️ Refactoring

## 追加した内容
- `TaskCardContext/index.ts` — Context object + `useTaskCardContext` フック（Provider 外で throw）+ 型 (`TaskCardContextValue` / `MilestonesByName`)
- `TaskCardRoot/index.tsx` — draggable コンテナ + Context Provider。Context Value と `subIssueCounts` を `useMemo` で安定化（Column の `tasks.map` での子再描画を抑制）。`EMPTY_TASKS` 定数で `childTasks` 省略時の fallback 配列の参照を固定。
- `TaskCardHeader/` `TaskCardMilestone/` `TaskCardLabels/` `TaskCardProgress/` `TaskCardFooter/` — 5 子サブコンポ（`useTaskCardContext` 経由で Context を読む表示専用）
- 各サブフォルダの `__tests__/{Name}.behavior.test.{ts,tsx}`（合計 7 ファイル）
- `__tests__/TaskCard.compound.test.tsx` — Compound 経路 + Legacy 互換性同値の統合テスト
- Storybook に新 API Story（`HeaderOnly` / `MilestoneOnly` / `LabelsOnly` / `ProgressOnly` / `FooterOnly` / `CompoundFull` / `ReorderedFooterFirst` / `WithMilestoneAndLabels`）

## 変更した内容
- `TaskCard/index.tsx` — 旧 270 行の単一実装を削除し、`TaskCardLegacy` ラッパ + `Object.assign` 公開のみに刷新（66 行）。13 props を explicit destructure で `TaskCardRoot` に転送する。
- `TaskCard/index.stories.tsx` — 既存 10 Story 残置 + 新規 8 Story 追加

## 削除した内容
- 旧 `CardContent` 内部関数と旧 `TaskCard` 単一実装（`index.tsx` 内）

## 仕様ドキュメント更新
- **不要（純粋なリファクタリング）**。表示挙動・公開 API・データ形式・設定項目すべて不変。`docs/spec-board/task-card-spec.md` 等の仕様ドキュメントは更新不要。

## システム図

### 旧構造（Before）

```mermaid
flowchart TD
  Column["Column tasks.map"] --> TaskCard["TaskCard (270 行 / 13 props)"]
  TaskCard --> CardContent["CardContent (内部 7 props)"]
  CardContent --> Badges["DraftBadge / PriorityBadge / DueBadge / MilestoneBadge / LabelTag"]
  CardContent --> Progress["SubIssueProgress"]
```

### 新構造（After）

```mermaid
flowchart TD
  Column["Column tasks.map"] --> TaskCardLegacy["TaskCard (Legacy ラッパ)"]:::new
  TaskCardLegacy --> TaskCardRoot["TaskCard.Root<br/>(draggable + Context Provider)"]:::new
  TaskCardRoot --> Provider["TaskCardContext<br/>(Value: useMemo 安定化)"]:::new
  Provider --> Header["TaskCard.Header"]:::new
  Provider --> Milestone["TaskCard.Milestone"]:::new
  Provider --> Labels["TaskCard.Labels"]:::new
  Provider --> Progress["TaskCard.Progress<br/>(props override 再集計)"]:::new
  Provider --> Footer["TaskCard.Footer"]:::new
  classDef new fill:#dff,stroke:#06c,color:#000
```

## 関連Issue
- なし（独立リファクタリング）

## テスト
- `pnpm test:run --exclude '**/.claude/**'`: 265 ファイル / 2228 テスト 全 GREEN
- TaskCard 関連: 14 ファイル / 84 テスト 全 GREEN
  - 既存 6 テストファイル（rendering / dnd / brokenLink / parseError / draft / milestone）が **無修正で通過** = 旧 API 完全互換の証明
  - 新規テスト: TaskCardContext / TaskCardRoot / 5 子 / Compound 統合
- `pnpm build`: 成功
- `pnpm lint`: 0 警告 0 エラー
- **実機 UI 検証は未実施**。本変更は表示挙動・公開 API 不変のリファクタなので、自動テストで担保。実機 DnD / Board 描画は merge 前後で目視確認推奨。

## レビューポイント
- **互換性**: `TaskCardLegacy` が `TaskCardRoot` に 13 props を explicit destructure で転送している（spread を避け、将来の Root prop 追加時の余剰漏出を防止）
- **メモ化**: `TaskCardRoot` の `EMPTY_TASKS` 定数 + `useMemo` 依存配列で Context Value の identity 安定化。`TaskCardRoot.behavior.test.tsx` に「依存不変なら同一参照」テスト 2 件で退行検出
- **Progress override**: `TaskCardProgress` は optional `childTasks` props を持ち、override 時は `done/total` も再集計（plan §3.4 の根拠）。override 無し時は Provider 値を pass-through し二重計算を回避
- **DnD synthetic click 抑止**: `dragGuardRef` + `setTimeout(0)` を `TaskCardRoot` に保持。`TaskCard.dnd.test.tsx`（既存・無修正）と `TaskCardRoot.behavior.test.tsx`（新規）の両方で fake timer 検証
- **テスト品質**: AI レビュー（5 エージェント並列）で CRITICAL 2 / WARNING 6 の指摘を反映済み。内部モジュール `TaskHierarchy.countSubIssueProgress` への spy 検証は削除し、`aria-valuenow` の DOM 観察で等価検証に置換
- **スコープ外として残置（次 PR 推奨）**:
  - `TaskCardRoot` → `Board/dragState` 兄弟参照（`DRAG_MIME_TYPE` の共有層移動）
  - `React.memo` 化（Column 側の `childTasks` インライン生成の安定化と合わせて別 spec）