### PR TITLE
♻️ [Refactoring]: [FE] KebabCase ドメインを TaskFileName にリネーム

### DIFF
--- a/src/domains/task-file-name/__tests__/task-file-name.behavior.test.ts
+++ b/src/domains/task-file-name/__tests__/task-file-name.behavior.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { KebabCase } from "..";
+import { TaskFileName } from "..";
 
 test("ASCII 基本ケース", () => {
   const cases: Array<[string, string, string]> = [
@@ -10,7 +10,7 @@ test("ASCII 基本ケース", () => {
     ["Hello_World.md", "hello-world-md", "underscore and dot are separators"],
   ];
   for (const [input, expected, label] of cases) {
-    expect(KebabCase.from(input), label).toBe(expected);
+    expect(TaskFileName.from(input), label).toBe(expected);
   }
 });
 
@@ -22,7 +22,7 @@ test("非 ASCII / mixed ケース", () => {
     ["バグ修正", "バグ修正", "all non-ascii passthrough"],
   ];
   for (const [input, expected, label] of cases) {
-    expect(KebabCase.from(input), label).toBe(expected);
+    expect(TaskFileName.from(input), label).toBe(expected);
   }
 });
 
@@ -32,6 +32,6 @@ test("空 / 記号のみ", () => {
     ["!!!", "", "all symbols collapse to empty"],
   ];
   for (const [input, expected, label] of cases) {
-    expect(KebabCase.from(input), label).toBe(expected);
+    expect(TaskFileName.from(input), label).toBe(expected);
   }
 });

--- a/src/domains/task-file-name/index.ts
+++ b/src/domains/task-file-name/index.ts
@@ -1,13 +1,13 @@
-declare const kebabCaseBrand: unique symbol;
+declare const taskFileNameBrand: unique symbol;
 
 /**
  * タスクタイトルから生成された kebab-case ファイル名 base 文字列。
- * `KebabCase.from` 経由でのみ生成される branded string。
+ * `TaskFileName.from` 経由でのみ生成される branded string。
  */
-export type KebabCase = string & { readonly [kebabCaseBrand]: true };
+export type TaskFileName = string & { readonly [taskFileNameBrand]: true };
 
-/** KebabCase の companion API。 */
-export const KebabCase = {
+/** TaskFileName の companion API。 */
+export const TaskFileName = {
   /**
    * 任意の文字列を kebab-case のファイル名 base 文字列に変換する。
    * BE 側 `to_kebab_case` と挙動を一致させる。
@@ -19,10 +19,10 @@ export const KebabCase = {
    * @param raw 任意の入力文字列
    * @returns kebab-case 化した branded 文字列
    */
-  from: (raw: string): KebabCase => {
+  from: (raw: string): TaskFileName => {
     const hasAscii = [...raw].some((c) => c.charCodeAt(0) < 128);
     if (!hasAscii) {
-      return raw as KebabCase;
+      return raw as TaskFileName;
     }
     let out = "";
     let lastWasSeparator = true;
@@ -55,6 +55,6 @@ export const KebabCase = {
     if (out.endsWith("-")) {
       out = out.slice(0, -1);
     }
-    return out as KebabCase;
+    return out as TaskFileName;
   },
 } as const;

--- a/src/features/task-form/lib/fields/fileName/index.ts
+++ b/src/features/task-form/lib/fields/fileName/index.ts
@@ -1,4 +1,4 @@
-import { KebabCase } from "@/domains/kebab-case";
+import { TaskFileName } from "@/domains/task-file-name";
 import { Result } from "@/utils/result";
 // 予約文字集合は title field の export 済み定数を再利用する（再定義しない）。
 import { FORBIDDEN_TITLE_CHARS } from "../title";
@@ -7,7 +7,7 @@ declare const fileNameFieldBrand: unique symbol;
 
 /**
  * FileNameField が保持する値（ファイル名欄の入力値）。
- * `KebabCase` / `Due` と同じ branded string パターンを踏襲し、
+ * `TaskFileName` / `Due` と同じ branded string パターンを踏襲し、
  * `initial` / `fromTitle` / `fromInput` の companion 経由でのみ生成される。
  *
  * 入力中の値は**生のまま**保持し（controlled input への正規化書き戻しは
@@ -45,12 +45,12 @@ export const FileNameField = {
 
   /**
    * タイトルから kebab-case base を導出する（自動追従用）。
-   * KebabCase brand から FileNameField brand へは companion 内でのみ詰め替える。
+   * TaskFileName brand から FileNameField brand へは companion 内でのみ詰め替える。
    * @param title - タイトルの生文字列
    * @returns kebab-case 化した base
    */
   fromTitle: (title: string): FileNameField =>
-    KebabCase.from(title.trim()) as string as FileNameField,
+    TaskFileName.from(title.trim()) as string as FileNameField,
 
   /**
    * UI の onChange から渡る生文字列を branded 値へ変換する唯一の入口。

--- a/src/features/task-form/lib/fields/title/index.ts
+++ b/src/features/task-form/lib/fields/title/index.ts
@@ -1,4 +1,4 @@
-import { KebabCase } from "@/domains/kebab-case";
+import { TaskFileName } from "@/domains/task-file-name";
 import { Result } from "@/utils/result";
 
 /** TitleField が保持する値の型（生の入力文字列） */
@@ -71,7 +71,7 @@ export const TitleField = {
         actual: trimmed.length,
       });
     }
-    const kebabBase = KebabCase.from(trimmed);
+    const kebabBase = TaskFileName.from(trimmed);
     if (kebabBase.length === 0) {
       // 記号のみ・アンダースコアのみ等で kebab base が空になる入力は
       // ファイル名 base が作れず、BE 側でも InvalidTitle となるため

--- a/src/features/task-form/lib/savePathPreview/index.ts
+++ b/src/features/task-form/lib/savePathPreview/index.ts
@@ -1,4 +1,4 @@
-import { KebabCase } from "@/domains/kebab-case";
+import { TaskFileName } from "@/domains/task-file-name";
 import { normalizeTaskPathForLookup } from "@/domains/task-path";
 import type { FileNameValidationError } from "@/features/task-form/lib/fields/fileName";
 import { FileNameField } from "@/features/task-form/lib/fields/fileName";
@@ -87,7 +87,7 @@ const resolveBase = (title: string, fileName: string): string => {
     // toParam は `${base}.md` を返すため末尾拡張子を剥がして base に戻す。
     return explicit.slice(0, explicit.length - ".md".length);
   }
-  return KebabCase.from(title.trim()) as string;
+  return TaskFileName.from(title.trim()) as string;
 };
 
 /** 保存先パスプレビューの companion object（pure function のみ）。 */


### PR DESCRIPTION
## 概要

`src/domains/kebab-case/` のドメイン名がアルゴリズム名（kebab-case 変換）になっており、値の意味（タスクファイル名 base 文字列）が型名から伝わらない問題を解消する。ドメイン名を値の意味側 `TaskFileName` に揃え、`FileNameField`（フォーム入力 field）との責務分離を読みやすくする純粋リネーム。**挙動・公開 API シグネチャ完全不変**。

## 変更の種類

- ♻️ Refactoring（純粋リネーム / 挙動変更なし）

## 追加した内容

- `src/domains/task-file-name/index.ts`（`src/domains/kebab-case/index.ts` から `git mv`、`R81%`）
- `src/domains/task-file-name/__tests__/task-file-name.behavior.test.ts`（同 `R84%`）

## 変更した内容

- ドメイン本体: brand symbol `kebabCaseBrand` → `taskFileNameBrand` / 型 `KebabCase` → `TaskFileName` / companion const 同名改名 / doc コメント中の型名参照追従
- テスト: `import { KebabCase }` → `import { TaskFileName }`、`KebabCase.from` → `TaskFileName.from`（3 件）
- caller 3 ファイル: import パス `@/domains/kebab-case` → `@/domains/task-file-name`、識別子追従
  - `src/features/task-form/lib/savePathPreview/index.ts`
  - `src/features/task-form/lib/fields/title/index.ts`（ローカル変数 `kebabBase` は実装ローカル命名のため温存）
  - `src/features/task-form/lib/fields/fileName/index.ts`（JSDoc 2 箇所追従、二段 cast `as string as FileNameField` 構造は温存）

## 削除した内容

- `src/domains/kebab-case/`（`git mv` による移動。履歴は `git log --follow` で追跡可能）

## システム図

```mermaid
flowchart LR
    subgraph before["BEFORE"]
        T1[Title raw string] --> K1["KebabCase.from<br/>@/domains/kebab-case"]
        K1 --> KB[KebabCase branded]
        KB --> F1["FileNameField.fromTitle<br/>(as string as FileNameField)"]
        F1 --> FF1[FileNameField]
    end
    subgraph after["AFTER"]
        T2[Title raw string] --> K2["TaskFileName.from<br/>@/domains/task-file-name"]
        K2 --> TB[TaskFileName branded]
        TB --> F2["FileNameField.fromTitle<br/>(as string as FileNameField)"]
        F2 --> FF2[FileNameField]
    end
    style K2 fill:#dff,stroke:#0a8,stroke-width:2px
    style TB fill:#dff,stroke:#0a8,stroke-width:2px
```

データ・型変換フローは完全同一。フォルダ名・型/const/symbol 名のみが変わる。

## 温存対象（意図的に残置している "kebab" 表記）

純粋リネームの境界として以下は識別子参照ではないため温存:

- UI placeholder「名前は kebab-case 推奨」（`LabelSettingsTab/CreateLabelForm/index.tsx:227`）
- `useTaskFormFields/index.ts` reducer コメント 3 箇所
- ローカル変数 `kebabBase`（`title/index.ts:74`、実装ローカル命名）
- `*.test.{ts,tsx}` 内のテスト label "kebab" / "kebab-case"
- BE 関数名参照コメント `to_kebab_case`
- doc コメント中のアルゴリズム説明としての「kebab-case」
- BE 側 `src-tauri/crates/fs/src/task/kebab_case.rs` は別 PR 扱い

## 関連 Issue

なし（リファクタリング）

## テスト

- `pnpm build`: tsc strict ゼロエラー ✅
- `pnpm test:run --exclude '**/.claude/**'`: 全 272 ファイル / **2312 件 pass** ✅
- `pnpm biome check`: 警告増加なし ✅
- `pnpm oxlint`: 0 warnings / 0 errors ✅
- `git grep -nE "KebabCase|kebabCaseBrand|@/domains/kebab-case" src/`: ヒット **0 件** ✅
- `git status` の `R100`（テスト）/ `R81%` 〜 `R84%`（diff stat）で rename 検出済み → `git log --follow` で履歴追跡可能

Codex AI レビュー（`.plugin-workspace/.specs/020-fe-kebab-case-domain-rename/code-review/review-001.md`）: 6 観点（同値性 / 温存漏れ / 改名漏れ / branded 整合 / JSDoc 整合 / ファイル構成）すべて ✅ で **Overall: APPROVE**。

## レビューポイント

1. **同値性**: `from` のアルゴリズム本体は 1 行も変更していないこと（diff 確認）
2. **温存リスト整合**: 上記「温存対象」が誤って改名されていないか
3. **branded type の二段 cast 保持**: `fileName/index.ts:53` の `TaskFileName.from(title.trim()) as string as FileNameField` 構造
4. **改名漏れ**: `KebabCase` / `kebabCaseBrand` / `@/domains/kebab-case` の参照残り

## チェックリスト

- [x] セルフレビューを実施した
- [x] 必要なテストを実施した（既存 3 件が改名後ファイル名で pass、新規追加なし）
- [x] 破壊的変更なし（FE 内部の型名のみ。Tauri IPC 境界には型情報が送られない branded string のため BE/IPC 影響ゼロ）