### PR TITLE
♻️ [Refactoring]: #436 [FE] カラム名インライン入力を useInlineColumnNameInput / ColumnNameInput へ共通化

### DIFF
--- a/src/features/board/components/AddColumnButton/index.tsx
+++ b/src/features/board/components/AddColumnButton/index.tsx
@@ -1,6 +1,6 @@
-import type { KeyboardEvent } from "react";
-import { useEffect, useId, useRef, useState } from "react";
+import { useInlineColumnNameInput } from "@/features/board/hooks/useInlineColumnNameInput";
 import { useBoardColumn } from "../BoardColumnProvider";
+import { ColumnNameInput } from "../ColumnNameInput";
 
 /** AddColumnButton の Props */
 type AddColumnButtonProps = {
@@ -24,115 +24,22 @@ type AddColumnButtonProps = {
  */
 export const AddColumnButton = ({ onAdd }: AddColumnButtonProps) => {
   const { existingNames } = useBoardColumn();
-  const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState("");
-  const [isBusy, setIsBusy] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const isCancelledRef = useRef(false);
-  const id = useId();
-  const errorId = `${id}-error`;
+  const field = useInlineColumnNameInput({
+    initialValue: "",
+    existingNames,
+    selectOnFocus: false,
+    onCommit: (trimmed) => onAdd(trimmed),
+  });
 
-  useEffect(() => {
-    if (isEditing) {
-      inputRef.current?.focus();
-    }
-  }, [isEditing]);
-
-  const startEditing = () => {
-    isCancelledRef.current = false;
-    setInputValue("");
-    setIsEditing(true);
-  };
-
-  const cancel = () => {
-    isCancelledRef.current = true;
-    setInputValue("");
-    setIsEditing(false);
-  };
-
-  const confirm = async (): Promise<boolean> => {
-    // re-entrant guard: pending 中の連打 (Enter 連打) を抑止する
-    if (isBusy) {
-      return false;
-    }
-    const trimmed = inputValue.trim();
-    if (trimmed.length === 0) {
-      isCancelledRef.current = true;
-      setInputValue("");
-      setIsEditing(false);
-      return true;
-    }
-    if (existingNames().includes(trimmed)) {
-      return false;
-    }
-    setIsBusy(true);
-    try {
-      await onAdd(trimmed);
-    } catch {
-      // 失敗時は editor を開いたままにし、ユーザの入力を保持する
-      // (caller 側で error toast 等の通知が出ている前提)
-      setIsBusy(false);
-      return false;
-    }
-    setIsBusy(false);
-    isCancelledRef.current = true;
-    setInputValue("");
-    setIsEditing(false);
-    return true;
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      if (e.nativeEvent.isComposing) {
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      void confirm();
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      e.stopPropagation();
-      cancel();
-    }
-  };
-
-  const trimmedInput = inputValue.trim();
-  const isDuplicate =
-    trimmedInput.length > 0 && existingNames().includes(trimmedInput);
-
-  if (isEditing) {
+  if (field.isEditing) {
     return (
       <div className="flex h-fit w-72 min-w-72 flex-col gap-1 rounded-lg bg-surface-muted p-2">
-        <input
-          ref={inputRef}
-          type="text"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onBlur={() => {
-            // isBusy 中は input が disabled になり browser が blur を発火するが、
-            // pending 中の cancel は editor を閉じてユーザの入力を失わせるため無視する
-            if (isBusy) {
-              return;
-            }
-            if (!isCancelledRef.current) {
-              cancel();
-            }
-            isCancelledRef.current = false;
-          }}
-          disabled={isBusy}
-          placeholder="カラム名"
-          aria-label="カラム名"
-          aria-invalid={isDuplicate}
-          aria-describedby={isDuplicate ? errorId : undefined}
+        <ColumnNameInput
+          field={field}
           className="w-full rounded border border-accent px-2 py-1 text-sm text-foreground outline-none disabled:bg-surface-muted"
-          data-testid="add-column-input"
+          dataTestId="add-column-input"
+          placeholder="カラム名"
         />
-        {isDuplicate && (
-          <p id={errorId} className="text-xs text-red-500" role="alert">
-            同じ名前のカラムが既に存在します
-          </p>
-        )}
       </div>
     );
   }
@@ -140,7 +47,7 @@ export const AddColumnButton = ({ onAdd }: AddColumnButtonProps) => {
   return (
     <button
       type="button"
-      onClick={startEditing}
+      onClick={field.startEditing}
       aria-label="カラムを追加"
       className="h-fit w-72 min-w-72 rounded-lg border-2 border-dashed border-border px-4 py-2 text-sm text-muted hover:border-border hover:text-foreground"
       data-testid="add-column-button"

--- a/src/features/board/components/ColumnHeader/index.tsx
+++ b/src/features/board/components/ColumnHeader/index.tsx
@@ -1,7 +1,9 @@
-import type { DragEvent, KeyboardEvent, MouseEvent } from "react";
-import { useEffect, useId, useRef, useState } from "react";
+import type { DragEvent, MouseEvent } from "react";
+import { useRef } from "react";
 import { ColumnColor } from "@/domains/column-color";
+import { useInlineColumnNameInput } from "@/features/board/hooks/useInlineColumnNameInput";
 import { COLUMN_DRAG_MIME_TYPE } from "../Board/mime";
+import { ColumnNameInput } from "../ColumnNameInput";
 
 /** カラムヘッダーの Props */
 type ColumnHeaderProps = {
@@ -69,87 +71,26 @@ export const ColumnHeader = ({
   onColumnDragStart,
   onColumnDragEnd,
 }: ColumnHeaderProps) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState(name);
-  const [isBusy, setIsBusy] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const isCancelledRef = useRef(false);
   // カラム dragend 直後の synthetic click を抑止するためのガード。
   // dragstart で true にし、root の onClick / 名前クリックの編集開始はこのフラグ中は無視する。
   // click は dragend より後に届くため、handleDragEnd では即解除せず setTimeout で遅延解除する。
   const dragGuardRef = useRef(false);
-  const reactId = useId();
-  const errorId = `${reactId}-error`;
 
-  useEffect(() => {
-    if (isEditing) {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    }
-  }, [isEditing]);
+  const field = useInlineColumnNameInput({
+    initialValue: name,
+    currentName: name,
+    existingNames: existingColumnNames,
+    selectOnFocus: true,
+    onCommit: (trimmed) => onRename?.(trimmed),
+  });
 
-  const startEditing = () => {
-    if (!onRename) {
-      return;
-    }
+  // dragGuard を噛ませた編集開始（dragend 直後の synthetic click では編集に入らない）。
+  const handleNameClick = () => {
     if (dragGuardRef.current) {
       dragGuardRef.current = false;
       return;
     }
-    isCancelledRef.current = false;
-    setInputValue(name);
-    setIsEditing(true);
-  };
-
-  const cancel = () => {
-    isCancelledRef.current = true;
-    setInputValue(name);
-    setIsEditing(false);
-  };
-
-  const confirm = async (): Promise<boolean> => {
-    // re-entrant guard: pending 中の連打 (Enter 連打) を抑止
-    if (isBusy) {
-      return false;
-    }
-    const trimmed = inputValue.trim();
-    if (trimmed.length === 0 || trimmed === name) {
-      isCancelledRef.current = true;
-      setInputValue(name);
-      setIsEditing(false);
-      return true;
-    }
-    if (existingColumnNames.includes(trimmed)) {
-      return false;
-    }
-    setIsBusy(true);
-    try {
-      await onRename?.(trimmed);
-    } catch {
-      // 失敗時は edit mode を維持し、ユーザの入力を保持する
-      // (caller 側で error toast 等の通知が出ている前提)
-      setIsBusy(false);
-      return false;
-    }
-    setIsBusy(false);
-    isCancelledRef.current = true;
-    setIsEditing(false);
-    return true;
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      if (e.nativeEvent.isComposing) {
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      void confirm();
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      e.stopPropagation();
-      cancel();
-    }
+    field.startEditing();
   };
 
   const handleDragStart = (e: DragEvent<HTMLDivElement>) => {
@@ -179,12 +120,6 @@ export const ColumnHeader = ({
     }
   };
 
-  const trimmedInput = inputValue.trim();
-  const isDuplicate =
-    trimmedInput.length > 0 &&
-    trimmedInput !== name &&
-    existingColumnNames.includes(trimmedInput);
-
   const accentColor = ColumnColor.resolveAccent(color, order);
 
   return (
@@ -201,45 +136,20 @@ export const ColumnHeader = ({
       onContextMenu={onContextMenu}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        {isEditing ? (
+        {field.isEditing ? (
           <div className="flex min-w-0 flex-1 flex-col gap-1">
-            <input
-              ref={inputRef}
-              type="text"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onBlur={() => {
-                // isBusy 中は input が disabled 化により blur が発火するが、
-                // pending 中の cancel は edit mode を閉じてユーザの入力を失わせる
-                // ため無視する
-                if (isBusy) {
-                  return;
-                }
-                if (!isCancelledRef.current) {
-                  cancel();
-                }
-                isCancelledRef.current = false;
-              }}
-              disabled={isBusy}
-              aria-label="カラム名"
-              aria-invalid={isDuplicate}
-              aria-describedby={isDuplicate ? errorId : undefined}
+            <ColumnNameInput
+              field={field}
               className="w-full min-w-32 rounded border border-accent px-1 py-0.5 text-sm font-semibold text-foreground outline-none disabled:bg-surface-muted"
-              data-column-dnd-disabled
-              data-testid="column-rename-input"
+              dataTestId="column-rename-input"
+              dndDisabled
             />
-            {isDuplicate && (
-              <p id={errorId} className="text-xs text-red-500" role="alert">
-                同じ名前のカラムが既に存在します
-              </p>
-            )}
           </div>
         ) : onRename ? (
           <h2 className="text-sm font-semibold text-foreground">
             <button
               type="button"
-              onClick={startEditing}
+              onClick={handleNameClick}
               aria-label={`${name}の名前を変更`}
               className="rounded px-1 py-0.5 hover:bg-surface-muted"
               data-column-dnd-disabled

--- a/src/features/board/components/ColumnNameInput/__tests__/ColumnNameInput.rendering.test.tsx
+++ b/src/features/board/components/ColumnNameInput/__tests__/ColumnNameInput.rendering.test.tsx
@@ -1,0 +1,178 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import type { ColumnNameInputFieldProps } from "@/features/board/hooks/useInlineColumnNameInput";
+import { ColumnNameInput, type ColumnNameInputProps } from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+/**
+ * getInputProps スタブを作る（必要な配線を上書き可能）。
+ * @param overrides - 上書きしたいフィールド
+ * @returns ColumnNameInputFieldProps スタブ
+ */
+const makeInputProps = (
+  overrides: Partial<ColumnNameInputFieldProps> = {},
+): ColumnNameInputFieldProps => ({
+  ref: { current: null },
+  value: "",
+  onChange: vi.fn(),
+  onKeyDown: vi.fn(),
+  onBlur: vi.fn(),
+  disabled: false,
+  "aria-label": "カラム名",
+  "aria-invalid": false,
+  "aria-describedby": undefined,
+  ...overrides,
+});
+
+/**
+ * field スタブを作る。
+ * @param opts - isDuplicate / errorId / inputProps 上書き
+ * @returns ColumnNameInputProps["field"]
+ */
+const makeField = (opts: {
+  isDuplicate?: boolean;
+  errorId?: string;
+  inputProps?: Partial<ColumnNameInputFieldProps>;
+}): ColumnNameInputProps["field"] => ({
+  isDuplicate: opts.isDuplicate ?? false,
+  errorId: opts.errorId ?? "err-1",
+  getInputProps: () => makeInputProps(opts.inputProps),
+});
+
+/**
+ * ColumnNameInput をレンダリングする。
+ * @param props - ColumnNameInputProps
+ */
+const render = (props: ColumnNameInputProps) => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(ColumnNameInput, props));
+  });
+};
+
+test("getInputProps の value/aria-label が input に spread され、個別 props も反映される", () => {
+  render({
+    field: makeField({ inputProps: { value: "Todo" } }),
+    className: "my-input-class",
+    dataTestId: "column-rename-input",
+    placeholder: "カラム名",
+  });
+  const input = container?.querySelector("input") as HTMLInputElement;
+  expect(input.value).toBe("Todo");
+  expect(input.getAttribute("aria-label")).toBe("カラム名");
+  expect(input.className).toBe("my-input-class");
+  expect(input.getAttribute("data-testid")).toBe("column-rename-input");
+  expect(input.getAttribute("placeholder")).toBe("カラム名");
+});
+
+test("getInputProps().disabled=true で input が disabled になる", () => {
+  render({
+    field: makeField({ inputProps: { disabled: true } }),
+    className: "c",
+    dataTestId: "add-column-input",
+  });
+  const input = container?.querySelector("input") as HTMLInputElement;
+  expect(input.disabled).toBe(true);
+});
+
+test("isDuplicate=true でエラー <p> が表示され aria-invalid/aria-describedby が付く", () => {
+  render({
+    field: makeField({
+      isDuplicate: true,
+      errorId: "dup-err",
+      inputProps: {
+        "aria-invalid": true,
+        "aria-describedby": "dup-err",
+      },
+    }),
+    className: "c",
+    dataTestId: "column-rename-input",
+  });
+  const input = container?.querySelector("input") as HTMLInputElement;
+  expect(input.getAttribute("aria-invalid")).toBe("true");
+  expect(input.getAttribute("aria-describedby")).toBe("dup-err");
+  const alert = container?.querySelector('[role="alert"]');
+  expect(alert?.id).toBe("dup-err");
+  expect(alert?.textContent).toContain("同じ名前のカラムが既に存在します");
+});
+
+test("isDuplicate=false ではエラー <p> 非表示・aria-describedby 未設定", () => {
+  render({
+    field: makeField({ isDuplicate: false }),
+    className: "c",
+    dataTestId: "column-rename-input",
+  });
+  const input = container?.querySelector("input") as HTMLInputElement;
+  expect(input.getAttribute("aria-describedby")).toBeNull();
+  expect(container?.querySelector('[role="alert"]')).toBeNull();
+});
+
+test("dndDisabled=true で data-column-dnd-disabled が付く", () => {
+  render({
+    field: makeField({}),
+    className: "c",
+    dataTestId: "column-rename-input",
+    dndDisabled: true,
+  });
+  const input = container?.querySelector("input") as HTMLInputElement;
+  expect(input.hasAttribute("data-column-dnd-disabled")).toBe(true);
+});
+
+test("dndDisabled 未指定で data-column-dnd-disabled は付かない", () => {
+  render({
+    field: makeField({}),
+    className: "c",
+    dataTestId: "add-column-input",
+  });
+  const input = container?.querySelector("input") as HTMLInputElement;
+  expect(input.hasAttribute("data-column-dnd-disabled")).toBe(false);
+});
+
+test("getInputProps 由来の onChange/onKeyDown/onBlur が対応イベントで呼ばれる", () => {
+  const onChange = vi.fn();
+  const onKeyDown = vi.fn();
+  const onBlur = vi.fn();
+  render({
+    field: makeField({ inputProps: { onChange, onKeyDown, onBlur } }),
+    className: "c",
+    dataTestId: "add-column-input",
+  });
+  const input = container?.querySelector("input") as HTMLInputElement;
+  // React 制御 input は tracked value と異なる時のみ onChange が発火するため、
+  // native setter で値を変えてから input イベントを送る（既存テストと同方式）。
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  act(() => {
+    nativeSetter?.call(input, "x");
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+  });
+  // React 19 のルート委譲は blur を focusout として拾う。
+  act(() => {
+    input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+  expect(onChange).toHaveBeenCalled();
+  expect(onKeyDown).toHaveBeenCalled();
+  expect(onBlur).toHaveBeenCalled();
+});

--- a/src/features/board/components/ColumnNameInput/index.tsx
+++ b/src/features/board/components/ColumnNameInput/index.tsx
@@ -1,0 +1,57 @@
+import type { UseInlineColumnNameInputResult } from "@/features/board/hooks/useInlineColumnNameInput";
+
+/**
+ * ColumnNameInput の Props。
+ * フックの配線束（getInputProps）と表示に必要な isDuplicate / errorId は
+ * `field` 1 つに集約し、見た目差分（className / dataTestId / placeholder / dndDisabled）
+ * だけを個別 props にする。フック戻り値をそのまま `field={field}` で渡せる。
+ */
+export type ColumnNameInputProps = {
+  /** useInlineColumnNameInput の戻り値。getInputProps / isDuplicate / errorId のみ使う */
+  field: Pick<
+    UseInlineColumnNameInputResult,
+    "getInputProps" | "isDuplicate" | "errorId"
+  >;
+  /** input 自身の className（外枠 wrapper は呼び出し側が持つ） */
+  className: string;
+  /** input の data-testid（column-rename-input / add-column-input） */
+  dataTestId: string;
+  /** プレースホルダ（AddColumnButton のみ "カラム名"） */
+  placeholder?: string;
+  /** ColumnHeader の input のみに付く data-column-dnd-disabled を出すか（DnD 識別属性） */
+  dndDisabled?: boolean;
+};
+
+/**
+ * カラム名インライン入力の presentational コンポーネント。
+ * `<input>` + 重複エラー `<p role="alert">` のみを描画し、外枠 wrapper は呼び出し側が持つ。
+ * 配線（value / onChange / onKeyDown / onBlur / disabled / ref / aria-*）は
+ * `field.getInputProps()` の spread に載る。
+ * @param props - {@link ColumnNameInputProps}
+ * @returns input + 条件付きエラー要素
+ */
+export const ColumnNameInput = ({
+  field,
+  className,
+  dataTestId,
+  placeholder,
+  dndDisabled = false,
+}: ColumnNameInputProps) => {
+  return (
+    <>
+      <input
+        {...field.getInputProps()}
+        type="text"
+        className={className}
+        placeholder={placeholder}
+        data-testid={dataTestId}
+        {...(dndDisabled ? { "data-column-dnd-disabled": true } : {})}
+      />
+      {field.isDuplicate && (
+        <p id={field.errorId} className="text-xs text-red-500" role="alert">
+          同じ名前のカラムが既に存在します
+        </p>
+      )}
+    </>
+  );
+};

--- a/src/features/board/hooks/useInlineColumnNameInput/__tests__/useInlineColumnNameInput.behavior.test.tsx
+++ b/src/features/board/hooks/useInlineColumnNameInput/__tests__/useInlineColumnNameInput.behavior.test.tsx
@@ -1,0 +1,292 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  type UseInlineColumnNameInputArgs,
+  type UseInlineColumnNameInputResult,
+  useInlineColumnNameInput,
+} from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+/**
+ * useInlineColumnNameInput の戻り値を外部に公開するテスト用コンポーネント。
+ * @param props - hook 引数 + 観測コールバック
+ * @returns null
+ */
+const Probe = (
+  props: UseInlineColumnNameInputArgs & {
+    onResult: (r: UseInlineColumnNameInputResult) => void;
+  },
+) => {
+  const { onResult, ...args } = props;
+  const result = useInlineColumnNameInput(args);
+  useEffect(() => {
+    onResult(result);
+  });
+  return null;
+};
+
+/**
+ * Probe をマウントし、最新の戻り値を取得する。
+ * @param args - useInlineColumnNameInput の引数
+ * @returns latest accessor
+ */
+const renderHook = (args: UseInlineColumnNameInputArgs) => {
+  let latest: UseInlineColumnNameInputResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const handleResult = (r: UseInlineColumnNameInputResult) => {
+    latest = r;
+  };
+  act(() => {
+    root?.render(
+      createElement(Probe, {
+        ...args,
+        onResult: handleResult,
+      }),
+    );
+  });
+  return {
+    get latest(): UseInlineColumnNameInputResult {
+      return latest as UseInlineColumnNameInputResult;
+    },
+  };
+};
+
+/**
+ * 編集開始してから input 値を設定する。
+ * @param probe - renderHook の戻り値
+ * @param value - 設定する input 値
+ */
+const startAndType = (
+  probe: { latest: UseInlineColumnNameInputResult },
+  value: string,
+) => {
+  act(() => {
+    probe.latest.startEditing();
+  });
+  act(() => {
+    probe.latest.getInputProps().onChange({
+      target: { value },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+  });
+};
+
+test("初期状態は非編集（isEditing=false / isDuplicate=false）", () => {
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    onCommit: vi.fn(),
+  });
+  expect(probe.latest.isEditing).toBe(false);
+  expect(probe.latest.isDuplicate).toBe(false);
+  expect(probe.latest.getInputProps().disabled).toBe(false);
+});
+
+test("startEditing で編集中（isEditing=true・value=initialValue）に遷移", () => {
+  const probe = renderHook({
+    initialValue: "Todo",
+    existingNames: [],
+    onCommit: vi.fn(),
+  });
+  act(() => {
+    probe.latest.startEditing();
+  });
+  expect(probe.latest.isEditing).toBe(true);
+  expect(probe.latest.getInputProps().value).toBe("Todo");
+});
+
+test("cancel 後に再度 startEditing で initialValue に戻り再編集できる", () => {
+  const probe = renderHook({
+    initialValue: "Todo",
+    existingNames: [],
+    onCommit: vi.fn(),
+  });
+  startAndType(probe, "変更中");
+  act(() => {
+    probe.latest.cancel();
+  });
+  expect(probe.latest.isEditing).toBe(false);
+  act(() => {
+    probe.latest.startEditing();
+  });
+  expect(probe.latest.isEditing).toBe(true);
+  expect(probe.latest.getInputProps().value).toBe("Todo");
+});
+
+test("有効入力の confirm で onCommit が trim 値で 1 回呼ばれ isEditing=false に戻る", async () => {
+  const onCommit = vi.fn();
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: ["Todo"],
+    onCommit,
+  });
+  startAndType(probe, "  Review  ");
+  await act(async () => {
+    await probe.latest.confirm();
+  });
+  expect(onCommit).toHaveBeenCalledTimes(1);
+  expect(onCommit).toHaveBeenCalledWith("Review");
+  expect(probe.latest.isEditing).toBe(false);
+});
+
+test("空文字は no-op 成功（onCommit 未呼び出し・isEditing=false・戻り値 true）", async () => {
+  const onCommit = vi.fn();
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    onCommit,
+  });
+  startAndType(probe, "");
+  let returned: boolean | undefined;
+  await act(async () => {
+    returned = await probe.latest.confirm();
+  });
+  expect(returned).toBe(true);
+  expect(onCommit).not.toHaveBeenCalled();
+  expect(probe.latest.isEditing).toBe(false);
+});
+
+test("空白のみ '   ' も trim 後空で no-op 成功", async () => {
+  const onCommit = vi.fn();
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    onCommit,
+  });
+  startAndType(probe, "   ");
+  let returned: boolean | undefined;
+  await act(async () => {
+    returned = await probe.latest.confirm();
+  });
+  expect(returned).toBe(true);
+  expect(onCommit).not.toHaveBeenCalled();
+});
+
+test("同期 onCommit（undefined 返し）でも確定して isEditing=false", async () => {
+  const onCommit = vi.fn().mockReturnValue(undefined);
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    onCommit,
+  });
+  startAndType(probe, "Review");
+  await act(async () => {
+    await probe.latest.confirm();
+  });
+  expect(onCommit).toHaveBeenCalledWith("Review");
+  expect(probe.latest.isEditing).toBe(false);
+});
+
+test("currentName 指定時に自己名一致は no-op 成功（onCommit 未呼び出し）", async () => {
+  const onCommit = vi.fn();
+  const probe = renderHook({
+    initialValue: "Todo",
+    currentName: "Todo",
+    existingNames: [],
+    onCommit,
+  });
+  startAndType(probe, "Todo");
+  let returned: boolean | undefined;
+  await act(async () => {
+    returned = await probe.latest.confirm();
+  });
+  expect(returned).toBe(true);
+  expect(onCommit).not.toHaveBeenCalled();
+  expect(probe.latest.isEditing).toBe(false);
+});
+
+test.each([
+  ["配列供給", ["In Progress", "Done"] as readonly string[]],
+  ["関数供給", () => ["In Progress", "Done"] as readonly string[]],
+])("重複時（%s）は isDuplicate=true・confirm は false・onCommit 未呼び出し・isEditing 維持", async (_label, existingNames) => {
+  const onCommit = vi.fn();
+  const probe = renderHook({
+    initialValue: "",
+    existingNames,
+    onCommit,
+  });
+  startAndType(probe, "Done");
+  expect(probe.latest.isDuplicate).toBe(true);
+  let returned: boolean | undefined;
+  await act(async () => {
+    returned = await probe.latest.confirm();
+  });
+  expect(returned).toBe(false);
+  expect(onCommit).not.toHaveBeenCalled();
+  expect(probe.latest.isEditing).toBe(true);
+});
+
+test("currentName 指定時の重複自己除外（自己名は isDuplicate=false）", () => {
+  const probe = renderHook({
+    initialValue: "Todo",
+    currentName: "Todo",
+    existingNames: ["Todo", "Done"],
+    onCommit: vi.fn(),
+  });
+  startAndType(probe, "Todo");
+  expect(probe.latest.isDuplicate).toBe(false);
+});
+
+test("re-entrant guard: busy 中の 2 回目 confirm は false・onCommit 1 回のみ", async () => {
+  let resolveCommit!: () => void;
+  const onCommit = vi.fn().mockImplementation(
+    () =>
+      new Promise<void>((res) => {
+        resolveCommit = res;
+      }),
+  );
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    onCommit,
+  });
+  startAndType(probe, "Review");
+  let secondReturn: boolean | undefined;
+  await act(async () => {
+    // 1 回目（pending のまま busy 化）
+    void probe.latest.confirm();
+    await Promise.resolve();
+  });
+  await act(async () => {
+    // 2 回目（busy guard で false）
+    secondReturn = await probe.latest.confirm();
+  });
+  expect(secondReturn).toBe(false);
+  expect(onCommit).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    resolveCommit();
+    await Promise.resolve();
+  });
+});
+
+test("reject 時は isBusy=false に戻り isEditing 維持・inputValue 保持", async () => {
+  const onCommit = vi.fn().mockRejectedValue(new Error("backend reject"));
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    onCommit,
+  });
+  startAndType(probe, "Review");
+  let returned: boolean | undefined;
+  await act(async () => {
+    returned = await probe.latest.confirm();
+  });
+  expect(returned).toBe(false);
+  expect(probe.latest.isEditing).toBe(true);
+  expect(probe.latest.getInputProps().disabled).toBe(false);
+  expect(probe.latest.getInputProps().value).toBe("Review");
+});

--- a/src/features/board/hooks/useInlineColumnNameInput/__tests__/useInlineColumnNameInput.keyboard.test.tsx
+++ b/src/features/board/hooks/useInlineColumnNameInput/__tests__/useInlineColumnNameInput.keyboard.test.tsx
@@ -1,0 +1,291 @@
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  type ColumnNameInputFieldProps,
+  type UseInlineColumnNameInputArgs,
+  type UseInlineColumnNameInputResult,
+  useInlineColumnNameInput,
+} from "..";
+
+let container: HTMLDivElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+/**
+ * useInlineColumnNameInput の戻り値を公開しつつ、getInputProps().ref を
+ * 実際の input 要素に配線するテスト用コンポーネント（focus/select 検証用）。
+ * @param props - hook 引数 + 観測コールバック
+ * @returns input 要素
+ */
+const Probe = (
+  props: UseInlineColumnNameInputArgs & {
+    onResult: (r: UseInlineColumnNameInputResult) => void;
+  },
+) => {
+  const { onResult, ...args } = props;
+  const result = useInlineColumnNameInput(args);
+  useEffect(() => {
+    onResult(result);
+  });
+  return createElement("input", result.getInputProps());
+};
+
+/**
+ * Probe をマウントし、最新の戻り値と input 要素を取得する。
+ * @param args - useInlineColumnNameInput の引数
+ * @returns latest accessor + input 要素取得
+ */
+const renderHook = (args: UseInlineColumnNameInputArgs) => {
+  let latest: UseInlineColumnNameInputResult | null = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const handleResult = (r: UseInlineColumnNameInputResult) => {
+    latest = r;
+  };
+  act(() => {
+    root?.render(
+      createElement(Probe, {
+        ...args,
+        onResult: handleResult,
+      }),
+    );
+  });
+  return {
+    get latest(): UseInlineColumnNameInputResult {
+      return latest as UseInlineColumnNameInputResult;
+    },
+    get input(): HTMLInputElement {
+      return container?.querySelector("input") as HTMLInputElement;
+    },
+  };
+};
+
+/**
+ * KeyboardEvent スタブを作る（isComposing も指定可能）。
+ * @param key - キー名
+ * @param isComposing - IME 変換中か
+ * @returns preventDefault / stopPropagation スパイ付きの疑似イベント
+ */
+const makeKeyEvent = (key: string, isComposing = false) => {
+  const preventDefault = vi.fn();
+  const stopPropagation = vi.fn();
+  const event = {
+    key,
+    preventDefault,
+    stopPropagation,
+    nativeEvent: { isComposing },
+  } as unknown as React.KeyboardEvent<HTMLInputElement>;
+  return { event, preventDefault, stopPropagation };
+};
+
+/**
+ * 編集開始して input に値を入れる。
+ * @param probe - renderHook の戻り値
+ * @param value - 設定する値
+ */
+const startAndType = (
+  probe: { latest: UseInlineColumnNameInputResult },
+  value: string,
+) => {
+  act(() => {
+    probe.latest.startEditing();
+  });
+  act(() => {
+    probe.latest.getInputProps().onChange({
+      target: { value },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+  });
+};
+
+test("Enter で confirm が走り preventDefault/stopPropagation が呼ばれる", async () => {
+  const onCommit = vi.fn();
+  const probe = renderHook({ initialValue: "", existingNames: [], onCommit });
+  startAndType(probe, "Review");
+  const { event, preventDefault, stopPropagation } = makeKeyEvent("Enter");
+  await act(async () => {
+    probe.latest.getInputProps().onKeyDown(event);
+    await Promise.resolve();
+  });
+  expect(preventDefault).toHaveBeenCalled();
+  expect(stopPropagation).toHaveBeenCalled();
+  expect(onCommit).toHaveBeenCalledWith("Review");
+});
+
+test("IME 変換中（isComposing=true）の Enter は confirm を呼ばない", async () => {
+  const onCommit = vi.fn();
+  const probe = renderHook({ initialValue: "", existingNames: [], onCommit });
+  startAndType(probe, "Review");
+  const { event, preventDefault } = makeKeyEvent("Enter", true);
+  await act(async () => {
+    probe.latest.getInputProps().onKeyDown(event);
+    await Promise.resolve();
+  });
+  expect(preventDefault).not.toHaveBeenCalled();
+  expect(onCommit).not.toHaveBeenCalled();
+});
+
+test("Escape で cancel（isEditing=false・値が initialValue に戻る）", () => {
+  const probe = renderHook({
+    initialValue: "Todo",
+    existingNames: [],
+    onCommit: vi.fn(),
+  });
+  startAndType(probe, "Changed");
+  const { event, preventDefault } = makeKeyEvent("Escape");
+  act(() => {
+    probe.latest.getInputProps().onKeyDown(event);
+  });
+  expect(preventDefault).toHaveBeenCalled();
+  expect(probe.latest.isEditing).toBe(false);
+  act(() => {
+    probe.latest.startEditing();
+  });
+  expect(probe.latest.getInputProps().value).toBe("Todo");
+});
+
+test("通常 blur で cancel される（isEditing=false）", () => {
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    onCommit: vi.fn(),
+  });
+  startAndType(probe, "途中入力");
+  act(() => {
+    probe.latest.getInputProps().onBlur();
+  });
+  expect(probe.latest.isEditing).toBe(false);
+});
+
+test("busy 中の blur は無視され isEditing 維持", async () => {
+  let resolveCommit!: () => void;
+  const onCommit = vi.fn().mockImplementation(
+    () =>
+      new Promise<void>((res) => {
+        resolveCommit = res;
+      }),
+  );
+  const probe = renderHook({ initialValue: "", existingNames: [], onCommit });
+  startAndType(probe, "Review");
+  await act(async () => {
+    void probe.latest.confirm();
+    await Promise.resolve();
+  });
+  // busy 中 blur
+  act(() => {
+    probe.latest.getInputProps().onBlur();
+  });
+  expect(probe.latest.isEditing).toBe(true);
+  await act(async () => {
+    resolveCommit();
+    await Promise.resolve();
+  });
+});
+
+test("Enter/Esc 直後の blur は cancel スキップ、次の blur では cancel が走る（2 段）", () => {
+  const probe = renderHook({
+    initialValue: "Todo",
+    existingNames: [],
+    onCommit: vi.fn(),
+  });
+  startAndType(probe, "Changed");
+  // Escape で cancel → isCancelledRef=true。その直後の blur は cancel スキップ。
+  const { event } = makeKeyEvent("Escape");
+  act(() => {
+    probe.latest.getInputProps().onKeyDown(event);
+  });
+  // 再度編集開始してから、cancel 経由で isCancelledRef を立てる状況を再現
+  act(() => {
+    probe.latest.startEditing();
+  });
+  act(() => {
+    probe.latest.cancel();
+  });
+  // 1 段目 blur: isCancelledRef=true なので cancel スキップ（isCancelledRef を false 化）
+  act(() => {
+    probe.latest.startEditing();
+  });
+  act(() => {
+    probe.latest.cancel();
+  });
+  act(() => {
+    probe.latest.getInputProps().onBlur();
+  });
+  // 2 段目: もう一度編集開始 → blur すると今度は cancel が走る
+  act(() => {
+    probe.latest.startEditing();
+  });
+  expect(probe.latest.isEditing).toBe(true);
+  act(() => {
+    probe.latest.getInputProps().onBlur();
+  });
+  expect(probe.latest.isEditing).toBe(false);
+});
+
+test("selectOnFocus=true で編集開始時に focus と select が呼ばれる", () => {
+  const probe = renderHook({
+    initialValue: "Todo",
+    existingNames: [],
+    selectOnFocus: true,
+    onCommit: vi.fn(),
+  });
+  const input = probe.input;
+  const focusSpy = vi.spyOn(input, "focus");
+  const selectSpy = vi.spyOn(input, "select");
+  act(() => {
+    probe.latest.startEditing();
+  });
+  expect(focusSpy).toHaveBeenCalled();
+  expect(selectSpy).toHaveBeenCalled();
+});
+
+test("selectOnFocus=false では select は呼ばれない（focus のみ）", () => {
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: [],
+    selectOnFocus: false,
+    onCommit: vi.fn(),
+  });
+  const input = probe.input;
+  const focusSpy = vi.spyOn(input, "focus");
+  const selectSpy = vi.spyOn(input, "select");
+  act(() => {
+    probe.latest.startEditing();
+  });
+  expect(focusSpy).toHaveBeenCalled();
+  expect(selectSpy).not.toHaveBeenCalled();
+});
+
+test("getInputProps の束: aria-* が isDuplicate に連動し onChange で value 更新", () => {
+  const probe = renderHook({
+    initialValue: "",
+    existingNames: ["Done"],
+    onCommit: vi.fn(),
+  });
+  act(() => {
+    probe.latest.startEditing();
+  });
+  const initial = probe.latest.getInputProps();
+  expect(initial["aria-label"]).toBe("カラム名");
+  expect(initial["aria-invalid"]).toBe(false);
+  expect(initial["aria-describedby"]).toBeUndefined();
+  act(() => {
+    probe.latest.getInputProps().onChange({
+      target: { value: "Done" },
+    } as unknown as React.ChangeEvent<HTMLInputElement>);
+  });
+  const props: ColumnNameInputFieldProps = probe.latest.getInputProps();
+  expect(props.value).toBe("Done");
+  expect(props["aria-invalid"]).toBe(true);
+  expect(props["aria-describedby"]).toBe(probe.latest.errorId);
+});

--- a/src/features/board/hooks/useInlineColumnNameInput/index.ts
+++ b/src/features/board/hooks/useInlineColumnNameInput/index.ts
@@ -1,0 +1,220 @@
+import type { ChangeEvent, KeyboardEvent, RefObject } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+
+/** useInlineColumnNameInput の引数 */
+export type UseInlineColumnNameInputArgs = {
+  /** 編集開始時に input へ入れる初期値（ColumnHeader=現在名 / AddColumnButton=""） */
+  initialValue: string;
+  /**
+   * 自己名。指定時（ColumnHeader）は「trim 後 === currentName」を no-op 成功として扱い、
+   * 重複判定から自己名を除外する。未指定（AddColumnButton）は空文字のみ no-op、自己除外なし。
+   */
+  currentName?: string;
+  /**
+   * 重複チェックに用いる既存カラム名。配列（ColumnHeader の自己除外済み prop）でも
+   * 関数（AddColumnButton の Context 由来 existingNames()）でも受けられるようにする。
+   */
+  existingNames: readonly string[] | (() => readonly string[]);
+  /** 編集開始時に select() も行うか（ColumnHeader=true / AddColumnButton=false） */
+  selectOnFocus?: boolean;
+  /**
+   * 確定成功時に呼ぶコールバック（onRename / onAdd を統一）。
+   * Promise を返した場合は await し、reject 時は edit 維持・入力保持。
+   * @param trimmed - trim 済みの入力値
+   */
+  onCommit: (trimmed: string) => void | Promise<void>;
+};
+
+/** `<input>` に spread する配線束（getInputProps の返り値） */
+export type ColumnNameInputFieldProps = {
+  /** input 要素への ref（focus / select 副作用の対象） */
+  ref: RefObject<HTMLInputElement | null>;
+  /** 現在の入力値 */
+  value: string;
+  /**
+   * 入力変更ハンドラ
+   * @param e - input の change イベント
+   */
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  /**
+   * キーダウンハンドラ（Enter 確定 / Escape キャンセル / IME 抑止）
+   * @param e - input の keydown イベント
+   */
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  /** blur ハンドラ（未確定なら cancel、busy 中は無視） */
+  onBlur: () => void;
+  /** 確定処理中は disabled */
+  disabled: boolean;
+  /** input の aria-label */
+  "aria-label": string;
+  /** 重複時 true */
+  "aria-invalid": boolean;
+  /** 重複時のみエラー <p> の id を指す */
+  "aria-describedby": string | undefined;
+};
+
+/** useInlineColumnNameInput の戻り値（消費者向け表面はこれだけ） */
+export type UseInlineColumnNameInputResult = {
+  /** 編集モードか（呼び出し側の描画分岐に使う） */
+  isEditing: boolean;
+  /** 重複エラー表示フラグ（ColumnNameInput が使う） */
+  isDuplicate: boolean;
+  /** エラー <p> の id（ColumnNameInput が使う。input の aria-describedby と共有） */
+  errorId: string;
+  /** 編集開始。呼び出し側で dragGuard 等を噛ませてから呼ぶ */
+  startEditing: () => void;
+  /** 確定（テスト・特殊操作用に公開。通常は getInputProps().onKeyDown 経由） */
+  confirm: () => Promise<boolean>;
+  /** キャンセル（同上） */
+  cancel: () => void;
+  /**
+   * <input> に spread する配線束を返す。ref / value / onChange / onKeyDown /
+   * onBlur / disabled / aria-* をまとめて返し、呼び出し側の props 素通しを無くす。
+   */
+  getInputProps: () => ColumnNameInputFieldProps;
+};
+
+/** input の aria-label（両呼び出し側で共通のため定数化） */
+const INPUT_ARIA_LABEL = "カラム名";
+
+/**
+ * existingNames が配列でも関数でも「現在の既存名配列」を得る。
+ * @param source - 既存名の供給元（配列 or 関数）
+ * @returns 現在の既存名配列
+ */
+const resolveExistingNames = (
+  source: readonly string[] | (() => readonly string[]),
+): readonly string[] => (typeof source === "function" ? source() : source);
+
+/**
+ * ColumnHeader / AddColumnButton で重複するカラム名インライン入力の状態・ハンドラ束を提供する。
+ * 状態遷移（IDLE → EDITING → BUSY）を単一実装に集約し、`getInputProps()` で `<input>` に
+ * spread できる配線束を返す。
+ * @param args - {@link UseInlineColumnNameInputArgs}
+ * @returns 編集状態と配線束（{@link UseInlineColumnNameInputResult}）
+ */
+export const useInlineColumnNameInput = ({
+  initialValue,
+  currentName,
+  existingNames,
+  selectOnFocus = false,
+  onCommit,
+}: UseInlineColumnNameInputArgs): UseInlineColumnNameInputResult => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(initialValue);
+  const [isBusy, setIsBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isCancelledRef = useRef(false);
+  const reactId = useId();
+  const errorId = `${reactId}-error`;
+
+  useEffect(() => {
+    if (!isEditing) {
+      return;
+    }
+    inputRef.current?.focus();
+    if (selectOnFocus) {
+      inputRef.current?.select();
+    }
+  }, [isEditing, selectOnFocus]);
+
+  const trimmedInput = inputValue.trim();
+  const isDuplicate =
+    trimmedInput.length > 0 &&
+    (currentName === undefined || trimmedInput !== currentName) &&
+    resolveExistingNames(existingNames).includes(trimmedInput);
+
+  const startEditing = () => {
+    isCancelledRef.current = false;
+    setInputValue(initialValue);
+    setIsEditing(true);
+  };
+
+  const cancel = () => {
+    isCancelledRef.current = true;
+    setInputValue(initialValue);
+    setIsEditing(false);
+  };
+
+  const confirm = async (): Promise<boolean> => {
+    // re-entrant guard: pending 中の連打 (Enter 連打) を抑止
+    if (isBusy) {
+      return false;
+    }
+    const trimmed = inputValue.trim();
+    const isNoOp =
+      trimmed.length === 0 ||
+      (currentName !== undefined && trimmed === currentName);
+    if (isNoOp) {
+      isCancelledRef.current = true;
+      setInputValue(initialValue);
+      setIsEditing(false);
+      return true;
+    }
+    if (resolveExistingNames(existingNames).includes(trimmed)) {
+      return false;
+    }
+    setIsBusy(true);
+    try {
+      await onCommit(trimmed);
+    } catch {
+      // 失敗時は edit mode を維持し、ユーザの入力を保持する
+      // (caller 側で error toast 等の通知が出ている前提)
+      setIsBusy(false);
+      return false;
+    }
+    setIsBusy(false);
+    isCancelledRef.current = true;
+    setIsEditing(false);
+    return true;
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      void confirm();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      cancel();
+    }
+  };
+
+  const handleBlur = () => {
+    // isBusy 中は input が disabled 化により blur が発火するが、
+    // pending 中の cancel は edit mode を閉じてユーザの入力を失わせるため無視する
+    if (isBusy) {
+      return;
+    }
+    if (!isCancelledRef.current) {
+      cancel();
+    }
+    isCancelledRef.current = false;
+  };
+
+  const getInputProps = (): ColumnNameInputFieldProps => ({
+    ref: inputRef,
+    value: inputValue,
+    onChange: (e) => setInputValue(e.target.value),
+    onKeyDown: handleKeyDown,
+    onBlur: handleBlur,
+    disabled: isBusy,
+    "aria-label": INPUT_ARIA_LABEL,
+    "aria-invalid": isDuplicate,
+    "aria-describedby": isDuplicate ? errorId : undefined,
+  });
+
+  return {
+    isEditing,
+    isDuplicate,
+    errorId,
+    startEditing,
+    confirm,
+    cancel,
+    getInputProps,
+  };
+};


### PR DESCRIPTION
## 概要

`ColumnHeader`（カラム名リネーム）と `AddColumnButton`（新規カラム追加）に**ほぼ行単位で重複していた**インライン入力ロジック（`isEditing` / `inputValue` / `isBusy` / `isCancelledRef` / `confirm` / `cancel` / `handleKeyDown` / `onBlur` 抑止 / `isDuplicate`）と編集用 input JSX を、単一実装へ集約する**純粋な内部リファクタリング**です。公開仕様（画面挙動・DOM 契約・aria）は不変です。

- **フック** `useInlineColumnNameInput`: 状態とハンドラ束（ロジック層）を提供。`initialValue` + オプショナル `currentName` + `existingNames`（配列/関数）供給で 2 コンポーネントの差分を吸収。`getInputProps()` で `<input>` に spread できる配線束（ref/value/onChange/onKeyDown/onBlur/disabled/aria-*）を返す。
- **表示コンポーネント** `ColumnNameInput`: `<input>` + 重複エラー `<p role="alert">` のみを描画する presentational（副作用レス）。外枠 wrapper は呼び出し側。

## 変更の種類

- ♻️ リファクタリング (Refactoring)

## 詳細な変更内容

### 追加

| ファイル | 内容 |
|:--|:--|
| `hooks/useInlineColumnNameInput/index.ts` | 編集ロジックの単一実装フック（220行） |
| `hooks/useInlineColumnNameInput/__tests__/*.behavior/keyboard.test.tsx` | フック単体テスト 22件（confirm/state・keyDown/blur/IME/focus） |
| `components/ColumnNameInput/index.tsx` | presentational コンポーネント（5 props: field + className/dataTestId/placeholder?/dndDisabled?） |
| `components/ColumnNameInput/__tests__/ColumnNameInput.rendering.test.tsx` | 描画・aria・testid・エラー表示テスト 7件 |

### 変更

- `components/ColumnHeader/index.tsx`（-90行）: 編集ロジック/編集 input JSX を除去しフック + `ColumnNameInput` へ委譲。**`dragGuard`（handleDragStart/End/RootClick）と `onRename` 未指定時の編集無効化分岐は残置**。
- `components/AddColumnButton/index.tsx`（-93行）: 編集ロジック一式を除去しフック + `ColumnNameInput` へ委譲。Context 由来の `existingNames()` 関数をそのまま供給。

## 📊 差分の吸収（1 フックで 2 パターン）

```mermaid
flowchart TD
    CH["ColumnHeader（改修）<br/>dragGuard / onRename未指定分岐を残置"] -->|"initialValue=name<br/>currentName=name<br/>existingNames=配列prop<br/>selectOnFocus=true<br/>onCommit=onRename"| HOOK
    ACB["AddColumnButton（改修）<br/>useBoardColumn().existingNames"] -->|"initialValue=''<br/>currentName=undefined<br/>existingNames=Context関数<br/>selectOnFocus=false<br/>onCommit=onAdd"| HOOK
    HOOK["useInlineColumnNameInput（新規・ロジック層）<br/>state: isEditing/inputValue/isBusy<br/>getInputProps() で配線束を返す"]:::new -->|"field 1束を渡す"| CNI
    CNI["ColumnNameInput（新規・表示層）<br/>input + 条件付きエラーp のみ<br/>外枠wrapperは呼び出し側"]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

| 差分観点 | ColumnHeader | AddColumnButton | 吸収方法 |
|:--|:--|:--|:--|
| 初期値 | `name` | `""` | `initialValue` |
| 自己名 no-op / 重複自己除外 | あり（`trimmed === name`） | なし | `currentName` 有無で分岐 |
| 既存名供給 | 配列 prop（自己除外済み） | Context 関数 `existingNames()` | union 型 + `resolveExistingNames` |
| focus/select | focus + select | focus のみ | `selectOnFocus` フラグ |
| 成功コールバック | `onRename?.(t)` | `onAdd(t)` | `onCommit(trimmed)` に統一 |
| dragGuard / onRename未指定の編集無効化 | あり | 該当なし | **フック外（ColumnHeader に残置）** |

## 📋 関連 Issue

- Refs #436

## 🧪 テスト

```bash
pnpm test:run --exclude '**/.claude/**'
pnpm build   # tsc + Vite
pnpm lint    # oxlint
```

### テスト項目

- [x] 単体テスト（フック 22件 + ColumnNameInput 7件 新規追加）
- [x] 既存テスト回帰（ColumnHeader ×3 = 23件 / AddColumnButton 10件 を**無変更で**全緑）
- [ ] 手動テスト（下記「レビューポイント」参照・要 `pnpm tauri dev`）

### テスト結果

- **`pnpm test:run`**: 293ファイル / **2517件 全緑**
- **`pnpm build`（tsc + Vite）**: 型エラーなし
- **oxlint / biome**: 警告・エラーなし
- **Codex レビュー**: 問題なし（critical: 0 / major: 0 / minor: 0）。挙動同値性・currentName 分岐吸収・isCancelledRef/blur 抑止・focus/select・getInputProps の spread 事故なしを確認

## 🔍 レビューポイント

- **挙動同値性**: 状態遷移（IDLE→EDITING→BUSY）、Enter/Esc/blur/IME 抑止/re-entrant guard/reject 時の入力保持/no-op 成功が集約後も厳密維持されているか。
- **`currentName` による分岐吸収**: ColumnHeader の自己名 no-op・重複自己除外と、AddColumnButton の「空のみ no-op・自己除外なし」が `currentName === undefined` 分岐で再現されているか。
- **DOM/aria 契約**: `column-rename-input` / `add-column-input` / `column-name-button` / `add-column-button` / `column-header` の testid、`role="alert"`・エラー文言、`aria-invalid`/`aria-describedby`、`data-column-dnd-disabled`（ColumnHeader input のみ）を維持。
- **手動検証（要 `pnpm tauri dev`）**: カラム名リネーム / `+ カラムを追加` の各操作、およびカラム DnD 直後のヘッダー名クリックで誤編集に入らない（dragGuard）こと。

## ⚠️ 破壊的変更

- なし。公開 API（`src/features/board/index.ts`）への追加もなし（feature 内部利用）。純リファクタのため spec ドキュメント更新は不要。問題発生時は当該コミットを `git revert` するだけで旧実装へ完全復帰できる。