### PR TITLE
♻️ [Refactoring]: [FE] PopoverSelect を SelectedDisplay / PopoverOption + swatch/badge プリミティブに分割

### DIFF
--- a/src/features/task-form/components/TaskForm/PopoverSelect/OptionBadge/__tests__/OptionBadge.rendering.test.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/OptionBadge/__tests__/OptionBadge.rendering.test.tsx
@@ -1,0 +1,53 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test } from "vitest";
+import { OptionBadge } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const render = (props: Parameters<typeof OptionBadge>[0]) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(OptionBadge, props));
+  });
+};
+
+const badge = (): HTMLElement =>
+  container?.querySelector("span") as HTMLElement;
+
+test("label が表示される", () => {
+  render({ label: "High", badgeClassName: "bg-red-100 text-red-800" });
+  expect(badge().textContent).toBe("High");
+});
+
+test("ベースの静的クラスと動的 badgeClassName の両方が連結される", () => {
+  render({ label: "High", badgeClassName: "bg-red-100 text-red-800" });
+  const className = badge().className;
+  expect(className).toContain("inline-flex");
+  expect(className).toContain("rounded-full");
+  expect(className).toContain("text-xs");
+  expect(className).toContain("font-semibold");
+  expect(className).toContain("bg-red-100");
+  expect(className).toContain("text-red-800");
+});
+
+test.each([
+  ["High", "bg-red-100 text-red-800"],
+  ["Low", "bg-blue-100 text-blue-800"],
+])("label=%s / badgeClassName=%s が反映される", (label, badgeClassName) => {
+  render({ label, badgeClassName });
+  expect(badge().textContent).toBe(label);
+  expect(badge().className).toContain(badgeClassName);
+});

--- a/src/features/task-form/components/TaskForm/PopoverSelect/OptionBadge/index.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/OptionBadge/index.tsx
@@ -1,0 +1,19 @@
+type OptionBadgeProps = {
+  /** badge に表示するテキスト。 */
+  label: string;
+  /** 配色などの追加クラス（呼び出し側供給の動的値）。 */
+  badgeClassName: string;
+};
+
+/**
+ * 色付き badge ピル。trigger / option の両方から利用する単一実装。
+ * @param props - {@link OptionBadgeProps}
+ * @returns badge 要素
+ */
+export const OptionBadge = ({ label, badgeClassName }: OptionBadgeProps) => (
+  <span
+    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${badgeClassName}`}
+  >
+    {label}
+  </span>
+);

--- a/src/features/task-form/components/TaskForm/PopoverSelect/OptionSwatch/__tests__/OptionSwatch.rendering.test.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/OptionSwatch/__tests__/OptionSwatch.rendering.test.tsx
@@ -1,0 +1,49 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test } from "vitest";
+import { OptionSwatch } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const render = (color: string) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(OptionSwatch, { color }));
+  });
+};
+
+const swatch = (): HTMLElement =>
+  container?.querySelector("span") as HTMLElement;
+
+test("指定した color が inline style の backgroundColor に反映される", () => {
+  render("#ff0000");
+  expect(swatch().getAttribute("style")).toContain("#ff0000");
+});
+
+test("swatch の静的クラスが付与される", () => {
+  render("#123456");
+  expect(swatch().className).toContain("size-2.5");
+  expect(swatch().className).toContain("shrink-0");
+  expect(swatch().className).toContain("rounded-full");
+});
+
+test.each([
+  "#ffffff",
+  "rgb(0, 0, 0)",
+  "#abcdef",
+])("color=%s が backgroundColor に反映される", (color) => {
+  render(color);
+  expect(swatch().getAttribute("style")).toContain(color);
+});

--- a/src/features/task-form/components/TaskForm/PopoverSelect/OptionSwatch/index.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/OptionSwatch/index.tsx
@@ -1,0 +1,16 @@
+type OptionSwatchProps = {
+  /** swatch の CSS color 値（inline style の backgroundColor に渡す）。 */
+  color: string;
+};
+
+/**
+ * 色付きドット（swatch）。trigger / option の両方から利用する単一実装。
+ * @param props - {@link OptionSwatchProps}
+ * @returns swatch 要素
+ */
+export const OptionSwatch = ({ color }: OptionSwatchProps) => (
+  <span
+    className="size-2.5 shrink-0 rounded-full"
+    style={{ backgroundColor: color }}
+  />
+);

--- a/src/features/task-form/components/TaskForm/PopoverSelect/PopoverOption/__tests__/PopoverOption.rendering.test.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/PopoverOption/__tests__/PopoverOption.rendering.test.tsx
@@ -1,0 +1,129 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { PopoverOption } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const baseProps = (
+  overrides: Partial<Parameters<typeof PopoverOption>[0]> = {},
+): Parameters<typeof PopoverOption>[0] => ({
+  option: { value: "Doing", label: "Doing", swatchColor: "#222222" },
+  optionId: "lb-option-1",
+  testId: "ps-option-Doing",
+  selected: false,
+  active: false,
+  onMouseEnter: vi.fn(),
+  onSelect: vi.fn(),
+  ...overrides,
+});
+
+const render = (props: Parameters<typeof PopoverOption>[0]) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(PopoverOption, props));
+  });
+};
+
+const button = (): HTMLButtonElement =>
+  container?.querySelector("button") as HTMLButtonElement;
+const swatch = () => container?.querySelector("span[style]") ?? null;
+const badge = () => container?.querySelector(".font-semibold") ?? null;
+const label = () => container?.querySelector(".truncate") ?? null;
+
+test("swatch + label: button 直下に swatch と flex-1 truncate label が並ぶ", () => {
+  render(baseProps());
+  expect(swatch()?.getAttribute("style")).toContain("#222222");
+  expect(label()?.textContent).toBe("Doing");
+  expect(label()?.className).toContain("flex-1");
+  expect(label()?.className).toContain("truncate");
+});
+
+test("badge のみ: badge が描画され swatch なし", () => {
+  render(
+    baseProps({
+      option: { value: "High", label: "High", badgeClassName: "bg-red-100" },
+    }),
+  );
+  expect(badge()?.textContent).toBe("High");
+  expect(swatch()).toBeNull();
+});
+
+test("label のみ: truncate label のみで swatch なし", () => {
+  render(baseProps({ option: { value: "None", label: "None" } }));
+  expect(label()?.textContent).toBe("None");
+  expect(swatch()).toBeNull();
+});
+
+test("button 属性（id / role / data-testid / aria-selected）が反映される", () => {
+  render(
+    baseProps({
+      optionId: "lb-option-2",
+      testId: "ps-option-x",
+      selected: true,
+    }),
+  );
+  expect(button().id).toBe("lb-option-2");
+  expect(button().getAttribute("role")).toBe("option");
+  expect(button().getAttribute("data-testid")).toBe("ps-option-x");
+  expect(button().getAttribute("aria-selected")).toBe("true");
+});
+
+test("selected=true で font-medium が付く", () => {
+  render(baseProps({ selected: true }));
+  expect(button().className).toContain("font-medium");
+});
+
+test.each([
+  [true, "bg-panel-2", false],
+  [false, "hover:bg-panel-2", true],
+])("active=%s で %s が付く", (active, expectedClass, notPlainBg) => {
+  render(baseProps({ active }));
+  expect(button().className).toContain(expectedClass);
+  expect(button().className.includes("hover:bg-panel-2")).toBe(notPlainBg);
+});
+
+test("swatch + badge 同時: badge 優先で swatch を出さない", () => {
+  render(
+    baseProps({
+      option: {
+        value: "High",
+        label: "High",
+        swatchColor: "#222222",
+        badgeClassName: "bg-red-100",
+      },
+    }),
+  );
+  expect(badge()?.textContent).toBe("High");
+  expect(swatch()).toBeNull();
+});
+
+test("click で onSelect が 1 回呼ばれる", () => {
+  const onSelect = vi.fn();
+  render(baseProps({ onSelect }));
+  act(() => {
+    button().click();
+  });
+  expect(onSelect).toHaveBeenCalledTimes(1);
+});
+
+test("mouseover で onMouseEnter が 1 回呼ばれる", () => {
+  const onMouseEnter = vi.fn();
+  render(baseProps({ onMouseEnter }));
+  act(() => {
+    button().dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+  });
+  expect(onMouseEnter).toHaveBeenCalledTimes(1);
+});

--- a/src/features/task-form/components/TaskForm/PopoverSelect/PopoverOption/index.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/PopoverOption/index.tsx
@@ -1,0 +1,59 @@
+import { OptionBadge } from "../OptionBadge";
+import { OptionSwatch } from "../OptionSwatch";
+import type { PopoverSelectOption } from "../types";
+
+type PopoverOptionProps = {
+  /** 描画対象の option。 */
+  option: PopoverSelectOption;
+  /** button の id（`${listboxId}-option-${index}`）。aria-activedescendant の参照先。 */
+  optionId: string;
+  /** テスト用 ID（`${dataTestid}-option-${option.value}`）。 */
+  testId: string;
+  /** 現在値と一致しているか（aria-selected / font-medium）。 */
+  selected: boolean;
+  /** highlight 中か（activeIndex と一致：bg-panel-2）。 */
+  active: boolean;
+  /** マウスオーバーで activeIndex を移す。 */
+  onMouseEnter: () => void;
+  /** クリックで確定（selectAt）。 */
+  onSelect: () => void;
+};
+
+/**
+ * listbox の option 1 件（`role="option"` ボタン）。
+ * badge 優先、なければ swatch + label を button 直下に描画する。
+ * @param props - {@link PopoverOptionProps}
+ * @returns option ボタン要素
+ */
+export const PopoverOption = (props: PopoverOptionProps) => {
+  const { option } = props;
+  return (
+    <button
+      type="button"
+      id={props.optionId}
+      role="option"
+      aria-selected={props.selected}
+      tabIndex={-1}
+      onMouseEnter={props.onMouseEnter}
+      onClick={props.onSelect}
+      className={`flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm ${
+        props.active ? "bg-panel-2" : "hover:bg-panel-2"
+      } ${props.selected ? "font-medium" : ""}`}
+      data-testid={props.testId}
+    >
+      {option.badgeClassName !== undefined ? (
+        <OptionBadge
+          label={option.label}
+          badgeClassName={option.badgeClassName}
+        />
+      ) : (
+        <>
+          {option.swatchColor !== undefined && (
+            <OptionSwatch color={option.swatchColor} />
+          )}
+          <span className="min-w-0 flex-1 truncate">{option.label}</span>
+        </>
+      )}
+    </button>
+  );
+};

--- a/src/features/task-form/components/TaskForm/PopoverSelect/SelectedDisplay/__tests__/SelectedDisplay.rendering.test.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/SelectedDisplay/__tests__/SelectedDisplay.rendering.test.tsx
@@ -1,0 +1,70 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test } from "vitest";
+import type { PopoverSelectOption } from "../../types";
+import { SelectedDisplay } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const render = (option: PopoverSelectOption | undefined) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(SelectedDisplay, { option }));
+  });
+};
+
+const swatch = () => container?.querySelector("span[style]") ?? null;
+const badge = () => container?.querySelector(".font-semibold") ?? null;
+const wrapper = () => container?.querySelector(".gap-2") ?? null;
+const label = () => container?.querySelector(".truncate") ?? null;
+
+test("swatch + label: gap-2 ラッパ内に swatch と truncate label が並ぶ", () => {
+  render({ value: "Doing", label: "Doing", swatchColor: "#222222" });
+  expect(wrapper()).toBeTruthy();
+  expect(swatch()?.getAttribute("style")).toContain("#222222");
+  expect(label()?.textContent).toBe("Doing");
+});
+
+test("badge のみ: badge が描画され swatch も gap-2 ラッパも付かない", () => {
+  render({ value: "High", label: "High", badgeClassName: "bg-red-100" });
+  expect(badge()?.textContent).toBe("High");
+  expect(badge()?.className).toContain("bg-red-100");
+  expect(swatch()).toBeNull();
+  expect(wrapper()).toBeNull();
+});
+
+test("label のみ: ラッパ内に truncate label のみで swatch なし", () => {
+  render({ value: "None", label: "None" });
+  expect(wrapper()).toBeTruthy();
+  expect(label()?.textContent).toBe("None");
+  expect(swatch()).toBeNull();
+});
+
+test("未選択（undefined）: 何も描画されない", () => {
+  render(undefined);
+  expect(container?.querySelector("span")).toBeNull();
+  expect(container?.textContent).toBe("");
+});
+
+test("swatch + badge 同時: badge 優先で swatch を出さない", () => {
+  render({
+    value: "High",
+    label: "High",
+    swatchColor: "#222222",
+    badgeClassName: "bg-red-100",
+  });
+  expect(badge()?.textContent).toBe("High");
+  expect(swatch()).toBeNull();
+});

--- a/src/features/task-form/components/TaskForm/PopoverSelect/SelectedDisplay/index.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/SelectedDisplay/index.tsx
@@ -1,0 +1,36 @@
+import { OptionBadge } from "../OptionBadge";
+import { OptionSwatch } from "../OptionSwatch";
+import type { PopoverSelectOption } from "../types";
+
+type SelectedDisplayProps = {
+  /** 選択中 option（未選択時は undefined）。 */
+  option: PopoverSelectOption | undefined;
+};
+
+/**
+ * 選択中 option を trigger 内に描画する（badge 優先、なければ swatch + label）。
+ * 未選択（undefined）時は何も表示しない。
+ * @param props - {@link SelectedDisplayProps}
+ * @returns trigger 内の表示要素、未選択時は null
+ */
+export const SelectedDisplay = ({ option }: SelectedDisplayProps) => {
+  if (option === undefined) {
+    return null;
+  }
+  if (option.badgeClassName !== undefined) {
+    return (
+      <OptionBadge
+        label={option.label}
+        badgeClassName={option.badgeClassName}
+      />
+    );
+  }
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2">
+      {option.swatchColor !== undefined && (
+        <OptionSwatch color={option.swatchColor} />
+      )}
+      <span className="truncate">{option.label}</span>
+    </span>
+  );
+};

--- a/src/features/task-form/components/TaskForm/PopoverSelect/__tests__/PopoverSelect.empty.test.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/__tests__/PopoverSelect.empty.test.tsx
@@ -1,0 +1,108 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import { PopoverSelect } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+const baseProps = (
+  overrides: Partial<Parameters<typeof PopoverSelect>[0]> = {},
+): Parameters<typeof PopoverSelect>[0] => ({
+  label: "ステータス",
+  options: [],
+  value: "",
+  onChange: vi.fn(),
+  disabled: false,
+  "data-testid": "ps",
+  ...overrides,
+});
+
+const render = (props: Parameters<typeof PopoverSelect>[0]) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(PopoverSelect, props));
+  });
+};
+
+const trigger = (): HTMLButtonElement =>
+  document.querySelector('[data-testid="ps"]') as HTMLButtonElement;
+
+const listbox = (): HTMLElement | null =>
+  document.querySelector('[data-testid="ps-listbox"]');
+
+const openPopover = () => {
+  act(() => {
+    trigger().click();
+  });
+};
+
+const keydownOn = (el: Element, key: string) => {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+};
+
+test("空配列で開くと listbox は描画されるが option は 0 個", () => {
+  render(baseProps());
+  openPopover();
+  expect(listbox()).toBeTruthy();
+  expect(document.querySelectorAll('[role="option"]').length).toBe(0);
+});
+
+test.each([
+  "Enter",
+  " ",
+  "ArrowDown",
+  "ArrowUp",
+  "Home",
+  "End",
+])("空配列で %s を押下しても onChange は呼ばれない", (key) => {
+  const onChange = vi.fn();
+  render(baseProps({ onChange }));
+  openPopover();
+  act(() => {
+    keydownOn(listbox() as HTMLElement, key);
+  });
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test("空配列で ArrowDown を押しても aria-activedescendant は変化しない", () => {
+  render(baseProps());
+  openPopover();
+  const before = listbox()?.getAttribute("aria-activedescendant");
+  act(() => {
+    keydownOn(listbox() as HTMLElement, "ArrowDown");
+  });
+  const after = listbox()?.getAttribute("aria-activedescendant");
+  expect(after).toBe(before);
+});
+
+test("空配列で Esc を押すと閉じる", () => {
+  render(baseProps());
+  openPopover();
+  act(() => {
+    keydownOn(listbox() as HTMLElement, "Escape");
+  });
+  expect(listbox()).toBeNull();
+  expect(trigger().getAttribute("aria-expanded")).toBe("false");
+});
+
+test("空配列で外側 mousedown すると閉じる", () => {
+  render(baseProps());
+  openPopover();
+  act(() => {
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  });
+  expect(listbox()).toBeNull();
+  expect(trigger().getAttribute("aria-expanded")).toBe("false");
+});

--- a/src/features/task-form/components/TaskForm/PopoverSelect/__tests__/PopoverSelect.empty.test.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/__tests__/PopoverSelect.empty.test.tsx
@@ -76,6 +76,13 @@ test.each([
   expect(onChange).not.toHaveBeenCalled();
 });
 
+test("空配列で開いても aria-activedescendant は存在しない id を指さない", () => {
+  render(baseProps());
+  openPopover();
+  // 空配列時 activeIndex は範囲外になるため、実在しない option を参照しない。
+  expect(listbox()?.getAttribute("aria-activedescendant")).toBeNull();
+});
+
 test("空配列で ArrowDown を押しても aria-activedescendant は変化しない", () => {
   render(baseProps());
   openPopover();

--- a/src/features/task-form/components/TaskForm/PopoverSelect/index.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/index.tsx
@@ -209,7 +209,7 @@ export const PopoverSelect = (props: PopoverSelectProps) => {
           role="listbox"
           aria-labelledby={labelId}
           aria-activedescendant={
-            activeIndex === NO_ACTIVE
+            activeIndex === NO_ACTIVE || activeIndex >= props.options.length
               ? undefined
               : `${listboxId}-option-${activeIndex}`
           }

--- a/src/features/task-form/components/TaskForm/PopoverSelect/index.tsx
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/index.tsx
@@ -1,17 +1,8 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
-
-/** popover select の選択肢 1 件。 */
-export type PopoverSelectOption = {
-  /** onChange に渡す値 */
-  value: string;
-  /** trigger / option に表示するテキスト */
-  label: string;
-  /** swatch（status の色付きドット）の CSS color 値。 */
-  swatchColor?: string;
-  /** option / trigger を badge 表示にする場合の追加クラス（優先度の配色など）。 */
-  badgeClassName?: string;
-};
+import { PopoverOption } from "./PopoverOption";
+import { SelectedDisplay } from "./SelectedDisplay";
+import type { PopoverSelectOption } from "./types";
 
 type PopoverSelectProps = {
   /** フィールドのラベルテキスト */
@@ -38,41 +29,6 @@ type PopoverSelectProps = {
 
 /** ハイライトなしを表す activeIndex 値。 */
 const NO_ACTIVE = -1;
-
-/**
- * 選択中 option を trigger 内に描画する（swatch + label、または badge）。
- * @param props - 選択中 option（未選択時は undefined）
- * @returns trigger 内の表示要素
- */
-const SelectedDisplay = ({
-  option,
-}: {
-  option: PopoverSelectOption | undefined;
-}) => {
-  if (option === undefined) {
-    return null;
-  }
-  if (option.badgeClassName !== undefined) {
-    return (
-      <span
-        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${option.badgeClassName}`}
-      >
-        {option.label}
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex min-w-0 items-center gap-2">
-      {option.swatchColor !== undefined && (
-        <span
-          className="size-2.5 shrink-0 rounded-full"
-          style={{ backgroundColor: option.swatchColor }}
-        />
-      )}
-      <span className="truncate">{option.label}</span>
-    </span>
-  );
-};
 
 /**
  * status / priority 共用の popover select。
@@ -261,43 +217,18 @@ export const PopoverSelect = (props: PopoverSelectProps) => {
           className="absolute left-0 right-0 z-10 mt-1 max-h-72 max-w-[340px] overflow-y-auto rounded-lg border border-border-strong bg-panel p-1.5 shadow-lg outline-none"
           data-testid={`${props["data-testid"]}-listbox`}
         >
-          {props.options.map((option, index) => {
-            const isSelected = option.value === props.value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                id={`${listboxId}-option-${index}`}
-                role="option"
-                aria-selected={isSelected}
-                tabIndex={-1}
-                onMouseEnter={() => setActiveIndex(index)}
-                onClick={() => selectAt(index)}
-                className={`flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-sm ${
-                  index === activeIndex ? "bg-panel-2" : "hover:bg-panel-2"
-                } ${isSelected ? "font-medium" : ""}`}
-                data-testid={`${props["data-testid"]}-option-${option.value}`}
-              >
-                {option.swatchColor !== undefined && (
-                  <span
-                    className="size-2.5 shrink-0 rounded-full"
-                    style={{ backgroundColor: option.swatchColor }}
-                  />
-                )}
-                {option.badgeClassName !== undefined ? (
-                  <span
-                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${option.badgeClassName}`}
-                  >
-                    {option.label}
-                  </span>
-                ) : (
-                  <span className="min-w-0 flex-1 truncate">
-                    {option.label}
-                  </span>
-                )}
-              </button>
-            );
-          })}
+          {props.options.map((option, index) => (
+            <PopoverOption
+              key={option.value}
+              option={option}
+              optionId={`${listboxId}-option-${index}`}
+              testId={`${props["data-testid"]}-option-${option.value}`}
+              selected={option.value === props.value}
+              active={index === activeIndex}
+              onMouseEnter={() => setActiveIndex(index)}
+              onSelect={() => selectAt(index)}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/src/features/task-form/components/TaskForm/PopoverSelect/types.ts
+++ b/src/features/task-form/components/TaskForm/PopoverSelect/types.ts
@@ -1,0 +1,11 @@
+/** popover select の選択肢 1 件。 */
+export type PopoverSelectOption = {
+  /** onChange に渡す値 */
+  value: string;
+  /** trigger / option に表示するテキスト */
+  label: string;
+  /** swatch（status の色付きドット）の CSS color 値。 */
+  swatchColor?: string;
+  /** option / trigger を badge 表示にする場合の追加クラス（優先度の配色など）。 */
+  badgeClassName?: string;
+};


### PR DESCRIPTION
## 概要

`PopoverSelect/index.tsx`（305L）に同居していた `SelectedDisplay`（trigger 内の選択中表示）を別ファイルへ移設し、trigger 側と listbox option 側でほぼ二重定義になっていた swatch / badge 描画を共有プリミティブ（`OptionSwatch` / `OptionBadge`）に単一化する **挙動不変のリファクタリング**。

公開 API・描画 DOM 構造・`data-testid` 体系・`aria-*`・キーボード操作・開閉挙動はすべて維持。消費者（`TaskFormStatus` / `TaskFormPriority`）と既存テストは無変更で PASS。

## 変更の種類

- ♻️ リファクタリング（内部実装の分割・共通化のみ。破壊的変更なし）

## 詳細な変更内容

### 追加

- `OptionSwatch/` — 色ドット（swatch）の単一実装プリミティブ + rendering テスト
- `OptionBadge/` — badge ピルの単一実装プリミティブ + rendering テスト
- `SelectedDisplay/` — trigger 内表示を切り出し（`undefined→null` + プリミティブ委譲）+ rendering テスト
- `PopoverOption/` — listbox option 1 件（`<button role="option">`）を切り出し + rendering テスト
- `types.ts` — `PopoverSelectOption` 型を移設（親↔子循環回避）
- `__tests__/PopoverSelect.empty.test.tsx` — `options` 空配列の境界テスト（新規）

### 変更

- `index.tsx` — 型定義・内部 `SelectedDisplay` を削除し import へ置換、`options.map` を `PopoverOption` へ委譲、export を `PopoverSelect` 1 つに集約。開閉ロジック（4 effect / open / close / selectAt / キーボードハンドラ）は不変。

## 設計判断

swatch/badge の DOM・Tailwind class 文字列という「二重定義された知識」だけをプリミティブへ単一化し、`badge→swatch→label` の判定順（3 行分岐）は `SelectedDisplay` / `PopoverOption` の各自にインラインで残す。判定順を括り出す中間層（`OptionContent`）は、trigger/option の本物の差異（ラッパ有無・label class）を吸収する props の間接コストが勝るため**採用しない**。

> swatch+badge 同時指定時のみ「badge 優先で swatch を出さない」に統合（trigger 挙動へ寄せる）。実データは status=swatch のみ / priority=badge のみ / なし=label のみで同時指定は発生しないため、DOM は実データ上で不変。

## システム図

```mermaid
flowchart TD
    PS[PopoverSelect index.tsx] -->|selectedOption| SD[SelectedDisplay]
    PS -->|options.map| PO[PopoverOption]
    SD --> OB[OptionBadge]
    SD --> OSw[OptionSwatch]
    PO --> OB
    PO --> OSw
    SD -.->|import type| T[types.ts PopoverSelectOption]
    PO -.->|import type| T
    PS -.->|import type| T
    style OB fill:#2d6
    style OSw fill:#2d6
    style SD fill:#6cf
    style PO fill:#6cf
    style T fill:#fc6
```

## テスト

- ✅ `pnpm test:run`: 286 files / **2447 tests PASS**
- ✅ `pnpm lint`（oxlint）: 0 errors ／ ✅ `pnpm typecheck`（tsc -b）／ ✅ `pnpm build`
- ✅ 既存 `PopoverSelect.interaction.test.tsx`（12 test）・消費者 `TaskFormStatus` / `TaskFormPriority` は**無改変で PASS**（回帰網）
- ✅ 新規サブコンポーネント rendering テスト（OptionSwatch 5 / OptionBadge 4 / SelectedDisplay 5 / PopoverOption 10）+ 空配列テスト 10 が GREEN
- ✅ Codex コードレビュー「問題なし」（指摘 0 件）

### 手動確認（未実施・レビュー時にお願いしたい点）

- [ ] `pnpm storybook` で Status / Priority / Empty / Disabled の 4 story が分割前と同一表示
- [ ] `pnpm tauri dev` で status（swatch）/ priority（badge）/ 未選択（label のみ）の表示・キーボード・開閉が従来どおり

## レビューポイント

- `index.tsx` の `options.map` → `PopoverOption` 差し替えで DOM / `data-testid`（`{testid}-option-{value}` / id `{listboxId}-option-{index}`）/ `aria-*` が完全一致しているか
- プリミティブの Tailwind 静的クラスが完全文字列で保持され JIT 検出可能か

## 関連Issue

Closes #434
Refs #390