### PR TITLE
🐛 [Bug Fix]: HeaderBar のストーリーに ThemeProvider を与えて描画を復旧

### DIFF
--- a/src/features/board/components/HeaderBar/index.stories.tsx
+++ b/src/features/board/components/HeaderBar/index.stories.tsx
@@ -1,9 +1,19 @@
 // @jsdoc-rules-disable
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ThemeProvider } from "@/features/shell";
 import { HeaderBar } from ".";
 
 const meta: Meta<typeof HeaderBar> = {
   component: HeaderBar,
+  // HeaderBar は ThemeToggleButton 経由で useTheme を呼ぶため、Provider が無いと
+  // Storybook のエラー画面になる。
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
   parameters: {
     layout: "fullscreen",
   },


### PR DESCRIPTION
## 概要

`HeaderBar` のストーリーが Storybook のエラー画面しか描画していなかったので、`ThemeProvider` の decorator を足して実際のコンポーネントが描画されるようにする。

`HeaderBar` は `ThemeToggleButton` 経由で `useTheme` を呼ぶが、ストーリー側に Provider が無いため以下のエラー画面になっていた。

```
useTheme は ThemeProvider の内側で使用してください
```

## 変更の種類

- 🐛 バグ修正

## 詳細な変更内容

`src/features/board/components/HeaderBar/index.stories.tsx` の `meta` に decorator を 1 つ追加しただけで、コンポーネント本体・テストには手を入れていない。

```tsx
decorators: [
  (Story) => (
    <ThemeProvider>
      <Story />
    </ThemeProvider>
  ),
],
```

## なぜ今か

visual regression（#487 で追加）の baseline にもこのエラー画面が焼き付いており、**スタックトレースに含まれる開発サーバのポート番号とアセットハッシュが実行ごとに変わる**ため、無関係な PR でも `HeaderBar` の 3 ストーリーが恒常的に差分として検出される状態だった。

実際に #489（Task 集計 projection の BE 移管）で以下の差分が出ている。

| ストーリー | diffRatio | 差分の中身 |
|:--|:--|:--|
| `headerbar--board-view` | 0.0044 | `127.0.0.1:34047` → `37377` / `shell-LC90ucUu.js` → `shell-wGfHSY-e.js` |
| `headerbar--settings-view` | 0.0044 | 同上 |
| `headerbar--with-milestone` | 0.0044 | 同上 |

## テスト

- `tsc --noEmit`: エラーなし
- `biome check` / `oxlint`: 緑

## レビューポイント

本 PR 自体の visual regression は**赤になります**。baseline は main から撮影されたエラー画面なので、正しい `HeaderBar` が描画されるようになると差分が大きく出るためです。これは意図した差分で、マージ後に main 側の baseline が正しい画面へ更新されます。

差分レポートで「エラー画面 → 実際の HeaderBar」になっていることを確認のうえマージしてください。マージ後は #489 を再実行すれば、そちらの visual regression も緑になる想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)