### PR TITLE
♻️ [Refactoring]: #448 [FE] columnDraggable を BoardColumnProvider 導出 + Context 化

### DIFF
--- a/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
@@ -40,7 +40,6 @@ const renderWithProviders = (options: RenderOptions) => {
   document.body.appendChild(container);
   root = createRoot(container);
   const ordered = [...options.columns].sort((a, b) => a.order - b.order);
-  const columnDraggable = ordered.length > 1;
   const onAddTask = options.onAddTask ?? (() => {});
   act(() => {
     root?.render(
@@ -58,7 +57,6 @@ const renderWithProviders = (options: RenderOptions) => {
               color={col.color}
               order={index}
               onAddClick={() => onAddTask(col.name)}
-              columnDraggable={columnDraggable}
             />
           ))}
         </Board>

--- a/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
@@ -65,7 +65,6 @@ const renderWithProviders = (options: RenderOptions) => {
   const tasks = options.tasks ?? [];
   const allTasks = options.allTasks ?? tasks;
   const ordered = [...options.columns].sort((a, b) => a.order - b.order);
-  const columnDraggable = ordered.length > 1;
   const onAddTask = options.onAddTask ?? (() => {});
   act(() => {
     root?.render(
@@ -83,7 +82,6 @@ const renderWithProviders = (options: RenderOptions) => {
               color={col.color}
               order={index}
               onAddClick={() => onAddTask(col.name)}
-              columnDraggable={columnDraggable}
             />
           ))}
         </Board>

--- a/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
@@ -66,7 +66,6 @@ const renderWithProviders = (options: RenderOptions) => {
   const tasks = options.tasks ?? [];
   const allTasks = options.allTasks ?? tasks;
   const ordered = [...options.columns].sort((a, b) => a.order - b.order);
-  const columnDraggable = ordered.length > 1;
   const onAddTask = options.onAddTask ?? (() => {});
   const { onTaskClick, onAddColumn, onRenameColumn, onDeleteColumn } = options;
   act(() => {
@@ -95,7 +94,6 @@ const renderWithProviders = (options: RenderOptions) => {
                   ? (destColumn) => onDeleteColumn(col.name, destColumn)
                   : undefined
               }
-              columnDraggable={columnDraggable}
             />
           ))}
           {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}
@@ -344,27 +342,12 @@ test("任意 ReactNode の children を素通しで描画する（型制約な�
           <div data-testid="pass-foo" />
           {null}
           <Fragment key="frag-wrap">
-            <Board.Column
-              name="Frag"
-              order={1}
-              onAddClick={() => {}}
-              columnDraggable={false}
-            />
+            <Board.Column name="Frag" order={1} onAddClick={() => {}} />
           </Fragment>
           {showHidden && (
-            <Board.Column
-              name="Hidden"
-              order={0}
-              onAddClick={() => {}}
-              columnDraggable={false}
-            />
+            <Board.Column name="Hidden" order={0} onAddClick={() => {}} />
           )}
-          <Board.Column
-            name="Todo"
-            order={0}
-            onAddClick={() => {}}
-            columnDraggable={false}
-          />
+          <Board.Column name="Todo" order={0} onAddClick={() => {}} />
         </Board>
       </BoardProviders>,
     );

--- a/src/features/board/components/Board/index.stories.tsx
+++ b/src/features/board/components/Board/index.stories.tsx
@@ -8,7 +8,6 @@ import { Board } from ".";
 
 const renderBoard = (columns: readonly ColumnType[]): ReactElement => {
   const ordered = [...columns].sort((a, b) => a.order - b.order);
-  const columnDraggable = ordered.length > 1;
   return (
     <Board>
       {ordered.map((col, index) => (
@@ -21,7 +20,6 @@ const renderBoard = (columns: readonly ColumnType[]): ReactElement => {
           onTaskClick={() => {}}
           onRename={() => {}}
           onDelete={() => {}}
-          columnDraggable={columnDraggable}
         />
       ))}
       <Board.AddColumn onAdd={() => {}} />

--- a/src/features/board/components/Board/index.tsx
+++ b/src/features/board/components/Board/index.tsx
@@ -13,7 +13,8 @@ type BoardProps = {
 
 /**
  * カラム一覧を横並びで表示するボードコンテナ。
- * sort / `columnDraggable` 判定 / handler bind は呼び出し側責務とし、
+ * sort / handler bind は呼び出し側責務（ドラッグ可否は BoardColumnProvider が
+ * columnDraggable として導出し Context で配布）とし、
  * 本コンポーネントは外側 flex-col + 内側 flex-row を提供する薄いレイアウトだけを担う。
  *
  * @param props - {@link BoardProps}

--- a/src/features/board/components/BoardColumnProvider/__tests__/BoardColumnProvider.lookup.test.tsx
+++ b/src/features/board/components/BoardColumnProvider/__tests__/BoardColumnProvider.lookup.test.tsx
@@ -131,6 +131,23 @@ test("canDelete は columns.length >= 2 で true を返す", () => {
   expect(probe.latest.canDelete("Todo")).toBe(true);
 });
 
+test("columnDraggable は columns.length === 1 で false", () => {
+  const probe = mountProbe({ columns: [COLUMNS[0]] });
+  expect(probe.latest.columnDraggable).toBe(false);
+});
+
+test("columnDraggable は columns.length >= 2 で true", () => {
+  const probe = mountProbe({ columns: COLUMNS });
+  expect(probe.latest.columnDraggable).toBe(true);
+});
+
+test("columnDraggable と canDelete は同値だが別プロパティ（値 vs 関数）", () => {
+  const probe = mountProbe({ columns: COLUMNS });
+  expect(probe.latest.columnDraggable).toBe(probe.latest.canDelete("Todo"));
+  expect(typeof probe.latest.columnDraggable).toBe("boolean");
+  expect(typeof probe.latest.canDelete).toBe("function");
+});
+
 test("taskCountInColumn は hierarchyTasks (allTasks ?? tasks) を status 別に集計する", () => {
   const a = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
   const b = makeTask({ id: "b", filePath: "tasks/b.md", status: "Todo" });

--- a/src/features/board/components/BoardColumnProvider/index.tsx
+++ b/src/features/board/components/BoardColumnProvider/index.tsx
@@ -90,6 +90,12 @@ export type BoardColumnApi = {
    */
   canDelete: (columnName: string) => boolean;
   /**
+   * カラムヘッダーを DnD ハンドルにできるか。columns.length > 1 なら true。
+   * canDelete と同値の件数導出だが、削除可否ではなくドラッグ可否を表すため
+   * 引数なしの値プロパティとして別に公開する。
+   */
+  columnDraggable: boolean;
+  /**
    * 指定カラムのタスク件数を返す（hierarchyTasks ベース）。
    * @param columnName 対象カラム名
    * @returns 件数（該当なしは 0）
@@ -249,6 +255,7 @@ export const BoardColumnProvider = ({
       existingNames,
       existingNamesExcluding,
       canDelete,
+      columnDraggable: columnNamesArr.length > 1,
       taskCountInColumn,
       orderOf,
     }),
@@ -263,6 +270,7 @@ export const BoardColumnProvider = ({
       existingNames,
       existingNamesExcluding,
       canDelete,
+      columnNamesArr,
       taskCountInColumn,
       orderOf,
     ],

--- a/src/features/board/components/BoardView/index.tsx
+++ b/src/features/board/components/BoardView/index.tsx
@@ -56,9 +56,10 @@ type BoardViewProps = {
 };
 
 /**
- * board 表示形態の描画を担う。カラムを order 昇順にソートし、
- * ドラッグ可否（columnDraggable = ordered.length > 1）を導出して
- * Board.Column を生成する。onAddColumn があるときだけ Board.AddColumn を出す。
+ * board 表示形態の描画を担う。カラムを order 昇順にソートして
+ * Board.Column を生成する（ドラッグ可否は BoardColumnProvider が
+ * columnDraggable として導出し Context で各 Column へ届く）。
+ * onAddColumn があるときだけ Board.AddColumn を出す。
  * @param props - {@link BoardViewProps}
  * @returns board 描画要素
  */
@@ -79,7 +80,6 @@ export const BoardView = ({
   onDeleteColumn,
 }: BoardViewProps) => {
   const ordered = [...columns].sort((a, b) => a.order - b.order);
-  const columnDraggable = ordered.length > 1;
   return (
     <BoardProviders
       columns={columns}
@@ -111,7 +111,6 @@ export const BoardView = ({
                 ? (destColumn) => onDeleteColumn(col.name, destColumn)
                 : undefined
             }
-            columnDraggable={columnDraggable}
           />
         ))}
         {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}

--- a/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
@@ -59,6 +59,8 @@ type RenderOptions = {
   onColumnReorder?: ColumnReorderHandler;
   /** Provider に渡す columns（未指定なら column.name 1 列） */
   columns?: readonly { name: string; order: number }[];
+  /** BoardCardProvider に渡す dndDisabled（Column は card.dndDisabled を参照する） */
+  dndDisabled?: boolean;
 };
 
 /**
@@ -97,6 +99,7 @@ const renderWithProviders = (options: RenderOptions) => {
       tasksByNormalizedPath={options.tasksByNormalizedPath}
       doneColumn={options.doneColumn}
       onTaskDrop={options.onTaskDrop}
+      dndDisabled={options.dndDisabled}
     >
       <BoardColumnProvider
         columns={columns}
@@ -415,13 +418,13 @@ test("column MIME の drop で fromColumnName が空文字列なら onColumnReor
   expect(event.defaultPrevented).toBe(true);
 });
 
-test("columnDraggable=true を渡すと内部 ColumnHeader に draggable=true が配線される", () => {
+test("columns 2 件以上なら内部 ColumnHeader に draggable=true が配線される", () => {
   renderWithProviders({
-    column: {
-      name: "Todo",
-      onAddClick: vi.fn(),
-      columnDraggable: true,
-    },
+    column: { name: "Todo", onAddClick: vi.fn() },
+    columns: [
+      { name: "Todo", order: 0 },
+      { name: "Done", order: 1 },
+    ],
   });
   const header = container?.querySelector<HTMLElement>(
     "[data-testid='column-header']",
@@ -429,9 +432,25 @@ test("columnDraggable=true を渡すと内部 ColumnHeader に draggable=true �
   expect(header?.getAttribute("draggable")).toBe("true");
 });
 
-test("columnDraggable=false / 未指定なら ColumnHeader の draggable は false", () => {
+test("columns 1 件なら ColumnHeader の draggable は false", () => {
   renderWithProviders({
     column: { name: "Todo", onAddClick: vi.fn() },
+    columns: [{ name: "Todo", order: 0 }],
+  });
+  const header = container?.querySelector<HTMLElement>(
+    "[data-testid='column-header']",
+  );
+  expect(header?.getAttribute("draggable")).toBe("false");
+});
+
+test("dndDisabled=true なら columns 2 件以上でも draggable は false", () => {
+  renderWithProviders({
+    column: { name: "Todo", onAddClick: vi.fn() },
+    columns: [
+      { name: "Todo", order: 0 },
+      { name: "Done", order: 1 },
+    ],
+    dndDisabled: true,
   });
   const header = container?.querySelector<HTMLElement>(
     "[data-testid='column-header']",

--- a/src/features/board/components/Column/index.tsx
+++ b/src/features/board/components/Column/index.tsx
@@ -49,8 +49,6 @@ type ColumnProps = {
    * @param destColumn - タスクの移動先カラム名。タスクが 0 件の場合は undefined
    */
   onDelete?: (destColumn: string | undefined) => void | Promise<void>;
-  /** 自カラムヘッダーを DnD ハンドルにするか。1 カラム時は false で渡す。 */
-  columnDraggable?: boolean;
 };
 
 /**
@@ -66,7 +64,6 @@ export const Column = ({
   onTaskClick,
   onRename,
   onDelete,
-  columnDraggable = false,
 }: ColumnProps) => {
   const card = useBoardCard();
   const col = useBoardColumn();
@@ -325,7 +322,7 @@ export const Column = ({
         onRename={onRename}
         existingColumnNames={[...otherColumnNames]}
         onContextMenu={handleContextMenu}
-        draggable={columnDraggable && !dndDisabled}
+        draggable={col.columnDraggable && !dndDisabled}
         onColumnDragStart={handleColumnDragStart}
         onColumnDragEnd={handleColumnDragEnd}
       />


### PR DESCRIPTION
## 概要

`Board.Column`（Column）が prop で受けていた `columnDraggable` を廃止し、`BoardColumnProvider` が `columns.length > 1` として導出して Context（`useBoardColumn` / `BoardColumnApi.columnDraggable`）経由で提供する形へ変更しました。呼び出し側が全カラムへ同一値を配る **prop threading を解消**する、**挙動不変の純粋リファクタリング**です。

DOM 構造・`draggable` 属性の真理値表（**カラム 1 件=false / 2 件以上=true / dndDisabled=true で常に false**）が不変であることを絶対条件としています。

## 変更の種類

- ♻️ リファクタリング (Refactoring)

## 詳細な変更内容

### 変更されたファイル

- `BoardColumnProvider/index.tsx` — `BoardColumnApi` に `columnDraggable: boolean` を追加（`columnNamesArr.length > 1` から導出）。`canDelete` と同値導出だがドラッグ可否として別プロパティで公開。`api` の `useMemo` 依存配列に `columnNamesArr` を追加し stale 値を防止
- `Column/index.tsx` — `ColumnProps` から `columnDraggable` prop を削除し、`draggable={col.columnDraggable && !dndDisabled}` で合成（`dndDisabled = card.dndDisabled` は現状維持）
- `BoardView/index.tsx` — `ordered.length > 1` の導出行と prop 渡しを削除、jsdoc を Provider 導出へ追従
- `Board/index.tsx` / `Board/index.stories.tsx` — jsdoc 追従・`renderBoard` の導出/prop 削除
- `BoardColumnProvider/__tests__/BoardColumnProvider.lookup.test.tsx` — `columnDraggable` の件数境界 3 件を追加
- `Column/__tests__/Column.dnd.test.tsx` — prop 直渡しテストを Provider の columns 件数駆動へ書換 + `dndDisabled=true` 合成のエッジケース追加
- `Board/__tests__/*.test.tsx`（rendering / dnd / column-dnd）— 導出行と prop 渡しの削除

## システム図

```mermaid
flowchart TD
    subgraph Before["Before（prop threading）"]
        BV1[BoardView] -->|"columnDraggable = ordered.length > 1"| C1[Board.Column]
        C1 --> D1["draggable = columnDraggable && !dndDisabled"]
    end

    subgraph After["After（Context 導出）"]
        P2[BoardColumnProvider]:::new -->|"columnDraggable = columns.length > 1"| CTX["BoardColumnApi.columnDraggable"]:::new
        CTX -->|"useBoardColumn()"| C2[Board.Column]
        C2 --> D2["draggable = col.columnDraggable && !dndDisabled"]:::new
        BCP[BoardCardProvider] -->|"card.dndDisabled"| D2
    end

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
```

## 関連 Issue

- Refs #448
- Refs #447（Epic）

## テスト

### テスト実行方法

```bash
pnpm test:run --exclude '**/.claude/**'
pnpm build
pnpm lint
```

### テスト項目

- [x] 単体テスト (Unit tests) — 287 files / 2464 tests PASS
- [x] 型チェック / ビルド — `pnpm build` 緑
- [x] Lint — oxlint 0 warnings / 0 errors
- [ ] 手動テスト (Manual testing) — `pnpm tauri dev` での挙動不変目視（レビュー後に実施）

### テスト結果

- 既存回帰テスト（`BoardView.behavior.test.tsx` / `BoardWorkspace.compound-wiring.test.tsx`）が**書換なしで緑**。Context 化後も破損せず、本番描画口での真理値表不変を担保しています。
- `columnNamesArr.length === columns.length`（`map` は要素数保存）により旧 `ordered.length > 1` と完全同値です。

## レビューポイント

- **挙動不変性**: `col.columnDraggable && !dndDisabled` の合成で真理値表（1件=false / 2件以上=true / dndDisabled=true で常に false）が保たれているか
- **useMemo 依存配列**: `api` の `useMemo` に `columnNamesArr` を追加し stale 値を防いでいる点（既存 `canDelete` 経由で invalidation タイミングは一致、追加コストなし）
- **canDelete と columnDraggable の分離**: 同値導出だが「削除可否」と「ドラッグ可否」で概念が異なるため統合せず別プロパティで公開

## 注意事項

- 外部レビュー（Codex）が利用上限で実行不可のため、`spec-based-code-review-plugin` の 5 観点エージェント（spec-alignment / design / performance / test-quality / comment-quality）で代替レビューを実施。**全観点 CRITICAL / WARNING ゼロ**、INFO のみでコード修正不要でした。
- design レビュー INFO: 合成式の左辺（Column Provider 由来）と右辺 `dndDisabled`（Card Provider 由来）の出所非対称は、両 Provider が同一 `dndDisabled` を受けるため挙動完全同値。spec 意図的スコープ外で Epic #447 系のフォロー候補です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)