### PR TITLE
✨ [New Feature]: [FE] Brand<T, Name> 型ユーティリティを追加

### DIFF
--- a/docs/impl/brand-type.md
+++ b/docs/impl/brand-type.md
@@ -1,0 +1,201 @@
+# Brand 型ユーティリティ実装ガイド
+
+## 何を提供するか
+
+`src/types/brand.ts` に汎用 nominal 型ユーティリティ `Brand<T, Name>` を 1 つだけ提供する。
+
+```ts
+export type Brand<T, Name extends string> = T & {
+  readonly [brandSymbol]: { readonly [K in Name]: K };
+};
+```
+
+これにより、1 行で「名前で区別された型」を宣言できる:
+
+```ts
+import type { Brand } from "@/types/brand";
+
+type TaskId = Brand<string, "TaskId">;
+type MilestoneId = Brand<string, "MilestoneId">;
+```
+
+主な性質は次の 4 つ:
+
+- 元の型 `T` への widening（`TaskId` → `string`）は OK。
+- 逆の narrowing（`string` → `TaskId`）は型エラー（`as` キャストが必要）。
+- 異なる `Name` 同士は相互非互換（`TaskId` ↔ `MilestoneId` の代入はどちらも型エラー）。
+- スタック可能: `Brand<Brand<string, "A">, "B">` のように積み重ねられる。
+
+## なぜこの形か
+
+TypeScript の型システムは構造的部分型なので、`type TaskId = string` のような単純な別名を作っても、コンパイラは `string` と `TaskId` を完全に同じ型として扱う。同じ string ベースの ID 同士を取り違えても検出できない。これを「名目的（nominal）に」区別するために、実体としては存在しない `unique symbol` をキーに使った見えない印（タグ）を交差型で付与する、というのが Brand パターンの基本アイデアである。
+
+`Brand<T, Name>` のポイントは次の 3 つ。
+
+### モジュールスコープに `unique symbol` を 1 本だけ宣言する
+
+```ts
+declare const brandSymbol: unique symbol;
+```
+
+`declare const` は実行時には**存在しない**宣言で、コンパイル後の JS には残らない。これにより、
+
+- `[brandSymbol]` プロパティを持つ「ふり」をする型を作っても、ランタイムオーバーヘッドはゼロ。
+- `tsconfig.json` の `noUnusedLocals: true` 下でも警告にならない（TypeScript の仕様。`declare const` は宣言扱いで未使用判定の対象外）。
+
+各 Brand 型ごとに symbol を分ける必要はない。1 本の symbol を共有し、Name パラメータで識別する。
+
+### `Name extends string` を最小制約に置く
+
+`Name` は通常リテラル型（`"TaskId"` のような文字列リテラル）を受け取る。型エラーを起こすメッセージに `Name` の文字列がそのまま現れるため、デバッグしやすい。
+
+> **注意**: `string` 自体（広い型）を渡してはいけない。[アンチパターン](#アンチパターン) 参照。
+
+### 内部表現に Mapped Type を使う
+
+```ts
+{ readonly [brandSymbol]: { readonly [K in Name]: K } }
+```
+
+`{ [K in Name]: K }` は Mapped Type で、`Name = "TaskId"` のときは `{ TaskId: "TaskId" }` 相当のオブジェクト型になる。スタック時の振る舞いがポイントになる:
+
+```ts
+type Stack = Brand<Brand<string, "A">, "B">;
+//   = string
+//     & { [brandSymbol]: { A: "A" } }
+//     & { [brandSymbol]: { B: "B" } }
+//   = string
+//     & { [brandSymbol]: { A: "A" } & { B: "B" } }
+//   = string
+//     & { [brandSymbol]: { A: "A", B: "B" } }
+```
+
+同じプロパティキー `[brandSymbol]` の交差は値型の交差に降りる。Mapped Type 同士の交差は**キーが積み上がる**ため、スタックすると Name キーが結合される。
+
+もし単純な `T & { [brandSymbol]: Name }` 形式（値型に Name 文字列をそのまま入れる）だと、スタック時に `[brandSymbol]: "A" & "B"` となり、`"A" & "B" = never` に簡約されてしまう。`never` は bottom type として「任意の型に代入可能」なため、無関係な `Brand<string, "C">` への代入まで通ってしまい、nominal safety が崩れる。Mapped Type を使うのはこの落とし穴を回避するためである。
+
+## 使い方
+
+### 1. ID 型を nominal に区別する
+
+```ts
+type TaskId = Brand<string, "TaskId">;
+type MilestoneId = Brand<string, "MilestoneId">;
+
+declare const TaskId: {
+  parse: (raw: string) => TaskId | undefined;
+};
+
+const id = TaskId.parse("task-1");
+if (id !== undefined) {
+  // id: TaskId として安全に扱える
+  saveTask(id);
+}
+
+declare function saveTask(id: TaskId): void;
+saveTask("task-2"); // 型エラー: string は TaskId に代入できない
+```
+
+ポイント:
+
+- 値の生成は companion 関数 (`TaskId.parse` 等) に閉じる。`as TaskId` キャストはこの内部に閉じ込め、呼び出し側で書かない。
+- `saveTask` の引数を `string` ではなく `TaskId` にすることで、未検証の string を渡すミスが型エラーになる。
+
+### 2. 検証済み値の段階的絞り込み（スタック）
+
+`Brand` は積み重ねできるので、「検証段階」を型で表現できる。
+
+```ts
+type KebabCase = Brand<string, "KebabCase">;
+type UniqueFileName = Brand<KebabCase, "UniqueFileName">;
+
+declare const FileName: {
+  toKebab: (raw: string) => KebabCase;
+  ensureUnique: (base: KebabCase, existing: ReadonlySet<string>) => UniqueFileName;
+};
+
+const kebab = FileName.toKebab("My Task");
+const unique = FileName.ensureUnique(kebab, new Set(["my-task"]));
+
+const k: KebabCase = unique;   // OK: 二段目を一段目に widening
+const plain: string = unique;  // OK: 二段ぶん widening
+```
+
+逆向き（`KebabCase` → `UniqueFileName`、`string` → `UniqueFileName`）は型エラーになる。「衝突回避まで完了している」ことを型で保証できる。
+
+### 3. 非 string 型にも適用
+
+`T` は無制約なので、number / 配列 / オブジェクトなど何でも Brand 化できる。
+
+```ts
+type Year = Brand<number, "Year">;
+type Tags = Brand<readonly string[], "Tags">;
+type Config = Brand<{ debug: boolean }, "Config">;
+```
+
+## 既存 Brand 3 箇所との関係
+
+本ユーティリティ導入時点では、既存の以下 3 箇所は**置き換えない**:
+
+- `src/domains/task-file-name/index.ts` — `TaskFileName`
+- `src/domains/due/index.ts` — `Due`
+- `src/features/task-form/lib/fields/fileName/index.ts` — `FileNameField`
+
+これらは個別に `declare const xxxBrand: unique symbol` を持つ旧式パターンだが、機能的には等価なので、今すぐ書き換える必要はない。将来的に `Brand<string, "TaskFileName">` の形へ寄せる場合は後続 spec で行う。
+
+## 代入可能性マトリクス
+
+`A = Brand<string, "A">`、`B = Brand<string, "B">`、`AB = Brand<Brand<string, "A">, "B">` として:
+
+| from \ to | `string` | `A` | `B` | `AB` | `Brand<string, "C">` |
+|-----------|----------|-----|-----|------|----------------------|
+| `string`  | OK       | NG  | NG  | NG   | NG                   |
+| `A`       | OK       | OK  | NG  | NG   | NG                   |
+| `B`       | OK       | NG  | OK  | NG   | NG                   |
+| `AB`      | OK       | OK  | OK  | OK   | NG                   |
+
+ルール:
+
+- **widening（Brand → 元の型 / 上位 Brand）**: 常に OK。
+- **narrowing（元の型 → Brand）**: 常に NG。生成は cast で行う（companion 内）。
+- **Name 不一致（横移動）**: NG。`[brandSymbol]` の値型が要求するキーセットが異なる。
+
+## アンチパターン
+
+### `brand()` / `unbrand()` ヘルパを作らない
+
+```ts
+// やらない
+export const brand = <T, N extends string>(v: T): Brand<T, N> => v as Brand<T, N>;
+```
+
+理由:
+
+- 生成位置を 1 箇所に閉じ込められない（呼び出し側で `brand<string, "TaskId">(raw)` のように何処でも書けてしまう）。
+- 検証ロジックと cast を引き剥がしてしまい、「validate を通っていない値を Brand する」ミスを誘発する。
+
+代わりに、各 Brand 型は対応する companion 関数（`TaskId.parse` / `Due.parse` 等）の中でのみ `as TaskId` を許す運用にする。
+
+### companion 層以外で cast しない
+
+```ts
+// やらない（feature 層で生 string を cast）
+const id = rawInput as TaskId;
+saveTask(id);
+```
+
+`as` キャストはコンパイラの型検査をすり抜けるため、validate なしの値を Brand 型に詰めてしまうと、型システムが提供する保証が崩れる。validate と cast はセットで domain 層の companion に閉じる。
+
+### 第 2 引数に `string` を渡さない
+
+```ts
+// やらない
+type Bad = Brand<string, string>;
+```
+
+`Name extends string` という制約は最小の型制約に過ぎず、`Name = string` を許す。しかし `string` を渡すと:
+
+- `{ [K in string]: K }` は `{ [k: string]: string }` 相当のインデックスシグネチャ型になり、特定の Name キーで区別する nominal 性が失われる。
+- 全ての `Brand<T, string>` が相互代入可能になり、Brand を導入した意味が消える。
+
+必ず文字列リテラル型（`"TaskId"` / `"Year"` 等）を渡すこと。

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -b && vite build",
     "typecheck": "tsc -b",
     "test": "vitest",
-    "test:run": "vitest run --passWithNoTests",
+    "test:run": "vitest run --passWithNoTests --exclude \"**/.claude/**\"",
     "test:coverage": "vitest run --coverage",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/src/types/__tests__/brand.type.test.ts
+++ b/src/types/__tests__/brand.type.test.ts
@@ -30,7 +30,7 @@ test("FooId は BarId に代入できない（順方向）", () => {
   expectTypeOf(bar).toEqualTypeOf<BarId>();
 });
 
-test('Brand<string, "B"> は Brand<string, "A"> に代入できない（逆方向）', () => {
+test("BarId は FooId に代入できない（逆方向）", () => {
   const bar = "xyz" as BarId;
   // @ts-expect-error BarId と FooId は Name が異なるため非互換
   const foo: FooId = bar;

--- a/src/types/__tests__/brand.type.test.ts
+++ b/src/types/__tests__/brand.type.test.ts
@@ -23,7 +23,7 @@ test("プリミティブ string は Brand 型に直接代入できない（narro
   expectTypeOf(foo).toEqualTypeOf<FooId>();
 });
 
-test('Brand<string, "A"> は Brand<string, "B"> に代入できない（順方向）', () => {
+test("FooId は BarId に代入できない（順方向）", () => {
   const foo = "abc" as FooId;
   // @ts-expect-error FooId と BarId は Name が異なるため非互換
   const bar: BarId = foo;

--- a/src/types/__tests__/brand.type.test.ts
+++ b/src/types/__tests__/brand.type.test.ts
@@ -1,0 +1,106 @@
+import { expectTypeOf, test } from "vitest";
+import type { Brand } from "../brand";
+
+type FooId = Brand<string, "FooId">;
+type BarId = Brand<string, "BarId">;
+
+test("Brand 型は元のプリミティブ型 string に代入できる（widening）", () => {
+  const foo = "abc" as FooId;
+  const plain: string = foo;
+  expectTypeOf(plain).toEqualTypeOf<string>();
+});
+
+test("同じ Name の Brand 同士は代入できる", () => {
+  const foo1 = "abc" as FooId;
+  const foo2: FooId = foo1;
+  expectTypeOf(foo2).toEqualTypeOf<FooId>();
+});
+
+test("プリミティブ string は Brand 型に直接代入できない（narrowing は cast 必須）", () => {
+  const plain: string = "abc";
+  // @ts-expect-error string は FooId へ直接代入できない
+  const foo: FooId = plain;
+  expectTypeOf(foo).toEqualTypeOf<FooId>();
+});
+
+test('Brand<string, "A"> は Brand<string, "B"> に代入できない（順方向）', () => {
+  const foo = "abc" as FooId;
+  // @ts-expect-error FooId と BarId は Name が異なるため非互換
+  const bar: BarId = foo;
+  expectTypeOf(bar).toEqualTypeOf<BarId>();
+});
+
+test('Brand<string, "B"> は Brand<string, "A"> に代入できない（逆方向）', () => {
+  const bar = "xyz" as BarId;
+  // @ts-expect-error BarId と FooId は Name が異なるため非互換
+  const foo: FooId = bar;
+  expectTypeOf(foo).toEqualTypeOf<FooId>();
+});
+
+type Inner = Brand<string, "Inner">;
+type Outer = Brand<Inner, "Outer">;
+type Unrelated = Brand<string, "Unrelated">;
+
+test("スタック値は第 1 Brand に代入できる（widening）", () => {
+  const stacked = "abc" as Outer;
+  const inner: Inner = stacked;
+  expectTypeOf(inner).toEqualTypeOf<Inner>();
+});
+
+test("スタック値は第 2 Brand 単独としても扱える", () => {
+  const stacked = "abc" as Outer;
+  type OuterAlone = Brand<string, "Outer">;
+  const outerAlone: OuterAlone = stacked;
+  expectTypeOf(outerAlone).toEqualTypeOf<OuterAlone>();
+});
+
+test("スタック値は元の string に代入できる（二段 widening）", () => {
+  const stacked = "abc" as Outer;
+  const plain: string = stacked;
+  expectTypeOf(plain).toEqualTypeOf<string>();
+});
+
+test("スタック値は無関係な Brand には代入できない（Mapped Type による nominal safety）", () => {
+  const stacked = "abc" as Outer;
+  // @ts-expect-error Outer は Unrelated の Name キー "Unrelated" を持たない
+  const unrelated: Unrelated = stacked;
+  expectTypeOf(unrelated).toEqualTypeOf<Unrelated>();
+});
+
+test("第 1 Brand 単独はスタック型に直接代入できない（narrowing）", () => {
+  const inner = "abc" as Inner;
+  // @ts-expect-error Inner は Outer の Name キー "Outer" を持たない
+  const stacked: Outer = inner;
+  expectTypeOf(stacked).toEqualTypeOf<Outer>();
+});
+
+test("string はスタック型に直接代入できない（narrowing）", () => {
+  const plain: string = "abc";
+  // @ts-expect-error string はスタック型の Brand キーをいずれも持たない
+  const stacked: Outer = plain;
+  expectTypeOf(stacked).toEqualTypeOf<Outer>();
+});
+
+type Year = Brand<number, "Year">;
+
+test('Brand<number, "Year"> で number ベースの nominal 型が作れて number に widening できる', () => {
+  const year = 2026 as Year;
+  const num: number = year;
+  expectTypeOf(num).toEqualTypeOf<number>();
+});
+
+type Tags = Brand<readonly string[], "Tags">;
+
+test('Brand<readonly string[], "Tags"> で配列ベースの nominal 型が作れて配列に widening できる', () => {
+  const tags = ["a", "b"] as unknown as Tags;
+  const arr: readonly string[] = tags;
+  expectTypeOf(arr).toEqualTypeOf<readonly string[]>();
+});
+
+type ConfigBrand = Brand<{ a: 1 }, "Config">;
+
+test('Brand<{ a: 1 }, "Config"> でオブジェクトベースの nominal 型が作れてオブジェクトに widening できる', () => {
+  const cfg = { a: 1 } as ConfigBrand;
+  const obj: { a: 1 } = cfg;
+  expectTypeOf(obj).toEqualTypeOf<{ a: 1 }>();
+});

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -1,0 +1,46 @@
+declare const brandSymbol: unique symbol;
+
+/**
+ * 構造的型システムを補強する nominal 型ユーティリティ。
+ * `string` / `number` 等のプリミティブや既存型を「名前」で区別し、
+ * 誤代入を型レベルで検出する。
+ *
+ * 値の生成は cast で行う運用（`brand()` / `unbrand()` 等のヘルパは提供しない）。
+ * 生成は domain 層の companion 関数（例: `Due.parse`, `TaskFileName.from`）に閉じる。
+ *
+ * **Name には必ず文字列リテラル型を渡すこと**。`Brand<string, string>` のように
+ * `string` 自体を渡すと nominal 性が失われ、全ての Brand が相互代入可能になる。
+ *
+ * **内部表現に Mapped Type `{ [K in Name]: K }` を使う理由**:
+ * 単純な `{ name: Name }` 形式だと、`Brand<Brand<T, "A">, "B">` のスタック時に
+ * `name: "A" & "B"` が `name: never` に簡約される。`never` は bottom type として
+ * 任意の型に代入可能なため、無関係な `Brand<T, "C">` への代入も通ってしまい
+ * nominal safety が崩れる。Mapped Type で書くと、スタック時に
+ * `{ A: "A" } & { B: "B" } = { A: "A", B: "B" }` のようにキーが積み上がり、
+ * `{ C: "C" }` を要求する `Brand<T, "C">` への代入は構造的に拒否される。
+ *
+ * @example
+ * // 1. ID 型を nominal に区別する
+ * type TaskId = Brand<string, "TaskId">;
+ * type MilestoneId = Brand<string, "MilestoneId">;
+ *
+ * const taskId = "abc" as TaskId;
+ * const milestoneId: MilestoneId = taskId; // 型エラー（Name が異なる）
+ *
+ * @example
+ * // 2. 検証済み値の段階的絞り込み（スタック）
+ * type KebabCase = Brand<string, "KebabCase">;
+ * type UniqueFileName = Brand<KebabCase, "UniqueFileName">;
+ *
+ * const unique = "task-1" as UniqueFileName;
+ * const kebab: KebabCase = unique;     // OK（widening）
+ * const plain: string = unique;        // OK（widening）
+ *
+ * @example
+ * // 3. 非 string 型にも適用可能
+ * type Year = Brand<number, "Year">;
+ * type Tags = Brand<readonly string[], "Tags">;
+ */
+export type Brand<T, Name extends string> = T & {
+  readonly [brandSymbol]: { readonly [K in Name]: K };
+};


### PR DESCRIPTION
## 概要

汎用 nominal 型ユーティリティ `Brand<T, Name>` を `src/types/brand.ts` に追加。既存 3 箇所（`TaskFileName` / `Due` / `FileNameField`）で重複している `declare const xxxBrand: unique symbol` ボイラープレートを、後続 spec で `type FooId = Brand<string, "FooId">` の 1 行宣言に置き換えるための基盤を整える。

副次的に、ローカル開発時に `.claude/worktrees/` 配下の他ブランチテストが `pnpm test:run` で偽失敗する問題への恒久対策（`--exclude "**/.claude/**"`）も同 PR に含む。

## 変更の種類

- ✨ **New Feature**: Brand 型ユーティリティの追加
- 🧪 **Tests**: 型レベルテスト 14 ケース追加
- 🔧 **Config**: `pnpm test:run` の worktree exclude
- 📝 **Doc**: `docs/impl/brand-type.md` 新設

## 追加した内容

- `src/types/brand.ts` — `Brand<T, Name extends string>` を 1 export
  - 形式: `T & { readonly [brandSymbol]: { readonly [K in Name]: K } }` の Mapped Type 交差
  - `declare const brandSymbol: unique symbol` をモジュールスコープに 1 本だけ宣言
- `src/types/__tests__/brand.type.test.ts` — vitest `expectTypeOf` + `@ts-expect-error` で 14 ケース検証
- `docs/impl/brand-type.md` — TS 初学者向け実装ガイド（6 章立て + 代入可能性マトリクス + アンチパターン）

## 変更した内容

- `package.json` `scripts.test:run`: `vitest run --passWithNoTests` → `vitest run --passWithNoTests --exclude "**/.claude/**"`
  - CI は `test:coverage` を使うため影響なし

## 仕様ドキュメント更新

不要（公開 API・データ形式・画面挙動・設定項目への影響なし）。型ユーティリティの追加とローカル開発体験の改善のみ。実装ガイドは `docs/impl/brand-type.md` として追加。

## システム図

代入可能性マトリクス（`A = Brand<string,"A">`、`B = Brand<string,"B">`、`AB = Brand<Brand<string,"A">,"B">`）:

```mermaid
flowchart TB
    string["string (primitive)"]
    A["Brand&lt;string, 'A'&gt;"]
    B["Brand&lt;string, 'B'&gt;"]
    AB["Brand&lt;Brand&lt;string,'A'&gt;,'B'&gt; (stack)"]
    C["Brand&lt;string, 'C'&gt; (unrelated)"]

    AB -- widening --> A
    AB -- widening --> B
    AB -- 2 段 widening --> string
    A -- widening --> string
    B -- widening --> string

    A -. "NG (Name 不一致)" .-> B
    B -. "NG (Name 不一致)" .-> A
    string -. "NG (narrowing — cast 必須)" .-> A
    AB -. "NG (C キーを持たない)" .-> C

    style AB fill:#cfe8ff,stroke:#333,stroke-width:2px
    style A fill:#e8f5e9
    style B fill:#e8f5e9
    style C fill:#ffebee
```

## 関連Issue

なし（Issue 未起票）。

## テスト

- ✅ `pnpm test:run`: **273 files / 2326 tests pass**（`brand.type.test.ts` の 14 ケース含む）
- ✅ `pnpm typecheck` (`tsc -b`): エラーなし（`@ts-expect-error` が正しく機能していることを確認）
- ✅ `pnpm build`: 成功
- ✅ Codex CLI レビュー 1 周: Brand 実装は計画通り APPROVE
- 既存 3 箇所（`TaskFileName` / `Due` / `FileNameField`）・`vite.config.ts` には変更が入っていないことを `git diff` で確認
- `.claude/worktrees/` 配下に他ブランチファイルが存在する状態での偽失敗回避は実機未確認（パターン自体は vitest 公式の `--exclude <glob>` 形式に準拠）

## レビューポイント

1. **Mapped Type 採用の妥当性**: 単純な `T & { [brandSymbol]: Name }` 形式だとスタック時に `"A" & "B" = never` に簡約され、`never` は bottom type として無関係な `Brand<T, "C">` への代入も通ってしまう。`{ [K in Name]: K }` で書くとキーが積み上がり、`{ C: "C" }` を要求する Brand への代入が構造的に拒否される（`brand.type.test.ts` の「スタック値は無関係な Brand には代入できない」テストで担保）
2. **`Name extends string` 制約**: 文字列リテラル型を渡す運用を JSDoc / 実装ガイドで明記。`Brand<string, string>` を渡すと nominal 性が失われるアンチパターンを `docs/impl/brand-type.md` に記載
3. **既存 3 箇所の置き換えは本 PR のスコープ外**: 後続 spec で `Brand<string, "TaskFileName">` 等への寄せを検討
4. **`package.json` 変更の独立性**: Brand 型本体とは独立した worktree pollution 対策。CI には影響なし（`test:coverage` 経路）