### PR TITLE
♻️ [Refactoring]: #432 [FE] BoardWorkspace の ActiveBoardView / BoardView を独立コンポーネント化

### DIFF
--- a/src/features/board/components/ActiveBoardView/__tests__/ActiveBoardView.behavior.test.tsx
+++ b/src/features/board/components/ActiveBoardView/__tests__/ActiveBoardView.behavior.test.tsx
@@ -1,0 +1,207 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { BoardWorkspaceProps } from "@/features/board/components/BoardWorkspace";
+import type { BoardViewMode } from "@/features/board/hooks/useBoardViewMode";
+import type { Column as ColumnType } from "@/types/column";
+import { Task, type TaskPayload } from "@/types/task";
+import { ActiveBoardView } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  mountContainer();
+});
+
+afterEach(() => {
+  unmountView();
+});
+
+const mountContainer = () => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+};
+
+const unmountView = () => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+};
+
+const makeTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+/** BoardWorkspaceProps の必須項目を補完しつつ上書きを許すヘルパー。 */
+const makeWorkspace = (
+  overrides: Partial<BoardWorkspaceProps> = {},
+): BoardWorkspaceProps => ({
+  columns: [{ name: "Todo", order: 0 }],
+  tasks: [],
+  onAddTask: () => {},
+  onTaskClick: () => {},
+  ...overrides,
+});
+
+const renderActiveBoardView = (props: {
+  viewMode: BoardViewMode;
+  filtered: Task[];
+  filterActive?: boolean;
+  workspace: BoardWorkspaceProps;
+}) => {
+  act(() => {
+    root?.render(
+      <ActiveBoardView
+        viewMode={props.viewMode}
+        filtered={props.filtered}
+        filterActive={props.filterActive ?? false}
+        workspace={props.workspace}
+      />,
+    );
+  });
+};
+
+/** 指定タイトルのタスクボタンを DOM から探してクリックする。 */
+const clickTaskByTitle = (title: string) => {
+  const button = Array.from(
+    container?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+  ).find((b) => b.textContent?.includes(title));
+  act(() => {
+    button?.click();
+  });
+};
+
+test("viewMode='board' で BoardView 経由の描画が成立する", async () => {
+  const columns: ColumnType[] = [
+    { name: "Todo", order: 0 },
+    { name: "Done", order: 1 },
+  ];
+  renderActiveBoardView({
+    viewMode: "board",
+    filtered: [],
+    workspace: makeWorkspace({ columns }),
+  });
+  await vi.waitFor(() => {
+    const labels = Array.from(
+      container?.querySelectorAll("section[aria-label]") ?? [],
+    ).map((s) => s.getAttribute("aria-label"));
+    expect(labels).toEqual(["Todo", "Done"]);
+  });
+});
+
+const nonBoardCases: {
+  viewMode: BoardViewMode;
+  selector: string;
+}[] = [
+  { viewMode: "list", selector: "ul.divide-y" },
+  { viewMode: "tree", selector: "ul.py-2" },
+  { viewMode: "calendar", selector: "button[aria-label='前の月']" },
+];
+
+test.each(
+  nonBoardCases,
+)("viewMode='$viewMode' で該当ビューが描画され board 特有の section は出ない", async ({
+  viewMode,
+  selector,
+}) => {
+  renderActiveBoardView({
+    viewMode,
+    filtered: [makeTask({ id: "a", filePath: "tasks/a.md", title: "タスクA" })],
+    workspace: makeWorkspace(),
+  });
+  await vi.waitFor(() => {
+    expect(container?.querySelector(selector)).not.toBeNull();
+  });
+  expect(container?.querySelector("section[aria-label]")).toBeNull();
+});
+
+test("非 board ビューへ filtered が委譲され件数分描画される", async () => {
+  renderActiveBoardView({
+    viewMode: "list",
+    filtered: [
+      makeTask({ id: "a", filePath: "tasks/a.md", title: "A" }),
+      makeTask({ id: "b", filePath: "tasks/b.md", title: "B" }),
+    ],
+    workspace: makeWorkspace(),
+  });
+  await vi.waitFor(() => {
+    expect(container?.querySelectorAll("ul.divide-y > li").length).toBe(2);
+  });
+});
+
+test.each(
+  nonBoardCases,
+)("viewMode='$viewMode' でタスククリック時に workspace.onTaskClick(task.id) が発火する", async ({
+  viewMode,
+}) => {
+  const onTaskClick = vi.fn();
+  renderActiveBoardView({
+    viewMode,
+    filtered: [makeTask({ id: "a", filePath: "tasks/a.md", title: "タスクA" })],
+    workspace: makeWorkspace({ onTaskClick }),
+  });
+  await vi.waitFor(() => {
+    const hit = Array.from(
+      container?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+    ).some((b) => b.textContent?.includes("タスクA"));
+    expect(hit).toBe(true);
+  });
+  clickTaskByTitle("タスクA");
+  expect(onTaskClick).toHaveBeenCalledTimes(1);
+  expect(onTaskClick).toHaveBeenCalledWith("a");
+});
+
+test("board で allTasks(絞り込み前) と filtered(絞り込み後) が別々に BoardView へ委譲される", async () => {
+  const parent = makeTask({
+    id: "p",
+    filePath: "tasks/p.md",
+    title: "親",
+    status: "Todo",
+    children: ["tasks/c.md"],
+  });
+  const child = makeTask({
+    id: "c",
+    filePath: "tasks/c.md",
+    title: "子",
+    status: "Done",
+    parent: "tasks/p.md",
+  });
+  renderActiveBoardView({
+    viewMode: "board",
+    filtered: [parent],
+    workspace: makeWorkspace({
+      columns: [{ name: "Todo", order: 0 }],
+      tasks: [parent, child],
+      doneColumn: "Done",
+    }),
+  });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelector("[data-testid='task-card']"),
+    ).not.toBeNull();
+  });
+  // 表示カードは filtered 由来の 1 件のみ。
+  expect(container?.querySelectorAll("[data-testid='task-card']").length).toBe(
+    1,
+  );
+  // 階層カウントは allTasks(=workspace.tasks) 由来で total=1 が算出される。
+  const badge = container?.querySelector(
+    "[data-testid='task-card-subissue-count']",
+  );
+  expect(badge?.textContent).toBe("1/1");
+});

--- a/src/features/board/components/ActiveBoardView/index.tsx
+++ b/src/features/board/components/ActiveBoardView/index.tsx
@@ -1,0 +1,65 @@
+import { BoardView } from "@/features/board/components/BoardView";
+import type { BoardWorkspaceProps } from "@/features/board/components/BoardWorkspace";
+import { CalendarView } from "@/features/board/components/CalendarView";
+import { ListView } from "@/features/board/components/ListView";
+import { TreeView } from "@/features/board/components/TreeView";
+import type { BoardViewMode } from "@/features/board/hooks/useBoardViewMode";
+import type { Task } from "@/types/task";
+
+/** ActiveBoardView の Props。 */
+type ActiveBoardViewProps = {
+  /** 現在の表示形態 */
+  viewMode: BoardViewMode;
+  /** 絞り込み後のタスク */
+  filtered: Task[];
+  /**
+   * 絞り込みが有効か。board 表示時に DnD を無効化し、隠れたカードを跨ぐ
+   * 並べ替えで cardOrder が壊れるのを防ぐ。
+   */
+  filterActive: boolean;
+  /** BoardWorkspace が受け取った全 props（board 表示時に BoardView へ委譲する） */
+  workspace: BoardWorkspaceProps;
+};
+
+/**
+ * 選択中の表示形態に対応するビューを描画する。board のみ BoardView へ委譲し、
+ * 階層カウント用に絞り込み前の全タスクを allTasks として渡す。
+ * @param props - {@link ActiveBoardViewProps}
+ * @returns 表示形態に応じたビュー要素
+ */
+export const ActiveBoardView = ({
+  viewMode,
+  filtered,
+  filterActive,
+  workspace,
+}: ActiveBoardViewProps) => {
+  if (viewMode === "list") {
+    return <ListView tasks={filtered} onTaskClick={workspace.onTaskClick} />;
+  }
+  if (viewMode === "tree") {
+    return <TreeView tasks={filtered} onTaskClick={workspace.onTaskClick} />;
+  }
+  if (viewMode === "calendar") {
+    return (
+      <CalendarView tasks={filtered} onTaskClick={workspace.onTaskClick} />
+    );
+  }
+  return (
+    <BoardView
+      columns={workspace.columns}
+      filtered={filtered}
+      allTasks={workspace.tasks}
+      filterActive={filterActive}
+      tasksByNormalizedPath={workspace.tasksByNormalizedPath}
+      milestonesByName={workspace.milestonesByName}
+      doneColumn={workspace.doneColumn}
+      onTaskDrop={workspace.onTaskDrop}
+      onColumnReorder={workspace.onColumnReorder}
+      onAddTask={workspace.onAddTask}
+      onTaskClick={workspace.onTaskClick}
+      onAddColumn={workspace.onAddColumn}
+      onRenameColumn={workspace.onRenameColumn}
+      onDeleteColumn={workspace.onDeleteColumn}
+    />
+  );
+};

--- a/src/features/board/components/BoardView/__tests__/BoardView.behavior.test.tsx
+++ b/src/features/board/components/BoardView/__tests__/BoardView.behavior.test.tsx
@@ -1,0 +1,250 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import type { Column as ColumnType } from "@/types/column";
+import { Task, type TaskPayload } from "@/types/task";
+import { BoardView } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeEach(() => {
+  mountContainer();
+});
+
+afterEach(() => {
+  unmountView();
+});
+
+const mountContainer = () => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+};
+
+const unmountView = () => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+};
+
+const makeColumn = (name: string, order: number): ColumnType => ({
+  name,
+  order,
+});
+
+const makeTask = (overrides: Partial<TaskPayload> = {}): Task =>
+  Task.fromPayload({
+    id: "id",
+    title: "t",
+    status: "Todo",
+    labels: [],
+    links: [],
+    children: [],
+    reverseLinks: [],
+    body: "",
+    filePath: "tasks/x.md",
+    ...overrides,
+  });
+
+/** BoardView の必須 props をデフォルト補完しつつ render するヘルパー。 */
+type RenderOptions = {
+  columns: ColumnType[];
+  filtered?: Task[];
+  allTasks?: Task[];
+  filterActive?: boolean;
+  onAddTask?: (columnName: string) => void;
+  onTaskClick?: (taskId: string) => void;
+  onAddColumn?: (columnName: string) => void;
+  onRenameColumn?: (oldName: string, newName: string) => void;
+  onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
+};
+
+const renderBoardView = (options: RenderOptions) => {
+  act(() => {
+    root?.render(
+      <BoardView
+        columns={options.columns}
+        filtered={options.filtered ?? []}
+        allTasks={options.allTasks ?? options.filtered ?? []}
+        filterActive={options.filterActive ?? false}
+        onAddTask={options.onAddTask ?? (() => {})}
+        onTaskClick={options.onTaskClick ?? (() => {})}
+        onAddColumn={options.onAddColumn}
+        onRenameColumn={options.onRenameColumn}
+        onDeleteColumn={options.onDeleteColumn}
+      />,
+    );
+  });
+};
+
+const columnLabels = (): (string | null)[] =>
+  Array.from(container?.querySelectorAll("section[aria-label]") ?? []).map(
+    (s) => s.getAttribute("aria-label"),
+  );
+
+const columnHeaders = (): HTMLElement[] =>
+  Array.from(
+    container?.querySelectorAll<HTMLElement>("[data-testid='column-header']") ??
+      [],
+  );
+
+test("逆順 columns が order 昇順で描画される", async () => {
+  renderBoardView({
+    columns: [
+      makeColumn("Done", 2),
+      makeColumn("Todo", 0),
+      makeColumn("In Progress", 1),
+    ],
+  });
+  await vi.waitFor(() => {
+    expect(columnLabels()).toEqual(["Todo", "In Progress", "Done"]);
+  });
+});
+
+test("`+ 追加` クリックで onAddTask が該当 columnName で呼ばれる", async () => {
+  const onAddTask = vi.fn();
+  renderBoardView({
+    columns: [makeColumn("Todo", 0), makeColumn("Done", 1)],
+    onAddTask,
+  });
+  let addButton: HTMLButtonElement | null = null;
+  await vi.waitFor(() => {
+    addButton =
+      container?.querySelector<HTMLButtonElement>(
+        "button[aria-label='Todoに追加']",
+      ) ?? null;
+    expect(addButton).not.toBeNull();
+  });
+  act(() => {
+    addButton?.click();
+  });
+  expect(onAddTask).toHaveBeenCalledTimes(1);
+  expect(onAddTask).toHaveBeenCalledWith("Todo");
+});
+
+test("カードクリックで onTaskClick が該当 task.id で呼ばれる", async () => {
+  const onTaskClick = vi.fn();
+  renderBoardView({
+    columns: [makeColumn("Todo", 0)],
+    filtered: [makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" })],
+    onTaskClick,
+  });
+  let card: HTMLElement | null = null;
+  await vi.waitFor(() => {
+    card =
+      container?.querySelector<HTMLElement>("[data-testid='task-card']") ??
+      null;
+    expect(card).not.toBeNull();
+  });
+  act(() => {
+    card?.click();
+  });
+  expect(onTaskClick).toHaveBeenCalledTimes(1);
+  expect(onTaskClick).toHaveBeenCalledWith("a");
+});
+
+test("columns 1 件のとき columnDraggable=false（draggable='false'）", async () => {
+  renderBoardView({ columns: [makeColumn("Todo", 0)] });
+  await vi.waitFor(() => {
+    expect(columnHeaders().length).toBe(1);
+  });
+  expect(columnHeaders()[0]?.getAttribute("draggable")).toBe("false");
+});
+
+test("columns 2 件以上のとき columnDraggable=true（全て draggable='true'）", async () => {
+  renderBoardView({
+    columns: [makeColumn("Todo", 0), makeColumn("Done", 1)],
+  });
+  await vi.waitFor(() => {
+    expect(columnHeaders().length).toBe(2);
+  });
+  for (const header of columnHeaders()) {
+    expect(header.getAttribute("draggable")).toBe("true");
+  }
+});
+
+test("columns 0 件のとき Column を描画せず AddColumn だけ出す", async () => {
+  renderBoardView({ columns: [], onAddColumn: vi.fn() });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelector("[data-testid='add-column-button']"),
+    ).not.toBeNull();
+  });
+  expect(columnLabels()).toEqual([]);
+});
+
+test("onAddColumn の有無で追加ボタンが双方向に切り替わる", async () => {
+  renderBoardView({
+    columns: [makeColumn("Todo", 0)],
+    onAddColumn: undefined,
+  });
+  await vi.waitFor(() => {
+    expect(columnLabels().length).toBeGreaterThan(0);
+  });
+  expect(
+    container?.querySelector("[data-testid='add-column-button']"),
+  ).toBeNull();
+
+  unmountView();
+  mountContainer();
+
+  renderBoardView({
+    columns: [makeColumn("Todo", 0)],
+    onAddColumn: vi.fn(),
+  });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelector("[data-testid='add-column-button']"),
+    ).not.toBeNull();
+  });
+});
+
+test("onRenameColumn / onDeleteColumn 指定時に rename / delete UI が表示される", async () => {
+  renderBoardView({
+    columns: [makeColumn("Todo", 0)],
+    onRenameColumn: vi.fn(),
+    onDeleteColumn: vi.fn(),
+  });
+  await vi.waitFor(() => {
+    expect(
+      container?.querySelector("[data-testid='column-name-button']"),
+    ).not.toBeNull();
+  });
+  expect(
+    container?.querySelector("[data-testid='column-menu-button']"),
+  ).not.toBeNull();
+});
+
+test("onRenameColumn / onDeleteColumn undefined 時に rename / delete UI が出ない", async () => {
+  renderBoardView({
+    columns: [makeColumn("Todo", 0)],
+    onRenameColumn: undefined,
+    onDeleteColumn: undefined,
+  });
+  await vi.waitFor(() => {
+    expect(columnHeaders().length).toBe(1);
+  });
+  expect(
+    container?.querySelector("[data-testid='column-name-button']"),
+  ).toBeNull();
+  expect(
+    container?.querySelector("[data-testid='column-menu-button']"),
+  ).toBeNull();
+});
+
+test("filterActive=true のとき columns 2 件でも DnD 無効（draggable='false'）が伝播する", async () => {
+  renderBoardView({
+    columns: [makeColumn("Todo", 0), makeColumn("Done", 1)],
+    filterActive: true,
+  });
+  await vi.waitFor(() => {
+    expect(columnHeaders().length).toBe(2);
+  });
+  for (const header of columnHeaders()) {
+    expect(header.getAttribute("draggable")).toBe("false");
+  }
+});

--- a/src/features/board/components/BoardView/index.tsx
+++ b/src/features/board/components/BoardView/index.tsx
@@ -1,0 +1,121 @@
+import { Board } from "@/features/board/components/Board";
+import type { TaskDropHandler } from "@/features/board/components/BoardCardProvider";
+import type { ColumnReorderHandler } from "@/features/board/components/BoardColumnProvider";
+import { BoardProviders } from "@/features/board/components/BoardProviders";
+import type { MilestonesByName } from "@/features/board/components/TaskCard";
+import type { Column as ColumnType } from "@/types/column";
+import type { Task } from "@/types/task";
+
+/** BoardView の Props。board 描画に必要な最小集合を明示的に受ける。 */
+type BoardViewProps = {
+  /** カラム定義の配列（内部で order 昇順ソートする） */
+  columns: ColumnType[];
+  /** 絞り込み後の表示用タスク（BoardProviders の tasks に渡す） */
+  filtered: Task[];
+  /** 絞り込み前の全タスク（階層カウント用に allTasks へ渡す） */
+  allTasks: Task[];
+  /** 絞り込みが有効か。true のとき DnD を無効化する（dndDisabled へ伝播） */
+  filterActive: boolean;
+  /** 正規化済み Task.filePath → Task の lookup Map */
+  tasksByNormalizedPath?: ReadonlyMap<string, Task>;
+  /** name → マイルストーン定義の Map（カードバッジ用） */
+  milestonesByName?: MilestonesByName;
+  /** 完了カラム名 */
+  doneColumn?: string;
+  /** タスク drop ハンドラ。Provider 側で sync / async を吸収する。 */
+  onTaskDrop?: TaskDropHandler;
+  /** カラム並び替えハンドラ。Provider 側で sync / async を吸収する。 */
+  onColumnReorder?: ColumnReorderHandler;
+  /**
+   * カラムの「+ 追加」クリック時のコールバック。
+   * @param columnName - 追加対象のカラム名
+   */
+  onAddTask: (columnName: string) => void;
+  /**
+   * タスククリック時のコールバック。
+   * @param taskId - クリックされたタスクの ID
+   */
+  onTaskClick: (taskId: string) => void;
+  /**
+   * 新規カラム追加コールバック（undefined のとき AddColumn を出さない）。
+   * @param columnName - 追加するカラム名
+   */
+  onAddColumn?: (columnName: string) => void;
+  /**
+   * カラム名リネームコールバック（undefined のとき rename UI を出さない）。
+   * @param oldName - 元のカラム名
+   * @param newName - 新しいカラム名
+   */
+  onRenameColumn?: (oldName: string, newName: string) => void;
+  /**
+   * カラム削除コールバック（undefined のとき delete UI を出さない）。
+   * @param columnName - 削除するカラム名
+   * @param destColumn - タスクの移動先カラム名
+   */
+  onDeleteColumn?: (columnName: string, destColumn: string | undefined) => void;
+};
+
+/**
+ * board 表示形態の描画を担う。カラムを order 昇順にソートし、
+ * ドラッグ可否（columnDraggable = ordered.length > 1）を導出して
+ * Board.Column を生成する。onAddColumn があるときだけ Board.AddColumn を出す。
+ * @param props - {@link BoardViewProps}
+ * @returns board 描画要素
+ */
+export const BoardView = ({
+  columns,
+  filtered,
+  allTasks,
+  filterActive,
+  tasksByNormalizedPath,
+  milestonesByName,
+  doneColumn,
+  onTaskDrop,
+  onColumnReorder,
+  onAddTask,
+  onTaskClick,
+  onAddColumn,
+  onRenameColumn,
+  onDeleteColumn,
+}: BoardViewProps) => {
+  const ordered = [...columns].sort((a, b) => a.order - b.order);
+  const columnDraggable = ordered.length > 1;
+  return (
+    <BoardProviders
+      columns={columns}
+      tasks={filtered}
+      allTasks={allTasks}
+      tasksByNormalizedPath={tasksByNormalizedPath}
+      milestonesByName={milestonesByName}
+      doneColumn={doneColumn}
+      dndDisabled={filterActive}
+      onTaskDrop={onTaskDrop}
+      onColumnReorder={onColumnReorder}
+    >
+      <Board>
+        {ordered.map((col, index) => (
+          <Board.Column
+            key={col.name}
+            name={col.name}
+            color={col.color}
+            order={index}
+            onAddClick={() => onAddTask(col.name)}
+            onTaskClick={onTaskClick}
+            onRename={
+              onRenameColumn
+                ? (newName) => onRenameColumn(col.name, newName)
+                : undefined
+            }
+            onDelete={
+              onDeleteColumn
+                ? (destColumn) => onDeleteColumn(col.name, destColumn)
+                : undefined
+            }
+            columnDraggable={columnDraggable}
+          />
+        ))}
+        {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}
+      </Board>
+    </BoardProviders>
+  );
+};

--- a/src/features/board/components/BoardWorkspace/index.tsx
+++ b/src/features/board/components/BoardWorkspace/index.tsx
@@ -5,6 +5,7 @@ import {
   tabNavPanelId,
   tabNavTabId,
 } from "@/components/TabNav";
+import { ActiveBoardView } from "@/features/board/components/ActiveBoardView";
 import type { MilestoneDefinition } from "@/lib/tauri";
 import type { Column as ColumnType } from "@/types/column";
 import type { Task } from "@/types/task";
@@ -13,15 +14,11 @@ import {
   useBoardViewMode,
 } from "../../hooks/useBoardViewMode";
 import { useTaskFilter } from "../../hooks/useTaskFilter";
-import { Board } from "../Board";
+// 型 import は export 化した BoardWorkspaceProps が参照するため残す（削除すると build が落ちる）。
 import type { TaskDropHandler } from "../BoardCardProvider";
 import type { ColumnReorderHandler } from "../BoardColumnProvider";
-import { BoardProviders } from "../BoardProviders";
-import { CalendarView } from "../CalendarView";
-import { ListView } from "../ListView";
 import type { MilestonesByName } from "../TaskCard";
 import { TaskFilterBar } from "../TaskFilterBar";
-import { TreeView } from "../TreeView";
 
 /** ビュー切替タブの定義（表示形態 ID と表示名）。 */
 const VIEW_TABS: readonly TabItem[] = [
@@ -35,7 +32,7 @@ const VIEW_TABS: readonly TabItem[] = [
 const VIEW_TAB_PREFIX = "board-view";
 
 /** BoardWorkspace の Props。 */
-type BoardWorkspaceProps = {
+export type BoardWorkspaceProps = {
   /** カラム定義の配列 */
   columns: ColumnType[];
   /** 全タスク（絞り込み前） */
@@ -110,92 +107,6 @@ const collectLabels = (tasks: Task[]): string[] => {
     }
   }
   return Array.from(labels).sort();
-};
-
-type ActiveBoardViewProps = {
-  /** 現在の表示形態 */
-  viewMode: BoardViewMode;
-  /** 絞り込み後のタスク */
-  filtered: Task[];
-  /**
-   * 絞り込みが有効か。board 表示時に Board の DnD を無効化し、隠れたカードを跨ぐ
-   * 並べ替えで cardOrder が壊れるのを防ぐ。
-   */
-  filterActive: boolean;
-  /** BoardWorkspace が受け取った全 props（board 表示時に Board へ委譲する） */
-  workspace: BoardWorkspaceProps;
-};
-
-/**
- * 選択中の表示形態に対応するビューを描画する。board のみ既存 Board へ委譲し、
- * 階層カウント用に絞り込み前の全タスクを allTasks として渡す。
- * @param props - {@link ActiveBoardViewProps}
- * @returns 表示形態に応じたビュー要素
- */
-const ActiveBoardView = ({
-  viewMode,
-  filtered,
-  filterActive,
-  workspace,
-}: ActiveBoardViewProps) => {
-  if (viewMode === "list") {
-    return <ListView tasks={filtered} onTaskClick={workspace.onTaskClick} />;
-  }
-  if (viewMode === "tree") {
-    return <TreeView tasks={filtered} onTaskClick={workspace.onTaskClick} />;
-  }
-  if (viewMode === "calendar") {
-    return (
-      <CalendarView tasks={filtered} onTaskClick={workspace.onTaskClick} />
-    );
-  }
-  const ordered = [...workspace.columns].sort((a, b) => a.order - b.order);
-  const columnDraggable = ordered.length > 1;
-  const {
-    onAddTask,
-    onTaskClick,
-    onAddColumn,
-    onRenameColumn,
-    onDeleteColumn,
-  } = workspace;
-  return (
-    <BoardProviders
-      columns={workspace.columns}
-      tasks={filtered}
-      allTasks={workspace.tasks}
-      tasksByNormalizedPath={workspace.tasksByNormalizedPath}
-      milestonesByName={workspace.milestonesByName}
-      doneColumn={workspace.doneColumn}
-      dndDisabled={filterActive}
-      onTaskDrop={workspace.onTaskDrop}
-      onColumnReorder={workspace.onColumnReorder}
-    >
-      <Board>
-        {ordered.map((col, index) => (
-          <Board.Column
-            key={col.name}
-            name={col.name}
-            color={col.color}
-            order={index}
-            onAddClick={() => onAddTask(col.name)}
-            onTaskClick={onTaskClick}
-            onRename={
-              onRenameColumn
-                ? (newName) => onRenameColumn(col.name, newName)
-                : undefined
-            }
-            onDelete={
-              onDeleteColumn
-                ? (destColumn) => onDeleteColumn(col.name, destColumn)
-                : undefined
-            }
-            columnDraggable={columnDraggable}
-          />
-        ))}
-        {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}
-      </Board>
-    </BoardProviders>
-  );
 };
 
 /**


### PR DESCRIPTION
## 概要

`BoardWorkspace/index.tsx`（326L）に同居していた非公開コンポーネント `ActiveBoardView`（viewMode 分岐器）と、その board 分岐のカラム bind ブロックを、それぞれ独立フォルダ `ActiveBoardView/` ・ `BoardView/` へ抽出する**挙動不変の純粋リファクタリング**です。「コンポーネントは `{Name}/index.tsx` に配置」規約を満たし、抽出により生じる Pure Logic（order 昇順ソート / `columnDraggable` 導出 / AddColumn 出し分け）を単体テスト可能にします。

## 変更の種類

- ♻️ リファクタリング
- 🚨 テスト追加

## 詳細な変更内容

### 追加
- `src/features/board/components/BoardView/index.tsx` — board 専用描画（`ordered` order 昇順ソート / `columnDraggable = ordered.length > 1` 導出 / `Board.Column` 生成 / `onAddColumn` 有無で `Board.AddColumn` 出し分け / `BoardProviders` 内包）
- `src/features/board/components/ActiveBoardView/index.tsx` — viewMode 分岐器（list / tree / calendar は各ビューへ、board は `BoardView` へ委譲。`workspace: BoardWorkspaceProps` を丸受け）
- `BoardView.behavior.test.tsx`（10 件） / `ActiveBoardView.behavior.test.tsx`（9 件）— 生 DOM 単体テスト

### 変更
- `src/features/board/components/BoardWorkspace/index.tsx` — 旧 `ActiveBoardView` 定義を削除しスリム化。`BoardWorkspaceProps` を `export` 化（ActiveBoardView が型 import）。未使用の値 import 5 本（`Board` / `BoardProviders` / `CalendarView` / `ListView` / `TreeView`）を削除。`{isActiveTab && <ActiveBoardView />}` の hidden 制御・フック配線・`collectLabels` は維持

## システム図

```mermaid
flowchart TD
    BW["BoardWorkspace (薄く残る)<br/>hooks 配線 + tabpanel + hidden 制御"]
    BW -->|"{isActiveTab && ...}<br/>viewMode / filtered / filterActive / workspace"| ABV["ActiveBoardView [NEW]<br/>viewMode 分岐器"]
    ABV -->|list| LV["ListView"]
    ABV -->|tree| TV["TreeView"]
    ABV -->|calendar| CV["CalendarView"]
    ABV -->|"board<br/>allTasks=workspace.tasks / filtered 分離"| BV["BoardView [NEW]<br/>ordered ソート + columnDraggable 導出"]
    BV --> BP["BoardProviders<br/>dndDisabled=filterActive"]
    BP --> B["Board → Board.Column×N / Board.AddColumn"]
    style ABV fill:#2d5016,color:#fff
    style BV fill:#2d5016,color:#fff
```

## 関連Issue

Refs #432（Epic #390: コンポーネント責務の分離 / 関連 #367）

## テスト

- ✅ `pnpm test:run`: 290 files / **2488 tests PASS**（新規 19 件込み、既存 `BoardWorkspace.compound-wiring.test.tsx` 4 件も緑維持）
- ✅ `pnpm build`（`tsc -b && vite build`）: strict TS / 未使用 import・props エラーなく通過
- ✅ `pnpm lint`（oxlint）: 0 warnings / 0 errors
- ✅ 内部コードレビュー: 問題なし（挙動等価性・props 委譲網羅性・規約・テスト検出力を確認）
- ⏳ 手動検証（未実施・レビュー後に実施予定）: `pnpm tauri dev` で board / list / tree / calendar 全ビュー・DnD・フィルタ・タブ hidden 制御、Storybook 挙動

### 生 DOM テストの検出力（主なケース）
- order 昇順描画 / `columnDraggable` の 1 件⇔2 件境界 / AddColumn の双方向切替 / rename・delete UI の undefined 対称 / `filterActive=true` の DnD 無効伝播
- **allTasks(絞り込み前) と filtered(絞り込み後) の分離委譲**をサブイシューカウント `1/1` で検証（allTasks 取り違えバグを直接検出）

## レビューポイント

- **破壊的変更なし**: `BoardWorkspace` の公開 props / feature 公開 API（`src/features/board/index.ts`）/ `App.tsx` 呼び出しはいずれも不変。DOM 構造・アクセシビリティ属性も不変
- `BoardWorkspaceProps` の export は board feature 内部参照に留め、公開 API（`index.ts`）には出していません
- 新フォルダの依存参照は `@/features/board/components/{Name}` alias に統一
- ⚠️ `ActiveBoardView` の `import type { BoardWorkspaceProps }` と `BoardWorkspace` の `ActiveBoardView` 値 import はモジュールグラフ上は循環に見えますが、前者は `import type` でコンパイル時に消去されランタイム循環はありません（計画通りの設計）

## ドキュメント

spec ドキュメント（`docs/spec-board/`）の更新は**不要**です（公開 API・データ形式・画面挙動を変えない純粋リファクタリングのため）。