### PR TITLE
VRT の日本語文字化けを解消する

### DIFF
--- a/.devcontainer/node/Dockerfile
+++ b/.devcontainer/node/Dockerfile
@@ -10,10 +10,14 @@ ENV LANG=C.UTF-8
 
 # 基本パッケージとNode.jsのインストール
 # Tauri開発に必要なシステムライブラリも併せてインストール
+# fonts-noto-cjk: ubuntu:24.04 には CJK フォントが無く、Storybook や
+# playwright-cli での目視確認で日本語が豆腐(□)になる。
+# CI(storybook-visual-regression.yml)と同じフォントを入れて描画結果を揃える。
 RUN apt-get update \
     && apt-get install -y \
         curl \
         ca-certificates \
+        fonts-noto-cjk \
         gnupg \
         git \
         jq \

--- a/.github/workflows/deploy-storybook-main.yml
+++ b/.github/workflows/deploy-storybook-main.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Japanese fonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-noto-cjk
+          fc-cache -f
+          fc-list :lang=ja family
+
       - name: Build Storybook
         run: pnpm build-storybook
 

--- a/.github/workflows/storybook-visual-regression.yml
+++ b/.github/workflows/storybook-visual-regression.yml
@@ -62,6 +62,16 @@ jobs:
           }
           NODE
 
+      # ubuntu-24.04 ランナーには CJK フォントが無く、日本語が豆腐(□)で描画される。
+      # 豆腐は「差分なし」で baseline に焼き付いてしまうため、撮影前に必ず導入する。
+      - name: Install Japanese fonts
+        if: github.event.action != 'closed'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-noto-cjk
+          fc-cache -f
+          fc-list :lang=ja family
+
       - name: Build Storybook
         if: github.event.action != 'closed'
         run: pnpm build-storybook

--- a/scripts/storybook-visual-regression.mjs
+++ b/scripts/storybook-visual-regression.mjs
@@ -116,6 +116,51 @@ const openCdp = async (wsUrl) => {
   return { send, close: () => socket.close() };
 };
 
+// ページ内で評価して、日本語グリフが notdef(豆腐)へフォールバックしていないか調べる。
+// 同条件で「あ」「未割り当てコードポイント」「空白」を描き分け、ビットマップを比較する。
+// 未割り当てコードポイントはどのフォントでも必ず notdef になるため、これと一致したら
+// 「あ」も notdef、つまり日本語フォントが解決できていないと判定できる。
+const japaneseGlyphProbe = () => {
+  const draw = (text) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 64;
+    canvas.height = 64;
+    const context = canvas.getContext("2d");
+    context.font = "48px sans-serif";
+    context.textBaseline = "top";
+    context.fillText(text, 0, 0);
+    return canvas.toDataURL();
+  };
+  return { japanese: draw("あ"), notdef: draw("\u{10FFFD}"), blank: draw(" ") };
+};
+
+// Chrome は fontconfig 経由でフォントを解決するため、CJK フォントが無い環境では
+// 日本語が豆腐(□)で描画される。豆腐は毎回同じ絵なので比較では差分として現れず、
+// 気づかないまま baseline に焼き付いてしまう。撮影を始める前に落とす。
+const assertJapaneseFontAvailable = async () => {
+  const target = await requestJson(`http://127.0.0.1:9222/json/new?${encodeURIComponent("about:blank")}`, { method: "PUT" });
+  const cdp = await openCdp(target.webSocketDebuggerUrl);
+  try {
+    const { result, exceptionDetails } = await cdp.send("Runtime.evaluate", {
+      expression: `(${japaneseGlyphProbe.toString()})()`,
+      returnByValue: true,
+    });
+    if (exceptionDetails) {
+      throw new Error(`Japanese font probe failed to evaluate: ${exceptionDetails.text ?? "unknown error"}`);
+    }
+    const { japanese, notdef, blank } = result.value;
+    if (japanese === notdef || japanese === blank) {
+      throw new Error(
+        "No Japanese font is available to Chrome; Japanese text would be captured as tofu (□).\n" +
+          "Install a CJK font before capturing, e.g. `apt-get install -y fonts-noto-cjk && fc-cache -f`.",
+      );
+    }
+  } finally {
+    cdp.close();
+    await requestOk(`http://127.0.0.1:9222/json/close/${target.id}`);
+  }
+};
+
 const capture = async (options) => {
   const storybookDir = options["storybook-dir"] ?? "storybook-static";
   const out = options.out ?? "visual-actual";
@@ -175,6 +220,7 @@ const capture = async (options) => {
     if (!version) {
       throw new Error(describeChromeFailure());
     }
+    await assertJapaneseFontAvailable();
     const index = await requestJson(`${origin}/index.json`);
     const stories = Object.values(index.entries ?? {}).filter((entry) => entry.type === "story").sort((a, b) => a.id.localeCompare(b.id));
     writeFileSync(join(out, "stories.json"), JSON.stringify(stories.map(({ id, title, name }) => ({ id, title, name })), null, 2));


### PR DESCRIPTION
## 背景

design-composer PR #75 と同じ根本原因の修正を spec-board にも適用する。

GitHub Actions の `ubuntu-24.04` ランナーイメージには **CJK フォントが含まれていない**。VRT のスクリーンショットはランナー上の Chrome を CDP 経由で操作して撮影しているため、fontconfig が日本語グリフを解決できず豆腐（□）で焼き付く。

同じ根本原因が devcontainer にもある。`.devcontainer/node/Dockerfile` は `ubuntu:24.04` ベースでフォントパッケージを入れていないため、playwright-cli での目視確認でも日本語が豆腐になる。

## 変更内容

1. **CI にフォントを導入** — VRT workflow (`storybook-visual-regression.yml`) と deploy workflow (`deploy-storybook-main.yml`) のキャプチャ前に `fonts-noto-cjk` を導入し、`fc-cache -f` でキャッシュを更新する。
2. **devcontainer にも同じフォントを導入** — ローカルの Storybook / playwright-cli 目視確認と CI の描画結果を揃える。
3. **再発防止ガードを capture スクリプトに追加** — 撮影前に日本語グリフが notdef（豆腐）へフォールバックしていないかを実レンダリングで検査し、検出したら撮影を始める前に fail させる。

   canvas に `あ` と**未割り当てコードポイント**（どのフォントでも必ず notdef になる）を同条件で描画し、ビットマップが一致したら「`あ` も notdef」と判定する。空白との一致も同時に見る。

### なぜガードが必要か

豆腐は**毎回同じ絵**として描画されるため、比較では差分として現れない。つまりフォントが無いまま撮影すると「差分なし」で通り、そのまま baseline に焼き付いてしまう。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1xR8CNnrEFngg4DMQX4Hq)_