### PR TITLE
♻️ [Refactoring]: #449 [FE] Board.Column の per-column ハンドラを columnName 素通し API に統一

### DIFF
--- a/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.column-dnd.test.tsx
@@ -56,7 +56,7 @@ const renderWithProviders = (options: RenderOptions) => {
               name={col.name}
               color={col.color}
               order={index}
-              onAddClick={() => onAddTask(col.name)}
+              onAddTask={onAddTask}
             />
           ))}
         </Board>

--- a/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.dnd.test.tsx
@@ -81,7 +81,7 @@ const renderWithProviders = (options: RenderOptions) => {
               name={col.name}
               color={col.color}
               order={index}
-              onAddClick={() => onAddTask(col.name)}
+              onAddTask={onAddTask}
             />
           ))}
         </Board>

--- a/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
+++ b/src/features/board/components/Board/__tests__/Board.rendering.test.tsx
@@ -82,18 +82,10 @@ const renderWithProviders = (options: RenderOptions) => {
               name={col.name}
               color={col.color}
               order={index}
-              onAddClick={() => onAddTask(col.name)}
+              onAddTask={onAddTask}
               onTaskClick={onTaskClick}
-              onRename={
-                onRenameColumn
-                  ? (newName) => onRenameColumn(col.name, newName)
-                  : undefined
-              }
-              onDelete={
-                onDeleteColumn
-                  ? (destColumn) => onDeleteColumn(col.name, destColumn)
-                  : undefined
-              }
+              onRenameColumn={onRenameColumn}
+              onDeleteColumn={onDeleteColumn}
             />
           ))}
           {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}
@@ -342,12 +334,12 @@ test("任意 ReactNode の children を素通しで描画する（型制約な�
           <div data-testid="pass-foo" />
           {null}
           <Fragment key="frag-wrap">
-            <Board.Column name="Frag" order={1} onAddClick={() => {}} />
+            <Board.Column name="Frag" order={1} onAddTask={() => {}} />
           </Fragment>
           {showHidden && (
-            <Board.Column name="Hidden" order={0} onAddClick={() => {}} />
+            <Board.Column name="Hidden" order={0} onAddTask={() => {}} />
           )}
-          <Board.Column name="Todo" order={0} onAddClick={() => {}} />
+          <Board.Column name="Todo" order={0} onAddTask={() => {}} />
         </Board>
       </BoardProviders>,
     );

--- a/src/features/board/components/Board/index.stories.tsx
+++ b/src/features/board/components/Board/index.stories.tsx
@@ -16,10 +16,10 @@ const renderBoard = (columns: readonly ColumnType[]): ReactElement => {
           name={col.name}
           color={col.color}
           order={index}
-          onAddClick={() => {}}
+          onAddTask={() => {}}
           onTaskClick={() => {}}
-          onRename={() => {}}
-          onDelete={() => {}}
+          onRenameColumn={() => {}}
+          onDeleteColumn={() => {}}
         />
       ))}
       <Board.AddColumn onAdd={() => {}} />

--- a/src/features/board/components/BoardView/index.tsx
+++ b/src/features/board/components/BoardView/index.tsx
@@ -99,18 +99,10 @@ export const BoardView = ({
             name={col.name}
             color={col.color}
             order={index}
-            onAddClick={() => onAddTask(col.name)}
+            onAddTask={onAddTask}
             onTaskClick={onTaskClick}
-            onRename={
-              onRenameColumn
-                ? (newName) => onRenameColumn(col.name, newName)
-                : undefined
-            }
-            onDelete={
-              onDeleteColumn
-                ? (destColumn) => onDeleteColumn(col.name, destColumn)
-                : undefined
-            }
+            onRenameColumn={onRenameColumn}
+            onDeleteColumn={onDeleteColumn}
           />
         ))}
         {onAddColumn && <Board.AddColumn onAdd={onAddColumn} />}

--- a/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.dnd.test.tsx
@@ -130,7 +130,7 @@ const querySection = (): HTMLElement => {
 
 test("独自 MIME を持つ dragover で preventDefault される", () => {
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
   });
   const section = querySection();
   const event = createDragEvent("dragover");
@@ -143,7 +143,7 @@ test("独自 MIME を持つ dragover で preventDefault される", () => {
 
 test("他 MIME (text/plain) の dragover では preventDefault されない", () => {
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
   });
   const section = querySection();
   const event = createDragEvent("dragover");
@@ -156,7 +156,7 @@ test("他 MIME (text/plain) の dragover では preventDefault されない", ()
 
 test("dragover で hover ターゲット (name, index) が Provider に通知される", async () => {
   const probe = renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
   });
   act(() => {
     probe.cardApi.startDrag("tasks/a.md", "Done");
@@ -174,7 +174,7 @@ test("dragover で hover ターゲット (name, index) が Provider に通知さ
 
 test("currentTarget 外への dragleave で hover ターゲットが (null, null) にリセットされる", () => {
   const probe = renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
   });
   act(() => {
     probe.cardApi.startDrag("tasks/a.md", "Done");
@@ -192,7 +192,7 @@ test("drop で onTaskDrop が期待引数で呼ばれる", async () => {
   const onTaskDrop = vi.fn();
   const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
   const probe = renderWithProviders({
-    column: { name: "Done", onAddClick: vi.fn() },
+    column: { name: "Done", onAddTask: vi.fn() },
     allTasks: [taskA],
     onTaskDrop,
   });
@@ -219,7 +219,7 @@ test("dataTransfer 空の drop（外部 D&D）では onTaskDrop が呼ばれな�
   const onTaskDrop = vi.fn();
   const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
   const probe = renderWithProviders({
-    column: { name: "Done", onAddClick: vi.fn() },
+    column: { name: "Done", onAddTask: vi.fn() },
     allTasks: [taskA],
     onTaskDrop,
   });
@@ -238,7 +238,7 @@ test("dataTransfer の filePath が dragState と不一致なら onTaskDrop が�
   const onTaskDrop = vi.fn();
   const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
   const probe = renderWithProviders({
-    column: { name: "Done", onAddClick: vi.fn() },
+    column: { name: "Done", onAddTask: vi.fn() },
     allTasks: [taskA],
     onTaskDrop,
   });
@@ -258,7 +258,7 @@ test("空カラムでの drop は toIndex=0 で呼ばれる", async () => {
   const onTaskDrop = vi.fn();
   const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
   const probe = renderWithProviders({
-    column: { name: "Done", onAddClick: vi.fn() },
+    column: { name: "Done", onAddTask: vi.fn() },
     allTasks: [taskA],
     onTaskDrop,
   });
@@ -290,7 +290,7 @@ test("非空カラムでの drop は drop event の clientY から toIndex を�
   const taskA = makeTask({ id: "a", filePath: "tasks/a.md", status: "Todo" });
   const onTaskDrop = vi.fn();
   const probe = renderWithProviders({
-    column: { name: "Done", onAddClick: vi.fn() },
+    column: { name: "Done", onAddTask: vi.fn() },
     tasks,
     allTasks: [...tasks, taskA],
     onTaskDrop,
@@ -341,7 +341,7 @@ test("非空カラムでの drop は drop event の clientY から toIndex を�
 test("hoverTarget.column === name の時のみ drop-placeholder が出る", () => {
   const tasks = [makeTask({ id: "1", filePath: "tasks/1.md" })];
   const probe = renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     tasks,
   });
   act(() => {
@@ -356,7 +356,7 @@ test("hoverTarget.column === name の時のみ drop-placeholder が出る", () =
 test("hoverTarget.column が他カラムの時は placeholder が出ない", () => {
   const tasks = [makeTask({ id: "1", filePath: "tasks/1.md" })];
   const probe = renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     tasks,
   });
   act(() => {
@@ -370,7 +370,7 @@ test("hoverTarget.column が他カラムの時は placeholder が出ない", () 
 
 test("column MIME の dragover で preventDefault される", () => {
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
   });
   const section = querySection();
   const event = createDragEvent("dragover");
@@ -384,7 +384,7 @@ test("column MIME の dragover で preventDefault される", () => {
 test("column MIME の drop で onColumnReorder({fromColumnName, toColumnName})", async () => {
   const onColumnReorder = vi.fn();
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     onColumnReorder,
   });
   const section = querySection();
@@ -405,7 +405,7 @@ test("column MIME の drop で onColumnReorder({fromColumnName, toColumnName})",
 test("column MIME の drop で fromColumnName が空文字列なら onColumnReorder は呼ばれないが preventDefault は実行される", () => {
   const onColumnReorder = vi.fn();
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     onColumnReorder,
   });
   const section = querySection();
@@ -420,7 +420,7 @@ test("column MIME の drop で fromColumnName が空文字列なら onColumnReor
 
 test("columns 2 件以上なら内部 ColumnHeader に draggable=true が配線される", () => {
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     columns: [
       { name: "Todo", order: 0 },
       { name: "Done", order: 1 },
@@ -434,7 +434,7 @@ test("columns 2 件以上なら内部 ColumnHeader に draggable=true が配線�
 
 test("columns 1 件なら ColumnHeader の draggable は false", () => {
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     columns: [{ name: "Todo", order: 0 }],
   });
   const header = container?.querySelector<HTMLElement>(
@@ -445,7 +445,7 @@ test("columns 1 件なら ColumnHeader の draggable は false", () => {
 
 test("dndDisabled=true なら columns 2 件以上でも draggable は false", () => {
   renderWithProviders({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     columns: [
       { name: "Todo", order: 0 },
       { name: "Done", order: 1 },

--- a/src/features/board/components/Column/__tests__/Column.interaction.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.interaction.test.tsx
@@ -92,7 +92,7 @@ function dispatchContextMenu(target: Element) {
 
 test("ヘッダー右クリックでコンテキストメニューが表示される", () => {
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn: vi.fn() },
     otherColumnNames: ["Done"],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -101,9 +101,9 @@ test("ヘッダー右クリックでコンテキストメニューが表示さ�
   expect(menu).toBeTruthy();
 });
 
-test("onDelete 未指定時は右クリックしてもメニューが表示されない", () => {
+test("onDeleteColumn 未指定時は右クリックしてもメニューが表示されない", () => {
   render({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
   });
   const header = container?.querySelector("section > div") as HTMLElement;
   dispatchContextMenu(header);
@@ -111,9 +111,69 @@ test("onDelete 未指定時は右クリックしてもメニューが表示さ�
   expect(menu).toBeFalsy();
 });
 
+test("onRenameColumn 未指定時は column-name-button が描画されず名前編集不能", () => {
+  render({
+    column: { name: "Todo", onAddTask: vi.fn() },
+  });
+  const renameButton = container?.querySelector(
+    '[data-testid="column-name-button"]',
+  );
+  expect(renameButton).toBeFalsy();
+  const heading = container?.querySelector("h2");
+  expect(heading?.textContent).toBe("Todo");
+});
+
+test("Add ボタンクリックで onAddTask が自 name で呼ばれる", () => {
+  const onAddTask = vi.fn();
+  render({
+    column: { name: "Todo", onAddTask },
+  });
+  const addButton = container?.querySelector(
+    'button[aria-label="Todoに追加"]',
+  ) as HTMLButtonElement;
+  act(() => {
+    addButton.click();
+  });
+  expect(onAddTask).toHaveBeenCalledWith("Todo");
+});
+
+test("Rename 確定で onRenameColumn が (name, newName) で呼ばれる", () => {
+  const onRenameColumn = vi.fn();
+  render({
+    column: { name: "Todo", onAddTask: vi.fn(), onRenameColumn },
+  });
+  const nameButton = container?.querySelector(
+    '[data-testid="column-name-button"]',
+  ) as HTMLButtonElement;
+  act(() => {
+    nameButton.click();
+  });
+  const input = container?.querySelector(
+    '[data-testid="column-rename-input"]',
+  ) as HTMLInputElement;
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  act(() => {
+    nativeSetter?.call(input, "Todo v2");
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  });
+  expect(onRenameColumn).toHaveBeenCalledWith("Todo", "Todo v2");
+});
+
 test("メニューの「削除」クリックで ConfirmDialog が表示される", () => {
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn: vi.fn() },
     otherColumnNames: ["Done"],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -130,7 +190,7 @@ test("メニューの「削除」クリックで ConfirmDialog が表示され�
 
 test("タスクありの場合、移動先ドロップダウンが表示される", () => {
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn: vi.fn() },
     tasks: [createTask({ status: "Todo" }), createTask({ id: "task-2" })],
     otherColumnNames: ["In Progress", "Done"],
   });
@@ -152,7 +212,7 @@ test("タスクありの場合、移動先ドロップダウンが表示され�
 
 test("タスクなしの場合、移動先ドロップダウンは表示されない", () => {
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn: vi.fn() },
     otherColumnNames: ["Done"],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -175,7 +235,7 @@ test("表示カードが空でも allTasks にフィルタで隠れている分�
     createTask({ id: "h2", status: "Todo", filePath: "tasks/h2.md" }),
   ];
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn: vi.fn() },
     tasks: [],
     allTasks: hiddenTasks,
     otherColumnNames: ["Done"],
@@ -195,10 +255,10 @@ test("表示カードが空でも allTasks にフィルタで隠れている分�
   expect(dropdown).toBeTruthy();
 });
 
-test("タスクありで確定すると onDelete が移動先と共に呼ばれる", () => {
-  const onDelete = vi.fn();
+test("タスクありで確定すると onDeleteColumn が (name, dest) で呼ばれる", () => {
+  const onDeleteColumn = vi.fn();
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn },
     tasks: [createTask({ status: "Todo" })],
     otherColumnNames: ["In Progress", "Done"],
   });
@@ -229,13 +289,13 @@ test("タスクありで確定すると onDelete が移動先と共に呼ばれ�
       ) as HTMLButtonElement
     ).click();
   });
-  expect(onDelete).toHaveBeenCalledWith("Done");
+  expect(onDeleteColumn).toHaveBeenCalledWith("Todo", "Done");
 });
 
-test("タスクなしで確定すると onDelete が undefined で呼ばれる", () => {
-  const onDelete = vi.fn();
+test("タスクなしで確定すると onDeleteColumn が (name, undefined) で呼ばれる", () => {
+  const onDeleteColumn = vi.fn();
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn },
     otherColumnNames: ["Done"],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -254,12 +314,12 @@ test("タスクなしで確定すると onDelete が undefined で呼ばれる",
       ) as HTMLButtonElement
     ).click();
   });
-  expect(onDelete).toHaveBeenCalledWith(undefined);
+  expect(onDeleteColumn).toHaveBeenCalledWith("Todo", undefined);
 });
 
 test("タスクがあるのに移動先カラムが無い場合、メニューの削除項目が無効化される", () => {
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn: vi.fn() },
     tasks: [createTask({ status: "Todo" })],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -272,7 +332,7 @@ test("タスクがあるのに移動先カラムが無い場合、メニュー�
 
 test("columns.length === 1 の場合、メニューの削除項目が無効化される (Provider 経由の canDelete)", () => {
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn: vi.fn() },
   });
   const header = container?.querySelector("section > div") as HTMLElement;
   dispatchContextMenu(header);
@@ -282,10 +342,10 @@ test("columns.length === 1 の場合、メニューの削除項目が無効化�
   expect(deleteItem?.disabled).toBe(true);
 });
 
-test("onDelete が reject した場合、ConfirmDialog は閉じずに開いたまま", async () => {
-  const onDelete = vi.fn().mockRejectedValue(new Error("backend reject"));
+test("onDeleteColumn が reject した場合、ConfirmDialog は閉じずに開いたまま", async () => {
+  const onDeleteColumn = vi.fn().mockRejectedValue(new Error("backend reject"));
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn },
     otherColumnNames: ["Done"],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -307,22 +367,22 @@ test("onDelete が reject した場合、ConfirmDialog は閉じずに開いた�
   await act(async () => {
     await Promise.resolve();
   });
-  expect(onDelete).toHaveBeenCalledTimes(1);
+  expect(onDeleteColumn).toHaveBeenCalledTimes(1);
   // ConfirmDialog は維持される
   const dialog = document.querySelector('[data-testid="confirm-dialog"]');
   expect(dialog).toBeTruthy();
 });
 
-test("onDelete pending 中の confirm ボタン連打は二重実行されない (re-entrant guard)", async () => {
+test("onDeleteColumn pending 中の confirm ボタン連打は二重実行されない (re-entrant guard)", async () => {
   let resolveDelete!: () => void;
-  const onDelete = vi.fn().mockImplementation(
+  const onDeleteColumn = vi.fn().mockImplementation(
     () =>
       new Promise<void>((res) => {
         resolveDelete = res;
       }),
   );
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn },
     otherColumnNames: ["Done"],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -356,17 +416,17 @@ test("onDelete pending 中の confirm ボタン連打は二重実行されない
   await act(async () => {
     await Promise.resolve();
   });
-  expect(onDelete).toHaveBeenCalledTimes(1);
+  expect(onDeleteColumn).toHaveBeenCalledTimes(1);
   await act(async () => {
     resolveDelete();
     await Promise.resolve();
   });
 });
 
-test("キャンセルで ConfirmDialog が閉じ、onDelete は呼ばれない", () => {
-  const onDelete = vi.fn();
+test("キャンセルで ConfirmDialog が閉じ、onDeleteColumn は呼ばれない", () => {
+  const onDeleteColumn = vi.fn();
   render({
-    column: { name: "Todo", onAddClick: vi.fn(), onDelete },
+    column: { name: "Todo", onAddTask: vi.fn(), onDeleteColumn },
     otherColumnNames: ["Done"],
   });
   const header = container?.querySelector("section > div") as HTMLElement;
@@ -385,7 +445,7 @@ test("キャンセルで ConfirmDialog が閉じ、onDelete は呼ばれない",
       ) as HTMLButtonElement
     ).click();
   });
-  expect(onDelete).not.toHaveBeenCalled();
+  expect(onDeleteColumn).not.toHaveBeenCalled();
   const dialog = document.querySelector('[data-testid="confirm-dialog"]');
   expect(dialog).toBeFalsy();
 });

--- a/src/features/board/components/Column/__tests__/Column.parseError.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.parseError.test.tsx
@@ -85,7 +85,7 @@ function render(options: RenderOptions) {
 test("invalid warning を持つ task を渡すとカードに parse-error-icon が表示される", () => {
   const task = createTask({ warnings: [invalidWarning] });
   render({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     tasks: [task],
   });
   expect(
@@ -96,7 +96,7 @@ test("invalid warning を持つ task を渡すとカードに parse-error-icon �
 test("除外コード（parentCycle）のみの task では parse-error-icon は描画されない", () => {
   const task = createTask({ warnings: [cycleWarning] });
   render({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     tasks: [task],
   });
   expect(document.querySelector('[data-testid="parse-error-icon"]')).toBeNull();
@@ -105,7 +105,7 @@ test("除外コード（parentCycle）のみの task では parse-error-icon は
 test("warnings 空の task では parse-error-icon は描画されない", () => {
   const task = createTask({ warnings: [] });
   render({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     tasks: [task],
   });
   expect(document.querySelector('[data-testid="parse-error-icon"]')).toBeNull();

--- a/src/features/board/components/Column/__tests__/Column.rendering.test.tsx
+++ b/src/features/board/components/Column/__tests__/Column.rendering.test.tsx
@@ -83,7 +83,7 @@ function render(options: RenderOptions) {
 }
 
 test("カラム名がヘッダーに表示される", async () => {
-  render({ column: { name: "In Progress", onAddClick: vi.fn() } });
+  render({ column: { name: "In Progress", onAddTask: vi.fn() } });
   await vi.waitFor(() => {
     expect(container?.textContent).toContain("In Progress");
   });
@@ -94,7 +94,7 @@ test("タスク件数がヘッダーに表示される", async () => {
     createTask({ id: "task-1", title: "タスク1" }),
     createTask({ id: "task-2", title: "タスク2" }),
   ];
-  render({ column: { name: "Todo", onAddClick: vi.fn() }, tasks });
+  render({ column: { name: "Todo", onAddTask: vi.fn() }, tasks });
   await vi.waitFor(() => {
     expect(container?.textContent).toContain("2");
   });
@@ -102,14 +102,14 @@ test("タスク件数がヘッダーに表示される", async () => {
 
 test("タスクのタイトルが表示される", async () => {
   const tasks = [createTask({ title: "ログイン修正" })];
-  render({ column: { name: "Todo", onAddClick: vi.fn() }, tasks });
+  render({ column: { name: "Todo", onAddTask: vi.fn() }, tasks });
   await vi.waitFor(() => {
     expect(container?.textContent).toContain("ログイン修正");
   });
 });
 
 test("「+ 追加」ボタンが表示される", async () => {
-  render({ column: { name: "Todo", onAddClick: vi.fn() } });
+  render({ column: { name: "Todo", onAddTask: vi.fn() } });
   await vi.waitFor(() => {
     const btn = Array.from(container?.querySelectorAll("button") ?? []).find(
       (b): b is HTMLButtonElement => b.textContent === "+ 追加",
@@ -119,7 +119,7 @@ test("「+ 追加」ボタンが表示される", async () => {
 });
 
 test("aria-label にカラム名が設定される", async () => {
-  render({ column: { name: "Done", onAddClick: vi.fn() } });
+  render({ column: { name: "Done", onAddTask: vi.fn() } });
   await vi.waitFor(() => {
     const section = container?.querySelector("section");
     expect(section?.getAttribute("aria-label")).toBe("Done");
@@ -156,7 +156,7 @@ test("3 階層 fixture（root + 子 1 + 孫 2 のうち done 1）で TaskCard �
   const allTasks = [rootTask, child, grand1, grand2];
 
   render({
-    column: { name: "Todo", onAddClick: vi.fn() },
+    column: { name: "Todo", onAddTask: vi.fn() },
     tasks: [rootTask],
     allTasks,
     doneColumn: "Done",

--- a/src/features/board/components/Column/index.stories.tsx
+++ b/src/features/board/components/Column/index.stories.tsx
@@ -32,10 +32,10 @@ const meta: Meta<typeof Column> = {
   ],
   args: {
     name: "Todo",
-    onAddClick: () => {},
+    onAddTask: () => {},
     onTaskClick: () => {},
-    onRename: () => {},
-    onDelete: () => {},
+    onRenameColumn: () => {},
+    onDeleteColumn: () => {},
   },
 };
 
@@ -104,5 +104,5 @@ export const ManyTasks: Story = {
 };
 
 export const WithoutMenu: Story = {
-  args: { onDelete: undefined, onRename: undefined },
+  args: { onDeleteColumn: undefined, onRenameColumn: undefined },
 };

--- a/src/features/board/components/Column/index.tsx
+++ b/src/features/board/components/Column/index.tsx
@@ -29,8 +29,12 @@ type ColumnProps = {
    * フォールバック色決定に必須のため、呼び出し側（Board）は表示順インデックスを渡す。
    */
   order: number;
-  /** 「+ 追加」ボタンクリック時のコールバック */
-  onAddClick: () => void;
+  /**
+   * 「+ 追加」ボタンクリック時のコールバック。
+   * 第 1 引数として自カラム名を素通しで渡す。
+   * @param columnName - 自カラム名
+   */
+  onAddTask: (columnName: string) => void;
   /**
    * タスクカードクリック時のコールバック
    * @param taskId - クリックされたタスクのID
@@ -39,16 +43,23 @@ type ColumnProps = {
   /**
    * カラム名リネーム確定時のコールバック。
    * 未指定の場合はヘッダー名編集 UI を無効化する。
+   * 第 1 引数として自カラム名を素通しで渡す。
+   * @param columnName - 自カラム名（rename 前）
    * @param newName - 新しいカラム名（trim 済み、既存と非重複）
    */
-  onRename?: (newName: string) => void;
+  onRenameColumn?: (columnName: string, newName: string) => void;
   /**
    * カラム削除確定時のコールバック。
    * 未指定の場合は削除 UI を無効化する。
    * Promise を返した場合は await し、reject した場合は ConfirmDialog を維持する。
+   * 第 1 引数として自カラム名を素通しで渡す。
+   * @param columnName - 削除対象カラム名
    * @param destColumn - タスクの移動先カラム名。タスクが 0 件の場合は undefined
    */
-  onDelete?: (destColumn: string | undefined) => void | Promise<void>;
+  onDeleteColumn?: (
+    columnName: string,
+    destColumn: string | undefined,
+  ) => void | Promise<void>;
 };
 
 /**
@@ -60,10 +71,10 @@ export const Column = ({
   name,
   color,
   order,
-  onAddClick,
+  onAddTask,
   onTaskClick,
-  onRename,
-  onDelete,
+  onRenameColumn,
+  onDeleteColumn,
 }: ColumnProps) => {
   const card = useBoardCard();
   const col = useBoardColumn();
@@ -221,7 +232,7 @@ export const Column = ({
   const [destColumn, setDestColumn] = useState<string>("");
   const triggerRef = useRef<HTMLElement | null>(null);
 
-  const handleContextMenu = onDelete
+  const handleContextMenu = onDeleteColumn
     ? (e: MouseEvent<HTMLElement>) => {
         e.preventDefault();
         triggerRef.current = e.currentTarget;
@@ -260,7 +271,7 @@ export const Column = ({
     const hasTasksInside = deletionCount > 0;
     setIsDeleting(true);
     try {
-      await onDelete?.(hasTasksInside ? destColumn : undefined);
+      await onDeleteColumn?.(name, hasTasksInside ? destColumn : undefined);
     } catch {
       // 失敗時は ConfirmDialog を開いたままにし、ユーザの destColumn 選択も保持する
       // (caller 側で error toast 等の通知が出ている前提)
@@ -318,8 +329,12 @@ export const Column = ({
         taskCount={tasks.length}
         color={color}
         order={order}
-        onAddClick={onAddClick}
-        onRename={onRename}
+        onAddClick={() => onAddTask(name)}
+        onRename={
+          onRenameColumn
+            ? (newName) => onRenameColumn(name, newName)
+            : undefined
+        }
         existingColumnNames={[...otherColumnNames]}
         onContextMenu={handleContextMenu}
         draggable={col.columnDraggable && !dndDisabled}


### PR DESCRIPTION
## 概要

`Column` の Props 3 種（`onAddClick` / `onRename` / `onDelete`）を、`columnName` を第 1 引数に取る素通し API（`onAddTask` / `onRenameColumn` / `onDeleteColumn`）に rename + 引数追加。`BoardView` の map 内で組み立てられていた **per-column closure 3 個** と **undefined 三項 2 個** を排除し、Column 内部で自 `name` を bind する責務を集約した。

**挙動不変の純粋リファクタリング**。`docs/spec-board/` 配下の spec ドキュメントは仕様（外部挙動）が変わらないため更新不要。

## 変更内容

### 🎯 変更の種類

- [x] ♻️ リファクタリング (Refactoring)

### 📝 詳細な変更内容

#### API 変更（board feature 内スコープ）

- `Column` の Props: `onAddClick` → `onAddTask(columnName)` / `onRename` → `onRenameColumn(columnName, newName)` / `onDelete` → `onDeleteColumn(columnName, destColumn)`
- `ColumnProps` 型は非公開（`src/features/board/index.ts` から re-export されていない）ため、board feature 外への波及なし
- 子コンポーネント（`ColumnHeader` / `ColumnContextMenu`）の Props 型は不変

#### 変更されたファイル（11 ファイル）

- `src/features/board/components/Column/index.tsx` — Props 型 rename + `handleContextMenu` / `handleConfirm` / `ColumnHeader` 呼び出しの追従（`handleConfirm` の try/catch 順序は完全に不変）
- `src/features/board/components/Column/index.stories.tsx` — args を新 API に rename、`WithoutMenu` の undefined 割当も追従
- `src/features/board/components/Column/__tests__/*.test.tsx`（4 ファイル）— render options を新 API 名に rename + `interaction` に F-6 追加 assertion 3 件
- `src/features/board/components/BoardView/index.tsx` — map 内 Column callsite を素通しに置換（closure 3 個 + 三項 2 個の削減）
- `src/features/board/components/Board/index.stories.tsx` — Column callsite を新 API に rename（no-op 関数のまま）
- `src/features/board/components/Board/__tests__/{rendering,dnd,column-dnd}.test.tsx`（3 ファイル）— callsite を BoardView と同じ素通し形に追従

## 📊 システム図

### データフロー: name 境界の集約

\`\`\`
[ callsite: BoardView / Board tests / stories ]
              │
              │  onAddTask       : (columnName: string) => void
              │  onRenameColumn  : (columnName, newName) => void
              │  onDeleteColumn  : (columnName, dest?)  => void
              │
              ▼  (per-column closure なし = [NEW])
      <Board.Column
        onAddTask={onAddTask}                ← 素通し
        onRenameColumn={onRenameColumn}      ← 素通し（undefined OK）
        onDeleteColumn={onDeleteColumn}      ← 素通し（undefined OK）
      />
              │
              ▼
       ┌───────────────────────┐
       │ Column (name 境界)    │
       │  自 name を bind した │
       │  closure を組み立て   │
       └────┬──────────────────┘
            │
   ┌────────┴──────────────────────┐
   ▼                               ▼
[ColumnHeader]                [ColumnContextMenu]
 onAddClick={() =>             onDelete={(dest) =>
   onAddTask(name)}              onDeleteColumn?.(
 onRename={onRenameColumn         name,
   ? (n) => onRename-             hasTasks ? destCol
      Column(name, n)             : undefined,
   : undefined}                 )}
  (Props 型不変)               (Props 型不変)
\`\`\`

要点:
- **callsite** は「name-first API を素通し」で渡すだけ
- **Column** が「自 name を bind する」責務を集約（name 境界）
- **子（ColumnHeader / ColumnContextMenu）** は既存契約（name-less な callback）のまま = 型変更なし

## 📋 関連 Issue

- Refs #449
- 親 Epic: #447 / #390

## 🧪 テスト

### テスト実行方法

\`\`\`bash
pnpm test:run
pnpm build
pnpm lint
\`\`\`

### テスト項目

- [x] 単体テスト (Unit tests) — Vitest 2467 tests PASS
- [x] 統合テスト (Integration tests) — Board 系 51 test files PASS
- [ ] E2E テスト — 追加なし（純粋リファクタで挙動不変のため）
- [ ] 手動テスト (tauri dev) — レビュー後に実施

### テスト結果

\`\`\`
Test Files  287 passed (287)
     Tests  2467 passed (2467)
     Build  PASS (tsc + vite build)
      Lint  0 warning / 0 error
\`\`\`

#### F-6 追加 assertion（`Column.interaction.test.tsx`）

- \`expect(onAddTask).toHaveBeenCalledWith(\"Todo\")\`
- \`expect(onRenameColumn).toHaveBeenCalledWith(\"Todo\", \"Todo v2\")\`
- \`expect(onDeleteColumn).toHaveBeenCalledWith(\"Todo\", \"Done\")\` / \`(\"Todo\", undefined)\`
- \`onRenameColumn: undefined\` 時に \`column-name-button\` が描画されない UI 出し分け（UC-2）

#### grep 漏れ検知（DoD 対応）

- BoardView の per-column closure / undefined 三項が 0 件
- Column callsite 側の旧 API（`onAddClick=` / `onRename=` / `onDelete=`）が 0 件

## 🔍 レビューポイント

- **`Column/index.tsx` の `handleConfirm`（line 256-272）**: `await onDelete?.(...)` を `await onDeleteColumn?.(name, ...)` に置換した 1 行のみが差分。try/catch 内 `setIsDeleting(false); return;` の位置関係が F-5「Promise reject 時の ConfirmDialog 維持」を成立させているため、この構造は完全に不変であることを確認してください
- **`ColumnHeader` / `ColumnContextMenu` の Props 型は不変**: Column が自 name を bind した closure を渡すことで子側の契約を維持しています（C-3）
- **コミット粒度（案 A / 3 コミット）**: コミット 1 の中間状態で BoardView 側が TypeScript エラーになりますが、レビュアビリティを優先した判断です（計画 Section 7）

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます（feature 内スコープのため board feature 外への波及なし）

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（純粋リファクタで挙動不変のため \`docs/spec-board/\` 更新不要）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR に紐づいている（Refs #449）
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている（feature 内スコープのため N/A）