### PR TITLE
♻️ [Refactoring]: [FE] Board の Provider 2 段を BoardProviders に hoist

### DIFF
--- a/src/features/board/components/AddColumnButton/index.stories.tsx
+++ b/src/features/board/components/AddColumnButton/index.stories.tsx
@@ -1,6 +1,6 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { withBoardColumnProvider } from "../BoardColumnProvider/decorator";
+import { withBoardColumnProvider } from "../BoardColumnProvider/storybook/decorator";
 import { AddColumnButton } from ".";
 
 const meta: Meta<typeof AddColumnButton> = {

--- a/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
@@ -1,8 +1,10 @@
-import { act, createElement } from "react";
+import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import { createDragEvent } from "@/test-fixtures/createDragEvent";
 import type { Column as ColumnType } from "@/types/column";
+import type { ColumnReorderHandler } from "../../BoardColumnProvider";
+import { BoardProviders } from "../../BoardProviders";
 import { Board } from "..";
 import { COLUMN_DRAG_MIME_TYPE } from "../mime";
 
@@ -18,12 +20,33 @@ afterEach(() => {
   container = null;
 });
 
-const render = (props: Parameters<typeof Board>[0]) => {
+type RenderOptions = {
+  /** Board に渡す presentational props */
+  boardProps: Parameters<typeof Board>[0];
+  /** カラム並び替え確定時のコールバック */
+  onColumnReorder?: ColumnReorderHandler;
+};
+
+/**
+ * BoardProviders で 1 段ラップして Board を mount するローカルヘルパー。
+ * 表示用 tasks / allTasks は空配列固定（カラム DnD は task 側を参照しない）。
+ * @param options - render に使う props 群
+ */
+const renderWithProviders = (options: RenderOptions) => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root?.render(createElement(Board, props));
+    root?.render(
+      <BoardProviders
+        columns={options.boardProps.columns}
+        tasks={[]}
+        allTasks={[]}
+        onColumnReorder={options.onColumnReorder}
+      >
+        <Board {...options.boardProps} />
+      </BoardProviders>,
+    );
   });
 };
 
@@ -52,7 +75,9 @@ test("columns が逆順でも表示順 (order 昇順) で render される", () 
     { name: "B", order: 1 },
     { name: "A", order: 0 },
   ];
-  render({ columns: reversed, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: reversed, onAddTask: vi.fn() },
+  });
   expect(columnSections().map((s) => s.getAttribute("aria-label"))).toEqual([
     "A",
     "B",
@@ -61,17 +86,20 @@ test("columns が逆順でも表示順 (order 昇順) で render される", () 
 });
 
 test("カラムが 2 件以上のとき、ColumnHeader は draggable=true で render される", () => {
-  render({ columns: columns3, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: columns3, onAddTask: vi.fn() },
+  });
   for (const header of headers()) {
     expect(header.getAttribute("draggable")).toBe("true");
   }
 });
 
 test("カラムが 1 件のとき、ColumnHeader は draggable=false で render される", () => {
-  render({
-    columns: [{ name: "Only", order: 0 }],
-    tasks: [],
-    onAddTask: vi.fn(),
+  renderWithProviders({
+    boardProps: {
+      columns: [{ name: "Only", order: 0 }],
+      onAddTask: vi.fn(),
+    },
   });
   const header = headers()[0];
   expect(header?.getAttribute("draggable")).toBe("false");
@@ -79,10 +107,8 @@ test("カラムが 1 件のとき、ColumnHeader は draggable=false で render 
 
 test("カラムヘッダーで dragstart → 別カラムで drop すると onColumnReorder({fromColumnName, toColumnName})", () => {
   const onColumnReorder = vi.fn();
-  render({
-    columns: columns3,
-    tasks: [],
-    onAddTask: vi.fn(),
+  renderWithProviders({
+    boardProps: { columns: columns3, onAddTask: vi.fn() },
     onColumnReorder,
   });
   const [headerA, , headerC] = headers();

--- a/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
@@ -1,9 +1,11 @@
-import { act, createElement } from "react";
+import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import { createDragEvent } from "@/test-fixtures/createDragEvent";
 import type { Column as ColumnType } from "@/types/column";
 import { Task, type TaskPayload } from "@/types/task";
+import type { TaskDropHandler } from "../../BoardCardProvider";
+import { BoardProviders } from "../../BoardProviders";
 import { Board } from "..";
 import { DRAG_MIME_TYPE } from "../mime";
 
@@ -38,12 +40,38 @@ const columns: ColumnType[] = [
   { name: "Done", order: 1 },
 ];
 
-const render = (props: Parameters<typeof Board>[0]) => {
+type RenderOptions = {
+  /** Board に渡す presentational props */
+  boardProps: Parameters<typeof Board>[0];
+  /** Provider にも渡す表示用タスク */
+  tasks?: readonly Task[];
+  /** Provider にも渡す全タスク（省略時は tasks を流用） */
+  allTasks?: readonly Task[];
+  /** drop ハンドラ */
+  onTaskDrop?: TaskDropHandler;
+};
+
+/**
+ * BoardProviders で 1 段ラップして Board を mount するローカルヘルパー。
+ * @param options - render に使う props 群
+ */
+const renderWithProviders = (options: RenderOptions) => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  const tasks = options.tasks ?? [];
+  const allTasks = options.allTasks ?? tasks;
   act(() => {
-    root?.render(createElement(Board, props));
+    root?.render(
+      <BoardProviders
+        columns={options.boardProps.columns}
+        tasks={tasks}
+        allTasks={allTasks}
+        onTaskDrop={options.onTaskDrop}
+      >
+        <Board {...options.boardProps} />
+      </BoardProviders>,
+    );
   });
 };
 
@@ -68,7 +96,10 @@ const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
 const taskB = makeTask({ id: "b", filePath: "tasks/b.md", status: "Done" });
 
 test("dragstart 後、対象カードに data-dragging='true' が付く", () => {
-  render({ columns, tasks: [taskA, taskB], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns, onAddTask: vi.fn() },
+    tasks: [taskA, taskB],
+  });
   const cards =
     container?.querySelectorAll<HTMLElement>("[data-testid='task-card']") ?? [];
   const cardA = cards[0];
@@ -84,10 +115,9 @@ test("dragstart 後、対象カードに data-dragging='true' が付く", () => 
 
 test("drop で onTaskDrop prop が期待引数で呼ばれる", async () => {
   const onTaskDrop = vi.fn().mockResolvedValue(undefined);
-  render({
-    columns,
+  renderWithProviders({
+    boardProps: { columns, onAddTask: vi.fn() },
     tasks: [taskA, taskB],
-    onAddTask: vi.fn(),
     onTaskDrop,
   });
   const cardA = queryCardInColumn("Todo", 0);
@@ -122,10 +152,9 @@ test("drop で onTaskDrop prop が期待引数で呼ばれる", async () => {
 
 test("drop 完了後に dragState がリセットされる（プレースホルダ消失）", async () => {
   const onTaskDrop = vi.fn().mockResolvedValue(undefined);
-  render({
-    columns,
+  renderWithProviders({
+    boardProps: { columns, onAddTask: vi.fn() },
     tasks: [taskA, taskB],
-    onAddTask: vi.fn(),
     onTaskDrop,
   });
   const cardA = queryCardInColumn("Todo", 0);
@@ -160,10 +189,9 @@ test("drop 完了後に dragState がリセットされる（プレースホル�
 
 test("onTaskDrop が reject しても finally で dragState が null になる", async () => {
   const onTaskDrop = vi.fn().mockRejectedValue(new Error("boom"));
-  render({
-    columns,
+  renderWithProviders({
+    boardProps: { columns, onAddTask: vi.fn() },
     tasks: [taskA, taskB],
-    onAddTask: vi.fn(),
     onTaskDrop,
   });
   const cardA = queryCardInColumn("Todo", 0);
@@ -189,7 +217,10 @@ test("onTaskDrop が reject しても finally で dragState が null になる",
 });
 
 test("dragend 単独（drop なし）で dragState が null になる", () => {
-  render({ columns, tasks: [taskA, taskB], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns, onAddTask: vi.fn() },
+    tasks: [taskA, taskB],
+  });
   const cardA = queryCardInColumn("Todo", 0);
   act(() => {
     cardA.dispatchEvent(createDragEvent("dragstart"));

--- a/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
@@ -1,8 +1,9 @@
-import { act, createElement } from "react";
+import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import type { Column as ColumnType } from "@/types/column";
 import { Task, type TaskPayload } from "@/types/task";
+import { BoardProviders } from "../../BoardProviders";
 import { Board } from "..";
 
 let container: HTMLDivElement | null = null;
@@ -32,14 +33,37 @@ function createTask(overrides: Partial<TaskPayload> = {}): Task {
   });
 }
 
-function render(props: Parameters<typeof Board>[0]) {
+type RenderOptions = {
+  /** Board に渡す presentational props */
+  boardProps: Parameters<typeof Board>[0];
+  /** Provider にも届ける表示用タスク（省略時は空配列） */
+  tasks?: readonly Task[];
+  /** Provider にも届ける全タスク（省略時は tasks を流用） */
+  allTasks?: readonly Task[];
+};
+
+/**
+ * BoardProviders で 1 段ラップしたうえで Board を mount するローカルヘルパー。
+ * @param options - render に使う props 群
+ */
+const renderWithProviders = (options: RenderOptions) => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  const tasks = options.tasks ?? [];
+  const allTasks = options.allTasks ?? tasks;
   act(() => {
-    root?.render(createElement(Board, props));
+    root?.render(
+      <BoardProviders
+        columns={options.boardProps.columns}
+        tasks={tasks}
+        allTasks={allTasks}
+      >
+        <Board {...options.boardProps} />
+      </BoardProviders>,
+    );
   });
-}
+};
 
 const defaultColumns: ColumnType[] = [
   { name: "Todo", order: 0 },
@@ -48,7 +72,9 @@ const defaultColumns: ColumnType[] = [
 ];
 
 test("columns に応じたカラムが表示される", async () => {
-  render({ columns: defaultColumns, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
+  });
   await vi.waitFor(() => {
     const sections = container?.querySelectorAll("section") ?? [];
     expect(sections.length).toBe(3);
@@ -67,7 +93,10 @@ test("各カラムヘッダーにステータス名とタスク件数が表示�
     createTask({ id: "task-2", title: "タスク2", status: "Todo" }),
     createTask({ id: "task-3", title: "タスク3", status: "In Progress" }),
   ];
-  render({ columns: defaultColumns, tasks, onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
+    tasks,
+  });
   await vi.waitFor(() => {
     const todoSection = container?.querySelector('section[aria-label="Todo"]');
     expect(todoSection?.textContent).toContain("Todo");
@@ -86,7 +115,9 @@ test("各カラムヘッダーにステータス名とタスク件数が表示�
 });
 
 test("「+ 追加」ボタンが各カラムに表示される", async () => {
-  render({ columns: defaultColumns, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
+  });
   await vi.waitFor(() => {
     const buttons = Array.from(
       container?.querySelectorAll("button") ?? [],
@@ -100,7 +131,9 @@ test("カラムが 10 個以上ある場合でも表示される", async () => {
     name: `Status-${i}`,
     order: i,
   }));
-  render({ columns: manyColumns, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: manyColumns, onAddTask: vi.fn() },
+  });
   await vi.waitFor(() => {
     const sections = container?.querySelectorAll("section") ?? [];
     expect(sections.length).toBe(12);
@@ -113,7 +146,9 @@ test("カラムが order 順に表示される", async () => {
     { name: "Todo", order: 0 },
     { name: "In Progress", order: 1 },
   ];
-  render({ columns: unorderedColumns, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: unorderedColumns, onAddTask: vi.fn() },
+  });
   await vi.waitFor(() => {
     const sections = container?.querySelectorAll("section") ?? [];
     const labels = Array.from(sections).map((s) =>
@@ -124,7 +159,9 @@ test("カラムが order 順に表示される", async () => {
 });
 
 test("onAddColumn 未指定の場合はカラム追加ボタンが表示されない", async () => {
-  render({ columns: defaultColumns, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
+  });
   await vi.waitFor(() => {
     const button = container?.querySelector(
       '[data-testid="add-column-button"]',
@@ -134,11 +171,12 @@ test("onAddColumn 未指定の場合はカラム追加ボタンが表示され�
 });
 
 test("onAddColumn 指定時はボード右端にカラム追加ボタンが表示される", async () => {
-  render({
-    columns: defaultColumns,
-    tasks: [],
-    onAddTask: vi.fn(),
-    onAddColumn: vi.fn(),
+  renderWithProviders({
+    boardProps: {
+      columns: defaultColumns,
+      onAddTask: vi.fn(),
+      onAddColumn: vi.fn(),
+    },
   });
   await vi.waitFor(() => {
     const button = container?.querySelector(
@@ -155,11 +193,12 @@ test("onAddColumn 指定時はボード右端にカラム追加ボタンが表�
 
 test("カラム追加ボタンから Enter で onAddColumn が呼ばれる", async () => {
   const onAddColumn = vi.fn();
-  render({
-    columns: defaultColumns,
-    tasks: [],
-    onAddTask: vi.fn(),
-    onAddColumn,
+  renderWithProviders({
+    boardProps: {
+      columns: defaultColumns,
+      onAddTask: vi.fn(),
+      onAddColumn,
+    },
   });
   let button: HTMLButtonElement | null = null;
   await vi.waitFor(() => {
@@ -192,11 +231,12 @@ test("カラム追加ボタンから Enter で onAddColumn が呼ばれる", asy
 
 test("既存カラム名と同じ名前は onAddColumn に渡されない", async () => {
   const onAddColumn = vi.fn();
-  render({
-    columns: defaultColumns,
-    tasks: [],
-    onAddTask: vi.fn(),
-    onAddColumn,
+  renderWithProviders({
+    boardProps: {
+      columns: defaultColumns,
+      onAddTask: vi.fn(),
+      onAddColumn,
+    },
   });
   let button: HTMLButtonElement | null = null;
   await vi.waitFor(() => {
@@ -237,7 +277,9 @@ test("color 未指定カラムは非連番 order でも表示順インデック�
     { name: "First", order: 10 },
     { name: "Second", order: 20 },
   ];
-  render({ columns, tasks: [], onAddTask: vi.fn() });
+  renderWithProviders({
+    boardProps: { columns, onAddTask: vi.fn() },
+  });
   const hdrs = Array.from(
     container?.querySelectorAll<HTMLElement>("[data-testid='column-header']") ??
       [],

--- a/src/features/board/components/Board/index.stories.tsx
+++ b/src/features/board/components/Board/index.stories.tsx
@@ -1,7 +1,7 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
 import { initialColumns, initialTasks } from "@/test-fixtures";
+import { withBoardProviders } from "../BoardProviders/decorator";
 import { Board } from ".";
 
 const meta: Meta<typeof Board> = {
@@ -9,16 +9,21 @@ const meta: Meta<typeof Board> = {
   parameters: {
     layout: "fullscreen",
   },
+  decorators: [
+    withBoardProviders({
+      columns: initialColumns,
+      tasks: initialTasks,
+      allTasks: initialTasks,
+      doneColumn: "Done",
+    }),
+  ],
   args: {
     columns: initialColumns,
-    tasks: initialTasks,
-    doneColumn: "Done",
     onAddTask: () => {},
     onTaskClick: () => {},
     onAddColumn: () => {},
     onRenameColumn: () => {},
     onDeleteColumn: () => {},
-    onTaskDrop: fn(),
   },
 };
 
@@ -29,12 +34,28 @@ type Story = StoryObj<typeof Board>;
 export const Default: Story = {};
 
 export const Empty: Story = {
-  args: { tasks: [] },
+  decorators: [
+    withBoardProviders({
+      columns: initialColumns,
+      tasks: [],
+      allTasks: [],
+      doneColumn: "Done",
+    }),
+  ],
+  args: { columns: initialColumns },
 };
 
+const singleTodoColumn = [{ name: "Todo", order: 0 }];
+const singleColumnTasks = initialTasks.filter((t) => t.status === "Todo");
+
 export const SingleColumn: Story = {
-  args: {
-    columns: [{ name: "Todo", order: 0 }],
-    tasks: initialTasks.filter((t) => t.status === "Todo"),
-  },
+  decorators: [
+    withBoardProviders({
+      columns: singleTodoColumn,
+      tasks: singleColumnTasks,
+      allTasks: initialTasks,
+      doneColumn: "Done",
+    }),
+  ],
+  args: { columns: singleTodoColumn },
 };

--- a/src/features/board/components/Board/index.stories.tsx
+++ b/src/features/board/components/Board/index.stories.tsx
@@ -1,7 +1,7 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { initialColumns, initialTasks } from "@/test-fixtures";
-import { withBoardProviders } from "../BoardProviders/decorator";
+import { withBoardProviders } from "../BoardProviders/storybook/decorator";
 import { Board } from ".";
 
 const meta: Meta<typeof Board> = {

--- a/src/features/board/components/Board/index.tsx
+++ b/src/features/board/components/Board/index.tsx
@@ -1,36 +1,11 @@
 import type { Column as ColumnType } from "@/types/column";
-import type { Task } from "@/types/task";
 import { AddColumnButton } from "../AddColumnButton";
-import { BoardCardProvider, type TaskDropHandler } from "../BoardCardProvider";
-import {
-  BoardColumnProvider,
-  type ColumnReorderHandler,
-} from "../BoardColumnProvider";
 import { Column } from "../Column";
-import type { MilestonesByName } from "../TaskCard";
 
 /** ボードの Props */
 type BoardProps = {
   /** カラム定義の配列 */
   columns: ColumnType[];
-  /** カラムへ表示するタスクの配列（絞り込み済みの表示用集合） */
-  tasks: Task[];
-  /**
-   * 階層カウント（子孫数など）の解決に使う全タスク集合。絞り込みで tasks が減っても
-   * 子孫カウントを正確に保つため、未絞り込みの全タスクを渡す。未指定なら tasks を使う。
-   */
-  allTasks?: Task[];
-  /** 正規化済み Task.filePath → Task の lookup Map。Provider 経由で配布する。 */
-  tasksByNormalizedPath?: ReadonlyMap<string, Task>;
-  /** 完了カラム名 */
-  doneColumn?: string;
-  /** name → マイルストーン定義の Map（カードバッジ用） */
-  milestonesByName?: MilestonesByName;
-  /**
-   * カード / カラムの DnD を無効化するか。フィルタ有効時など、表示集合（tasks）が全タスクと
-   * 異なり並べ替えが cardOrder を壊しうる状況で true にする。
-   */
-  dndDisabled?: boolean;
   /** カラムの「+ 追加」ボタンクリック時のコールバック
    * @param columnName - 追加対象のカラム名
    */
@@ -62,89 +37,51 @@ type BoardProps = {
    * @param destColumn - タスクの移動先カラム名。削除対象カラムにタスクが 0 件の場合は undefined
    */
   onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
-  /**
-   * Board が drop を受けたら呼ぶ。App.tsx で useProject.moveTask に配線する。
-   * Provider が sync / async どちらも await し、throw は内部で握る。
-   */
-  onTaskDrop?: TaskDropHandler;
-  /**
-   * Board が column の drop を受けたら呼ぶ。App.tsx で useProject.reorderColumns に配線する。
-   * Provider が sync / async どちらも await し、throw は内部で握る。
-   */
-  onColumnReorder?: ColumnReorderHandler;
 };
 
 /**
  * カラム一覧を横並びで表示するボードコンテナ。
- * 派生計算（tasksByStatus / columnNames / hierarchyTasks など）は
- * すべて {@link BoardCardProvider} / {@link BoardColumnProvider} に閉じ込め、
- * Board 本体は Provider マウントとカラム配置のみを担う宣言的なコンポジション。
+ * カラムの order ソートと Column / AddColumnButton への配線のみを担う presentational。
+ * Card / Column 用の Context Provider 2 段は呼び出し側の `BoardProviders` が配線する。
  *
  * @param props - {@link BoardProps}
  * @returns ボード要素
  */
 export const Board = ({
   columns,
-  tasks,
-  allTasks,
-  tasksByNormalizedPath,
-  doneColumn,
-  milestonesByName,
-  dndDisabled = false,
   onAddTask,
   onTaskClick,
   onAddColumn,
   onRenameColumn,
   onDeleteColumn,
-  onTaskDrop,
-  onColumnReorder,
 }: BoardProps) => {
+  const ordered = [...columns].sort((a, b) => a.order - b.order);
   return (
-    <BoardCardProvider
-      tasks={tasks}
-      allTasks={allTasks ?? tasks}
-      tasksByNormalizedPath={tasksByNormalizedPath}
-      milestonesByName={milestonesByName}
-      doneColumn={doneColumn}
-      dndDisabled={dndDisabled}
-      onTaskDrop={onTaskDrop}
-    >
-      <BoardColumnProvider
-        columns={columns}
-        tasks={tasks}
-        allTasks={allTasks}
-        dndDisabled={dndDisabled}
-        onColumnReorder={onColumnReorder}
-      >
-        <div className="flex h-full flex-col">
-          <div className="flex flex-1 gap-4 overflow-x-auto p-4">
-            {[...columns]
-              .sort((a, b) => a.order - b.order)
-              .map((col, index) => (
-                <Column
-                  key={col.name}
-                  name={col.name}
-                  color={col.color}
-                  order={index}
-                  onAddClick={() => onAddTask(col.name)}
-                  onTaskClick={onTaskClick}
-                  onRename={
-                    onRenameColumn
-                      ? (newName) => onRenameColumn(col.name, newName)
-                      : undefined
-                  }
-                  onDelete={
-                    onDeleteColumn
-                      ? (destColumn) => onDeleteColumn(col.name, destColumn)
-                      : undefined
-                  }
-                  columnDraggable={columns.length > 1}
-                />
-              ))}
-            {onAddColumn && <AddColumnButton onAdd={onAddColumn} />}
-          </div>
-        </div>
-      </BoardColumnProvider>
-    </BoardCardProvider>
+    <div className="flex h-full flex-col">
+      <div className="flex flex-1 gap-4 overflow-x-auto p-4">
+        {ordered.map((col, index) => (
+          <Column
+            key={col.name}
+            name={col.name}
+            color={col.color}
+            order={index}
+            onAddClick={() => onAddTask(col.name)}
+            onTaskClick={onTaskClick}
+            onRename={
+              onRenameColumn
+                ? (newName) => onRenameColumn(col.name, newName)
+                : undefined
+            }
+            onDelete={
+              onDeleteColumn
+                ? (destColumn) => onDeleteColumn(col.name, destColumn)
+                : undefined
+            }
+            columnDraggable={columns.length > 1}
+          />
+        ))}
+        {onAddColumn && <AddColumnButton onAdd={onAddColumn} />}
+      </div>
+    </div>
   );
 };

--- a/src/features/board/components/Board/index.tsx
+++ b/src/features/board/components/Board/index.tsx
@@ -4,8 +4,8 @@ import { Column } from "../Column";
 
 /** ボードの Props */
 type BoardProps = {
-  /** カラム定義の配列 */
-  columns: ColumnType[];
+  /** カラム定義の配列。Board は内部で sort コピーのみ行い元配列を mutate しない */
+  columns: readonly ColumnType[];
   /** カラムの「+ 追加」ボタンクリック時のコールバック
    * @param columnName - 追加対象のカラム名
    */

--- a/src/features/board/components/BoardCardProvider/storybook/decorator.tsx
+++ b/src/features/board/components/BoardCardProvider/storybook/decorator.tsx
@@ -1,5 +1,5 @@
 import type { Decorator } from "@storybook/react-vite";
-import { BoardCardProvider, type BoardCardProviderProps } from "./index";
+import { BoardCardProvider, type BoardCardProviderProps } from "../index";
 
 /** decorator に渡せる Partial の props（children は Story が当てる） */
 type BoardCardDecoratorArgs = Partial<Omit<BoardCardProviderProps, "children">>;

--- a/src/features/board/components/BoardColumnProvider/storybook/decorator.tsx
+++ b/src/features/board/components/BoardColumnProvider/storybook/decorator.tsx
@@ -1,5 +1,5 @@
 import type { Decorator } from "@storybook/react-vite";
-import { BoardColumnProvider, type BoardColumnProviderProps } from "./index";
+import { BoardColumnProvider, type BoardColumnProviderProps } from "../index";
 
 /** decorator に渡せる Partial の props（children は Story が当てる） */
 type BoardColumnDecoratorArgs = Partial<

--- a/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
+++ b/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
@@ -49,10 +49,13 @@ const Probe = (props: {
 }) => {
   const card = useBoardCard();
   const column = useBoardColumn();
+  // Context 値が変化したときだけ通知する。依存配列を省略すると毎レンダー発火し、
+  // 将来コールバック側で state 更新が入った場合に無限ループの原因になり得る。
+  // onCard / onColumn は mountProbe 内で固定参照のため依存に含めない。
   useEffect(() => {
     props.onCard(card);
     props.onColumn(column);
-  });
+  }, [card, column, props.onCard, props.onColumn]);
   return null;
 };
 

--- a/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
+++ b/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
@@ -81,11 +81,15 @@ const mountProbe = (overrides: MountOverrides = {}) => {
   const handleColumn = (api: BoardColumnApi) => {
     latestColumn = api;
   };
+  // allTasks 省略時は tasks を流用する（Column.dnd.test.tsx の renderWithProviders と同型）。
+  // 別々に [] へフォールバックすると tasks のみ渡したケースで byPath / 集計系が空になる。
+  const tasks = overrides.tasks ?? [];
+  const allTasks = overrides.allTasks ?? tasks;
   const tree: ReactNode = (
     <BoardProviders
       columns={overrides.columns ?? [{ name: "Todo", order: 0 }]}
-      tasks={overrides.tasks ?? []}
-      allTasks={overrides.allTasks ?? []}
+      tasks={tasks}
+      allTasks={allTasks}
       dndDisabled={overrides.dndDisabled}
     >
       <Probe onCard={handleCard} onColumn={handleColumn} />

--- a/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
+++ b/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
@@ -51,7 +51,8 @@ const Probe = (props: {
   const column = useBoardColumn();
   // Context 値が変化したときだけ通知する。依存配列を省略すると毎レンダー発火し、
   // 将来コールバック側で state 更新が入った場合に無限ループの原因になり得る。
-  // onCard / onColumn は mountProbe 内で固定参照のため依存に含めない。
+  // onCard / onColumn も exhaustive-deps の要件として依存に含めるが、
+  // mountProbe 内で固定参照のため通常は余計な再発火を起こさない。
   useEffect(() => {
     props.onCard(card);
     props.onColumn(column);

--- a/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
+++ b/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
@@ -1,6 +1,7 @@
 import { act, type ReactNode, useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, expect, test } from "vitest";
+import type { Column as ColumnType } from "@/types/column";
 import { Task, type TaskPayload } from "@/types/task";
 import { type BoardCardApi, useBoardCard } from "../../BoardCardProvider";
 import { type BoardColumnApi, useBoardColumn } from "../../BoardColumnProvider";
@@ -61,7 +62,7 @@ const Probe = (props: {
 };
 
 type MountOverrides = {
-  columns?: readonly { name: string; order: number }[];
+  columns?: readonly ColumnType[];
   tasks?: readonly Task[];
   allTasks?: readonly Task[];
   dndDisabled?: boolean;

--- a/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
+++ b/src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx
@@ -1,0 +1,134 @@
+import { act, type ReactNode, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { Task, type TaskPayload } from "@/types/task";
+import { type BoardCardApi, useBoardCard } from "../../BoardCardProvider";
+import { type BoardColumnApi, useBoardColumn } from "../../BoardColumnProvider";
+import { BoardProviders } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const makeTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+/**
+ * useBoardCard / useBoardColumn を観測する Probe。BoardProviders 配下に置く。
+ * @param props - 最新値を受け取るコールバック
+ * @returns null
+ */
+const Probe = (props: {
+  onCard: (api: BoardCardApi) => void;
+  onColumn: (api: BoardColumnApi) => void;
+}) => {
+  const card = useBoardCard();
+  const column = useBoardColumn();
+  useEffect(() => {
+    props.onCard(card);
+    props.onColumn(column);
+  });
+  return null;
+};
+
+type MountOverrides = {
+  columns?: readonly { name: string; order: number }[];
+  tasks?: readonly Task[];
+  allTasks?: readonly Task[];
+  dndDisabled?: boolean;
+};
+
+/**
+ * BoardProviders 配下に Probe を mount し、Card / Column 両 context を観測する。
+ * @param overrides 上書きしたい props
+ * @returns latest accessor
+ */
+const mountProbe = (overrides: MountOverrides = {}) => {
+  let latestCard: BoardCardApi | null = null;
+  let latestColumn: BoardColumnApi | null = null;
+  const handleCard = (api: BoardCardApi) => {
+    latestCard = api;
+  };
+  const handleColumn = (api: BoardColumnApi) => {
+    latestColumn = api;
+  };
+  const tree: ReactNode = (
+    <BoardProviders
+      columns={overrides.columns ?? [{ name: "Todo", order: 0 }]}
+      tasks={overrides.tasks ?? []}
+      allTasks={overrides.allTasks ?? []}
+      dndDisabled={overrides.dndDisabled}
+    >
+      <Probe onCard={handleCard} onColumn={handleColumn} />
+    </BoardProviders>
+  );
+  act(() => {
+    root?.render(tree);
+  });
+  return {
+    get card(): BoardCardApi {
+      return latestCard as BoardCardApi;
+    },
+    get column(): BoardColumnApi {
+      return latestColumn as BoardColumnApi;
+    },
+  };
+};
+
+test("dndDisabled=true を渡すと Card / Column 両方の context に反映される", () => {
+  const probe = mountProbe({ dndDisabled: true });
+  expect(probe.card.dndDisabled).toBe(true);
+  expect(probe.column.dndDisabled).toBe(true);
+});
+
+test("dndDisabled 省略時は Card / Column 両方とも false がデフォルト", () => {
+  const probe = mountProbe();
+  expect(probe.card.dndDisabled).toBe(false);
+  expect(probe.column.dndDisabled).toBe(false);
+});
+
+test("allTasks が Column 側の taskCountInColumn 集計に到達する", () => {
+  const todoA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
+  const todoB = makeTask({ id: "b", filePath: "tasks/b.md", status: "Todo" });
+  const probe = mountProbe({
+    columns: [{ name: "Todo", order: 0 }],
+    tasks: [],
+    allTasks: [todoA, todoB],
+  });
+  expect(probe.column.taskCountInColumn("Todo")).toBe(2);
+});
+
+test("allTasks が Card 側の byPath lookup に到達する（両 Provider に同値で配線される）", () => {
+  const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
+  const probe = mountProbe({
+    tasks: [],
+    allTasks: [taskA],
+  });
+  expect(probe.card.byPath("tasks/a.md")?.filePath).toBe("tasks/a.md");
+  expect(probe.card.byPath("tasks/missing.md")).toBeUndefined();
+});

--- a/src/features/board/components/BoardProviders/decorator.tsx
+++ b/src/features/board/components/BoardProviders/decorator.tsx
@@ -2,23 +2,24 @@ import type { Decorator } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
 import { BoardProviders } from ".";
 
-/** decorator に渡せる props（children は Story が当てる） */
-type BoardProvidersDecoratorArgs = Omit<
-  ComponentProps<typeof BoardProviders>,
-  "children"
+/** decorator に渡せる Partial の props（children は Story が当てる） */
+type BoardProvidersDecoratorArgs = Partial<
+  Omit<ComponentProps<typeof BoardProviders>, "children">
 >;
 
 /**
  * Storybook の decorators 配列向けに `BoardProviders` で Story をラップする。
- * 既存 `withBoardCardProvider` / `withBoardColumnProvider` と同 tier の API。
+ * 既存 `withBoardCardProvider` / `withBoardColumnProvider` と同 tier の API で、
+ * 未指定の prop は空配列 / no-op で埋まる（required な columns / tasks / allTasks も
+ * Story 側で省略可能にすることで、追加 Story でのボイラープレートと渡し忘れを防ぐ）。
  *
- * @param args 上書きしたい props
+ * @param args 上書きしたい props（任意）
  * @returns Storybook の Decorator
  */
 export const withBoardProviders =
-  (args: BoardProvidersDecoratorArgs): Decorator =>
+  (args: BoardProvidersDecoratorArgs = {}): Decorator =>
   (Story) => (
-    <BoardProviders {...args}>
+    <BoardProviders columns={[]} tasks={[]} allTasks={[]} {...args}>
       <Story />
     </BoardProviders>
   );

--- a/src/features/board/components/BoardProviders/decorator.tsx
+++ b/src/features/board/components/BoardProviders/decorator.tsx
@@ -1,0 +1,24 @@
+import type { Decorator } from "@storybook/react-vite";
+import type { ComponentProps } from "react";
+import { BoardProviders } from ".";
+
+/** decorator に渡せる props（children は Story が当てる） */
+type BoardProvidersDecoratorArgs = Omit<
+  ComponentProps<typeof BoardProviders>,
+  "children"
+>;
+
+/**
+ * Storybook の decorators 配列向けに `BoardProviders` で Story をラップする。
+ * 既存 `withBoardCardProvider` / `withBoardColumnProvider` と同 tier の API。
+ *
+ * @param args 上書きしたい props
+ * @returns Storybook の Decorator
+ */
+export const withBoardProviders =
+  (args: BoardProvidersDecoratorArgs): Decorator =>
+  (Story) => (
+    <BoardProviders {...args}>
+      <Story />
+    </BoardProviders>
+  );

--- a/src/features/board/components/BoardProviders/index.tsx
+++ b/src/features/board/components/BoardProviders/index.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react";
+import type { Column as ColumnType } from "@/types/column";
+import type { Task } from "@/types/task";
+import { BoardCardProvider, type TaskDropHandler } from "../BoardCardProvider";
+import {
+  BoardColumnProvider,
+  type ColumnReorderHandler,
+} from "../BoardColumnProvider";
+import type { MilestonesByName } from "../TaskCard";
+
+/**
+ * Board feature の Context Provider 2 段（{@link BoardCardProvider} +
+ * {@link BoardColumnProvider}）を 1 つに合成した Provider の Props。
+ * 共通項（`tasks` / `allTasks` / `dndDisabled`）は呼び出し側で 1 度書けば
+ * 内部で両 Provider に同値で配線される。
+ */
+type BoardProvidersProps = {
+  /** カラム定義の配列 */
+  columns: readonly ColumnType[];
+  /** 表示中のタスク（絞り込み後の表示用集合） */
+  tasks: readonly Task[];
+  /** 階層カウント等の解決に使う全タスク集合。共通項として両 Provider に同値で渡される */
+  allTasks: readonly Task[];
+  /** 正規化済み Task.filePath → Task の lookup Map */
+  tasksByNormalizedPath?: ReadonlyMap<string, Task>;
+  /** 完了カラム名 */
+  doneColumn?: string;
+  /** name → マイルストーン定義の Map（カードバッジ用） */
+  milestonesByName?: MilestonesByName;
+  /** カード / カラムの DnD を無効化するか。両 Provider に同値で配線される */
+  dndDisabled?: boolean;
+  /** タスク drop ハンドラ */
+  onTaskDrop?: TaskDropHandler;
+  /** カラム並び替えハンドラ */
+  onColumnReorder?: ColumnReorderHandler;
+  /** 配下に置く子要素 */
+  children: ReactNode;
+};
+
+/**
+ * Board feature の Context Provider 2 段（BoardCard + BoardColumn）を
+ * 1 つに合成した Provider。flat な props を受け取り、内部で
+ * `BoardCardProvider`（外側）→ `BoardColumnProvider`（内側）の順にラップする。
+ *
+ * 共通項（`tasks` / `allTasks` / `dndDisabled`）は両 Provider に同値で配線するため、
+ * `ActiveBoardView` / Storybook decorator / テスト render ハーネスで二重に書かなくて済む。
+ *
+ * @param props - {@link BoardProvidersProps}
+ * @returns Provider 要素
+ */
+export const BoardProviders = ({
+  columns,
+  tasks,
+  allTasks,
+  tasksByNormalizedPath,
+  doneColumn,
+  milestonesByName,
+  dndDisabled = false,
+  onTaskDrop,
+  onColumnReorder,
+  children,
+}: BoardProvidersProps) => {
+  return (
+    <BoardCardProvider
+      tasks={tasks}
+      allTasks={allTasks}
+      tasksByNormalizedPath={tasksByNormalizedPath}
+      milestonesByName={milestonesByName}
+      doneColumn={doneColumn}
+      dndDisabled={dndDisabled}
+      onTaskDrop={onTaskDrop}
+    >
+      <BoardColumnProvider
+        columns={columns}
+        tasks={tasks}
+        allTasks={allTasks}
+        dndDisabled={dndDisabled}
+        onColumnReorder={onColumnReorder}
+      >
+        {children}
+      </BoardColumnProvider>
+    </BoardCardProvider>
+  );
+};

--- a/src/features/board/components/BoardProviders/storybook/decorator.tsx
+++ b/src/features/board/components/BoardProviders/storybook/decorator.tsx
@@ -1,6 +1,6 @@
 import type { Decorator } from "@storybook/react-vite";
 import type { ComponentProps } from "react";
-import { BoardProviders } from ".";
+import { BoardProviders } from "..";
 
 /** decorator に渡せる Partial の props（children は Story が当てる） */
 type BoardProvidersDecoratorArgs = Partial<

--- a/src/features/board/components/BoardProviders/storybook/decorator.tsx
+++ b/src/features/board/components/BoardProviders/storybook/decorator.tsx
@@ -13,13 +13,21 @@ type BoardProvidersDecoratorArgs = Partial<
  * 未指定の prop は空配列 / no-op で埋まる（required な columns / tasks / allTasks も
  * Story 側で省略可能にすることで、追加 Story でのボイラープレートと渡し忘れを防ぐ）。
  *
+ * `allTasks` 省略時は `tasks` を流用する（`BoardProviders.state.test.tsx` の
+ * `mountProbe` と同型）。tasks だけ渡して allTasks 空のままだと
+ * `BoardCardProvider.byPath` や階層集計が壊れた状態の Story が作れてしまうため。
+ *
  * @param args 上書きしたい props（任意）
  * @returns Storybook の Decorator
  */
 export const withBoardProviders =
   (args: BoardProvidersDecoratorArgs = {}): Decorator =>
-  (Story) => (
-    <BoardProviders columns={[]} tasks={[]} allTasks={[]} {...args}>
-      <Story />
-    </BoardProviders>
-  );
+  (Story) => {
+    const tasks = args.tasks ?? [];
+    const allTasks = args.allTasks ?? tasks;
+    return (
+      <BoardProviders columns={[]} {...args} tasks={tasks} allTasks={allTasks}>
+        <Story />
+      </BoardProviders>
+    );
+  };

--- a/src/features/board/components/BoardWorkspace/index.tsx
+++ b/src/features/board/components/BoardWorkspace/index.tsx
@@ -16,6 +16,7 @@ import { useTaskFilter } from "../../hooks/useTaskFilter";
 import { Board } from "../Board";
 import type { TaskDropHandler } from "../BoardCardProvider";
 import type { ColumnReorderHandler } from "../BoardColumnProvider";
+import { BoardProviders } from "../BoardProviders";
 import { CalendarView } from "../CalendarView";
 import { ListView } from "../ListView";
 import type { MilestonesByName } from "../TaskCard";
@@ -149,22 +150,26 @@ const ActiveBoardView = ({
     );
   }
   return (
-    <Board
+    <BoardProviders
       columns={workspace.columns}
       tasks={filtered}
       allTasks={workspace.tasks}
       tasksByNormalizedPath={workspace.tasksByNormalizedPath}
-      doneColumn={workspace.doneColumn}
       milestonesByName={workspace.milestonesByName}
-      onAddTask={workspace.onAddTask}
-      onTaskClick={workspace.onTaskClick}
-      onAddColumn={workspace.onAddColumn}
-      onRenameColumn={workspace.onRenameColumn}
-      onDeleteColumn={workspace.onDeleteColumn}
+      doneColumn={workspace.doneColumn}
       dndDisabled={filterActive}
       onTaskDrop={workspace.onTaskDrop}
       onColumnReorder={workspace.onColumnReorder}
-    />
+    >
+      <Board
+        columns={workspace.columns}
+        onAddTask={workspace.onAddTask}
+        onTaskClick={workspace.onTaskClick}
+        onAddColumn={workspace.onAddColumn}
+        onRenameColumn={workspace.onRenameColumn}
+        onDeleteColumn={workspace.onDeleteColumn}
+      />
+    </BoardProviders>
   );
 };
 

--- a/src/features/board/components/Column/index.stories.tsx
+++ b/src/features/board/components/Column/index.stories.tsx
@@ -2,8 +2,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { initialTasks } from "@/test-fixtures";
 import { Task } from "@/types/task";
-import { withBoardCardProvider } from "../BoardCardProvider/decorator";
-import { withBoardColumnProvider } from "../BoardColumnProvider/decorator";
+import { withBoardCardProvider } from "../BoardCardProvider/storybook/decorator";
+import { withBoardColumnProvider } from "../BoardColumnProvider/storybook/decorator";
 import { Column } from ".";
 
 const todoTasks = initialTasks.filter((t) => t.status === "Todo");

--- a/src/features/board/components/TaskCard/index.stories.tsx
+++ b/src/features/board/components/TaskCard/index.stories.tsx
@@ -2,7 +2,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { initialTasks } from "@/test-fixtures";
 import type { Task } from "@/types/task";
-import { withBoardCardProvider } from "../BoardCardProvider/decorator";
+import { withBoardCardProvider } from "../BoardCardProvider/storybook/decorator";
 import { TaskCard } from ".";
 
 const baseTask: Task = initialTasks[0];

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -1,4 +1,3 @@
-export { Board } from "./components/Board";
 export { BoardWorkspace } from "./components/BoardWorkspace";
 export { EmptyState } from "./components/EmptyState";
 export { HeaderBar } from "./components/HeaderBar";


### PR DESCRIPTION
## 概要

`Board` の責務を「カラム横並び layout + Column へのコールバック配線」に絞り、`BoardCardProvider` / `BoardColumnProvider` の 2 段を 1 つにまとめた合成 Provider `BoardProviders` を新設して `BoardWorkspace.ActiveBoardView` の `board` 分岐へ hoist する。`BoardProps` は **14 → 6 fields** に削減され、`Board` は presentational コンポーネントになる。エンドユーザー視点では振る舞い変更なし。

## 変更の種類

- ♻️ [Refactoring]: Board の責務分離（presentational 化）+ 合成 Provider 新設 + barrel 除外

## 追加した内容

- `src/features/board/components/BoardProviders/index.tsx` — `BoardCardProvider`（外側）→ `BoardColumnProvider`（内側）の順に合成し、共通項（`tasks` / `allTasks` / `dndDisabled`）を 1 度書けば両 Provider に同値で配線される flat props Provider
- `src/features/board/components/BoardProviders/decorator.tsx` — Storybook 用 `withBoardProviders` decorator
- `src/features/board/components/BoardProviders/__tests__/BoardProviders.state.test.tsx` — Probe で `useBoardCard()` / `useBoardColumn()` を観測し、`dndDisabled` 両分配 / `allTasks` の Card 側 byPath 到達 / Column 側 taskCountInColumn 到達 を担保する 4 ケース

## 変更した内容

- `Board/index.tsx` — `BoardProps` を 6 fields（`columns` / `onAddTask` / `onTaskClick` / `onAddColumn` / `onRenameColumn` / `onDeleteColumn`）に縮小し、`BoardCardProvider` / `BoardColumnProvider` のマウントを撤去
- `BoardWorkspace/index.tsx` — `ActiveBoardView` の `board` 分岐で `<BoardProviders>` 1 段でラップし、`allTasks={workspace.tasks}` / `dndDisabled={filterActive}` を 1 度ずつ渡す。list / tree / calendar 分岐は触らない（Provider は board 分岐配下にのみマウントされる）
- `Board/__tests__/Board.{rendering,dnd,column-dnd}.test.tsx` — ファイル内ローカル `renderWithProviders` で `<BoardProviders>` 1 段ラップして mount するハーネスへ移行。**期待値は変更なし**
- `Board/index.stories.tsx` — `decorators: [withBoardProviders(args)]` 1 個へ統一し、`args` は presentational props のみに整理

## 削除した内容

- `src/features/board/index.ts` から `Board` の re-export を削除（Board は `BoardWorkspace` 経由のみ消費されるため feature 内部に閉じる）

## 仕様ドキュメント更新

不要（純粋なリファクタリング — 公開 API・データ形式・画面挙動・設定項目に変更なし。`BoardProps` 型は feature 内部 API でユーザー向け仕様には現れない）。

## システム図

```mermaid
flowchart TB
  subgraph before["Before"]
    direction TB
    AV1["ActiveBoardView (viewMode=board)"]
    B1["Board (14 props)<br/>columns, tasks, allTasks,<br/>tasksByNormalizedPath, doneColumn,<br/>milestonesByName, dndDisabled,<br/>onAddTask, onTaskClick, onAddColumn,<br/>onRenameColumn, onDeleteColumn,<br/>onTaskDrop, onColumnReorder"]
    BCP1["BoardCardProvider"]
    BColP1["BoardColumnProvider"]
    Col1["Column x N + AddColumnButton"]
    AV1 --> B1
    B1 --> BCP1
    BCP1 --> BColP1
    BColP1 --> Col1
  end

  subgraph after["After"]
    direction TB
    AV2["ActiveBoardView (viewMode=board)"]
    BPS["BoardProviders (NEW)<br/>columns, tasks, allTasks,<br/>tasksByNormalizedPath, doneColumn,<br/>milestonesByName, dndDisabled,<br/>onTaskDrop, onColumnReorder"]
    B2["Board (6 props)<br/>columns, onAddTask, onTaskClick,<br/>onAddColumn, onRenameColumn,<br/>onDeleteColumn"]
    BCP2["BoardCardProvider (内部)"]
    BColP2["BoardColumnProvider (内部)"]
    Col2["Column x N + AddColumnButton"]
    AV2 --> BPS
    BPS --> BCP2
    BCP2 --> BColP2
    BColP2 --> B2
    B2 --> Col2
  end

  style BPS fill:#fff3b0,stroke:#d4a017
  style B2 fill:#d8f3dc,stroke:#2d6a4f
```

list / tree / calendar 分岐では `BoardProviders` はマウントされないため、`BoardCardProvider` の `descendantMap` / `buildTasksByNormalizedPath` 等の重い memo 計算は走らない（副次効果）。

## 関連Issue

なし（spec 023-fe-board-provider-hoist に基づくリファクタリング）

## テスト

- `pnpm typecheck` ✅
- `pnpm lint` ✅（0 warnings / 0 errors）
- `pnpm test:run -- --exclude '**/.claude/**'` ✅（274 files / **2330 tests** PASS。既存 Board 3 テストは期待値不変、新規 `BoardProviders.state.test.tsx` 4 ケース追加）
- `pnpm build` ✅
- `pnpm tauri dev` 手動検証は未実施（board / list / tree / calendar 切替・DnD・フィルタ ON/OFF・カラム CRUD・カード CRUD はレビュー時に確認予定）

## レビューポイント

- **`columns` の二重指定**: `BoardProviders` と `Board` の両方に `columns` を渡す必要がある（`ActiveBoardView` / テスト 3 ファイル / Storybook）。spec で明示スコープ外と認識済みの設計負債で、将来は `Board` から `columns` を削除して `useBoardColumn()` 経由で取得する案を検討する（`spec-based-code-review/review-001.md` の W-001）
- **Storybook `args.columns` と decorator の `columns` ドリフト**: Controls から `columns` を編集すると `BoardColumnProvider` の派生値が古いままで壊れた表示になる。本 PR ではスコープ外として残置（W-002）
- **`BoardCardProvider/wrapper.tsx` / `BoardColumnProvider/wrapper.tsx`** は使用実績 0 件の dead code だが、スコープ外として残置
- **`BoardProviders.state.test.tsx`** の Card 側 byPath / Column 側 taskCountInColumn 観測で `allTasks` の両 Provider 到達を担保している。`dndDisabled` も両 Provider に同値で配線されることをテスト
- `App.tsx` / `Column` / `AddColumnButton` / `TaskCard/TaskCardRoot` は無変更（`git diff` 確認済）