### PR TITLE
♻️ [Refactoring]: [FE] Board を compound component 化（Board / Board.Column / Board.AddColumn）

### DIFF
--- a/docs/impl/board-compound-component.md
+++ b/docs/impl/board-compound-component.md
@@ -1,0 +1,67 @@
+# 実装メモ: Board の Compound Component 化
+
+`Board` を `<Board>{children}</Board>` の compound component に再設計した背景と判断を残す。`docs/spec-board/board-view-spec.md` が「何が起きるか」、ここでは「なぜそう書いたか」を扱う。
+
+## なぜ Board を compound にしたか
+
+旧 `Board` は `columns: ColumnType[]` を受け取り、内部で
+
+- `[...columns].sort((a, b) => a.order - b.order)` で並べ替え
+- `Column` を `.map` して `key` / `order` / 各種ハンドラを bind
+- `columns.length > 1` で `columnDraggable` を決定
+- `onAddColumn` が指定されたときだけ末尾に `AddColumnButton` を出す
+
+という「子に何を並べるか」を全部知っていた。実際の中身は `Column[]` と末尾の `AddColumnButton` 1 個だけしかありえないにもかかわらず、Board が configuration を介して子を組み立てていた。
+
+compound component（`Board.Column` / `Board.AddColumn`）として alias を提供すると、呼び出し側は次のように書ける。
+
+```tsx
+<Board>
+  {ordered.map((col, index) => (
+    <Board.Column key={col.name} name={col.name} order={index} ... />
+  ))}
+  {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}
+</Board>
+```
+
+このとき `Board` は children を素通しするだけのレイアウトコンテナ（外側 flex-col + 内側 flex-row）になり、「子をどう並べるか」は呼び出し側の責任になる。React 初心者向けに言えば、HTML の `<ul>` が要素として `<li>` を受け取るだけで「`<li>` をどう作るか」を知らないのと同じ構図に揃えた。
+
+副次効果として、`Board` に対する props を増やす圧（「`columnDraggable` を外から渡したい」「`onAddColumn` だけ条件で出したい」「カラムごとに別ハンドラを持たせたい」）が無くなる。新しい子要素を増やすときは alias を `Object.assign` に足すだけで済む。
+
+## なぜ sort を呼び出し側に移したか
+
+旧 Board は `columns` 配列を受け取って中で sort していた。これは便利だが、次の問題があった。
+
+- **「色」と「順番」の責務がずれる**: フォールバック色は表示順 index（0, 1, 2...）で決定する仕様で、`column.order` の生値（10, 20, ...）とは別物。にもかかわらず、その index を Board が握っていたため「config の生 order が見える人」と「表示順 index しか見えない人」が同じ階層に混在していた。呼び出し側で sort してから `Board.Column` に `order={index}` を渡す形にすると、`Board.Column` 利用者から見えるのは常に「表示順 index」だけで、混線しない。
+- **テストや Storybook で並びを差し替えづらい**: Board 内で sort されると、「逆順にしたい」「sort 自体を観察したい」というとき配列で渡すしか手が無い。呼び出し側で `.map` するなら、テストや Story が JSX を直接書ける。
+- **`ActiveBoardView` の責務が明示化される**: BoardWorkspace は元から「columns / handlers をどう束ねるか」を握っているレイヤーで、sort を Board の内側に隠すより、ここに集約したほうが「並び順を変えるなら BoardWorkspace」と一意に決まる。
+
+React 初心者向けに補足すると、sort は `useMemo` で memoize したくなる場面だが、ここではあえて inline にしてある。columns の更新頻度が低く、配列の copy + sort は O(N log N) で 1 桁件数のため、memo の管理コストのほうが上回ると判断した。
+
+## なぜ `Object.assign` パターンを採用したか
+
+`TaskCard` / `DetailFields` が既に同じ書式
+
+```tsx
+type FooComponent = ((props: FooProps) => ReactNode) & {
+  Sub: typeof Sub;
+};
+export const Foo: FooComponent = Object.assign(FooRoot, { Sub });
+```
+
+で揃っていたため、新しいパターンを発明する必要がなかった。コードベース内で「compound component の書式はこれ」と一意に読める利点がある。
+
+`Object.assign` の代替として、
+
+- `Board.Column = Column` を後から代入する: 型が `BoardComponent` まで持ち上がらず、`Board.Column` の補完が効かない。
+- `React.Children.map` で子を覗き見て型を絞る: 「Board は中身を知らない」という今回の目的に逆行する。
+- namespace import (`import * as Board from "./Board"`): Tree-shaking と JSX 表記の自然さが失われる。
+
+を検討して退けた。React 19 の関数コンポーネント戻り型は `ReactNode` なので、`type BoardComponent = ((props) => ReactNode) & { Column: typeof Column; AddColumn: typeof AddColumnButton; }` で表現すれば、`<Board.Column ... />` の型推論が「`Column` を直接 import したのと完全同等」になる。
+
+## やらなかったこと
+
+- **`Board` の children 型を `ReactElement<typeof Board.Column | typeof Board.AddColumn>` に制限する**: Fragment / 条件レンダー (`cond && <Board.Column ...>`) / `null` を素直に書ける柔軟性を取った。runtime warning も入れていない。利用者が `<Board><div /></Board>` のような誤用を書く可能性は残るが、`Board` は「flex コンテナにそのまま流す」というプリミティブな責務しか持たないため、誤用しても壊れずに DOM が描画されるだけで済む。
+- **`Column` / `AddColumnButton` 自体の compound 化**: 本改修の非対象。`Column` の中はヘッダー / リスト / ContextMenu / ConfirmDialog の複合体だが、`Board` 経由の利用パターンとして「分解して再構成したい」という要求はまだない。
+- **`BoardProviders` の改修**: spec 023 で `Card` / `Column` の 2 段 Context Provider を hoist 済みのため触らない。`Board` を薄くしても Provider 構造は変わらない。
+- **`columnDraggable` の自動算出**: 呼び出し側で `ordered.length > 1` を inline で書くだけなので、helper も hook も切り出さない。3 行同じものが並んだら helper を検討する程度のラインで十分。

--- a/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
@@ -21,14 +21,17 @@ afterEach(() => {
 });
 
 type RenderOptions = {
-  /** Board に渡す presentational props */
-  boardProps: Parameters<typeof Board>[0];
+  /** Board.Column の元になるカラム定義 */
+  columns: readonly ColumnType[];
+  /** 「+ 追加」クリック時のコールバック（省略時は no-op） */
+  onAddTask?: (columnName: string) => void;
   /** カラム並び替え確定時のコールバック */
   onColumnReorder?: ColumnReorderHandler;
 };
 
 /**
- * BoardProviders で 1 段ラップして Board を mount するローカルヘルパー。
+ * BoardProviders で 1 段ラップしたうえで、フラットな options を Board.Column に
+ * 組み替えて Board を mount するローカルヘルパー。
  * 表示用 tasks / allTasks は空配列固定（カラム DnD は task 側を参照しない）。
  * @param options - render に使う props 群
  */
@@ -36,15 +39,29 @@ const renderWithProviders = (options: RenderOptions) => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  const ordered = [...options.columns].sort((a, b) => a.order - b.order);
+  const columnDraggable = ordered.length > 1;
+  const onAddTask = options.onAddTask ?? (() => {});
   act(() => {
     root?.render(
       <BoardProviders
-        columns={options.boardProps.columns}
+        columns={options.columns}
         tasks={[]}
         allTasks={[]}
         onColumnReorder={options.onColumnReorder}
       >
-        <Board {...options.boardProps} />
+        <Board>
+          {ordered.map((col, index) => (
+            <Board.Column
+              key={col.name}
+              name={col.name}
+              color={col.color}
+              order={index}
+              onAddClick={() => onAddTask(col.name)}
+              columnDraggable={columnDraggable}
+            />
+          ))}
+        </Board>
       </BoardProviders>,
     );
   });
@@ -76,7 +93,8 @@ test("columns が逆順でも表示順 (order 昇順) で render される", () 
     { name: "A", order: 0 },
   ];
   renderWithProviders({
-    boardProps: { columns: reversed, onAddTask: vi.fn() },
+    columns: reversed,
+    onAddTask: vi.fn(),
   });
   expect(columnSections().map((s) => s.getAttribute("aria-label"))).toEqual([
     "A",
@@ -87,7 +105,8 @@ test("columns が逆順でも表示順 (order 昇順) で render される", () 
 
 test("カラムが 2 件以上のとき、ColumnHeader は draggable=true で render される", () => {
   renderWithProviders({
-    boardProps: { columns: columns3, onAddTask: vi.fn() },
+    columns: columns3,
+    onAddTask: vi.fn(),
   });
   for (const header of headers()) {
     expect(header.getAttribute("draggable")).toBe("true");
@@ -96,10 +115,8 @@ test("カラムが 2 件以上のとき、ColumnHeader は draggable=true で re
 
 test("カラムが 1 件のとき、ColumnHeader は draggable=false で render される", () => {
   renderWithProviders({
-    boardProps: {
-      columns: [{ name: "Only", order: 0 }],
-      onAddTask: vi.fn(),
-    },
+    columns: [{ name: "Only", order: 0 }],
+    onAddTask: vi.fn(),
   });
   const header = headers()[0];
   expect(header?.getAttribute("draggable")).toBe("false");
@@ -108,7 +125,8 @@ test("カラムが 1 件のとき、ColumnHeader は draggable=false で render 
 test("カラムヘッダーで dragstart → 別カラムで drop すると onColumnReorder({fromColumnName, toColumnName})", () => {
   const onColumnReorder = vi.fn();
   renderWithProviders({
-    boardProps: { columns: columns3, onAddTask: vi.fn() },
+    columns: columns3,
+    onAddTask: vi.fn(),
     onColumnReorder,
   });
   const [headerA, , headerC] = headers();

--- a/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
@@ -41,8 +41,10 @@ const columns: ColumnType[] = [
 ];
 
 type RenderOptions = {
-  /** Board に渡す presentational props */
-  boardProps: Parameters<typeof Board>[0];
+  /** Board.Column の元になるカラム定義 */
+  columns: readonly ColumnType[];
+  /** 「+ 追加」クリック時のコールバック（省略時は no-op） */
+  onAddTask?: (columnName: string) => void;
   /** Provider にも渡す表示用タスク */
   tasks?: readonly Task[];
   /** Provider にも渡す全タスク（省略時は tasks を流用） */
@@ -52,7 +54,8 @@ type RenderOptions = {
 };
 
 /**
- * BoardProviders で 1 段ラップして Board を mount するローカルヘルパー。
+ * BoardProviders で 1 段ラップしたうえで、フラットな options を Board.Column に
+ * 組み替えて Board を mount するローカルヘルパー。
  * @param options - render に使う props 群
  */
 const renderWithProviders = (options: RenderOptions) => {
@@ -61,15 +64,29 @@ const renderWithProviders = (options: RenderOptions) => {
   root = createRoot(container);
   const tasks = options.tasks ?? [];
   const allTasks = options.allTasks ?? tasks;
+  const ordered = [...options.columns].sort((a, b) => a.order - b.order);
+  const columnDraggable = ordered.length > 1;
+  const onAddTask = options.onAddTask ?? (() => {});
   act(() => {
     root?.render(
       <BoardProviders
-        columns={options.boardProps.columns}
+        columns={options.columns}
         tasks={tasks}
         allTasks={allTasks}
         onTaskDrop={options.onTaskDrop}
       >
-        <Board {...options.boardProps} />
+        <Board>
+          {ordered.map((col, index) => (
+            <Board.Column
+              key={col.name}
+              name={col.name}
+              color={col.color}
+              order={index}
+              onAddClick={() => onAddTask(col.name)}
+              columnDraggable={columnDraggable}
+            />
+          ))}
+        </Board>
       </BoardProviders>,
     );
   });
@@ -97,7 +114,8 @@ const taskB = makeTask({ id: "b", filePath: "tasks/b.md", status: "Done" });
 
 test("dragstart 後、対象カードに data-dragging='true' が付く", () => {
   renderWithProviders({
-    boardProps: { columns, onAddTask: vi.fn() },
+    columns,
+    onAddTask: vi.fn(),
     tasks: [taskA, taskB],
   });
   const cards =
@@ -116,7 +134,8 @@ test("dragstart 後、対象カードに data-dragging='true' が付く", () => 
 test("drop で onTaskDrop prop が期待引数で呼ばれる", async () => {
   const onTaskDrop = vi.fn().mockResolvedValue(undefined);
   renderWithProviders({
-    boardProps: { columns, onAddTask: vi.fn() },
+    columns,
+    onAddTask: vi.fn(),
     tasks: [taskA, taskB],
     onTaskDrop,
   });
@@ -153,7 +172,8 @@ test("drop で onTaskDrop prop が期待引数で呼ばれる", async () => {
 test("drop 完了後に dragState がリセットされる（プレースホルダ消失）", async () => {
   const onTaskDrop = vi.fn().mockResolvedValue(undefined);
   renderWithProviders({
-    boardProps: { columns, onAddTask: vi.fn() },
+    columns,
+    onAddTask: vi.fn(),
     tasks: [taskA, taskB],
     onTaskDrop,
   });
@@ -190,7 +210,8 @@ test("drop 完了後に dragState がリセットされる（プレースホル�
 test("onTaskDrop が reject しても finally で dragState が null になる", async () => {
   const onTaskDrop = vi.fn().mockRejectedValue(new Error("boom"));
   renderWithProviders({
-    boardProps: { columns, onAddTask: vi.fn() },
+    columns,
+    onAddTask: vi.fn(),
     tasks: [taskA, taskB],
     onTaskDrop,
   });
@@ -218,7 +239,8 @@ test("onTaskDrop が reject しても finally で dragState が null になる",
 
 test("dragend 単独（drop なし）で dragState が null になる", () => {
   renderWithProviders({
-    boardProps: { columns, onAddTask: vi.fn() },
+    columns,
+    onAddTask: vi.fn(),
     tasks: [taskA, taskB],
   });
   const cardA = queryCardInColumn("Todo", 0);

--- a/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
@@ -1,9 +1,11 @@
-import { act } from "react";
+import { act, Fragment } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, expect, test, vi } from "vitest";
 import type { Column as ColumnType } from "@/types/column";
 import { Task, type TaskPayload } from "@/types/task";
+import { AddColumnButton } from "../../AddColumnButton";
 import { BoardProviders } from "../../BoardProviders";
+import { Column } from "../../Column";
 import { Board } from "..";
 
 let container: HTMLDivElement | null = null;
@@ -34,8 +36,18 @@ function createTask(overrides: Partial<TaskPayload> = {}): Task {
 }
 
 type RenderOptions = {
-  /** Board に渡す presentational props */
-  boardProps: Parameters<typeof Board>[0];
+  /** Board.Column の元になるカラム定義 */
+  columns: readonly ColumnType[];
+  /** 「+ 追加」クリック時のコールバック（省略時は no-op） */
+  onAddTask?: (columnName: string) => void;
+  /** タスクカードクリック時のコールバック */
+  onTaskClick?: (taskId: string) => void;
+  /** 指定時のみ Board.AddColumn を末尾に置く */
+  onAddColumn?: (columnName: string) => void;
+  /** カラム名リネーム時のコールバック */
+  onRenameColumn?: (oldName: string, newName: string) => void;
+  /** カラム削除時のコールバック */
+  onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
   /** Provider にも届ける表示用タスク（省略時は空配列） */
   tasks?: readonly Task[];
   /** Provider にも届ける全タスク（省略時は tasks を流用） */
@@ -43,7 +55,8 @@ type RenderOptions = {
 };
 
 /**
- * BoardProviders で 1 段ラップしたうえで Board を mount するローカルヘルパー。
+ * BoardProviders で 1 段ラップしたうえで、フラットな options を Board.Column / Board.AddColumn に
+ * 組み替えて Board を mount するローカルヘルパー。
  * @param options - render に使う props 群
  */
 const renderWithProviders = (options: RenderOptions) => {
@@ -52,14 +65,41 @@ const renderWithProviders = (options: RenderOptions) => {
   root = createRoot(container);
   const tasks = options.tasks ?? [];
   const allTasks = options.allTasks ?? tasks;
+  const ordered = [...options.columns].sort((a, b) => a.order - b.order);
+  const columnDraggable = ordered.length > 1;
+  const onAddTask = options.onAddTask ?? (() => {});
+  const { onTaskClick, onAddColumn, onRenameColumn, onDeleteColumn } = options;
   act(() => {
     root?.render(
       <BoardProviders
-        columns={options.boardProps.columns}
+        columns={options.columns}
         tasks={tasks}
         allTasks={allTasks}
       >
-        <Board {...options.boardProps} />
+        <Board>
+          {ordered.map((col, index) => (
+            <Board.Column
+              key={col.name}
+              name={col.name}
+              color={col.color}
+              order={index}
+              onAddClick={() => onAddTask(col.name)}
+              onTaskClick={onTaskClick}
+              onRename={
+                onRenameColumn
+                  ? (newName) => onRenameColumn(col.name, newName)
+                  : undefined
+              }
+              onDelete={
+                onDeleteColumn
+                  ? (destColumn) => onDeleteColumn(col.name, destColumn)
+                  : undefined
+              }
+              columnDraggable={columnDraggable}
+            />
+          ))}
+          {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}
+        </Board>
       </BoardProviders>,
     );
   });
@@ -72,9 +112,7 @@ const defaultColumns: ColumnType[] = [
 ];
 
 test("columns に応じたカラムが表示される", async () => {
-  renderWithProviders({
-    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
-  });
+  renderWithProviders({ columns: defaultColumns });
   await vi.waitFor(() => {
     const sections = container?.querySelectorAll("section") ?? [];
     expect(sections.length).toBe(3);
@@ -93,10 +131,7 @@ test("各カラムヘッダーにステータス名とタスク件数が表示�
     createTask({ id: "task-2", title: "タスク2", status: "Todo" }),
     createTask({ id: "task-3", title: "タスク3", status: "In Progress" }),
   ];
-  renderWithProviders({
-    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
-    tasks,
-  });
+  renderWithProviders({ columns: defaultColumns, tasks });
   await vi.waitFor(() => {
     const todoSection = container?.querySelector('section[aria-label="Todo"]');
     expect(todoSection?.textContent).toContain("Todo");
@@ -115,9 +150,7 @@ test("各カラムヘッダーにステータス名とタスク件数が表示�
 });
 
 test("「+ 追加」ボタンが各カラムに表示される", async () => {
-  renderWithProviders({
-    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
-  });
+  renderWithProviders({ columns: defaultColumns });
   await vi.waitFor(() => {
     const buttons = Array.from(
       container?.querySelectorAll("button") ?? [],
@@ -131,9 +164,7 @@ test("カラムが 10 個以上ある場合でも表示される", async () => {
     name: `Status-${i}`,
     order: i,
   }));
-  renderWithProviders({
-    boardProps: { columns: manyColumns, onAddTask: vi.fn() },
-  });
+  renderWithProviders({ columns: manyColumns });
   await vi.waitFor(() => {
     const sections = container?.querySelectorAll("section") ?? [];
     expect(sections.length).toBe(12);
@@ -146,9 +177,7 @@ test("カラムが order 順に表示される", async () => {
     { name: "Todo", order: 0 },
     { name: "In Progress", order: 1 },
   ];
-  renderWithProviders({
-    boardProps: { columns: unorderedColumns, onAddTask: vi.fn() },
-  });
+  renderWithProviders({ columns: unorderedColumns });
   await vi.waitFor(() => {
     const sections = container?.querySelectorAll("section") ?? [];
     const labels = Array.from(sections).map((s) =>
@@ -159,9 +188,7 @@ test("カラムが order 順に表示される", async () => {
 });
 
 test("onAddColumn 未指定の場合はカラム追加ボタンが表示されない", async () => {
-  renderWithProviders({
-    boardProps: { columns: defaultColumns, onAddTask: vi.fn() },
-  });
+  renderWithProviders({ columns: defaultColumns });
   await vi.waitFor(() => {
     const button = container?.querySelector(
       '[data-testid="add-column-button"]',
@@ -172,11 +199,8 @@ test("onAddColumn 未指定の場合はカラム追加ボタンが表示され�
 
 test("onAddColumn 指定時はボード右端にカラム追加ボタンが表示される", async () => {
   renderWithProviders({
-    boardProps: {
-      columns: defaultColumns,
-      onAddTask: vi.fn(),
-      onAddColumn: vi.fn(),
-    },
+    columns: defaultColumns,
+    onAddColumn: vi.fn(),
   });
   await vi.waitFor(() => {
     const button = container?.querySelector(
@@ -194,11 +218,8 @@ test("onAddColumn 指定時はボード右端にカラム追加ボタンが表�
 test("カラム追加ボタンから Enter で onAddColumn が呼ばれる", async () => {
   const onAddColumn = vi.fn();
   renderWithProviders({
-    boardProps: {
-      columns: defaultColumns,
-      onAddTask: vi.fn(),
-      onAddColumn,
-    },
+    columns: defaultColumns,
+    onAddColumn,
   });
   let button: HTMLButtonElement | null = null;
   await vi.waitFor(() => {
@@ -232,11 +253,8 @@ test("カラム追加ボタンから Enter で onAddColumn が呼ばれる", asy
 test("既存カラム名と同じ名前は onAddColumn に渡されない", async () => {
   const onAddColumn = vi.fn();
   renderWithProviders({
-    boardProps: {
-      columns: defaultColumns,
-      onAddTask: vi.fn(),
-      onAddColumn,
-    },
+    columns: defaultColumns,
+    onAddColumn,
   });
   let button: HTMLButtonElement | null = null;
   await vi.waitFor(() => {
@@ -277,9 +295,7 @@ test("color 未指定カラムは非連番 order でも表示順インデック�
     { name: "First", order: 10 },
     { name: "Second", order: 20 },
   ];
-  renderWithProviders({
-    boardProps: { columns, onAddTask: vi.fn() },
-  });
+  renderWithProviders({ columns });
   const hdrs = Array.from(
     container?.querySelectorAll<HTMLElement>("[data-testid='column-header']") ??
       [],
@@ -290,4 +306,79 @@ test("color 未指定カラムは非連番 order でも表示順インデック�
   expect(hdrs[1]?.getAttribute("style")).toContain(
     "var(--color-column-accent-2)",
   );
+});
+
+test("Board.Column が 0 件のとき空ボード（カラム / 追加ボタン共に無し）を描画する", async () => {
+  renderWithProviders({ columns: [] });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelectorAll("section[data-testid^='column-']").length,
+    ).toBe(0);
+  });
+  // Board ルートは描画されており、内側コンテナの子は空（追加ボタンも無し）
+  const boardRoot = container?.firstElementChild;
+  const innerRow = boardRoot?.firstElementChild;
+  expect(innerRow).not.toBeNull();
+  expect(innerRow?.childElementCount).toBe(0);
+  expect(
+    container?.querySelector("[data-testid='add-column-button']"),
+  ).toBeNull();
+});
+
+test("任意 ReactNode の children を素通しで描画する（型制約なし）", async () => {
+  const showHidden = false;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <BoardProviders
+        columns={[
+          { name: "Todo", order: 0 },
+          { name: "Frag", order: 1 },
+        ]}
+        tasks={[]}
+        allTasks={[]}
+      >
+        <Board>
+          <div data-testid="pass-foo" />
+          {null}
+          <Fragment key="frag-wrap">
+            <Board.Column
+              name="Frag"
+              order={1}
+              onAddClick={() => {}}
+              columnDraggable={false}
+            />
+          </Fragment>
+          {showHidden && (
+            <Board.Column
+              name="Hidden"
+              order={0}
+              onAddClick={() => {}}
+              columnDraggable={false}
+            />
+          )}
+          <Board.Column
+            name="Todo"
+            order={0}
+            onAddClick={() => {}}
+            columnDraggable={false}
+          />
+        </Board>
+      </BoardProviders>,
+    );
+  });
+  await vi.waitFor(() => {
+    expect(container?.querySelector("[data-testid='pass-foo']")).not.toBeNull();
+  });
+  // Fragment 越しの Board.Column と直書きの Board.Column 双方が描画される（>=2）
+  expect(
+    container?.querySelectorAll("section[data-testid^='column-']").length,
+  ).toBeGreaterThanOrEqual(2);
+});
+
+test("compound 名前空間に既存 Column / AddColumnButton と同一参照を露出する", () => {
+  expect(Board.Column).toBe(Column);
+  expect(Board.AddColumn).toBe(AddColumnButton);
 });

--- a/src/features/board/components/Board/index.stories.tsx
+++ b/src/features/board/components/Board/index.stories.tsx
@@ -1,8 +1,33 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
 import { initialColumns, initialTasks } from "@/test-fixtures";
+import type { Column as ColumnType } from "@/types/column";
 import { withBoardProviders } from "../BoardProviders/storybook/decorator";
 import { Board } from ".";
+
+const renderBoard = (columns: readonly ColumnType[]): ReactElement => {
+  const ordered = [...columns].sort((a, b) => a.order - b.order);
+  const columnDraggable = ordered.length > 1;
+  return (
+    <Board>
+      {ordered.map((col, index) => (
+        <Board.Column
+          key={col.name}
+          name={col.name}
+          color={col.color}
+          order={index}
+          onAddClick={() => {}}
+          onTaskClick={() => {}}
+          onRename={() => {}}
+          onDelete={() => {}}
+          columnDraggable={columnDraggable}
+        />
+      ))}
+      <Board.AddColumn onAdd={() => {}} />
+    </Board>
+  );
+};
 
 const meta: Meta<typeof Board> = {
   component: Board,
@@ -17,21 +42,15 @@ const meta: Meta<typeof Board> = {
       doneColumn: "Done",
     }),
   ],
-  args: {
-    columns: initialColumns,
-    onAddTask: () => {},
-    onTaskClick: () => {},
-    onAddColumn: () => {},
-    onRenameColumn: () => {},
-    onDeleteColumn: () => {},
-  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof Board>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: () => renderBoard(initialColumns),
+};
 
 export const Empty: Story = {
   decorators: [
@@ -42,10 +61,10 @@ export const Empty: Story = {
       doneColumn: "Done",
     }),
   ],
-  args: { columns: initialColumns },
+  render: () => renderBoard(initialColumns),
 };
 
-const singleTodoColumn = [{ name: "Todo", order: 0 }];
+const singleTodoColumn: ColumnType[] = [{ name: "Todo", order: 0 }];
 const singleColumnTasks = initialTasks.filter((t) => t.status === "Todo");
 
 export const SingleColumn: Story = {
@@ -57,5 +76,5 @@ export const SingleColumn: Story = {
       doneColumn: "Done",
     }),
   ],
-  args: { columns: singleTodoColumn },
+  render: () => renderBoard(singleTodoColumn),
 };

--- a/src/features/board/components/Board/index.tsx
+++ b/src/features/board/components/Board/index.tsx
@@ -1,87 +1,40 @@
-import type { Column as ColumnType } from "@/types/column";
+import type { ReactNode } from "react";
 import { AddColumnButton } from "../AddColumnButton";
 import { Column } from "../Column";
 
-/** ボードの Props */
+/** Board の Props（compound 形）。中身は children として呼び出し側が組み立てる。 */
 type BoardProps = {
-  /** カラム定義の配列。Board は内部で sort コピーのみ行い元配列を mutate しない */
-  columns: readonly ColumnType[];
-  /** カラムの「+ 追加」ボタンクリック時のコールバック
-   * @param columnName - 追加対象のカラム名
-   */
-  onAddTask: (columnName: string) => void;
-  /**
-   * タスクカードクリック時のコールバック
-   * @param taskId - クリックされたタスクのID
-   */
-  onTaskClick?: (taskId: string) => void;
-  /**
-   * 新規カラム追加時のコールバック。
-   * ボード右端の AddColumnButton から呼び出される。
-   * 未指定の場合はカラム追加 UI を非表示にする。
-   * @param columnName - 追加するカラム名（trim 済み、既存と非重複）
-   */
-  onAddColumn?: (columnName: string) => void;
-  /**
-   * カラム名リネーム確定時のコールバック。
-   * 未指定の場合はカラム名編集 UI を無効化する。
-   * @param oldName - 元のカラム名
-   * @param newName - 新しいカラム名（trim 済み、既存と非重複）
-   */
-  onRenameColumn?: (oldName: string, newName: string) => void;
-  /**
-   * カラム削除確定時のコールバック。
-   * 未指定の場合はカラム削除 UI を無効化する。
-   * カラムが 1 つの場合は内部で削除操作を禁止する。
-   * @param columnName - 削除するカラム名
-   * @param destColumn - タスクの移動先カラム名。削除対象カラムにタスクが 0 件の場合は undefined
-   */
-  onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
+  /** {@link Column}（= `Board.Column`）と {@link AddColumnButton}（= `Board.AddColumn`）を中心にした任意の ReactNode */
+  children: ReactNode;
 };
 
 /**
  * カラム一覧を横並びで表示するボードコンテナ。
- * カラムの order ソートと Column / AddColumnButton への配線のみを担う presentational。
- * Card / Column 用の Context Provider 2 段は呼び出し側の `BoardProviders` が配線する。
+ * sort / `columnDraggable` 判定 / handler bind は呼び出し側責務とし、
+ * 本コンポーネントは外側 flex-col + 内側 flex-row を提供する薄いレイアウトだけを担う。
  *
  * @param props - {@link BoardProps}
  * @returns ボード要素
  */
-export const Board = ({
-  columns,
-  onAddTask,
-  onTaskClick,
-  onAddColumn,
-  onRenameColumn,
-  onDeleteColumn,
-}: BoardProps) => {
-  const ordered = [...columns].sort((a, b) => a.order - b.order);
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex flex-1 gap-4 overflow-x-auto p-4">
-        {ordered.map((col, index) => (
-          <Column
-            key={col.name}
-            name={col.name}
-            color={col.color}
-            order={index}
-            onAddClick={() => onAddTask(col.name)}
-            onTaskClick={onTaskClick}
-            onRename={
-              onRenameColumn
-                ? (newName) => onRenameColumn(col.name, newName)
-                : undefined
-            }
-            onDelete={
-              onDeleteColumn
-                ? (destColumn) => onDeleteColumn(col.name, destColumn)
-                : undefined
-            }
-            columnDraggable={columns.length > 1}
-          />
-        ))}
-        {onAddColumn && <AddColumnButton onAdd={onAddColumn} />}
-      </div>
-    </div>
-  );
+const BoardRoot = ({ children }: BoardProps) => (
+  <div className="flex h-full flex-col">
+    <div className="flex flex-1 gap-4 overflow-x-auto p-4">{children}</div>
+  </div>
+);
+
+/** Compound コンポーネント本体（Root + 2 サブ部品の名前空間） */
+type BoardComponent = ((props: BoardProps) => ReactNode) & {
+  Column: typeof Column;
+  AddColumn: typeof AddColumnButton;
 };
+
+/**
+ * ボード（Compound コンポーネント）。
+ * `<Board><Board.Column .../><Board.AddColumn .../></Board>` の形で利用する。
+ * `Board.Column` は {@link Column}、`Board.AddColumn` は {@link AddColumnButton} の alias で、
+ * 参照同一性を保ったまま名前空間として公開する。
+ */
+export const Board: BoardComponent = Object.assign(BoardRoot, {
+  Column,
+  AddColumn: AddColumnButton,
+});

--- a/src/features/board/components/Board/index.tsx
+++ b/src/features/board/components/Board/index.tsx
@@ -4,8 +4,11 @@ import { Column } from "../Column";
 
 /** Board の Props（compound 形）。中身は children として呼び出し側が組み立てる。 */
 type BoardProps = {
-  /** {@link Column}（= `Board.Column`）と {@link AddColumnButton}（= `Board.AddColumn`）を中心にした任意の ReactNode */
-  children: ReactNode;
+  /**
+   * {@link Column}（= `Board.Column`）と {@link AddColumnButton}（= `Board.AddColumn`）を
+   * 中心にした任意の ReactNode。`<Board />` の形（空ボード）も許容するため optional。
+   */
+  children?: ReactNode;
 };
 
 /**

--- a/src/features/board/components/BoardWorkspace/__tests__/BoardWorkspace.compound-wiring.test.tsx
+++ b/src/features/board/components/BoardWorkspace/__tests__/BoardWorkspace.compound-wiring.test.tsx
@@ -1,0 +1,177 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { Column as ColumnType } from "@/types/column";
+import { Task, type TaskPayload } from "@/types/task";
+import { BoardWorkspace } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  // 表示形態は localStorage 経由で復元されるため、テスト間でリーク防止に毎回クリア。
+  // default は "board" タブで render される。
+  localStorage.clear();
+});
+
+afterEach(() => {
+  unmountWorkspace();
+  localStorage.clear();
+});
+
+const unmountWorkspace = () => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+};
+
+const makeTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+type RenderOptions = {
+  /** カラム定義 */
+  columns: ColumnType[];
+  /** 表示用タスク（省略時は空） */
+  tasks?: Task[];
+  /** 「+ 追加」クリック時のコールバック（省略時は no-op） */
+  onAddTask?: (columnName: string) => void;
+  /** 新規カラム追加コールバック（明示的に undefined を渡すと AddColumnButton 非表示） */
+  onAddColumn?: ((columnName: string) => void) | undefined;
+};
+
+const renderWorkspace = (options: RenderOptions) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <BoardWorkspace
+        columns={options.columns}
+        tasks={options.tasks ?? []}
+        onAddTask={options.onAddTask ?? (() => {})}
+        onTaskClick={() => {}}
+        onAddColumn={options.onAddColumn}
+      />,
+    );
+  });
+};
+
+test("逆順 columns が order 順で描画される", async () => {
+  const columns: ColumnType[] = [
+    { name: "Done", order: 2 },
+    { name: "Todo", order: 0 },
+    { name: "In Progress", order: 1 },
+  ];
+  renderWorkspace({ columns });
+  await vi.waitFor(() => {
+    const labels = Array.from(
+      container?.querySelectorAll("section[aria-label]") ?? [],
+    ).map((s) => s.getAttribute("aria-label"));
+    expect(labels).toEqual(["Todo", "In Progress", "Done"]);
+  });
+});
+
+test("columnDraggable は件数境界で双方向に切り替わる（1 件で false / 2 件で true）", async () => {
+  renderWorkspace({ columns: [{ name: "Todo", order: 0 }] });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelectorAll<HTMLElement>("[data-testid='column-header']")
+        .length,
+    ).toBe(1);
+  });
+  const singleHeader = container?.querySelector<HTMLElement>(
+    "[data-testid='column-header']",
+  );
+  expect(singleHeader?.getAttribute("draggable")).toBe("false");
+
+  unmountWorkspace();
+
+  renderWorkspace({
+    columns: [
+      { name: "Todo", order: 0 },
+      { name: "Done", order: 1 },
+    ],
+  });
+  await vi.waitFor(() => {
+    const headers = container?.querySelectorAll<HTMLElement>(
+      "[data-testid='column-header']",
+    );
+    expect(headers?.length).toBe(2);
+  });
+  const headers = Array.from(
+    container?.querySelectorAll<HTMLElement>("[data-testid='column-header']") ??
+      [],
+  );
+  for (const header of headers) {
+    expect(header.getAttribute("draggable")).toBe("true");
+  }
+});
+
+test("onAddColumn の有無で追加ボタンが双方向に切り替わる", async () => {
+  renderWorkspace({
+    columns: [{ name: "Todo", order: 0 }],
+    onAddColumn: undefined,
+  });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelectorAll("section[aria-label]").length,
+    ).toBeGreaterThan(0);
+  });
+  expect(
+    container?.querySelector("[data-testid='add-column-button']"),
+  ).toBeNull();
+
+  unmountWorkspace();
+
+  renderWorkspace({
+    columns: [{ name: "Todo", order: 0 }],
+    onAddColumn: vi.fn(),
+  });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelector("[data-testid='add-column-button']"),
+    ).not.toBeNull();
+  });
+});
+
+test("`+ 追加` クリックで onAddTask が該当 columnName で呼ばれる", async () => {
+  const onAddTask = vi.fn();
+  renderWorkspace({
+    columns: [
+      { name: "Todo", order: 0 },
+      { name: "Done", order: 1 },
+    ],
+    tasks: [makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" })],
+    onAddTask,
+  });
+  let addButton: HTMLButtonElement | null = null;
+  await vi.waitFor(() => {
+    const todoSection = container?.querySelector<HTMLElement>(
+      "section[aria-label='Todo']",
+    );
+    addButton =
+      (Array.from(todoSection?.querySelectorAll("button") ?? []).find(
+        (b) => b.textContent?.trim() === "+ 追加",
+      ) as HTMLButtonElement | undefined) ?? null;
+    expect(addButton).not.toBeNull();
+  });
+  act(() => {
+    addButton?.click();
+  });
+  expect(onAddTask).toHaveBeenCalledTimes(1);
+  expect(onAddTask).toHaveBeenCalledWith("Todo");
+});

--- a/src/features/board/components/BoardWorkspace/__tests__/BoardWorkspace.compound-wiring.test.tsx
+++ b/src/features/board/components/BoardWorkspace/__tests__/BoardWorkspace.compound-wiring.test.tsx
@@ -49,8 +49,8 @@ type RenderOptions = {
   tasks?: Task[];
   /** 「+ 追加」クリック時のコールバック（省略時は no-op） */
   onAddTask?: (columnName: string) => void;
-  /** 新規カラム追加コールバック（明示的に undefined を渡すと AddColumnButton 非表示） */
-  onAddColumn?: ((columnName: string) => void) | undefined;
+  /** 新規カラム追加コールバック（省略時は AddColumnButton 非表示） */
+  onAddColumn?: (columnName: string) => void;
 };
 
 const renderWorkspace = (options: RenderOptions) => {

--- a/src/features/board/components/BoardWorkspace/index.tsx
+++ b/src/features/board/components/BoardWorkspace/index.tsx
@@ -149,6 +149,15 @@ const ActiveBoardView = ({
       <CalendarView tasks={filtered} onTaskClick={workspace.onTaskClick} />
     );
   }
+  const ordered = [...workspace.columns].sort((a, b) => a.order - b.order);
+  const columnDraggable = ordered.length > 1;
+  const {
+    onAddTask,
+    onTaskClick,
+    onAddColumn,
+    onRenameColumn,
+    onDeleteColumn,
+  } = workspace;
   return (
     <BoardProviders
       columns={workspace.columns}
@@ -161,14 +170,30 @@ const ActiveBoardView = ({
       onTaskDrop={workspace.onTaskDrop}
       onColumnReorder={workspace.onColumnReorder}
     >
-      <Board
-        columns={workspace.columns}
-        onAddTask={workspace.onAddTask}
-        onTaskClick={workspace.onTaskClick}
-        onAddColumn={workspace.onAddColumn}
-        onRenameColumn={workspace.onRenameColumn}
-        onDeleteColumn={workspace.onDeleteColumn}
-      />
+      <Board>
+        {ordered.map((col, index) => (
+          <Board.Column
+            key={col.name}
+            name={col.name}
+            color={col.color}
+            order={index}
+            onAddClick={() => onAddTask(col.name)}
+            onTaskClick={onTaskClick}
+            onRename={
+              onRenameColumn
+                ? (newName) => onRenameColumn(col.name, newName)
+                : undefined
+            }
+            onDelete={
+              onDeleteColumn
+                ? (destColumn) => onDeleteColumn(col.name, destColumn)
+                : undefined
+            }
+            columnDraggable={columnDraggable}
+          />
+        ))}
+        {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}
+      </Board>
     </BoardProviders>
   );
 };


### PR DESCRIPTION
## 概要

`<Board>` の旧 6 props (`columns` / `onAddTask` / `onTaskClick` / `onAddColumn` / `onRenameColumn` / `onDeleteColumn`) を**完全削除**し、`children: ReactNode` のみを受けるレイアウトコンテナに薄くした。`Object.assign(BoardRoot, { Column, AddColumn: AddColumnButton })` で compound 名前空間を構築し、既存 `TaskCard` / `DetailFields` と同じパターンに揃える。

sort・`columnDraggable` 判定・handler bind・`AddColumn` の条件レンダーは唯一の呼び出し側 `BoardWorkspace.ActiveBoardView` に責務移譲した（同 PR で旧 API への参照を完全に排除しているため BC は持たない）。

## 変更の種類

- ♻️ Refactoring
- 💥 Breaking（`<Board>` の旧 props 互換は破棄。同 PR 内の唯一の呼び出し側を新 API へ追従済みのため外部影響なし）

## 追加した内容

- `Board.Column` / `Board.AddColumn` の compound 名前空間（`Column` / `AddColumnButton` の参照同一性 alias）
- `Board.rendering.test.tsx` に compound 固有 3 ケース
  - 0 件空ボード（構造セレクタで内側コンテナ・子件数を検証）
  - 任意 ReactNode children パススルー（`<div />` / `{null}` / `<Fragment key>` / 条件式 / `<Board.Column />` の混在）
  - `Board.Column === Column` / `Board.AddColumn === AddColumnButton` 参照同一性 smoke
- `BoardWorkspace.compound-wiring.test.tsx` を新規 4 ケース（責務移譲の回帰保護）
- `docs/impl/board-compound-component.md`（「なぜ X しない / なぜ Y する」体裁）

## 変更した内容

- `src/features/board/components/Board/index.tsx`: 旧 6 props 全削除 → `children: ReactNode` のみへ。`Object.assign` で compound 化
- `src/features/board/components/BoardWorkspace/index.tsx`: `ActiveBoardView` を sort / `columnDraggable` / handler bind / `Board.AddColumn` 条件レンダー inline 形式へ
- `src/features/board/components/Board/__tests__/*` 3 ファイル: `renderWithProviders` をフラット `RenderOptions` に統一、既存 19 ケースを新 API へ追従
- `src/features/board/components/Board/index.stories.tsx`: `args` → `render: () => renderBoard(...)` 形式へ

## 削除した内容

- `<Board>` の旧 props 6 種類とそれに伴う Board 内部の sort / `.map` / 条件レンダーロジック

## 仕様ドキュメント更新

不要（純粋なフロントエンド・コンポーネント API リファクタリング。`<Board>` の外部観察可能な振る舞い（DOM 構造・aria・DnD 挙動・追加 UI の有無）は完全不変で、`docs/spec-board/board-view-spec.md` 等のユーザー視点仕様には変更なし）。設計判断の根拠は `docs/impl/board-compound-component.md` に新規記述。

## システム図

### compound 化後のコンポーネント階層

\`\`\`mermaid
flowchart TD
  App --> BoardWorkspace
  BoardWorkspace --> ActiveBoardView
  ActiveBoardView -. "sort / columnDraggable 判定 / handler bind / 条件レンダー [NEW 責務]" .-> BoardProviders
  BoardProviders --> Board["Board (children: ReactNode のみ受ける薄いレイアウト)"]
  Board --> BoardColumn1["Board.Column"]
  Board --> BoardColumn2["Board.Column"]
  Board --> BoardColumnN["Board.Column ..."]
  Board --> BoardAddColumn["Board.AddColumn (条件レンダー)"]

  style Board fill:#e8f4ff,stroke:#1f7ad8
  style ActiveBoardView fill:#fff7d8,stroke:#c8941a
\`\`\`

### 責務移動マップ

| 責務 | before（Board 本体） | after（呼び出し側） |
|---|---|---|
| columns sort | `[...columns].sort((a,b)=>...)` | `ActiveBoardView` 内で inline sort |
| 表示順 index 再付番 | `ordered.map((col, index) => ...)` | 呼び出し側で `.map` index 付与 |
| `columnDraggable` | `columns.length > 1` | `ordered.length > 1`（呼び出し側） |
| handler bind | `onAddTask(col.name)` クロージャ | `Board.Column` ごとに inline 生成 |
| AddColumn 条件 | `{onAddColumn && <AddColumnButton/>}` | `{onAddColumn && <Board.AddColumn/>}` |
| レイアウト DOM | flex-col + flex-row | Board が引き続き保有（変更なし） |

## 関連Issue

なし（spec 024-fe-board-compound-component 起点の内部リファクタリング）。

## テスト

- ✅ `pnpm typecheck`（tsc -b、0 errors）
- ✅ `pnpm test:run`（275 files / **2337 tests** 全 PASS）
  - 既存 `Board/__tests__/*` 19 ケース（rendering 10 / dnd 5 / column-dnd 4）が新 API で再 PASS
  - 新規 compound 固有 3 ケース PASS
  - 新規 `BoardWorkspace.compound-wiring.test.tsx` 4 ケース PASS
  - 既存 `Column/__tests__/*` / `AddColumnButton/__tests__/*` / `App.*.test.tsx` は無修正で PASS（NFR-3）
- ✅ `pnpm lint`（oxlint 0 warnings / 0 errors、biome clean）
- ✅ Codex CLI レビュー: **問題なし**
- ✅ spec-based-code-review（5 並列 × 2 round）: CRITICAL/WARNING/INFO すべて 0 件で round 2 完了

⚠️ 手動検証は残課題（マージ前にレビュアー実施推奨）:
- [ ] `pnpm tauri dev` で order 順 / カラム追加 / column DnD（1 件で無効 / 2 件以上で有効）/ タスク追加 / list/tree/calendar タブ切替後の board 復帰
- [ ] `pnpm storybook` で `Default` / `Empty` / `SingleColumn` の見た目が改修前と同じ

## レビューポイント

- **破壊的変更の範囲**: `<Board>` の旧 props は同 PR 内の唯一の呼び出し側 `ActiveBoardView` を新 API に追従済み。feature 外からの `<Board>` import が無いことを確認済みだが、見落としがあれば指摘お願いします
- **責務移動の妥当性**: sort と表示順 index 採番を呼び出し側に出すことで、`Board.Column` 利用者から見えるのは常に「表示順 index」だけになり、`column.order` の生値（10, 20, ...）と混在しなくなる設計判断
- **`useMemo` 不採用**: `[...workspace.columns].sort(...)` を inline で実行する判断（実装計画 L194 で明示）。下流 `Column` が `React.memo` 非適用で実害なしを根拠とするが、将来 memo 化する場合は再評価ポイント
- **テストヘルパ重複**: 3 つの `Board/__tests__/*` の `renderWithProviders` は同型ロジックを再実装している（exploration-report 2.5 で「既存負債、本 spec の Out-of-Scope」と明示）。共通化は別 PR 候補