### PR TITLE
✨ [New Feature]: #458 Project load の部分失敗を structured load warnings として返す

### DIFF
--- a/docs/spec-board/board-view-spec.md
+++ b/docs/spec-board/board-view-spec.md
@@ -174,6 +174,12 @@ stateDiagram-v2
 | ファイル書き込み失敗 | ディスク容量不足、権限エラー | トースト通知（書き込み系コマンドは下記の一元化対象） | ファイルシステムの状態を確認 |
 | リンク切れ (プロジェクトロード時) | 開いたプロジェクトに `parent` / `links` / `children` / `reverseLinks` のいずれかが解決できないタスクが N >= 1 件含まれる | プロジェクトロード時 (state.kind が `"loaded"` に遷移したとき) に warning Toast「リンク切れが N 件あります」を 1 回表示。同一 `loadedPath` 内では再発火しない（別 project に切替後、N >= 1 なら再度 1 回発火する） | 詳細（全画面 2 ペイン）で該当 path を確認し、リンクを削除するか参照先ファイルを作成。詳細は [task-card-spec.md](./task-card-spec.md) の「エラー表示」セクション参照 |
 
+### プロジェクト読み込み時の注意
+
+`open_project` / `get_tasks` が返す `loadWarnings` は、読み込みを継続できた部分失敗を表す。loaded board のメイン領域上部に `ProjectLoadWarnings` の compact persistent panel を表示し、警告が 0 件なら panel 自体を描画しない。panel は初期状態では件数だけを示し、「原因を確認する」を展開すると code の表示名、stage、project root 相対 path（path が `null` の場合は「プロジェクト全体」）、message を確認できる。unknown code / stage や空 message でも汎用ラベルへ安全にフォールバックし、長い path / message はレイアウトを壊さず折り返す。
+
+初回 open と full rescan 後の warnings 更新では、同じ project path・同じ warnings fingerprint を重ねて通知せず、内容が変わった場合だけ `読み込み時の注意が N 件あります` の warning toast を表示する。空配列への遷移では toast を出さず panel を消す。project を切り替えた場合は path ごとに state と通知を分離し、旧 project の warnings を新 project に表示しない。panel は `settings` / `create` / no-project の画面には表示しない。
+
 ### 書き込み失敗トーストの一元化
 
 書き込み（ミューテーション）系コマンドの失敗トーストは、各ハンドラではなく IPC ラッパ層（`invokeWrapped`）に集約して発火する。これにより失敗通知の source of truth を一本化し、握り潰し・通知の不統一・二重通知を防ぐ。
@@ -285,3 +291,9 @@ DetailScreen の「削除」ボタン押下で確認ダイアログを表示す�
 - [task-card-spec.md](./task-card-spec.md) - タスクカードの表示内容・詳細（全画面 2 ペイン）・フォーム仕様
 - [file-system-spec.md](./file-system-spec.md) - ファイル監視・変更検知の仕組み
 - [task-format-spec.md](./task-format-spec.md) - mdファイルのフォーマットとフロントマターの定義
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 | 変更者 |
+|:-----------|:-----|:---------|:-------|
+| 1.3 | 2026-08-01 | Issue #458: loaded board の `ProjectLoadWarnings` persistent panel、`loadWarnings` summary toast、fingerprint抑制とproject切替 isolationを追加 | - |

--- a/docs/spec-board/config-spec.md
+++ b/docs/spec-board/config-spec.md
@@ -566,10 +566,26 @@ task md と `config.json` は別ファイルのため、両者をまたぐトラ
 - project switch と same-path reopen は root + SessionId の pre-gate identity 検証で disk I/O 前に拒否し、resident commit は full SessionId + Revision CAS で行う
 - resident validation / target 解決後、store load、task disk read、write-ignore 登録、disk writeより先に revision increment を checked preflight する。revision 枯渇時は disk/store I/O ゼロで session と marker を不変に保つ
 - disk write 成功後に同じ session の revision conflict が判明した場合、同じ非 reentrant gate を再取得せず、operation と同じ injected task I/O / config loader / registry store で current disk state を再読込して CAS resync する
-- resync 成功時も command は元の typed conflict を返す。resync 失敗は warning diagnostic に残すが元の conflict を上書きしない。task/config 系の write-ignore marker は resync 成功時だけ watcher consume 用に残し、失敗時は cleanup する
+- resync 成功時も command は元の typed conflict を返す。resync 失敗は warning として残すが元の conflict を上書きしない。task/config 系の write-ignore marker は resync 成功時だけ watcher consume 用に残し、失敗時は cleanup する
 - project switch、same-path reopen、resource identity 不一致、revision 枯渇は内部では別々の typed error で保持する。Tauri command 名・引数・成功 payload と既存 validation/I/O error の表示文字列は変更しない
 
 ## エラーハンドリング
+
+### open_project の config fallback と `loadWarnings`
+
+`.spec-board/config.json` が存在しない場合は `Config::default()` を使用して正常に開き、warning は生成しない。既存 config の read / parse / validation / migration / backup に失敗した場合も `open_project` は `Config::default()` で継続し、`loadWarnings` に次の warning を 1 件追加する。
+
+```json
+{
+  "code": "configFallback",
+  "stage": "config",
+  "path": ".spec-board/config.json",
+  "message": "設定を読み込めないため既定値を使用しました",
+  "recoverable": true
+}
+```
+
+FE は `loadWarnings` の件数を warning toast と loaded board の展開パネルで示す。root access、hierarchy depth / cycle、labels / milestones registry、watcher 初期化、session / lock の失敗は設定 fallback では吸収せず、従来どおり `open_project` の fatal error とする。
 
 ### load_or_default が返す `LoadConfigError` バリアント
 
@@ -577,13 +593,13 @@ task md と `config.json` は別ファイルのため、両者をまたぐトラ
 
 | エラーケース | 発生条件 | バックエンド戻り値 | 呼び出し層の振る舞い | ログレベル |
 |:------------|:---------|:------------------|:-------------------|:----------|
-| JSON パース失敗 | JSON 構文エラー、必須フィールド欠落、`version` の型不一致 / `u32` 範囲外 | `LoadConfigError::Parse` | デフォルト設定で起動し、トースト通知 | ERROR |
-| 未来 version 検出 | `version > DEFAULT_VERSION` | `LoadConfigError::UnknownFutureVersion` | デフォルト設定で起動し、トースト通知（アプリの更新案内を含む） | ERROR |
-| カラム名重複 | `columns` 内に同一名のカラムが存在 | `LoadConfigError::DuplicateColumnName` | デフォルト設定で起動し、トースト通知 | ERROR |
-| 空カラム | `columns: []` (spec の「最低1つのカラムが必要」違反) | `LoadConfigError::EmptyColumns` | デフォルト設定で起動し、トースト通知 | ERROR |
-| マイグレーション失敗（**本Issue 時点では到達不能**: 詳細は表下注を参照） | `migrate_config` が `MigrationError` を返す | `LoadConfigError::MigrationFailed` | デフォルト設定で起動し、トースト通知 | ERROR |
-| バックアップ失敗 | `.bak` の書き出しに失敗（権限不足 / symlink 宛先 / ディレクトリ衝突など） | `LoadConfigError::BackupFailed` | デフォルト設定で起動し、トースト通知（バックアップ作成失敗の旨を明示） | ERROR |
-| I/O 失敗 | `.spec-board/` の作成 / `config.json` の読み取りに失敗 | `LoadConfigError::Io` | デフォルト設定で起動し、トースト通知 | ERROR |
+| JSON パース失敗 | JSON 構文エラー、必須フィールド欠落、`version` の型不一致 / `u32` 範囲外 | `LoadConfigError::Parse` | `Config::default()` で `open_project` を継続し、`configFallback` の `loadWarnings` を返す（FE は件数を warning toast で通知） | ERROR |
+| 未来 version 検出 | `version > DEFAULT_VERSION` | `LoadConfigError::UnknownFutureVersion` | `Config::default()` で `open_project` を継続し、`configFallback` の `loadWarnings` を返す（FE は件数を warning toast で通知）（アプリの更新案内を含む） | ERROR |
+| カラム名重複 | `columns` 内に同一名のカラムが存在 | `LoadConfigError::DuplicateColumnName` | `Config::default()` で `open_project` を継続し、`configFallback` の `loadWarnings` を返す（FE は件数を warning toast で通知） | ERROR |
+| 空カラム | `columns: []` (spec の「最低1つのカラムが必要」違反) | `LoadConfigError::EmptyColumns` | `Config::default()` で `open_project` を継続し、`configFallback` の `loadWarnings` を返す（FE は件数を warning toast で通知） | ERROR |
+| マイグレーション失敗（**本Issue 時点では到達不能**: 詳細は表下注を参照） | `migrate_config` が `MigrationError` を返す | `LoadConfigError::MigrationFailed` | `Config::default()` で `open_project` を継続し、`configFallback` の `loadWarnings` を返す（FE は件数を warning toast で通知） | ERROR |
+| バックアップ失敗 | `.bak` の書き出しに失敗（権限不足 / symlink 宛先 / ディレクトリ衝突など） | `LoadConfigError::BackupFailed` | `Config::default()` で `open_project` を継続し、`configFallback` の `loadWarnings` を返す（FE は件数を warning toast で通知）（バックアップ作成失敗の旨を明示） | ERROR |
+| I/O 失敗 | `.spec-board/` の作成 / `config.json` の読み取りに失敗 | `LoadConfigError::Io` | `Config::default()` で `open_project` を継続し、`configFallback` の `loadWarnings` を返す（FE は件数を warning toast で通知） | ERROR |
 
 > **`MigrationFailed` の到達可能性について**
 >
@@ -612,5 +628,6 @@ task md と `config.json` は別ファイルのため、両者をまたぐトラ
 
 | バージョン | 日付 | 変更内容 | 変更者 |
 |:-----------|:-----|:---------|:-------|
+| 1.3 | 2026-08-01 | Issue #458: config failure の `Config::default()` 継続、`configFallback` `loadWarnings`、registry / root fatal 境界を追加 | - |
 | 1.2 | 2026-07-31 | Issue #453: config/registry writer の project-scoped gate、session revision CAS、revision preflight、disk 後 conflict resync 契約を追加 | - |
 | 1.1 | 2026-07-29 | `open_project` / `get_tasks` の milestone projection 契約と `get_milestones.usageCounts` の互換方針を追加 | - |

--- a/docs/spec-board/file-system-spec.md
+++ b/docs/spec-board/file-system-spec.md
@@ -83,6 +83,7 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
       "taskFilePaths": ["tasks/fix-bug.md"]
     }
   },
+  "loadWarnings": [],
   "session": {
     "projectKey": "/home/user/specs",
     "generation": 1,
@@ -112,15 +113,31 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 | ディレクトリではない | 指定パスがディレクトリでない（通常ファイル等） | `ディレクトリではありません: {path}` |
 | アクセス権限なし | 読み取り権限がない | `ディレクトリにアクセスできません: {path}` |
 | 内部状態の lock 破損 | project domain / active resources / writer gate の Mutex が poison 状態 | `内部状態のロックが破損しました` |
-| スキャン致命エラー | parent 循環 / scan I/O など | `io scan failed: {message}` |
-| config 読み込み失敗 | `config.json` が壊れている等 | `config load failed (io|parse): {message}` |
+| スキャン致命エラー | root の metadata/read_dir、hierarchy 循環/深さ超過など | `io scan failed: {message}` |
+| config 読み込み失敗 | `config.json` が壊れている等 | `Config::default()` で継続し、`loadWarnings` に `configFallback` を含める |
 | ファイル監視の初期化失敗 | inotify 上限超過 / poll fallback 失敗 / path 消失等で `Watcher::start` が `Err` を返した場合 | `ファイル監視の初期化に失敗しました: {source}` |
 
-> 個別 md ファイルの `fs::read` 失敗、および `task_from_markdown` のパース失敗は致命扱いせず、`log::warn!` で記録して該当ファイルだけ skip する（コマンド全体は成功する）。warning を payload へ同梱する仕様は別 Issue 扱い。
+> 個別 md ファイルの fs::read 失敗、task_from_markdown のパース失敗、scanner の per-entry 失敗は recoverable な load warning として payload の loadWarnings に含め、該当ファイルを skip して残りのタスクで処理を継続する。root metadata/read_dir、hierarchy、labels/milestones、watcher/session 初期化、lock は従来どおり fatal とし、コマンド全体を失敗させる。
 >
 > ファイル監視の初期化、SessionId 枯渇、domain/resources lock のいずれの swap 前失敗でも resident `ProjectSession` と active resources は **一切変更されず**、フロントエンドは旧プロジェクトを表示したまま動作を継続する。予約済み SessionId は再利用せず、次の成功 open との間に gap が生じ得る。FE 側 `TauriError.PATTERNS` には watcher 初期化失敗の個別分類がないため `UNKNOWN` 分類になる。
 
 ---
+
+### ProjectLoadWarning と `loadWarnings`
+
+`open_project` と `get_tasks` は、タスクを一部読み込めない場合でも成功し、成功した `tasks` / projections と同じ snapshot に `loadWarnings` を同梱する。warning は UI が分類できる安定した値であり、fatal error の代替ではない。
+
+| フィールド | 型 | 説明 |
+|:----------|:---|:-----|
+| `code` | `scanEntryError` / `metadataError` / `unreadableFile` / `fileTooLarge` / `binaryFile` / `invalidPath` / `taskReadFailed` / `frontmatterParseFailed` / `configFallback` / `unknown` | 失敗分類。未知値は FE で `unknown` として安全に表示する |
+| `stage` | `scan` / `read` / `parse` / `config` / `unknown` | 発生段階 |
+| `path` | `string` または `null` | project root からの相対 path。相対化できない場合は `null`。config fallback は `.spec-board/config.json` |
+| `message` | `string` | 原因の補足。UI は raw message をそのまま HTML として解釈しない |
+| `recoverable` | `boolean` | 今回は load warning がすべて `true`。root / hierarchy / registry / watcher / session / lock の fatal error は payload に含めない |
+
+同一 `(stage, path, code, message, recoverable)` は payload 直前に重複除去し、順序を安定化する。`loadWarnings: []` は警告が無い正常な読み込みを表す。config が存在しない場合は既定値で開き、warning は生成しない。存在する config の read / parse / validation / migration / backup 失敗は `Config::default()` で継続し、`configFallback` を追加する。
+
+watcher の full rescan が成功した場合は、その rescan report の warnings で session の `loadWarnings` を tasks と atomic に置き換える。修復されたファイルの warning は消え、新たに失敗したファイルだけが残る。rescan 自体が fatal の場合は旧 tasks と旧 warnings を保持し、既存の watcher diagnostic を通知する。
 
 ### `get_tasks`
 
@@ -128,7 +145,7 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
 
 **引数**: なし
 
-**戻り値**: `{ tasks, projections, milestoneProjections, session }`。`tasks` は `open_project` と同じ Task 配列（`children` と `reverseLinks` の逆引き情報を含む）、`projections` は filePath をキーにした task 集計、`milestoneProjections` は milestone 名をキーにした集計、`session` は watcher イベント検証の baseline。
+**戻り値**: `{ tasks, projections, milestoneProjections, loadWarnings, session }`。`tasks` は `open_project` と同じ Task 配列（`children` と `reverseLinks` の逆引き情報を含む）、`projections` は filePath をキーにした task 集計、`milestoneProjections` は milestone 名をキーにした集計、`session` は watcher イベント検証の baseline。
 
 > `tasks` の並び順は `open_project` と**完全に同一**（カラム表示順 → `cardOrder` → `id` 昇順）。フロントエンドは配列順をそのまま表示順に使うため、片方だけ `id` 昇順にすると watcher の full rescan / イベント欠落からの復旧のたびに DnD で決めた並びが崩れる。並び順の決定は `TaskIndex::sorted_by_board_order` 1 箇所に集約する。`milestoneProjections[*].taskFilePaths` も、この `tasks` を milestone ごとに絞り込んだ順序と一致する。`config` が `None` の場合のみ `TaskIndex::sorted_by_id` にフォールバックし、`tasks` / `taskFilePaths` ともに `id` 昇順とする。この場合は完了カラムも解決できないため `done` は 0。
 
@@ -153,6 +170,7 @@ Tauriバックエンド（Rust）におけるmdファイルの読み書き・パ
       ]
     }
   },
+  "loadWarnings": [],
   "session": {
     "projectKey": "/home/user/specs",
     "generation": 1,
@@ -549,9 +567,9 @@ spec-board 自身がmdファイルを書き込んだ直後に、ファイル監�
 | エラーケース | 発生条件 | 振る舞い | ログレベル |
 |:------------|:---------|:---------|:----------|
 | ファイルスキャンの致命的エラー | スキャン root が不在 / アクセス不可 / ディレクトリでない | `open_project` 経由でフロントエンドに「ディレクトリが見つかりません / アクセスできません / ディレクトリではありません」相当のエラーを返却 | ERROR |
-| 走査中の個別 I/O エラー | 走査中の特定ファイル / サブディレクトリの権限不足等 | 黙って skip し、走査を継続する（ログ出力は別 Issue で本格導入予定） | （現状は出力しない） |
-| ファイル読み込み失敗 | 権限不足、ファイルロック中 | `log::warn!` で記録し該当ファイルだけ skip。`open_project` 全体は成功する。フロントエンドへの個別通知 / payload 同梱は別 Issue | WARN |
-| フロントマターパース失敗 | YAML構文エラー、必須フィールド欠損 | `log::warn!` で記録し該当ファイルだけ skip。`open_project` 全体は成功する。フロントエンドへの個別通知 / payload 同梱は別 Issue | WARN |
+| 走査中の個別 I/O エラー | `.md` 候補の entry / metadata 取得失敗 | `loadWarnings` に `scanEntryError` / `metadataError` を追加し、その項目を skip。ほかのファイルの走査を継続 | WARN |
+| ファイル読み込み失敗 | 個別 md の権限不足、ファイルロック中など | `loadWarnings` に `unreadableFile`/`taskReadFailed` を追加し、そのファイルだけ skip。残りのタスクで成功 | WARN |
+| フロントマターパース失敗 | YAML構文エラー、Task生成中の読み取り/解析失敗 | `loadWarnings` に `frontmatterParseFailed` を追加し、そのファイルだけ skip。残りのタスクで成功 | WARN |
 | ファイル書き込み失敗 | ディスク容量不足、権限不足 | エラーをフロントエンドに返却 | ERROR |
 | 監視の初期化失敗 | OS制限（inotify上限等） | `Watcher::start` 内部で recommended → poll の自動フォールバックを試み、両方失敗した場合のみ `open_project` から `ファイル監視の初期化に失敗しました: ...` を返す。AppState は **一切変更せず**、フロントエンドは旧プロジェクトを表示したまま動作を継続する | ERROR |
 | 監視稼働中の backend 障害 | 監視対象の消失 / 資源枯渇 / 権限剥奪 / I/O エラー | `FsEvent::Error(WatcherFailure)` を `watcher-diagnostic`（`cacheMutating: false`）として FE へ配信し、error トーストで可視化する。`tasks_cache` と `revision` は変更しない | WARN |
@@ -759,5 +777,6 @@ pub enum WatcherError {
 
 | バージョン | 日付 | 変更内容 | 変更者 |
 |:-----------|:-----|:---------|:-------|
+| 1.3 | 2026-08-01 | Issue #458: `open_project` / `get_tasks` の `loadWarnings`、partial success、config fallback、full rescan における warnings 置換契約を追加 | - |
 | 1.2 | 2026-07-31 | Issue #453: `ProjectSession` aggregate、session-local revision CAS、project-scoped writer gate、staged watcher swap、session-scoped resources と stale event guard を追加 | - |
 | 1.1 | 2026-07-29 | `open_project` / `get_tasks` の milestone projection、同一 snapshot・board order、mutation / watcher resync の atomic 同期契約を追加 | - |

--- a/docs/spec-board/index.md
+++ b/docs/spec-board/index.md
@@ -93,6 +93,7 @@ flowchart TD
 | フロントマター | mdファイル冒頭のYAMLメタデータブロック（`---` で囲まれた部分） |
 | カラム | ボードビューにおけるステータス別の列。ユーザーが自由に定義可能 |
 | マイルストーン | タスクをリリース単位で束ねる横断メタ情報。frontmatter `milestone`（単数）で参照し、`.spec-board/milestones.yml` でメタ情報（表示名・期日・並び順・状態）を定義する |
+| ProjectLoadWarning | open_project / get_tasks が返す、部分的な読み込み失敗を code / stage / path / message / recoverable で表す warning。fatal error とは区別し、loaded board の注意パネルと要約 toast に表示する |
 | ProjectSession | 現在開いている 1 project の root / SessionId / session-local Revision / config / registries / tasks を単一 snapshot として扱うバックエンド aggregate。watcher handle と write-ignore は session version で紐づく別 resource として保持する |
 | IDEシェル | ヘッダー下を「左サイドバー｜メイン」に分割した IDE 風の画面構成。サイドバー（プロジェクトスイッチャー / ファイルツリー）・ビュー切替サブバー・横断フィルタ・外観切替から成る |
 | ビュー（表示形態） | ボード領域の表示形態。ボード / リスト / ツリー / カレンダーをサブバーで切り替える |
@@ -106,4 +107,5 @@ flowchart TD
 | 1.1 | 2026-05-31 | 画面区分（ボード / 設定）と設定画面のサブナビ基盤・ラベル読み取りタブを追加 | - |
 | 1.2 | 2026-06-07 | IDEシェル（サイドバー / ビュー切替サブバー / 横断フィルタ / 外観テーマ）を追加。検索・フィルタを MVP 採用へ昇格 | - |
 | 1.3 | 2026-06-21 | マイルストーン専用ビューの仕様書 ([milestone-view-spec.md](./milestone-view-spec.md)) を追加 | - |
+| 1.5 | 2026-08-01 | Issue #458: ProjectLoadWarning、partial success、読み込み注意パネルとwarnings通知を追加 | - |
 | 1.4 | 2026-07-31 | Issue #453: backend の ProjectSession aggregate / writer gate / revision CAS / staged watcher swap を仕様化。multi-project cache (#189)、wire redesign (#465)、OwnWriteGuard (#468)、path canonicalization は対象外 | - |

--- a/docs/spec-board/index.md
+++ b/docs/spec-board/index.md
@@ -107,5 +107,5 @@ flowchart TD
 | 1.1 | 2026-05-31 | 画面区分（ボード / 設定）と設定画面のサブナビ基盤・ラベル読み取りタブを追加 | - |
 | 1.2 | 2026-06-07 | IDEシェル（サイドバー / ビュー切替サブバー / 横断フィルタ / 外観テーマ）を追加。検索・フィルタを MVP 採用へ昇格 | - |
 | 1.3 | 2026-06-21 | マイルストーン専用ビューの仕様書 ([milestone-view-spec.md](./milestone-view-spec.md)) を追加 | - |
-| 1.5 | 2026-08-01 | Issue #458: ProjectLoadWarning、partial success、読み込み注意パネルとwarnings通知を追加 | - |
 | 1.4 | 2026-07-31 | Issue #453: backend の ProjectSession aggregate / writer gate / revision CAS / staged watcher swap を仕様化。multi-project cache (#189)、wire redesign (#465)、OwnWriteGuard (#468)、path canonicalization は対象外 | - |
+| 1.5 | 2026-08-01 | Issue #458: ProjectLoadWarning、partial success、読み込み注意パネルとwarnings通知を追加 | - |

--- a/src-tauri/crates/fs/src/task/file_scanner.rs
+++ b/src-tauri/crates/fs/src/task/file_scanner.rs
@@ -27,10 +27,10 @@ const BINARY_PROBE_LEN: usize = 8 * 1024;
 /// - 先頭が `.` のディレクトリ・ファイル（`.git` / `.vscode` / `.DS_Store` / `.hidden.md` 等）は除外
 /// - ディレクトリ名が `node_modules` のものは深さを問わず除外
 /// - シンボリックリンクは辿らない（リンク先は走査しない）
-/// - 非 UTF-8 のパスを含むエントリは保守的に除外（後続の Tauri / JSON 境界で扱えないため）
+/// - 非 UTF-8 のパスを含む `.md` 候補は `InvalidPath` warning として記録し、ほかのファイルの走査を継続
 /// - サイズが 1MB（1,048,576 byte）を超えるファイルは除外（1MB ちょうどは含める）
 /// - 先頭 8KB に NUL byte (0x00) を含むバイナリ判定ファイルは除外
-/// - ファイル単位の I/O エラー（権限不足 / metadata 取得失敗 / read 失敗等）は黙って skip し、走査を継続する
+/// - ファイル単位の I/O エラー（権限不足 / metadata 取得失敗 / read 失敗等）は warning に変換し、走査を継続
 /// - 返却される `PathBuf` は `root` からの相対パス
 ///
 /// 除外パターン（先頭ドット / `node_modules`）は **root 配下の子孫エントリにのみ適用** する。
@@ -44,6 +44,15 @@ const BINARY_PROBE_LEN: usize = 8 * 1024;
 /// - `root` 自体が存在しない、またはアクセスできない（権限不足等）
 /// - `root` がディレクトリでない（ファイル等）
 pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
+    Ok(scan_md_files_with_warnings(root)?.items)
+}
+
+/// 指定ディレクトリ配下の md ファイルと、採用できなかった個別エントリの warning を返す。
+///
+/// root 自体の I/O 失敗は従来どおり ScanError::Io として全体を失敗させる。
+/// 一方、root 配下の個別エントリに関する失敗は warning に変換し、他のファイルの
+/// 走査を継続する。
+pub fn scan_md_files_with_warnings(root: &Path) -> Result<ScanOutcome, ScanError> {
     let metadata = std::fs::metadata(root).map_err(|source| ScanError::Io {
         path: root.to_path_buf(),
         source,
@@ -54,9 +63,6 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
             source: std::io::Error::from(std::io::ErrorKind::NotADirectory),
         });
     }
-    // Unix では権限のないディレクトリでも `metadata` は成功するため、`read_dir` で
-    // root のアクセス可否を確定させる。per-entry の I/O エラーは後段で skip するので、
-    // ここで弾かないと「アクセス不可の root」が `Ok(vec![])` として返ってしまう。
     std::fs::read_dir(root).map_err(|source| ScanError::Io {
         path: root.to_path_buf(),
         source,
@@ -66,62 +72,123 @@ pub fn scan_md_files(root: &Path) -> Result<Vec<PathBuf>, ScanError> {
         .follow_links(false)
         .into_iter()
         .filter_entry(should_descend);
-
-    let mut results: Vec<PathBuf> = Vec::new();
+    let mut items = Vec::new();
+    let mut warnings = Vec::new();
 
     for entry_result in walker {
         let entry = match entry_result {
-            Ok(e) => e,
-            Err(_) => continue,
+            Ok(entry) => entry,
+            Err(error) => {
+                warnings.push(ScanWarning {
+                    code: ScanWarningCode::EntryError,
+                    path: error
+                        .path()
+                        .and_then(|path| relative_path_string(path, root)),
+                    message: error.to_string(),
+                });
+                continue;
+            }
         };
-        if !should_include(&entry) {
+        if !is_candidate_entry(&entry) {
             continue;
         }
-        if let Some(rel) = relative_path(entry.path(), root) {
-            results.push(rel);
+
+        if entry.path().to_str().is_none() {
+            warnings.push(ScanWarning {
+                code: ScanWarningCode::InvalidPath,
+                path: None,
+                message: format!(
+                    "path cannot be represented as UTF-8: {}",
+                    entry.path().to_string_lossy()
+                ),
+            });
+            continue;
+        }
+
+        let relative_path = match relative_path(entry.path(), root) {
+            Some(path) => path,
+            None => {
+                warnings.push(ScanWarning {
+                    code: ScanWarningCode::InvalidPath,
+                    path: None,
+                    message: format!(
+                        "path is outside the scan root or cannot be represented as UTF-8: {}",
+                        entry.path().to_string_lossy()
+                    ),
+                });
+                continue;
+            }
+        };
+        let relative = relative_path.to_string_lossy().into_owned();
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                warnings.push(ScanWarning {
+                    code: ScanWarningCode::MetadataError,
+                    path: Some(relative),
+                    message: error.to_string(),
+                });
+                continue;
+            }
+        };
+        if metadata.len() > MAX_FILE_SIZE {
+            warnings.push(ScanWarning {
+                code: ScanWarningCode::FileTooLarge,
+                path: Some(relative),
+                message: format!("file is larger than the {} byte limit", MAX_FILE_SIZE),
+            });
+            continue;
+        }
+        match probe_text(entry.path()) {
+            Ok(true) => items.push(relative_path),
+            Ok(false) => warnings.push(ScanWarning {
+                code: ScanWarningCode::BinaryFile,
+                path: Some(relative),
+                message: format!(
+                    "file contains a NUL byte in the first {} bytes",
+                    BINARY_PROBE_LEN
+                ),
+            }),
+            Err(error) => warnings.push(ScanWarning {
+                code: ScanWarningCode::UnreadableFile,
+                path: Some(relative),
+                message: error.to_string(),
+            }),
         }
     }
 
-    Ok(results)
+    Ok(ScanOutcome { items, warnings })
 }
 
-/// `WalkDir` のエントリ属性 / ファイル内容ベースのフィルタを満たすかを判定する。
-///
-/// 判定条件（早期 return 順、軽い判定 → 重い判定）:
-/// 1. root 自身ではない（`depth() > 0`）
-/// 2. 通常ファイル
-/// 3. 拡張子 `.md`（大文字小文字非区別）
-/// 4. サイズが [`MAX_FILE_SIZE`] byte 以下
-/// 5. 先頭 [`BINARY_PROBE_LEN`] byte に NUL byte を含まない
-///
-/// ドット始まり名（`.hidden.md` 等）の除外はここでは行わない。`scan_md_files`
-/// は walker に [`should_descend`] を `filter_entry` として渡しており、ドット始まり
-/// エントリはファイル・ディレクトリを問わず descend 段階で枝刈りされ、本関数には
-/// 到達しないため。
-///
-/// I/O 失敗（metadata 取得失敗 / open 失敗 / read 失敗）は `false`（除外側）として扱う。
-///
-/// **責務の境界**: 本関数はエントリ単体のフィルタのみを担当する。
-/// root 相対パスへの変換と UTF-8 表現可能性の確認は [`relative_path`] が担当し、
-/// 最終的にスキャン結果に含めるかは「`should_include` が `true` かつ `relative_path` が `Some`」の AND 条件で決まる。
-fn should_include(entry: &walkdir::DirEntry) -> bool {
-    if entry.depth() == 0 {
-        return false;
-    }
-    if !entry.file_type().is_file() {
-        return false;
-    }
-    let path = entry.path();
-    if !is_md_extension(path) {
-        return false;
-    }
-    if !is_size_within_limit(entry) {
-        return false;
-    }
-    if !is_text(path) {
-        return false;
-    }
-    true
+/// 走査中の per-entry warning code。
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ScanWarningCode {
+    EntryError,
+    MetadataError,
+    FileTooLarge,
+    BinaryFile,
+    InvalidPath,
+    UnreadableFile,
+}
+
+/// scanner が返す per-entry warning。
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScanWarning {
+    pub code: ScanWarningCode,
+    pub path: Option<String>,
+    pub message: String,
+}
+
+/// scanner の採用項目と warning の組。
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScanOutcome {
+    pub items: Vec<PathBuf>,
+    pub warnings: Vec<ScanWarning>,
+}
+
+/// `WalkDir` のエントリが通常の markdown ファイル候補かを判定する。
+fn is_candidate_entry(entry: &walkdir::DirEntry) -> bool {
+    entry.depth() > 0 && entry.file_type().is_file() && is_md_extension(entry.path())
 }
 
 /// `path` を `root` からの相対パスに変換し、UTF-8 として表現可能な場合のみ返す。
@@ -133,16 +200,8 @@ fn relative_path(path: &Path, root: &Path) -> Option<PathBuf> {
     Some(rel.to_path_buf())
 }
 
-/// エントリのサイズが上限以内（[`MAX_FILE_SIZE`] byte 以下）かを判定する。
-///
-/// `> MAX_FILE_SIZE` で除外するため 1,048,576 byte ちょうどは含める。
-/// metadata 取得に失敗した場合は false（除外側）を返す。
-/// `entry.metadata()` を使うことで walkdir 内部キャッシュを活用できる。
-fn is_size_within_limit(entry: &walkdir::DirEntry) -> bool {
-    match entry.metadata() {
-        Ok(m) => m.len() <= MAX_FILE_SIZE,
-        Err(_) => false,
-    }
+fn relative_path_string(path: &Path, root: &Path) -> Option<String> {
+    relative_path(path, root).and_then(|relative| relative.to_str().map(ToOwned::to_owned))
 }
 
 /// 先頭 [`BINARY_PROBE_LEN`] byte をプローブし、NUL byte を含まなければテキストと判定する。
@@ -150,28 +209,29 @@ fn is_size_within_limit(entry: &walkdir::DirEntry) -> bool {
 /// open / read に失敗した場合は false（除外側）を返す。
 /// プローブ範囲を超えた位置の NUL byte は判定対象外（仕様として固定）。
 /// 空ファイルは NUL byte なし扱いで true。
-fn is_text(path: &Path) -> bool {
-    let mut file = match File::open(path) {
-        Ok(f) => f,
-        Err(_) => return false,
-    };
+fn probe_text(path: &Path) -> std::io::Result<bool> {
+    let mut file = File::open(path)?;
     let mut buf = [0u8; BINARY_PROBE_LEN];
     let mut filled = 0usize;
     while filled < BINARY_PROBE_LEN {
         match file.read(&mut buf[filled..]) {
             Ok(0) => break,
             Ok(n) => filled += n,
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(_) => return false,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
         }
     }
-    !buf[..filled].contains(&0u8)
+    Ok(!buf[..filled].contains(&0u8))
+}
+
+fn is_text(path: &Path) -> bool {
+    probe_text(path).unwrap_or(false)
 }
 
 /// [`scan_md_files`] 実行時に発生し得る致命的エラー。
 ///
 /// 個別ファイル / ディレクトリ単位の I/O エラー（権限不足など）は本エラーには
-/// 含まれず、`scan_md_files` 内部で黙って skip される。
+/// 含まれず、`scan_md_files_with_warnings` の warning として返される。
 #[derive(Debug, Error)]
 pub enum ScanError {
     /// 走査のルートに関する I/O エラー（不在 / 権限不足 / ディレクトリでない 等）。
@@ -260,16 +320,14 @@ pub fn task_md_relative_path(abs_path: &Path, root: &Path) -> Option<PathBuf> {
 /// （root のディレクトリ名が `.workspace` や `node_modules` でも root 配下の探索を継続する）。
 /// 除外パターンは root 配下の子孫エントリにのみ適用する。
 ///
-/// 非 UTF-8 のエントリ名は本走査でも保守的に枝刈りする（`scan_md_files` の最終結果側でも
-/// 非 UTF-8 を除外するため重複チェックになるが、`filter_entry` 段階で pruning することで
-/// 非 UTF-8 ディレクトリ配下の不要な走査を避けられる）。
+/// 非 UTF-8 のエントリ名は `filter_entry` で枝刈りせず、`.md` 候補まで到達させる。
+/// その候補を `scan_md_files_with_warnings` が `InvalidPath` warning として報告する。
 fn should_descend(entry: &walkdir::DirEntry) -> bool {
     if entry.depth() == 0 {
         return true;
     }
-    let name = match entry.file_name().to_str() {
-        Some(s) => s,
-        None => return false,
+    let Some(name) = entry.file_name().to_str() else {
+        return true;
     };
     !is_excluded_entry_name(name)
 }

--- a/src-tauri/crates/fs/src/task/file_scanner_tests.rs
+++ b/src-tauri/crates/fs/src/task/file_scanner_tests.rs
@@ -439,3 +439,83 @@ fn scan_md_files_skips_unreadable_file_silently() {
         assert_eq!(collected, vec!["locked.md", "readable.md"]);
     }
 }
+
+// ── structured warnings ─────────────────────────────────────────
+
+#[test]
+fn scan_md_files_with_warnings_reports_rejected_entries() {
+    let dir = TempDir::new().unwrap();
+    make_file_with_bytes(dir.path(), "ok.md", b"ok");
+    make_file_with_bytes(dir.path(), "binary.md", b"hello\x00world");
+    make_file_with_size(dir.path(), "too-large.md", 1024 * 1024 + 1);
+
+    let outcome = scan_md_files_with_warnings(dir.path()).unwrap();
+
+    assert_eq!(collect_sorted_relative(&outcome.items), vec!["ok.md"]);
+    assert!(outcome.warnings.iter().any(|warning| {
+        warning.code == ScanWarningCode::BinaryFile && warning.path.as_deref() == Some("binary.md")
+    }));
+    assert!(outcome.warnings.iter().any(|warning| {
+        warning.code == ScanWarningCode::FileTooLarge
+            && warning.path.as_deref() == Some("too-large.md")
+    }));
+}
+
+#[cfg(unix)]
+#[test]
+fn scan_md_files_with_warnings_reports_invalid_utf8_paths() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let dir = TempDir::new().unwrap();
+    let invalid_name = OsString::from_vec(b"invalid\xff.md".to_vec());
+    std::fs::write(dir.path().join(&invalid_name), b"content").unwrap();
+
+    let outcome = scan_md_files_with_warnings(dir.path()).unwrap();
+
+    assert!(outcome.items.is_empty());
+    assert!(outcome
+        .warnings
+        .iter()
+        .any(|warning| { warning.code == ScanWarningCode::InvalidPath && warning.path.is_none() }));
+}
+
+#[cfg(unix)]
+#[test]
+fn scan_md_files_with_warnings_reports_unreadable_files_when_os_denies_read() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    make_file_with_bytes(dir.path(), "locked.md", b"secret");
+    let locked = dir.path().join("locked.md");
+    let mut permissions = std::fs::metadata(&locked).unwrap().permissions();
+    permissions.set_mode(0o000);
+    std::fs::set_permissions(&locked, permissions).unwrap();
+    let actually_unreadable = std::fs::File::open(&locked).is_err();
+
+    let outcome = scan_md_files_with_warnings(dir.path());
+
+    let mut restore = std::fs::metadata(&locked).unwrap().permissions();
+    restore.set_mode(0o644);
+    std::fs::set_permissions(&locked, restore).unwrap();
+
+    let outcome = outcome.unwrap();
+    if actually_unreadable {
+        assert!(outcome.warnings.iter().any(|warning| {
+            warning.code == ScanWarningCode::UnreadableFile
+                && warning.path.as_deref() == Some("locked.md")
+        }));
+    } else {
+        assert_eq!(collect_sorted_relative(&outcome.items), vec!["locked.md"]);
+    }
+}
+
+#[test]
+fn scan_md_files_with_warnings_keeps_root_errors_fatal() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("missing");
+
+    let error = scan_md_files_with_warnings(&missing).unwrap_err();
+
+    assert!(matches!(error, ScanError::Io { .. }));
+}

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -1,4 +1,5 @@
 pub mod intent;
+pub mod load_warning;
 pub mod open;
 pub mod project_root;
 pub(crate) mod watcher_factory;

--- a/src-tauri/src/project/load_warning.rs
+++ b/src-tauri/src/project/load_warning.rs
@@ -1,0 +1,140 @@
+use serde::Serialize;
+
+/// Project load で発生した recoverable warning の分類。
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProjectLoadWarningCode {
+    ScanEntryError,
+    MetadataError,
+    UnreadableFile,
+    FileTooLarge,
+    BinaryFile,
+    InvalidPath,
+    TaskReadFailed,
+    FrontmatterParseFailed,
+    ConfigFallback,
+    Unknown,
+}
+
+/// Project load warning が発生した処理段階。
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProjectLoadWarningStage {
+    Scan,
+    Read,
+    Parse,
+    Config,
+    Unknown,
+}
+
+/// Task として採用されなかった file/config の理由。
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectLoadWarning {
+    pub code: ProjectLoadWarningCode,
+    pub stage: ProjectLoadWarningStage,
+    pub path: Option<String>,
+    pub message: String,
+    pub recoverable: bool,
+}
+
+impl ProjectLoadWarning {
+    /// recoverable な warning を作る。
+    pub fn new(
+        code: ProjectLoadWarningCode,
+        stage: ProjectLoadWarningStage,
+        path: Option<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            stage,
+            path,
+            message: message.into(),
+            recoverable: true,
+        }
+    }
+
+    /// config fallback を表す warning を作る。
+    pub fn config_fallback(message: impl Into<String>) -> Self {
+        Self::new(
+            ProjectLoadWarningCode::ConfigFallback,
+            ProjectLoadWarningStage::Config,
+            Some(".spec-board/config.json".to_owned()),
+            message,
+        )
+    }
+}
+
+/// warning の重複を除去し、payload に安定した順序で返す。
+pub fn deduplicate_and_sort(mut warnings: Vec<ProjectLoadWarning>) -> Vec<ProjectLoadWarning> {
+    warnings.sort_by(|left, right| warning_sort_key(left).cmp(&warning_sort_key(right)));
+    warnings.dedup();
+    warnings
+}
+
+fn warning_sort_key(warning: &ProjectLoadWarning) -> (String, String, String, String) {
+    (
+        format!("{:?}", warning.stage),
+        warning.path.clone().unwrap_or_default(),
+        format!("{:?}", warning.code),
+        warning.message.clone(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        deduplicate_and_sort, ProjectLoadWarning, ProjectLoadWarningCode, ProjectLoadWarningStage,
+    };
+
+    #[test]
+    fn warning_serializes_with_camel_case_fields_and_code() {
+        let warning = ProjectLoadWarning::new(
+            ProjectLoadWarningCode::FrontmatterParseFailed,
+            ProjectLoadWarningStage::Parse,
+            Some("tasks/broken.md".to_owned()),
+            "frontmatter is invalid",
+        );
+
+        let value = serde_json::to_value(warning).expect("warning should serialize");
+
+        assert_eq!(value["code"], "frontmatterParseFailed");
+        assert_eq!(value["stage"], "parse");
+        assert_eq!(value["path"], "tasks/broken.md");
+        assert_eq!(value["message"], "frontmatter is invalid");
+        assert_eq!(value["recoverable"], true);
+    }
+
+    #[test]
+    fn config_fallback_uses_stable_config_path_and_stage() {
+        let warning = ProjectLoadWarning::config_fallback("invalid config");
+
+        assert_eq!(warning.code, ProjectLoadWarningCode::ConfigFallback);
+        assert_eq!(warning.stage, ProjectLoadWarningStage::Config);
+        assert_eq!(warning.path.as_deref(), Some(".spec-board/config.json"));
+        assert!(warning.recoverable);
+    }
+
+    #[test]
+    fn duplicate_warnings_are_removed_in_stable_order() {
+        let duplicate = ProjectLoadWarning::new(
+            ProjectLoadWarningCode::TaskReadFailed,
+            ProjectLoadWarningStage::Read,
+            Some("tasks/b.md".to_owned()),
+            "read failed",
+        );
+        let earlier = ProjectLoadWarning::new(
+            ProjectLoadWarningCode::TaskReadFailed,
+            ProjectLoadWarningStage::Read,
+            Some("tasks/a.md".to_owned()),
+            "read failed",
+        );
+
+        let warnings = deduplicate_and_sort(vec![duplicate.clone(), earlier, duplicate]);
+
+        assert_eq!(warnings.len(), 2);
+        assert_eq!(warnings[0].path.as_deref(), Some("tasks/a.md"));
+        assert_eq!(warnings[1].path.as_deref(), Some("tasks/b.md"));
+    }
+}

--- a/src-tauri/src/project/load_warning.rs
+++ b/src-tauri/src/project/load_warning.rs
@@ -68,17 +68,18 @@ impl ProjectLoadWarning {
 
 /// warning の重複を除去し、payload に安定した順序で返す。
 pub fn deduplicate_and_sort(mut warnings: Vec<ProjectLoadWarning>) -> Vec<ProjectLoadWarning> {
-    warnings.sort_by(|left, right| warning_sort_key(left).cmp(&warning_sort_key(right)));
+    warnings.sort_by_cached_key(warning_sort_key);
     warnings.dedup();
     warnings
 }
 
-fn warning_sort_key(warning: &ProjectLoadWarning) -> (String, String, String, String) {
+fn warning_sort_key(warning: &ProjectLoadWarning) -> (String, String, String, String, bool) {
     (
         format!("{:?}", warning.stage),
         warning.path.clone().unwrap_or_default(),
         format!("{:?}", warning.code),
         warning.message.clone(),
+        warning.recoverable,
     )
 }
 
@@ -136,5 +137,25 @@ mod tests {
         assert_eq!(warnings.len(), 2);
         assert_eq!(warnings[0].path.as_deref(), Some("tasks/a.md"));
         assert_eq!(warnings[1].path.as_deref(), Some("tasks/b.md"));
+    }
+
+    #[test]
+    fn warnings_that_differ_by_recoverable_are_not_deduplicated() {
+        let recoverable = ProjectLoadWarning::new(
+            ProjectLoadWarningCode::TaskReadFailed,
+            ProjectLoadWarningStage::Read,
+            Some("tasks/a.md".to_owned()),
+            "read failed",
+        );
+        let non_recoverable = ProjectLoadWarning {
+            recoverable: false,
+            ..recoverable.clone()
+        };
+
+        let warnings =
+            deduplicate_and_sort(vec![recoverable.clone(), non_recoverable, recoverable]);
+
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().any(|warning| !warning.recoverable));
     }
 }

--- a/src-tauri/src/project/open.rs
+++ b/src-tauri/src/project/open.rs
@@ -74,9 +74,10 @@ use std::sync::Arc;
 use crate::config::column_name::ColumnName;
 use crate::config::{
     label_registry_store, load_or_default, milestone_registry_store,
-    write_guide_markdown_best_effort, Column, Config, LabelRegistryStore, LoadConfigError,
-    LoadLabelsError, LoadMilestonesError, MilestoneRegistryStore,
+    write_guide_markdown_best_effort, Column, Config, LabelRegistryStore, LoadLabelsError,
+    LoadMilestonesError, MilestoneRegistryStore,
 };
+use crate::project::load_warning::{deduplicate_and_sort, ProjectLoadWarning};
 use crate::project::watcher_factory::{TauriWatcherFactory, WatcherFactory};
 use crate::project::OpenProjectIntent;
 use crate::project_session::{
@@ -90,7 +91,7 @@ use crate::state::{AppState, AppStateError, OpenSwapError};
 use crate::task::io::FsTaskIo;
 use crate::task::parse::{default_status_for, TaskParseError};
 use crate::task::projection::{MilestoneProjectionMap, TaskProjectionMap};
-use crate::task::rebuild::{rebuild_tasks_from_disk, RebuildTasksError};
+use crate::task::rebuild::{rebuild_tasks_from_disk_with_report, RebuildTasksError};
 use crate::task::task_index::{Task, TaskIndex};
 use spec_board_fs::task::file_scanner::ScanError;
 use spec_board_fs::watcher::core::WatcherError;
@@ -109,6 +110,8 @@ pub struct OpenProjectPayload {
     pub projections: TaskProjectionMap,
     /// milestone 名ごとの進捗と、`tasks` と同じ順序の所属 task path。
     pub milestone_projections: MilestoneProjectionMap,
+    /// project load 中に個別ファイルや config fallback で発生した warning。
+    pub load_warnings: Vec<ProjectLoadWarning>,
     /// watcher event の検証基準。`tasks` と**同一トランザクション**で確定した
     /// 値であることが必須（そうでないと FE が復旧不能な split-brain に陥る）。
     pub session: WatcherSession,
@@ -274,25 +277,35 @@ pub(crate) fn open_project_impl_with_reporter<W: WatcherFactory>(
     let target_gate = state.writer_gate(intent.root())?;
     let open_guard = state.lock_writer_gate(target_gate.as_ref())?;
 
-    let config = load_or_default(root).map_err(map_load_config_error)?;
+    let (config, mut load_warnings) = match load_or_default(root) {
+        Ok(config) => (config, Vec::new()),
+        Err(error) => (
+            Config::default(),
+            vec![ProjectLoadWarning::config_fallback(error.to_string())],
+        ),
+    };
     let labels = labels_store.load().map_err(map_load_labels_error)?;
     let milestones = milestones_store.load().map_err(map_load_milestones_error)?;
     let default_status = default_status_for(&config);
-    let tasks = rebuild_tasks_from_disk(root, &default_status, &FsTaskIo)
+    let rebuild = rebuild_tasks_from_disk_with_report(root, &default_status, &FsTaskIo)
         .map_err(|error| map_rebuild_error(error, raw_path))?;
+    load_warnings.extend(rebuild.warnings);
+    let load_warnings = deduplicate_and_sort(load_warnings);
 
     // backend/channel と paused worker の構築を resident state の変更前に完了する。
     let prepared_watcher = watcher.prepare(root)?;
-    let task_cache = tasks
+    let task_cache = rebuild
+        .tasks
         .into_iter()
         .map(|task| (PathBuf::from(task.file_path.as_str()), task))
         .collect();
-    let prepared_session = PreparedProjectSession::new(
+    let prepared_session = PreparedProjectSession::new_with_warnings(
         intent.root().clone(),
         config.clone(),
         labels,
         milestones,
         task_cache,
+        load_warnings,
     );
     let session_id = state.reserve_session_id()?;
     let candidate = prepared_session.into_session(session_id);
@@ -412,26 +425,6 @@ fn map_scan_error(err: ScanError, raw_path: &str) -> OpenProjectError {
     }
 }
 
-/// `LoadConfigError` を `category` 付きの `ConfigLoadFailed` に分類する。
-///
-/// - `Io` / `BackupFailed` → `category: "io"`
-/// - `Parse` / `UnknownFutureVersion` / `DuplicateColumnName` /
-///   `EmptyColumns` / `MigrationFailed` → `category: "parse"`
-fn map_load_config_error(err: LoadConfigError) -> OpenProjectError {
-    let category = match &err {
-        LoadConfigError::Io(_) | LoadConfigError::BackupFailed { .. } => "io",
-        LoadConfigError::Parse { .. }
-        | LoadConfigError::UnknownFutureVersion { .. }
-        | LoadConfigError::DuplicateColumnName { .. }
-        | LoadConfigError::EmptyColumns { .. }
-        | LoadConfigError::MigrationFailed { .. } => "parse",
-    };
-    OpenProjectError::ConfigLoadFailed {
-        category,
-        message: err.to_string(),
-    }
-}
-
 /// `LoadLabelsError` を `category` 付きの `LabelsLoadFailed` に分類する。
 ///
 /// - `Io` → `category: "io"`
@@ -488,12 +481,23 @@ fn map_hierarchy_error(err: TaskParseError) -> OpenProjectError {
 /// `columns` のいずれにも一致しない `status` のタスクは全カラムの後ろへ回す。
 fn build_payload(snapshot: ProjectSessionSnapshot, session: WatcherSession) -> OpenProjectPayload {
     let tasks = snapshot.tasks().values().cloned().collect();
-    build_payload_from_parts(tasks, snapshot.config(), session)
+    let load_warnings = snapshot.load_warnings().to_vec();
+    build_payload_from_parts_with_warnings(tasks, snapshot.config(), load_warnings, session)
 }
 
+#[cfg(test)]
 fn build_payload_from_parts(
     tasks: Vec<Task>,
     config: &Config,
+    session: WatcherSession,
+) -> OpenProjectPayload {
+    build_payload_from_parts_with_warnings(tasks, config, Vec::new(), session)
+}
+
+fn build_payload_from_parts_with_warnings(
+    tasks: Vec<Task>,
+    config: &Config,
+    load_warnings: Vec<ProjectLoadWarning>,
     session: WatcherSession,
 ) -> OpenProjectPayload {
     // 並び順の契約は aggregate に集約する（`get_tasks` も同じ入口を通す）。
@@ -516,6 +520,7 @@ fn build_payload_from_parts(
         columns,
         projections,
         milestone_projections,
+        load_warnings,
         session,
     }
 }

--- a/src-tauri/src/project/open_tests.rs
+++ b/src-tauri/src/project/open_tests.rs
@@ -615,66 +615,68 @@ fn updates_app_state_fields_on_success() {
 }
 
 #[test]
-fn config_load_failure_for_invalid_json_returns_parse_category() {
+fn config_load_failure_for_invalid_json_falls_back_with_warning() {
     let state = Arc::new(AppState::new());
     let dir = tempdir();
-    // 壊れた JSON
     write_config_json(dir.path(), "{ this is not json");
     let raw = dir.path().to_str().expect("utf-8").to_string();
 
-    let err = open_with_noop(Arc::clone(&state), &raw).expect_err("invalid config should fail");
+    let payload = open_with_noop(Arc::clone(&state), &raw)
+        .expect("invalid config should fall back to the default config");
 
-    match err {
-        OpenProjectError::ConfigLoadFailed {
-            category,
-            ref message,
-        } => {
-            assert_eq!("parse", category);
-            let display = err.to_string();
-            assert!(display.contains("parse"), "display: {display}");
-            assert!(!message.is_empty());
-        }
-        other => panic!("expected ConfigLoadFailed, got {other:?}"),
-    }
+    assert_eq!(Config::default().columns.len(), payload.columns.len());
+    assert_eq!(1, payload.load_warnings.len());
+    assert_eq!(
+        crate::project::load_warning::ProjectLoadWarningCode::ConfigFallback,
+        payload.load_warnings[0].code
+    );
+    assert_eq!(
+        crate::project::load_warning::ProjectLoadWarningStage::Config,
+        payload.load_warnings[0].stage
+    );
+    assert_eq!(
+        Some(".spec-board/config.json"),
+        payload.load_warnings[0].path.as_deref()
+    );
 }
 
 #[test]
-fn config_load_failure_for_empty_columns_returns_parse_category() {
+fn config_load_failure_for_empty_columns_falls_back_with_warning() {
     let state = Arc::new(AppState::new());
     let dir = tempdir();
     let config_json = r#"{ "version": 1, "columns": [], "cardOrder": {} }"#;
     write_config_json(dir.path(), config_json);
     let raw = dir.path().to_str().expect("utf-8").to_string();
 
-    let err = open_with_noop(Arc::clone(&state), &raw).expect_err("empty columns should fail");
+    let payload = open_with_noop(Arc::clone(&state), &raw)
+        .expect("invalid config validation should fall back to defaults");
 
-    match err {
-        OpenProjectError::ConfigLoadFailed { category, .. } => {
-            assert_eq!("parse", category);
-            assert!(err.to_string().contains("parse"));
-        }
-        other => panic!("expected ConfigLoadFailed, got {other:?}"),
-    }
+    assert_eq!(
+        Config::default().columns,
+        state.test_config().expect("readable").unwrap().columns
+    );
+    assert!(payload.load_warnings.iter().any(|warning| {
+        warning.code == crate::project::load_warning::ProjectLoadWarningCode::ConfigFallback
+            && warning.stage == crate::project::load_warning::ProjectLoadWarningStage::Config
+    }));
 }
 
 #[test]
-fn config_load_failure_when_spec_board_path_is_a_file_returns_io_category() {
+fn registry_load_failure_remains_fatal_when_spec_board_path_is_a_file() {
     let state = Arc::new(AppState::new());
     let dir = tempdir();
-    // .spec-board をファイルにしておく → config.json への読み込みが Io エラーになる。
     let spec_path = dir.path().join(".spec-board");
     fs::write(&spec_path, "not a directory").expect("write file at .spec-board");
     let raw = dir.path().to_str().expect("utf-8").to_string();
 
     let err =
-        open_with_noop(Arc::clone(&state), &raw).expect_err(".spec-board as file should fail");
+        open_with_noop(Arc::clone(&state), &raw).expect_err("registry load should remain fatal");
 
     match err {
-        OpenProjectError::ConfigLoadFailed { category, .. } => {
+        OpenProjectError::LabelsLoadFailed { category, .. } => {
             assert_eq!("io", category);
-            assert!(err.to_string().contains("io"));
         }
-        other => panic!("expected ConfigLoadFailed io, got {other:?}"),
+        other => panic!("expected LabelsLoadFailed io, got {other:?}"),
     }
 }
 
@@ -997,39 +999,29 @@ fn displaced_watcher_stop_observes_the_new_committed_session() {
 }
 
 #[test]
-fn previous_app_state_is_preserved_when_load_fails() {
-    // 1 回目の open で AppState を確定させる。
+fn project_state_is_replaced_when_config_falls_back() {
     let state = Arc::new(AppState::new());
     let first_dir = tempdir();
     write_md(first_dir.path(), "tasks/a.md", &task_md("A", "Todo", None));
-    let first_raw = first_dir.path().to_str().expect("utf-8").to_string();
-    open_with_noop(Arc::clone(&state), &first_raw).expect("first open should succeed");
+    open_with_noop(
+        Arc::clone(&state),
+        first_dir.path().to_str().expect("utf-8"),
+    )
+    .expect("first open should succeed");
 
-    let snapshot_before = state.test_tasks_snapshot().expect("readable");
-    let project_before = state.test_project_root().expect("readable");
-
-    // 2 回目の open は config 不正で失敗させる。
     let bad_dir = tempdir();
     write_config_json(bad_dir.path(), "{ this is not json");
-    let bad_raw = bad_dir.path().to_str().expect("utf-8").to_string();
-    let err = open_with_noop(Arc::clone(&state), &bad_raw)
-        .expect_err("second open with broken config should fail");
-    assert!(matches!(err, OpenProjectError::ConfigLoadFailed { .. }));
+    let payload = open_with_noop(Arc::clone(&state), bad_dir.path().to_str().expect("utf-8"))
+        .expect("config failure should not prevent opening the project");
 
-    // 失敗時に前のプロジェクト state がそのまま残ることを担保する。
-    let snapshot_after = state.test_tasks_snapshot().expect("readable");
-    let project_after = state.test_project_root().expect("readable");
-    assert_eq!(project_before, project_after);
-    assert_eq!(snapshot_before.len(), snapshot_after.len());
-    let file_paths_before: Vec<String> = snapshot_before
-        .iter()
-        .map(|t| t.file_path.as_str().to_string())
-        .collect();
-    let file_paths_after: Vec<String> = snapshot_after
-        .iter()
-        .map(|t| t.file_path.as_str().to_string())
-        .collect();
-    assert_eq!(file_paths_before, file_paths_after);
+    assert_eq!(
+        Some(bad_dir.path().to_path_buf()),
+        state.test_project_root().expect("readable")
+    );
+    assert!(state.test_tasks_snapshot().expect("readable").is_empty());
+    assert!(payload.load_warnings.iter().any(|warning| {
+        warning.code == crate::project::load_warning::ProjectLoadWarningCode::ConfigFallback
+    }));
 }
 
 #[test]
@@ -1039,6 +1031,7 @@ fn payload_serialization_uses_camel_case() {
         columns: vec!["Todo".into()],
         projections: TaskProjectionMap::new(),
         milestone_projections: MilestoneProjectionMap::new(),
+        load_warnings: Vec::new(),
         session: zero_session(),
     };
     let json = serde_json::to_string(&payload).expect("serialize");
@@ -1128,8 +1121,7 @@ fn open_project_payload_round_trip() {
     // OpenProjectPayload は #[derive(Serialize)] のみだが、JSON 形状互換を
     // round-trip で機械検証する。Deserialize を派生せずに `serde_json::Value`
     // 経由で再パースする。
-    let json =
-        r#"{"tasks":[],"columns":["Todo","Done"],"projections":{},"milestoneProjections":{}}"#;
+    let json = r#"{"tasks":[],"columns":["Todo","Done"],"projections":{},"milestoneProjections":{},"loadWarnings":[]}"#;
     #[derive(Debug, Deserialize, PartialEq)]
     #[serde(rename_all = "camelCase")]
     struct PayloadShape {
@@ -1137,6 +1129,7 @@ fn open_project_payload_round_trip() {
         columns: Vec<String>,
         projections: serde_json::Map<String, serde_json::Value>,
         milestone_projections: serde_json::Map<String, serde_json::Value>,
+        load_warnings: Vec<serde_json::Value>,
     }
     let parsed: PayloadShape = serde_json::from_str(json).unwrap();
     assert_eq!(parsed.tasks.len(), 0);
@@ -1150,12 +1143,13 @@ fn open_project_payload_round_trip() {
         columns: vec!["Todo".into(), "Done".into()],
         projections: TaskProjectionMap::new(),
         milestone_projections: MilestoneProjectionMap::new(),
+        load_warnings: Vec::new(),
         session: zero_session(),
     };
     let serialized = serde_json::to_string(&payload).unwrap();
     assert_eq!(
         serialized,
-        r#"{"tasks":[],"columns":["Todo","Done"],"projections":{},"milestoneProjections":{},"session":{"projectKey":"/tmp/project","generation":0,"revision":0,"eventSeq":0}}"#
+        r#"{"tasks":[],"columns":["Todo","Done"],"projections":{},"milestoneProjections":{},"loadWarnings":[],"session":{"projectKey":"/tmp/project","generation":0,"revision":0,"eventSeq":0}}"#
     );
 }
 

--- a/src-tauri/src/project_session/aggregate.rs
+++ b/src-tauri/src/project_session/aggregate.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use crate::config::{Config, LabelRegistry, MilestoneRegistry};
+use crate::project::load_warning::ProjectLoadWarning;
 use crate::project::project_root::ProjectRoot;
 use crate::task::task_index::Task;
 
@@ -137,6 +138,7 @@ pub struct PreparedProjectSession {
     labels: LabelRegistry,
     milestones: MilestoneRegistry,
     tasks: HashMap<PathBuf, Task>,
+    load_warnings: Vec<ProjectLoadWarning>,
 }
 
 impl PreparedProjectSession {
@@ -148,12 +150,25 @@ impl PreparedProjectSession {
         milestones: MilestoneRegistry,
         tasks: HashMap<PathBuf, Task>,
     ) -> Self {
+        Self::new_with_warnings(root, config, labels, milestones, tasks, Vec::new())
+    }
+
+    /// load warning を伴う open 用の prepared session を作る。
+    pub fn new_with_warnings(
+        root: ProjectRoot,
+        config: Config,
+        labels: LabelRegistry,
+        milestones: MilestoneRegistry,
+        tasks: HashMap<PathBuf, Task>,
+        load_warnings: Vec<ProjectLoadWarning>,
+    ) -> Self {
         Self {
             root,
             config,
             labels,
             milestones,
             tasks,
+            load_warnings,
         }
     }
 
@@ -168,6 +183,7 @@ impl PreparedProjectSession {
             labels: self.labels,
             milestones: self.milestones,
             tasks: self.tasks,
+            load_warnings: self.load_warnings,
         }
     }
 }
@@ -182,6 +198,7 @@ pub struct ProjectSession {
     labels: LabelRegistry,
     milestones: MilestoneRegistry,
     tasks: HashMap<PathBuf, Task>,
+    load_warnings: Vec<ProjectLoadWarning>,
 }
 
 impl ProjectSession {
@@ -213,6 +230,7 @@ impl ProjectSession {
             labels: self.labels.clone(),
             milestones: self.milestones.clone(),
             tasks: self.tasks.clone(),
+            load_warnings: self.load_warnings.clone(),
         }
     }
 
@@ -240,6 +258,16 @@ impl ProjectSession {
     /// 互換adapterまたはcommit closureがtask mapを差し替える。
     pub(crate) fn replace_tasks(&mut self, tasks: HashMap<PathBuf, Task>) {
         self.tasks = tasks;
+    }
+
+    /// task map と load warnings を同じ session commit で置き換える。
+    pub(crate) fn replace_tasks_and_load_warnings(
+        &mut self,
+        tasks: HashMap<PathBuf, Task>,
+        load_warnings: Vec<ProjectLoadWarning>,
+    ) {
+        self.tasks = tasks;
+        self.load_warnings = load_warnings;
     }
 
     /// 互換adapterまたはcommit closureへtask mapの可変参照を渡す。
@@ -280,6 +308,7 @@ pub struct ProjectSessionSnapshot {
     labels: LabelRegistry,
     milestones: MilestoneRegistry,
     tasks: HashMap<PathBuf, Task>,
+    load_warnings: Vec<ProjectLoadWarning>,
 }
 
 impl ProjectSessionSnapshot {
@@ -312,6 +341,11 @@ impl ProjectSessionSnapshot {
     /// snapshotのtask mapを返す。
     pub fn tasks(&self) -> &HashMap<PathBuf, Task> {
         &self.tasks
+    }
+
+    /// snapshot 時点の project load warnings を返す。
+    pub fn load_warnings(&self) -> &[ProjectLoadWarning] {
+        &self.load_warnings
     }
 
     /// project rootとversionを持つcommit比較用identityを作る。

--- a/src-tauri/src/project_session/conflict_recovery.rs
+++ b/src-tauri/src/project_session/conflict_recovery.rs
@@ -9,6 +9,7 @@ use crate::config::{
     Config, LabelRegistry, LabelRegistryStore, LoadConfigError, LoadLabelsError,
     LoadMilestonesError, MilestoneRegistry, MilestoneRegistryStore,
 };
+use crate::project::load_warning::{deduplicate_and_sort, ProjectLoadWarningStage};
 use crate::project::project_root::ProjectRoot;
 use crate::project_session::{ProjectSession, ProjectSessionSnapshot, SessionConflict};
 use crate::state::{AppState, AppStateError, SessionWriteError};
@@ -62,10 +63,14 @@ pub(crate) enum ResyncSource<'a> {
 
 /// I/O完了後に1回のaggregate commitで反映する復旧値。
 enum RecoveredAggregate {
-    Tasks(HashMap<PathBuf, Task>),
+    Tasks {
+        tasks: HashMap<PathBuf, Task>,
+        load_warnings: Vec<crate::project::load_warning::ProjectLoadWarning>,
+    },
     ConfigAndTasks {
         config: Config,
         tasks: HashMap<PathBuf, Task>,
+        load_warnings: Vec<crate::project::load_warning::ProjectLoadWarning>,
     },
     Labels(LabelRegistry),
     Milestones(MilestoneRegistry),
@@ -75,10 +80,17 @@ impl RecoveredAggregate {
     /// 事前構築済みの復旧値を失敗しないresident mutationとして適用する。
     fn apply(self, session: &mut ProjectSession) {
         match self {
-            Self::Tasks(tasks) => session.replace_tasks(tasks),
-            Self::ConfigAndTasks { config, tasks } => {
+            Self::Tasks {
+                tasks,
+                load_warnings,
+            } => session.replace_tasks_and_load_warnings(tasks, load_warnings),
+            Self::ConfigAndTasks {
+                config,
+                tasks,
+                load_warnings,
+            } => {
                 session.replace_config(config);
-                session.replace_tasks(tasks);
+                session.replace_tasks_and_load_warnings(tasks, load_warnings);
             }
             Self::Labels(labels) => session.replace_labels(labels),
             Self::Milestones(milestones) => session.replace_milestones(milestones),
@@ -92,6 +104,20 @@ fn tasks_by_path(tasks: Vec<Task>) -> HashMap<PathBuf, Task> {
         .into_iter()
         .map(|task| (PathBuf::from(task.file_path.as_str()), task))
         .collect()
+}
+
+fn merge_task_load_warnings(
+    snapshot: &ProjectSessionSnapshot,
+    warnings: Vec<crate::project::load_warning::ProjectLoadWarning>,
+) -> Vec<crate::project::load_warning::ProjectLoadWarning> {
+    let mut merged = snapshot
+        .load_warnings()
+        .iter()
+        .filter(|warning| warning.stage == ProjectLoadWarningStage::Config)
+        .cloned()
+        .collect::<Vec<_>>();
+    merged.extend(warnings);
+    deduplicate_and_sort(merged)
 }
 
 /// callerが保持するexact-root write lease内でsame-session stateを再同期する。
@@ -143,9 +169,15 @@ fn load_recovered_aggregate(
     match source {
         ResyncSource::Tasks { task_io } => {
             let default_status = default_status_for(snapshot.config());
-            let tasks =
-                crate::task::rebuild::rebuild_tasks_from_disk(root, &default_status, task_io)?;
-            Ok(RecoveredAggregate::Tasks(tasks_by_path(tasks)))
+            let report = crate::task::rebuild::rebuild_tasks_from_disk_with_report(
+                root,
+                &default_status,
+                task_io,
+            )?;
+            Ok(RecoveredAggregate::Tasks {
+                tasks: tasks_by_path(report.tasks),
+                load_warnings: merge_task_load_warnings(snapshot, report.warnings),
+            })
         }
         ResyncSource::ConfigAndTasks {
             task_io,
@@ -153,11 +185,15 @@ fn load_recovered_aggregate(
         } => {
             let config = load_config(root)?;
             let default_status = default_status_for(&config);
-            let tasks =
-                crate::task::rebuild::rebuild_tasks_from_disk(root, &default_status, task_io)?;
+            let report = crate::task::rebuild::rebuild_tasks_from_disk_with_report(
+                root,
+                &default_status,
+                task_io,
+            )?;
             Ok(RecoveredAggregate::ConfigAndTasks {
                 config,
-                tasks: tasks_by_path(tasks),
+                tasks: tasks_by_path(report.tasks),
+                load_warnings: deduplicate_and_sort(report.warnings),
             })
         }
         ResyncSource::Labels { store } => Ok(RecoveredAggregate::Labels(store.load()?)),

--- a/src-tauri/src/task/get.rs
+++ b/src-tauri/src/task/get.rs
@@ -29,6 +29,7 @@ use thiserror::Error;
 
 use super::projection::{MilestoneProjectionMap, TaskProjectionMap};
 use super::task_index::{Task, TaskIndex};
+use crate::project::load_warning::ProjectLoadWarning;
 use crate::state::watcher_session::WatcherSession;
 use crate::state::{AppState, AppStateError};
 
@@ -44,6 +45,7 @@ pub struct GetTasksPayload {
     pub projections: TaskProjectionMap,
     /// milestone 名ごとの進捗と、`tasks` と同じ順序の所属 task path。
     pub milestone_projections: MilestoneProjectionMap,
+    pub load_warnings: Vec<ProjectLoadWarning>,
     /// この snapshot の watcher session（`open_project` 応答と同じ形）。
     ///
     /// FE は resync 完了時にこの値で envelope 検証の baseline を丸ごと取り直す。
@@ -99,6 +101,7 @@ pub(crate) fn get_tasks_impl(state: &AppState) -> Result<GetTasksPayload, GetTas
             tasks: Vec::new(),
             projections: TaskProjectionMap::new(),
             milestone_projections: MilestoneProjectionMap::new(),
+            load_warnings: Vec::new(),
             session: WatcherSession::idle(),
         });
     };
@@ -116,6 +119,7 @@ pub(crate) fn get_tasks_impl(state: &AppState) -> Result<GetTasksPayload, GetTas
         tasks,
         projections,
         milestone_projections,
+        load_warnings: snapshot.load_warnings().to_vec(),
         session: state.watcher_session_for_snapshot(&snapshot),
     })
 }

--- a/src-tauri/src/task/rebuild.rs
+++ b/src-tauri/src/task/rebuild.rs
@@ -19,9 +19,14 @@
 
 use std::path::{Path, PathBuf};
 
-use spec_board_fs::task::file_scanner::{scan_md_files, ScanError};
+use spec_board_fs::task::file_scanner::{
+    scan_md_files_with_warnings, ScanError, ScanWarning, ScanWarningCode,
+};
 
 use crate::config::column_name::ColumnName;
+use crate::project::load_warning::{
+    deduplicate_and_sort, ProjectLoadWarning, ProjectLoadWarningCode, ProjectLoadWarningStage,
+};
 use crate::task::io::TaskIo;
 use crate::task::parse::{task_from_markdown, TaskParseContext, TaskParseError};
 use crate::task::task_index::{Task, TaskIndex};
@@ -35,37 +40,87 @@ pub enum RebuildTasksError {
     Hierarchy(#[from] TaskParseError),
 }
 
-/// root 配下を再走査して `Task` 一覧を再構築する。
-///
-/// 個々の md の read / parse 失敗は `log::warn!` して skip し、全体は成功させる。
-/// 1 ファイルの破損で project 全体のロードを落とさないため。scan 自体の失敗と
-/// 親チェーンの深さ超過のみ `Err` になる。
+/// disk 上の md から再構築した task と recoverable warning の組。
+#[derive(Debug, PartialEq)]
+pub struct TaskRebuildReport {
+    pub tasks: Vec<Task>,
+    pub warnings: Vec<ProjectLoadWarning>,
+}
+
+/// root 配下を再走査して Task 一覧だけを返す互換 wrapper。
 pub fn rebuild_tasks_from_disk(
     root: &Path,
     default_status: &ColumnName,
     io: &dyn TaskIo,
 ) -> Result<Vec<Task>, RebuildTasksError> {
-    let md_paths = scan_md_files(root)?;
-    let tasks = collect_tasks(root, &md_paths, default_status, io);
-    Ok(TaskIndex::new(tasks)
-        .rebuild_derived_with_warnings()?
-        .into_tasks())
+    Ok(rebuild_tasks_from_disk_with_report(root, default_status, io)?.tasks)
 }
 
-/// 走査結果の `.md` から `Task` を集める。
+/// root 配下を再走査して task と、走査・read・parse の warning を再構築する。
+///
+/// 個々の md の read / parse 失敗は warning に変換して skip し、全体は成功させる。
+/// scan root の失敗と親チェーンの深さ超過・循環だけは従来どおり Err になる。
+pub fn rebuild_tasks_from_disk_with_report(
+    root: &Path,
+    default_status: &ColumnName,
+    io: &dyn TaskIo,
+) -> Result<TaskRebuildReport, RebuildTasksError> {
+    let scan = scan_md_files_with_warnings(root)?;
+    let mut warnings: Vec<ProjectLoadWarning> = scan
+        .warnings
+        .into_iter()
+        .map(project_warning_from_scan)
+        .collect();
+    let (tasks, task_warnings) = collect_tasks(root, &scan.items, default_status, io);
+    warnings.extend(task_warnings);
+    let tasks = TaskIndex::new(tasks)
+        .rebuild_derived_with_warnings()?
+        .into_tasks();
+
+    Ok(TaskRebuildReport {
+        tasks,
+        warnings: deduplicate_and_sort(warnings),
+    })
+}
+
+fn project_warning_from_scan(warning: ScanWarning) -> ProjectLoadWarning {
+    let code = match warning.code {
+        ScanWarningCode::EntryError => ProjectLoadWarningCode::ScanEntryError,
+        ScanWarningCode::MetadataError => ProjectLoadWarningCode::MetadataError,
+        ScanWarningCode::FileTooLarge => ProjectLoadWarningCode::FileTooLarge,
+        ScanWarningCode::BinaryFile => ProjectLoadWarningCode::BinaryFile,
+        ScanWarningCode::InvalidPath => ProjectLoadWarningCode::InvalidPath,
+        ScanWarningCode::UnreadableFile => ProjectLoadWarningCode::UnreadableFile,
+    };
+    ProjectLoadWarning::new(
+        code,
+        ProjectLoadWarningStage::Scan,
+        warning.path,
+        warning.message,
+    )
+}
+
+/// 走査結果の md から Task と warning を集める。
 fn collect_tasks(
     root: &Path,
     md_paths: &[PathBuf],
     default_status: &ColumnName,
     io: &dyn TaskIo,
-) -> Vec<Task> {
+) -> (Vec<Task>, Vec<ProjectLoadWarning>) {
     let mut tasks = Vec::with_capacity(md_paths.len());
+    let mut warnings = Vec::new();
     for rel_path in md_paths {
         let absolute = root.join(rel_path);
         let bytes = match io.read(&absolute) {
             Ok(bytes) => bytes,
             Err(err) => {
-                log::warn!("failed to read task file `{}`: {err}", absolute.display());
+                log::warn!("failed to read task file {}: {err}", absolute.display());
+                warnings.push(ProjectLoadWarning::new(
+                    ProjectLoadWarningCode::TaskReadFailed,
+                    ProjectLoadWarningStage::Read,
+                    Some(rel_path.to_string_lossy().into_owned()),
+                    err.to_string(),
+                ));
                 continue;
             }
         };
@@ -76,11 +131,17 @@ fn collect_tasks(
         match task_from_markdown(&bytes, &context) {
             Ok(task) => tasks.push(task),
             Err(err) => {
-                log::warn!("failed to parse task file `{}`: {err}", absolute.display());
+                log::warn!("failed to parse task file {}: {err}", absolute.display());
+                warnings.push(ProjectLoadWarning::new(
+                    ProjectLoadWarningCode::FrontmatterParseFailed,
+                    ProjectLoadWarningStage::Parse,
+                    Some(rel_path.to_string_lossy().into_owned()),
+                    err.to_string(),
+                ));
             }
         }
     }
-    tasks
+    (tasks, warnings)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/task/rebuild_tests.rs
+++ b/src-tauri/src/task/rebuild_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::project::load_warning::{ProjectLoadWarningCode, ProjectLoadWarningStage};
+
 use std::path::Path;
 
 use tempfile::TempDir;
@@ -145,4 +147,93 @@ fn applies_the_same_file_filter_as_scan_md_files() {
         paths
     };
     assert_eq!(scanned, sorted_paths(&tasks));
+}
+
+#[test]
+fn report_contains_frontmatter_parse_warning_and_keeps_valid_tasks() {
+    let dir = TempDir::new().expect("tempdir");
+    write_md(dir.path(), "tasks/ok.md", &task_md("Ok"));
+    write_md(
+        dir.path(),
+        "tasks/broken.md",
+        "---\ntitle: [unclosed\n---\n",
+    );
+
+    let report = rebuild_tasks_from_disk_with_report(dir.path(), &todo(), &FsTaskIo)
+        .expect("rebuild report should succeed");
+
+    assert_eq!(vec!["tasks/ok.md".to_string()], sorted_paths(&report.tasks));
+    assert!(report.warnings.iter().any(|warning| {
+        warning.code == ProjectLoadWarningCode::FrontmatterParseFailed
+            && warning.stage == ProjectLoadWarningStage::Parse
+            && warning.path.as_deref() == Some("tasks/broken.md")
+            && warning.recoverable
+    }));
+}
+
+#[test]
+fn report_contains_task_read_warning_from_io_port() {
+    let dir = TempDir::new().expect("tempdir");
+    write_md(dir.path(), "tasks/ok.md", &task_md("Ok"));
+    write_md(dir.path(), "tasks/unreadable.md", &task_md("Unreadable"));
+    let io = InMemoryTaskIo::new();
+    io.pre_register_dir(&dir.path().join("tasks"));
+    io.write_new(&dir.path().join("tasks/ok.md"), task_md("Ok").as_bytes())
+        .expect("seed readable file");
+
+    let report = rebuild_tasks_from_disk_with_report(dir.path(), &todo(), &io)
+        .expect("rebuild report should succeed");
+
+    assert_eq!(vec!["tasks/ok.md".to_string()], sorted_paths(&report.tasks));
+    assert!(report.warnings.iter().any(|warning| {
+        warning.code == ProjectLoadWarningCode::TaskReadFailed
+            && warning.stage == ProjectLoadWarningStage::Read
+            && warning.path.as_deref() == Some("tasks/unreadable.md")
+    }));
+}
+
+#[test]
+fn report_maps_scan_warnings_and_keeps_normal_tasks() {
+    let dir = TempDir::new().expect("tempdir");
+    write_md(dir.path(), "tasks/ok.md", &task_md("Ok"));
+    let binary_path = dir.path().join("tasks/binary.md");
+    std::fs::write(&binary_path, b"binary\x00content").expect("write binary file");
+    let oversized_path = dir.path().join("tasks/oversized.md");
+    let oversized = std::fs::File::create(&oversized_path).expect("create oversized file");
+    oversized
+        .set_len(1024 * 1024 + 1)
+        .expect("resize oversized file");
+
+    let report = rebuild_tasks_from_disk_with_report(dir.path(), &todo(), &FsTaskIo)
+        .expect("rebuild report should succeed");
+
+    assert_eq!(vec!["tasks/ok.md".to_string()], sorted_paths(&report.tasks));
+    assert!(report.warnings.iter().any(|warning| {
+        warning.code == ProjectLoadWarningCode::BinaryFile
+            && warning.stage == ProjectLoadWarningStage::Scan
+            && warning.path.as_deref() == Some("tasks/binary.md")
+    }));
+    assert!(report.warnings.iter().any(|warning| {
+        warning.code == ProjectLoadWarningCode::FileTooLarge
+            && warning.stage == ProjectLoadWarningStage::Scan
+            && warning.path.as_deref() == Some("tasks/oversized.md")
+    }));
+}
+
+#[test]
+fn report_keeps_hierarchy_failure_fatal() {
+    let dir = TempDir::new().expect("tempdir");
+    for index in 0..21 {
+        let body = format!(
+            "---\ntitle: Task {index}\nstatus: Todo\nparent: tasks/{}.md\n---\n",
+            index + 1
+        );
+        write_md(dir.path(), &format!("tasks/{index}.md"), &body);
+    }
+    write_md(dir.path(), "tasks/21.md", &task_md("Root"));
+
+    let error = rebuild_tasks_from_disk_with_report(dir.path(), &todo(), &FsTaskIo)
+        .expect_err("hierarchy depth must remain fatal");
+
+    assert!(matches!(error, RebuildTasksError::Hierarchy(_)));
 }

--- a/src-tauri/src/watcher_event/handler.rs
+++ b/src-tauri/src/watcher_event/handler.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, RecvError};
 
+use crate::project::load_warning::{deduplicate_and_sort, ProjectLoadWarningStage};
 use crate::project_session::{ProjectSessionSnapshot, SessionIdentity};
 use crate::state::project_generation::ProjectGeneration;
 use crate::state::project_key::ProjectKey;
@@ -18,7 +19,7 @@ use crate::state::{AppStateError, ResourceAccessError, SessionResourceAccess, Se
 use crate::task::parse::{
     default_status_for, normalized_task_file_path, task_from_markdown, TaskParseContext,
 };
-use crate::task::rebuild::rebuild_tasks_from_disk;
+use crate::task::rebuild::rebuild_tasks_from_disk_with_report;
 use crate::task::task_file_path::TaskFilePath;
 use crate::task::task_index::Task;
 use crate::task::warning::has_parent_cycle_warning;
@@ -347,12 +348,12 @@ fn handle_rescan(
             return Ok(());
         };
         let default_status = default_status_for(snapshot.config());
-        let tasks = match rebuild_tasks_from_disk(
+        let report = match rebuild_tasks_from_disk_with_report(
             ctx.project_root.as_path(),
             &default_status,
             ctx.io.as_ref(),
         ) {
-            Ok(tasks) => tasks,
+            Ok(report) => report,
             Err(err) => {
                 log::warn!("watcher_event: full rescan failed: {err}");
                 return emit_diagnostic(
@@ -365,13 +366,22 @@ fn handle_rescan(
                 );
             }
         };
-        let cache: HashMap<PathBuf, Task> = tasks
+        let mut load_warnings = snapshot
+            .load_warnings()
+            .iter()
+            .filter(|warning| warning.stage == ProjectLoadWarningStage::Config)
+            .cloned()
+            .collect::<Vec<_>>();
+        load_warnings.extend(report.warnings);
+        let load_warnings = deduplicate_and_sort(load_warnings);
+        let cache: HashMap<PathBuf, Task> = report
+            .tasks
             .into_iter()
             .map(|task| (PathBuf::from(task.file_path.as_str()), task))
             .collect();
         let expected = snapshot.identity();
         let commit = match ctx.state.commit_session_write(&expected, move |session| {
-            session.replace_tasks(cache);
+            session.replace_tasks_and_load_warnings(cache, load_warnings);
         }) {
             Ok(committed) => RescanCommit::Committed(committed.identity().clone()),
             Err(SessionWriteError::Conflict(conflict)) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type LiveAnnouncement, LiveRegion } from "@/components/LiveRegion";
+import { ProjectLoadWarnings } from "@/components/ProjectLoadWarnings";
 import { buildTasksByNormalizedPath } from "@/domains/broken-link";
 import { LabelRegistry } from "@/domains/label-registry";
 import {
@@ -936,36 +937,39 @@ const AppShell = () => {
     // board-view spec に従う)。空プロジェクト時のガイダンスは Board 上に
     // 重ねて表示する。
     return (
-      <div className="relative flex flex-1 overflow-hidden">
-        <BoardWorkspace
-          // settings 表示中は BoardWorkspace が unmount されるため、settings→board 遷移で
-          // 必ず remount される。これにより useTaskFilter の useState 初期 seed が遷移ごとに
-          // 1 回適用される（key の追加はかえって seed→クリア→再 remount で seed 消失を招く
-          // ので付けない）。
-          columns={columns}
-          tasks={tasks}
-          tasksByNormalizedPath={tasksByNormalizedPath}
-          doneColumn={doneColumn}
-          projections={projections}
-          milestonesByName={milestonesResource.byName}
-          milestones={milestonesResource.milestones}
-          onAddTask={handleAddTask}
-          onAddColumn={handleAddColumn}
-          onRenameColumn={handleRenameColumn}
-          onDeleteColumn={handleDeleteColumn}
-          onTaskClick={handleTaskClick}
-          onTaskDrop={handleTaskDrop}
-          onColumnReorder={handleColumnReorder}
-          initialLabelFilter={pendingLabelFilter}
-          onLabelFilterApplied={handleLabelFilterApplied}
-        />
-        {tasks.length === 0 && (
-          <div className="pointer-events-none absolute inset-x-0 top-12 flex justify-center">
-            <p className="rounded bg-surface/90 px-4 py-2 text-sm text-muted shadow">
-              タスクがありません。「+追加」ボタンまたはmdファイルを作成してタスクを追加してください
-            </p>
-          </div>
-        )}
+      <div className="relative flex flex-1 flex-col overflow-hidden">
+        <ProjectLoadWarnings warnings={state.data.loadWarnings} />
+        <div className="relative flex min-h-0 flex-1 overflow-hidden">
+          <BoardWorkspace
+            // settings 表示中は BoardWorkspace が unmount されるため、settings→board 遷移で
+            // 必ず remount される。これにより useTaskFilter の useState 初期 seed が遷移ごとに
+            // 1 回適用される（key の追加はかえって seed→クリア→再 remount で seed 消失を招く
+            // ので付けない）。
+            columns={columns}
+            tasks={tasks}
+            tasksByNormalizedPath={tasksByNormalizedPath}
+            doneColumn={doneColumn}
+            projections={projections}
+            milestonesByName={milestonesResource.byName}
+            milestones={milestonesResource.milestones}
+            onAddTask={handleAddTask}
+            onAddColumn={handleAddColumn}
+            onRenameColumn={handleRenameColumn}
+            onDeleteColumn={handleDeleteColumn}
+            onTaskClick={handleTaskClick}
+            onTaskDrop={handleTaskDrop}
+            onColumnReorder={handleColumnReorder}
+            initialLabelFilter={pendingLabelFilter}
+            onLabelFilterApplied={handleLabelFilterApplied}
+          />
+          {tasks.length === 0 && (
+            <div className="pointer-events-none absolute inset-x-0 top-12 flex justify-center">
+              <p className="rounded bg-surface/90 px-4 py-2 text-sm text-muted shadow">
+                タスクがありません。「+追加」ボタンまたはmdファイルを作成してタスクを追加してください
+              </p>
+            </div>
+          )}
+        </div>
       </div>
     );
   };

--- a/src/__tests__/App.addLinkOptimistic.test.tsx
+++ b/src/__tests__/App.addLinkOptimistic.test.tsx
@@ -98,6 +98,7 @@ const makeTaskB = (): Task =>
   });
 
 const makePayload = (tasks: Task[]): OpenProjectPayload => ({
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks,
   columns: ["Todo", "Done"],

--- a/src/__tests__/App.bodyOptimistic.test.tsx
+++ b/src/__tests__/App.bodyOptimistic.test.tsx
@@ -91,6 +91,7 @@ const makeSeedTask = (body: string): Task =>
   });
 
 const makePayload = (seedTask: Task): OpenProjectPayload => ({
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [seedTask],
   columns: ["Todo", "Doing", "Done"],

--- a/src/__tests__/App.brokenLinkToast.test.tsx
+++ b/src/__tests__/App.brokenLinkToast.test.tsx
@@ -140,6 +140,7 @@ const taskClean = Task.fromPayload({
 });
 
 const payloadWithBroken: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskWithBrokenParent],
   columns: ["Todo", "Done"],
@@ -147,6 +148,7 @@ const payloadWithBroken: OpenProjectPayload = {
   milestoneProjections: new Map(),
 };
 const payloadClean: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskClean],
   columns: ["Todo", "Done"],

--- a/src/__tests__/App.createModalProps.test.tsx
+++ b/src/__tests__/App.createModalProps.test.tsx
@@ -169,6 +169,7 @@ const openProjectWithTasks = async () => {
       columns: ["Todo", "Done"],
       projections: new Map(),
       milestoneProjections: new Map(),
+      loadWarnings: [],
     }),
   );
   const buttons = container?.querySelectorAll("header button") ?? [];

--- a/src/__tests__/App.deleteOptimistic.test.tsx
+++ b/src/__tests__/App.deleteOptimistic.test.tsx
@@ -92,6 +92,7 @@ const makeSeedTask = (): Task =>
   });
 
 const makePayload = (seedTask: Task): OpenProjectPayload => ({
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [seedTask],
   columns: ["Todo", "Doing", "Done"],
@@ -394,6 +395,7 @@ test("削除 pending 中に open-start (project switch) が走ると pendingDele
   await act(async () => {
     resolveOpen(
       Result.ok({
+        loadWarnings: [],
         session: WATCHER_SESSION_FIXTURE,
         tasks: [],
         columns: ["Todo"],

--- a/src/__tests__/App.detailOptimistic.test.tsx
+++ b/src/__tests__/App.detailOptimistic.test.tsx
@@ -115,6 +115,7 @@ const taskA: Task = Task.fromPayload({
 });
 
 const payload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskA],
   columns: ["Todo", "Doing", "Done"],

--- a/src/__tests__/App.detailView.test.tsx
+++ b/src/__tests__/App.detailView.test.tsx
@@ -122,6 +122,7 @@ const taskA: Task = Task.fromPayload({
 });
 
 const payload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskA],
   columns: ["Todo", "Doing", "Done"],
@@ -352,6 +353,7 @@ test("detail 表示中にプロジェクト切替で選択タスク消失→boar
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/other"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [otherTask],
       columns: ["Todo", "Doing", "Done"],

--- a/src/__tests__/App.interaction.test.tsx
+++ b/src/__tests__/App.interaction.test.tsx
@@ -136,6 +136,7 @@ const taskA: Task = Task.fromPayload({
 });
 
 const payload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskA],
   columns: ["Todo", "Done"],
@@ -210,6 +211,7 @@ test("loaded で tasks が 0 件のとき EmptyState type=empty-project が表�
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [],
       columns: ["Todo", "Done"],
@@ -655,6 +657,7 @@ test("プロジェクト切替: A で task 選択中に B を開いても stale 
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/project-b"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [taskAInProjectB],
       columns: ["Todo", "Done"],
@@ -794,6 +797,7 @@ const childTask: Task = Task.fromPayload({
 });
 
 const parentChildPayload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [parentTask, childTask],
   columns: ["Todo", "Done"],

--- a/src/__tests__/App.labelOptimistic.test.tsx
+++ b/src/__tests__/App.labelOptimistic.test.tsx
@@ -96,6 +96,7 @@ const makeSeedTask = (labels: readonly string[]): Task =>
 
 /** open_project mock の返り値を seed task で構築する。 */
 const makePayload = (seedTask: Task): OpenProjectPayload => ({
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [seedTask],
   columns: ["Todo", "Doing", "Done"],

--- a/src/__tests__/App.labelUsageLink.test.tsx
+++ b/src/__tests__/App.labelUsageLink.test.tsx
@@ -86,6 +86,7 @@ const taskFeature: Task = Task.fromPayload({
 });
 
 const payload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskBug, taskFeature],
   columns: ["Todo", "Done"],

--- a/src/__tests__/App.live-region.test.tsx
+++ b/src/__tests__/App.live-region.test.tsx
@@ -132,6 +132,7 @@ const taskB: Task = Task.fromPayload({
 });
 
 const payload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskA, taskB],
   columns: ["Todo", "Done"],
@@ -314,6 +315,7 @@ test("drop 後の LiveRegion は同一の安定 DOM ノードを維持しつつ 
 // === column reorder ===
 
 const threeColumnPayload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [],
   columns: ["A", "B", "C"],
@@ -420,6 +422,7 @@ const openParentChildProject = async (): Promise<void> => {
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/pc"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [parentTask, childTask],
       columns: ["Todo", "Done"],
@@ -561,6 +564,7 @@ const openLinkedTasksProject = async (options?: {
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/pl"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [linkedA, linkedB],
       columns: ["Todo", "Done"],

--- a/src/__tests__/App.mutationFailureToast.test.tsx
+++ b/src/__tests__/App.mutationFailureToast.test.tsx
@@ -93,6 +93,7 @@ const openProjectRawPayload = {
   columns: ["Todo", "Doing", "Done"],
   projections: {},
   milestoneProjections: {},
+  loadWarnings: [],
   session: {
     projectKey: "/test/project",
     generation: 1,
@@ -107,6 +108,7 @@ const twoTaskRawPayload = {
   columns: ["Todo", "Doing", "Done"],
   projections: {},
   milestoneProjections: {},
+  loadWarnings: [],
   session: {
     projectKey: "/test/project",
     generation: 1,
@@ -292,6 +294,7 @@ const makeInvoke =
           tasks: [],
           projections: {},
           milestoneProjections: {},
+          loadWarnings: [],
           session: {
             projectKey: "/test/project",
             generation: 1,

--- a/src/__tests__/App.parseErrorToast.test.tsx
+++ b/src/__tests__/App.parseErrorToast.test.tsx
@@ -162,6 +162,7 @@ const taskWithBrokenLink = Task.fromPayload({
 });
 
 const payloadWithParseError: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskWithParseError],
   columns: ["Todo", "Done"],
@@ -169,6 +170,7 @@ const payloadWithParseError: OpenProjectPayload = {
   milestoneProjections: new Map(),
 };
 const payloadClean: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskClean],
   columns: ["Todo", "Done"],
@@ -176,6 +178,7 @@ const payloadClean: OpenProjectPayload = {
   milestoneProjections: new Map(),
 };
 const payloadWithBoth: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskWithParseError, taskWithBrokenLink],
   columns: ["Todo", "Done"],

--- a/src/__tests__/App.removeLinkOptimistic.test.tsx
+++ b/src/__tests__/App.removeLinkOptimistic.test.tsx
@@ -111,6 +111,7 @@ const makeTaskBReversed = (): Task =>
  * @returns OpenProjectPayload
  */
 const makePayload = (tasks: Task[]): OpenProjectPayload => ({
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks,
   columns: ["Todo", "Done"],

--- a/src/__tests__/App.subIssuePartialFailure.test.tsx
+++ b/src/__tests__/App.subIssuePartialFailure.test.tsx
@@ -89,6 +89,7 @@ const openProjectRawPayload = {
   columns: ["Todo", "Doing", "Done"],
   projections: {},
   milestoneProjections: {},
+  loadWarnings: [],
   session: {
     projectKey: "/test/project",
     generation: 1,
@@ -139,6 +140,7 @@ const makeInvoke =
           tasks: [],
           projections: {},
           milestoneProjections: {},
+          loadWarnings: [],
           session: {
             projectKey: "/test/project",
             generation: 1,

--- a/src/components/ProjectLoadWarnings/__tests__/index.rendering.test.tsx
+++ b/src/components/ProjectLoadWarnings/__tests__/index.rendering.test.tsx
@@ -1,0 +1,118 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, beforeEach, expect, test } from "vitest";
+import { ProjectLoadWarnings } from "@/components/ProjectLoadWarnings";
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+beforeAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+const warning = (
+  overrides: Partial<ProjectLoadWarning> = {},
+): ProjectLoadWarning => ({
+  code: "binaryFile",
+  stage: "scan",
+  path: "tasks/broken.md",
+  message: "バイナリファイルのため読み込めません",
+  recoverable: true,
+  ...overrides,
+});
+
+const render = (warnings: readonly ProjectLoadWarning[]) => {
+  act(() => {
+    root?.render(createElement(ProjectLoadWarnings, { warnings }));
+  });
+};
+
+test("warnings が空なら panel を描画しない", () => {
+  render([]);
+  expect(
+    container?.querySelector('[data-testid="project-load-warnings"]'),
+  ).toBeNull();
+});
+
+test("件数と展開後の path / stage / message を表示する", () => {
+  render([
+    warning(),
+    warning({
+      code: "frontmatterParseFailed",
+      stage: "parse",
+      path: "tasks/invalid.md",
+      message: "frontmatter is invalid",
+    }),
+  ]);
+  expect(container?.textContent).toContain("読み込み時の注意（2件）");
+  const details = container?.querySelector("details");
+  expect(details).not.toBeNull();
+  act(() => {
+    details?.setAttribute("open", "");
+    root?.render(
+      createElement(ProjectLoadWarnings, {
+        warnings: [
+          warning(),
+          warning({
+            code: "frontmatterParseFailed",
+            stage: "parse",
+            path: "tasks/invalid.md",
+            message: "frontmatter is invalid",
+          }),
+        ],
+      }),
+    );
+  });
+  expect(container?.textContent).toContain("tasks/invalid.md");
+  expect(container?.textContent).toContain("解析");
+  expect(container?.textContent).toContain("frontmatter is invalid");
+});
+
+test("unknown code、null path、空messageを安全に表示する", () => {
+  render([
+    warning({
+      code: "unknown",
+      stage: "unknown",
+      path: null,
+      message: "",
+    }),
+  ]);
+  expect(container?.textContent).toContain("読み込み警告");
+  expect(container?.textContent).toContain("プロジェクト全体");
+  expect(container?.textContent).toContain("詳細は確認できませんでした");
+});
+
+test("長いpathとmessageに折り返し用classとpolite live regionがある", () => {
+  render([
+    warning({
+      path: "tasks/".concat("a".repeat(240), ".md"),
+      message: "x".repeat(240),
+    }),
+  ]);
+  const panel = container?.querySelector<HTMLElement>(
+    '[data-testid="project-load-warnings"]',
+  );
+  expect(panel?.getAttribute("aria-live")).toBe("polite");
+  expect(container?.querySelector("code")?.className).toContain("break-all");
+  expect(container?.querySelector("p")?.className).toContain("break-words");
+});

--- a/src/components/ProjectLoadWarnings/index.tsx
+++ b/src/components/ProjectLoadWarnings/index.tsx
@@ -1,0 +1,65 @@
+import {
+  ProjectLoadWarning,
+  type ProjectLoadWarning as ProjectLoadWarningT,
+} from "@/domains/project-load-warning";
+
+type ProjectLoadWarningsProps = {
+  /** プロジェクトの最新 snapshot に含まれる読み込み警告。 */
+  warnings: readonly ProjectLoadWarningT[];
+};
+
+/** loaded board に表示する、展開可能な読み込み警告一覧。 */
+export const ProjectLoadWarnings = ({ warnings }: ProjectLoadWarningsProps) => {
+  if (warnings.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="project-load-warnings-title"
+      aria-live="polite"
+      data-testid="project-load-warnings"
+      className="mx-3 mt-3 shrink-0 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-sm"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <h2
+          id="project-load-warnings-title"
+          className="min-w-0 truncate font-medium text-warning-foreground"
+        >
+          読み込み時の注意（{warnings.length}件）
+        </h2>
+        <details className="min-w-0 shrink-0">
+          <summary className="cursor-pointer text-warning-foreground underline-offset-2 hover:underline">
+            原因を確認する
+          </summary>
+          <ul className="mt-2 max-w-full space-y-2 border-t border-warning/30 pt-2">
+            {warnings.map((warning) => {
+              const warningKey = ProjectLoadWarning.fingerprint([warning]);
+              return (
+                <li
+                  key={warningKey}
+                  className="min-w-0 rounded border border-warning/30 bg-surface/70 p-2"
+                >
+                  <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="font-medium text-warning-foreground">
+                      {ProjectLoadWarning.codeLabel(warning.code)}
+                    </span>
+                    <span className="text-muted">
+                      処理: {ProjectLoadWarning.stageLabel(warning.stage)}
+                    </span>
+                    <code className="min-w-0 max-w-full break-all text-xs text-muted">
+                      {warning.path ?? "プロジェクト全体"}
+                    </code>
+                  </div>
+                  <p className="mt-1 max-w-full whitespace-pre-wrap break-words text-muted">
+                    {warning.message || "詳細は確認できませんでした"}
+                  </p>
+                </li>
+              );
+            })}
+          </ul>
+        </details>
+      </div>
+    </section>
+  );
+};

--- a/src/domains/project-data/__tests__/applyCardOrderUpdated.behavior.test.ts
+++ b/src/domains/project-data/__tests__/applyCardOrderUpdated.behavior.test.ts
@@ -18,6 +18,7 @@ const dataOf = (
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 test("対象カラム内のタスクを filePaths 順に並べ替える", () => {

--- a/src/domains/project-data/__tests__/applyTaskCreatedReverseLinks.behavior.test.ts
+++ b/src/domains/project-data/__tests__/applyTaskCreatedReverseLinks.behavior.test.ts
@@ -21,6 +21,7 @@ test("applyTaskCreated は作成タスクの links 先 target の reverseLinkedF
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskCreated(data, created);
@@ -49,6 +50,7 @@ test("applyTaskCreated は既に reverse 済みの場合は重複追加しない
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskCreated(data, created);
@@ -69,6 +71,7 @@ test("applyTaskCreated は links 空のとき既存 task の reverse を変更�
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskCreated(data, created);
@@ -95,6 +98,7 @@ test("applyTaskCreated は reverse 同期しつつ parent children 同期も維�
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskCreated(data, created);

--- a/src/domains/project-data/__tests__/projectData.behavior.test.ts
+++ b/src/domains/project-data/__tests__/projectData.behavior.test.ts
@@ -25,6 +25,7 @@ test("applyTaskCreated は task を追加し parent task の children を同期�
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskCreated(data, child);
@@ -54,6 +55,7 @@ test("applyTaskCreated は parent children を二重追加しない", () => {
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskCreated(data, child);
@@ -78,6 +80,7 @@ test("applyTaskUpdated は originalFilePath に一致する task を差し替え
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/a.md", updated);
@@ -113,6 +116,7 @@ test("applyTaskUpdated は parent が変わったとき旧親 children から該
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/c.md", updated);
@@ -149,6 +153,7 @@ test("applyTaskUpdated は parent が変わったとき新親 children に該当
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/c.md", updated);
@@ -179,6 +184,7 @@ test("applyTaskUpdated は parent が新規付与されたとき新親 children 
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/c.md", updated);
@@ -209,6 +215,7 @@ test("applyTaskUpdated は parent が解除されたとき旧親 children から
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/c.md", updated);
@@ -238,6 +245,7 @@ test("applyTaskUpdated は originalFilePath が存在しないとき parent-sync
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(
@@ -283,6 +291,7 @@ test("applyTaskUpdated は rename + reparent で旧親から originalFilePath �
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/c.md", updated);
@@ -319,6 +328,7 @@ test("applyTaskUpdated は rename のみ（parent 不変）の場合も旧親の
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/c.md", updated);
@@ -352,6 +362,7 @@ test("applyTaskUpdated は parent 変更がなければ他 task 参照を維持�
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskUpdated(data, "tasks/c.md", updated);
@@ -381,6 +392,7 @@ test("applyTaskDeleted は task を削除し hierarchy と links から参照を
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.applyTaskDeleted(data, "tasks/c.md");
@@ -405,6 +417,7 @@ test("replaceColumns は status と doneColumn を rename に追従させる", (
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.replaceColumns(data, {
@@ -425,6 +438,7 @@ test("replaceColumns は指定された doneColumn を rename 追従より優先
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
 
   const next = ProjectData.replaceColumns(data, {
@@ -450,6 +464,7 @@ test("applyTaskUpdated は children 空の payload でも既存の childFilePath
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
   // watcher の task-updated / 非 parent の update_task はどちらも children: [] を返す。
   const updated = makeTask({
@@ -485,6 +500,7 @@ test("applyTaskUpdated は payload の parentFilePath を採用する", () => {
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
   const updated = makeTask({
     id: "c",

--- a/src/domains/project-data/__tests__/projectData.projections.test.ts
+++ b/src/domains/project-data/__tests__/projectData.projections.test.ts
@@ -55,6 +55,7 @@ const dataWith = (
   projections,
   milestoneProjections,
   openRequestId: 1,
+  loadWarnings: [],
 });
 
 const replaceTaskProjections = (

--- a/src/domains/project-data/__tests__/projectData.resync.test.ts
+++ b/src/domains/project-data/__tests__/projectData.resync.test.ts
@@ -4,6 +4,7 @@ import {
   type MilestoneProjectionMap,
 } from "@/domains/milestone-projection";
 import { ProjectData } from "@/domains/project-data";
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
 import {
   TaskProjection,
   type TaskProjectionMap,
@@ -59,6 +60,7 @@ const baseData = (
   projections,
   milestoneProjections,
   openRequestId: 7,
+  loadWarnings: [],
   watcherSession: session,
 });
 
@@ -252,4 +254,52 @@ test("tasks と両 Map が等価なら resyncTasks は ProjectData 参照を保�
 
   expect(next).toBe(data);
   expect(next.milestoneProjections.get("v1")).toBe(milestoneEntry);
+});
+
+const loadWarning = (message: string): ProjectLoadWarning => ({
+  code: "unreadableFile",
+  stage: "read",
+  path: "tasks/broken.md",
+  message,
+  recoverable: true,
+});
+
+test("同一fingerprintのloadWarningsではProjectDataと配列参照を保持する", () => {
+  const previous = [loadWarning("読めません")];
+  const data = {
+    ...baseData([Task.fromPayload(payload())], new Map()),
+    loadWarnings: previous,
+  };
+  const next = ProjectData.resyncTasks(data, {
+    tasks: [Task.fromPayload(payload())],
+    projections: new Map(),
+    milestoneProjections: new Map(),
+    loadWarnings: [loadWarning("読めません")],
+  });
+
+  expect(next).toBe(data);
+  expect(next.loadWarnings).toBe(previous);
+});
+
+test("loadWarningsは内容変更と空配列への遷移をatomicに反映する", () => {
+  const data = {
+    ...baseData([Task.fromPayload(payload())], new Map()),
+    loadWarnings: [loadWarning("最初")],
+  };
+  const changed = ProjectData.resyncTasks(data, {
+    tasks: [Task.fromPayload(payload())],
+    projections: new Map(),
+    milestoneProjections: new Map(),
+    loadWarnings: [loadWarning("次")],
+  });
+  const cleared = ProjectData.resyncTasks(changed, {
+    tasks: [Task.fromPayload(payload())],
+    projections: new Map(),
+    milestoneProjections: new Map(),
+    loadWarnings: [],
+  });
+
+  expect(changed.loadWarnings).toHaveLength(1);
+  expect(changed.loadWarnings[0].message).toBe("次");
+  expect(cleared.loadWarnings).toEqual([]);
 });

--- a/src/domains/project-data/index.ts
+++ b/src/domains/project-data/index.ts
@@ -3,6 +3,7 @@ import {
   type MilestoneProjectionMap,
 } from "@/domains/milestone-projection";
 import type { ProjectColumnsChange } from "@/domains/project-columns";
+import { ProjectLoadWarning } from "@/domains/project-load-warning";
 import { TaskHierarchy } from "@/domains/task-hierarchy";
 import { TaskLinks } from "@/domains/task-links";
 import { parentReferencesTaskPath } from "@/domains/task-path";
@@ -46,6 +47,8 @@ export type ProjectData = {
    * `openRequestId`（FE 採番）とは由来が異なる（BE 採番）ので混同しないこと。
    */
   watcherSession: WatcherSession;
+  /** open/get が返した、継続可能な読み込み警告。 */
+  loadWarnings: ProjectLoadWarning[];
 };
 
 /**
@@ -367,6 +370,15 @@ const applyTaskDeletedToTask = (task: Task, filePath: string): Task =>
     filePath,
   );
 
+const mergeLoadWarnings = (
+  previous: readonly ProjectLoadWarning[],
+  next: readonly ProjectLoadWarning[],
+): ProjectLoadWarning[] =>
+  ProjectLoadWarning.fingerprint(previous) ===
+  ProjectLoadWarning.fingerprint(next)
+    ? (previous as ProjectLoadWarning[])
+    : [...next];
+
 export const ProjectData = {
   /**
    * 作成された task を追加し、親 task の children も同期する。
@@ -496,15 +508,31 @@ export const ProjectData = {
   }),
 
   /**
-   * BE から再取得した両 projection を同じ snapshot として差し替える。
-   * tasks / columns には触れない（tasks の真実源は差分更新経路のまま）。
+   * BE から再取得した load warnings を差し替える。
+   * 同じ fingerprint の warning は既存の配列・要素参照を保持する。
    *
-   * 全エントリが等価なら **`data` そのもの**を返す。ここで `{ ...data }` を返すと
-   * `ProjectState.updateData` が新 state を作り、`store.dispatch` が listener を
-   * 無条件に通知して全ツリーが再レンダーする。
    * @param data - 現在の ProjectData
-   * @param snapshot - 再取得した task / milestone projection maps
-   * @returns 変化が無ければ `data` そのもの、あれば両 projections を反映した新 ProjectData
+   * @param loadWarnings - 再取得した load warnings
+   * @returns 変化が無ければ `data` そのもの、あれば warnings を反映した新 ProjectData
+   */
+  replaceLoadWarnings: (
+    data: ProjectData,
+    loadWarnings: ProjectLoadWarning[],
+  ): ProjectData => {
+    const merged = mergeLoadWarnings(data.loadWarnings, loadWarnings);
+    if (merged === data.loadWarnings) {
+      return data;
+    }
+    return { ...data, loadWarnings: merged };
+  },
+
+  /**
+   * BE から再取得した task / milestone projection maps を差し替える。
+   * 変更がなければ現在の ProjectData 参照を保持する。
+   *
+   * @param data - 現在の ProjectData
+   * @param snapshot - 再取得した projection maps
+   * @returns projection 更新後の ProjectData
    */
   replaceProjections: (
     data: ProjectData,
@@ -552,6 +580,7 @@ export const ProjectData = {
       tasks: Task[];
       projections: TaskProjectionMap;
       milestoneProjections: MilestoneProjectionMap;
+      loadWarnings?: ProjectLoadWarning[];
     },
   ): ProjectData => {
     const tasks = mergeTasks(data.tasks, snapshot.tasks);
@@ -563,14 +592,19 @@ export const ProjectData = {
       data.milestoneProjections,
       snapshot.milestoneProjections,
     );
+    const loadWarnings = mergeLoadWarnings(
+      data.loadWarnings,
+      snapshot.loadWarnings ?? data.loadWarnings,
+    );
     if (
       tasks === data.tasks &&
       projections === data.projections &&
-      milestoneProjections === data.milestoneProjections
+      milestoneProjections === data.milestoneProjections &&
+      loadWarnings === data.loadWarnings
     ) {
       return data;
     }
-    return { ...data, tasks, projections, milestoneProjections };
+    return { ...data, tasks, projections, milestoneProjections, loadWarnings };
   },
 
   /**

--- a/src/domains/project-load-warning/__tests__/projectLoadWarning.behavior.test.ts
+++ b/src/domains/project-load-warning/__tests__/projectLoadWarning.behavior.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "vitest";
+import {
+  ProjectLoadWarning,
+  type ProjectLoadWarningPayloadInput,
+} from "@/domains/project-load-warning";
+
+const payload = (
+  overrides: Partial<ProjectLoadWarningPayloadInput> = {},
+): ProjectLoadWarningPayloadInput => ({
+  code: "binaryFile",
+  stage: "scan",
+  path: "tasks/a.md",
+  message: "binary file",
+  recoverable: true,
+  ...overrides,
+});
+
+test("fromPayload は既知の code / stage と nullable path を保持する", () => {
+  expect(
+    ProjectLoadWarning.fromPayload(
+      payload({ code: "configFallback", stage: "config", path: null }),
+    ),
+  ).toEqual({
+    code: "configFallback",
+    stage: "config",
+    path: null,
+    message: "binary file",
+    recoverable: true,
+  });
+});
+
+test("fromPayload は未知の code / stage を unknown に丸める", () => {
+  expect(
+    ProjectLoadWarning.fromPayload(
+      payload({ code: "futureCode", stage: "futureStage" }),
+    ),
+  ).toMatchObject({ code: "unknown", stage: "unknown" });
+});
+
+test("fingerprint は順序に依存せず、内容の変更を区別する", () => {
+  const first = ProjectLoadWarning.fromPayload(payload());
+  const second = ProjectLoadWarning.fromPayload(
+    payload({ code: "unreadableFile", message: "permission denied" }),
+  );
+
+  expect(ProjectLoadWarning.fingerprint([first, second])).toBe(
+    ProjectLoadWarning.fingerprint([second, first]),
+  );
+  expect(ProjectLoadWarning.fingerprint([first])).not.toBe(
+    ProjectLoadWarning.fingerprint([second]),
+  );
+  expect(ProjectLoadWarning.fingerprint([])).toBe("[]");
+});

--- a/src/domains/project-load-warning/index.ts
+++ b/src/domains/project-load-warning/index.ts
@@ -1,0 +1,134 @@
+/** BE の `ProjectLoadWarningCode` に対応するロード警告コード。 */
+export type ProjectLoadWarningCode =
+  | "scanEntryError"
+  | "metadataError"
+  | "unreadableFile"
+  | "fileTooLarge"
+  | "binaryFile"
+  | "invalidPath"
+  | "taskReadFailed"
+  | "frontmatterParseFailed"
+  | "configFallback"
+  | "unknown";
+
+/** ロード警告が発生した処理段階。 */
+export type ProjectLoadWarningStage =
+  | "scan"
+  | "read"
+  | "parse"
+  | "config"
+  | "unknown";
+
+/** Tauri から受け取るロード警告の入力型。未知値を受け入れて正規化する。 */
+export type ProjectLoadWarningPayloadInput = {
+  readonly code: string;
+  readonly stage: string;
+  readonly path?: string | null;
+  readonly message: string;
+  readonly recoverable: boolean;
+};
+
+/** プロジェクト読み込み中に発生した、処理継続可能な警告。 */
+export type ProjectLoadWarning = {
+  readonly code: ProjectLoadWarningCode;
+  readonly stage: ProjectLoadWarningStage;
+  readonly path: string | null;
+  readonly message: string;
+  readonly recoverable: boolean;
+};
+
+const KNOWN_CODES = [
+  "scanEntryError",
+  "metadataError",
+  "unreadableFile",
+  "fileTooLarge",
+  "binaryFile",
+  "invalidPath",
+  "taskReadFailed",
+  "frontmatterParseFailed",
+  "configFallback",
+  "unknown",
+] as const satisfies readonly ProjectLoadWarningCode[];
+
+const KNOWN_STAGES = [
+  "scan",
+  "read",
+  "parse",
+  "config",
+  "unknown",
+] as const satisfies readonly ProjectLoadWarningStage[];
+
+const isKnownCode = (raw: string): raw is ProjectLoadWarningCode =>
+  (KNOWN_CODES as readonly string[]).includes(raw);
+
+const isKnownStage = (raw: string): raw is ProjectLoadWarningStage =>
+  (KNOWN_STAGES as readonly string[]).includes(raw);
+
+const warningSortKey = (warning: ProjectLoadWarning): string =>
+  JSON.stringify([
+    warning.code,
+    warning.stage,
+    warning.path,
+    warning.message,
+    warning.recoverable,
+  ]);
+
+/** ProjectLoadWarning の正規化・識別用 companion API。 */
+export const ProjectLoadWarning = {
+  /** 未知の code を unknown に丸める。 */
+  normalizeCode: (raw: string): ProjectLoadWarningCode =>
+    isKnownCode(raw) ? raw : "unknown",
+
+  /** 未知の stage を unknown に丸める。 */
+  normalizeStage: (raw: string): ProjectLoadWarningStage =>
+    isKnownStage(raw) ? raw : "unknown",
+
+  /** raw payload を UI が扱う domain 値へ変換する。 */
+  fromPayload: (
+    payload: ProjectLoadWarningPayloadInput,
+  ): ProjectLoadWarning => ({
+    code: ProjectLoadWarning.normalizeCode(payload.code),
+    stage: ProjectLoadWarning.normalizeStage(payload.stage),
+    path: payload.path ?? null,
+    message: payload.message,
+    recoverable: payload.recoverable,
+  }),
+
+  /** 警告 code の安定した日本語表示名を返す。 */
+  codeLabel: (code: ProjectLoadWarningCode): string => {
+    const labels: Record<ProjectLoadWarningCode, string> = {
+      scanEntryError: "走査エラー",
+      metadataError: "メタデータ取得失敗",
+      unreadableFile: "読み取り不可",
+      fileTooLarge: "ファイルサイズ超過",
+      binaryFile: "バイナリファイル",
+      invalidPath: "無効なパス",
+      taskReadFailed: "タスク読み取り失敗",
+      frontmatterParseFailed: "フロントマター解析失敗",
+      configFallback: "設定の既定値適用",
+      unknown: "読み込み警告",
+    };
+    return labels[code];
+  },
+
+  /** 警告 stage の安定した日本語表示名を返す。 */
+  stageLabel: (stage: ProjectLoadWarningStage): string => {
+    const labels: Record<ProjectLoadWarningStage, string> = {
+      scan: "走査",
+      read: "読み取り",
+      parse: "解析",
+      config: "設定",
+      unknown: "不明",
+    };
+    return labels[stage];
+  },
+
+  /** 同じ警告集合かどうかを参照に依存せず判定するための安定 fingerprint。 */
+  fingerprint: (warnings: readonly ProjectLoadWarning[]): string =>
+    JSON.stringify(
+      [...warnings]
+        .map(warningSortKey)
+        .sort()
+        .map((key) => JSON.parse(key) as unknown[]),
+    ),
+} as const;

--- a/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.projectionIdentity.test.tsx
+++ b/src/features/board/components/TaskCard/TaskCardRoot/__tests__/TaskCardRoot.projectionIdentity.test.tsx
@@ -144,6 +144,7 @@ test("等価な projections で再同期しても Context Value は同一参照"
     projections: withParent(0, 1),
     milestoneProjections: new Map(),
     openRequestId: 1,
+    loadWarnings: [],
   };
   const merged = ProjectDataDomain.replaceProjections(data, {
     projections: withParent(0, 1),

--- a/src/lib/tauri/index.ts
+++ b/src/lib/tauri/index.ts
@@ -1,4 +1,12 @@
 // columnCommands
+
+// taskCommands
+export type {
+  ProjectLoadWarning,
+  ProjectLoadWarningCode,
+  ProjectLoadWarningPayloadInput,
+  ProjectLoadWarningStage,
+} from "@/domains/project-load-warning";
 export { getColumns } from "./columnCommands/getColumns";
 export type {
   ColumnRename,
@@ -40,8 +48,6 @@ export type {
   UpdateMilestoneArgs,
 } from "./milestoneCommands/types";
 export { updateMilestone } from "./milestoneCommands/updateMilestone";
-
-// taskCommands
 export { createTask } from "./taskCommands/createTask";
 export { deleteTask } from "./taskCommands/deleteTask";
 export { getTasks } from "./taskCommands/getTasks";

--- a/src/lib/tauri/taskCommands/getTasks/__tests__/getTasks.behavior.test.ts
+++ b/src/lib/tauri/taskCommands/getTasks/__tests__/getTasks.behavior.test.ts
@@ -27,6 +27,7 @@ const emptyRawPayload = {
   tasks: [],
   projections: {},
   milestoneProjections: {},
+  loadWarnings: [],
   session: {
     projectKey: "/home/user/specs",
     generation: 1,
@@ -68,6 +69,7 @@ test("成功時は tasks と projections を持つ payload を返す", async () 
         taskFilePaths: ["tasks/x.md"],
       },
     },
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 1,
@@ -103,6 +105,7 @@ test("projections は Map に変換される", async () => {
       },
     },
     milestoneProjections: {},
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 1,
@@ -129,6 +132,7 @@ test("tasks / projections が空でも成功する", async () => {
       tasks: [],
       projections: new Map(),
       milestoneProjections: new Map(),
+      loadWarnings: [],
       session: {
         projectKey: "/home/user/specs",
         generation: 1,
@@ -184,6 +188,7 @@ test("session の 4 フィールドが domain 型として透過する", async (
     tasks: [],
     projections: {},
     milestoneProjections: {},
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 3,
@@ -207,6 +212,7 @@ test("session の値が 0 でも欠落しない", async () => {
     tasks: [],
     projections: {},
     milestoneProjections: {},
+    loadWarnings: [],
     session: {
       projectKey: "",
       generation: 0,
@@ -223,4 +229,31 @@ test("session の値が 0 でも欠落しない", async () => {
     revision: 0,
     eventSeq: 0,
   });
+});
+
+test("unknown warning code / stage と null path は mapper で安全な domain 値になる", async () => {
+  vi.mocked(invoke).mockResolvedValue({
+    ...emptyRawPayload,
+    loadWarnings: [
+      {
+        code: "futureWarningCode",
+        stage: "futureStage",
+        path: null,
+        message: "unknown warning",
+        recoverable: true,
+      },
+    ],
+  });
+
+  const result = await getTasks();
+
+  expect(Result.isOk(result) && result.value.loadWarnings).toEqual([
+    {
+      code: "unknown",
+      stage: "unknown",
+      path: null,
+      message: "unknown warning",
+      recoverable: true,
+    },
+  ]);
 });

--- a/src/lib/tauri/taskCommands/getTasks/index.ts
+++ b/src/lib/tauri/taskCommands/getTasks/index.ts
@@ -1,4 +1,5 @@
 import { MilestoneProjection } from "@/domains/milestone-projection";
+import { ProjectLoadWarning } from "@/domains/project-load-warning";
 import { TaskProjection } from "@/domains/task-projection";
 import { WatcherSession } from "@/domains/watcher-session";
 import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
@@ -18,6 +19,7 @@ const toGetTasksPayload = (payload: GetTasksRawPayload): GetTasksPayload => ({
   milestoneProjections: MilestoneProjection.fromPayload(
     payload.milestoneProjections,
   ),
+  loadWarnings: payload.loadWarnings.map(ProjectLoadWarning.fromPayload),
   session: WatcherSession.fromPayload(payload.session),
 });
 

--- a/src/lib/tauri/taskCommands/openProject/__tests__/openProject.behavior.test.ts
+++ b/src/lib/tauri/taskCommands/openProject/__tests__/openProject.behavior.test.ts
@@ -33,6 +33,7 @@ test("invoke が 'open_project' という command 名で呼ばれる", async () 
     columns: [],
     projections: {},
     milestoneProjections: {},
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 1,
@@ -50,6 +51,7 @@ test("引数オブジェクト { path } がそのまま invoke 第 2 引数に�
     columns: [],
     projections: {},
     milestoneProjections: {},
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 1,
@@ -81,6 +83,7 @@ test("成功時は Result.ok({ tasks, columns, projections }) を返す", async 
         taskFilePaths: ["tasks/x.md"],
       },
     },
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 1,
@@ -114,6 +117,7 @@ test("成功時は Result.ok({ tasks, columns, projections }) を返す", async 
           },
         ],
       ]),
+      loadWarnings: [],
       session: {
         projectKey: "/home/user/specs",
         generation: 1,
@@ -130,6 +134,7 @@ test("projections が空オブジェクトでも成功する", async () => {
     columns: ["Todo"],
     projections: {},
     milestoneProjections: {},
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 1,
@@ -147,6 +152,7 @@ test("projections が空オブジェクトでも成功する", async () => {
       columns: ["Todo"],
       projections: new Map(),
       milestoneProjections: new Map(),
+      loadWarnings: [],
       session: {
         projectKey: "/home/user/specs",
         generation: 1,
@@ -170,6 +176,7 @@ test("milestoneProjections は特殊名と task path 順序を保つ Map に変�
     columns: [],
     projections: {},
     milestoneProjections,
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 1,
@@ -236,6 +243,7 @@ test.each([
     columns: [],
     projections: {},
     milestoneProjections: {},
+    loadWarnings: [],
     session: {
       projectKey: "/home/user/specs",
       generation: 3,
@@ -258,4 +266,40 @@ test("invoke が Err なら session 変換は走らず Result.err になる", as
   const result = await openProject({ path: "/x" });
 
   expect(Result.isOk(result)).toBe(false);
+});
+
+test("unknown warning code / stage と null path は mapper で安全な domain 値になる", async () => {
+  vi.mocked(invoke).mockResolvedValue({
+    tasks: [],
+    columns: [],
+    projections: {},
+    milestoneProjections: {},
+    loadWarnings: [
+      {
+        code: "futureWarningCode",
+        stage: "futureStage",
+        path: null,
+        message: "unknown warning",
+        recoverable: true,
+      },
+    ],
+    session: {
+      projectKey: "/home/user/specs",
+      generation: 1,
+      revision: 1,
+      eventSeq: 0,
+    },
+  });
+
+  const result = await openProject({ path: "/abs" });
+
+  expect(Result.isOk(result) && result.value.loadWarnings).toEqual([
+    {
+      code: "unknown",
+      stage: "unknown",
+      path: null,
+      message: "unknown warning",
+      recoverable: true,
+    },
+  ]);
 });

--- a/src/lib/tauri/taskCommands/openProject/index.ts
+++ b/src/lib/tauri/taskCommands/openProject/index.ts
@@ -1,4 +1,5 @@
 import { MilestoneProjection } from "@/domains/milestone-projection";
+import { ProjectLoadWarning } from "@/domains/project-load-warning";
 import { TaskProjection } from "@/domains/task-projection";
 import { WatcherSession } from "@/domains/watcher-session";
 import { invokeWrapped } from "@/lib/tauri/invokeWrapped";
@@ -25,6 +26,7 @@ const toOpenProjectPayload = (
   milestoneProjections: MilestoneProjection.fromPayload(
     payload.milestoneProjections,
   ),
+  loadWarnings: payload.loadWarnings.map(ProjectLoadWarning.fromPayload),
   session: WatcherSession.fromPayload(payload.session),
 });
 

--- a/src/lib/tauri/taskCommands/types.ts
+++ b/src/lib/tauri/taskCommands/types.ts
@@ -4,6 +4,10 @@ import type {
 } from "@/domains/milestone-projection";
 import type { Priority } from "@/domains/priority";
 import type {
+  ProjectLoadWarning,
+  ProjectLoadWarningPayloadInput,
+} from "@/domains/project-load-warning";
+import type {
   TaskProjectionMap,
   TaskProjectionPayloadInput,
   TaskProjectionsPayloadInput,
@@ -45,6 +49,8 @@ export type OpenProjectPayload = {
   projections: TaskProjectionMap;
   /** milestone 名 -> live progress / board-order task paths */
   milestoneProjections: MilestoneProjectionMap;
+  /** プロジェクト読み込み中に継続可能だった警告 */
+  loadWarnings: ProjectLoadWarning[];
   /** watcher event 検証の初期 baseline（tasks と同一トランザクションの値） */
   session: WatcherSession;
 };
@@ -59,6 +65,8 @@ export type OpenProjectRawPayload = {
   projections: TaskProjectionsPayload;
   /** milestone 名をキーにした projection の raw payload */
   milestoneProjections: MilestoneProjectionsPayloadInput;
+  /** プロジェクト読み込み中に継続可能だった警告 */
+  loadWarnings: ProjectLoadWarningPayloadInput[];
   /** watcher session の raw payload */
   session: WatcherSessionPayload;
 };
@@ -75,6 +83,8 @@ export type GetTasksPayload = {
   projections: TaskProjectionMap;
   /** milestone 名 -> live progress / board-order task paths */
   milestoneProjections: MilestoneProjectionMap;
+  /** プロジェクト読み込み中に継続可能だった警告 */
+  loadWarnings: ProjectLoadWarning[];
   /** この snapshot の watcher session（envelope 検証の baseline 再設定用） */
   session: WatcherSession;
 };
@@ -87,6 +97,8 @@ export type GetTasksRawPayload = {
   projections: TaskProjectionsPayload;
   /** milestone 名をキーにした projection の raw payload */
   milestoneProjections: MilestoneProjectionsPayloadInput;
+  /** プロジェクト読み込み中に継続可能だった警告 */
+  loadWarnings: ProjectLoadWarningPayloadInput[];
   /** watcher session の raw payload */
   session: WatcherSessionPayload;
 };

--- a/src/providers/ProjectNotificationsProvider/__tests__/ProjectNotificationsProvider.interaction.test.tsx
+++ b/src/providers/ProjectNotificationsProvider/__tests__/ProjectNotificationsProvider.interaction.test.tsx
@@ -1,6 +1,7 @@
 import { act, createElement, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, expect, test } from "vitest";
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
 import { WATCHER_SESSION_FIXTURE } from "@/domains/watcher-session/__tests__/fixture";
 import { TauriError } from "@/lib/tauri";
 import type { ProjectData } from "@/providers/ProjectProvider";
@@ -58,6 +59,7 @@ const dataOf = (tasks: Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 /** 購読者へ ProjectEvent を配信できる制御可能なイベント基盤。 */
@@ -232,6 +234,68 @@ test("unmount 後は購読が解除されイベントを受け取らない", () 
   });
   root = null;
   expect(harness.listenerCount()).toBe(0);
+});
+
+const warningOf = (message: string): ProjectLoadWarning => ({
+  code: "unreadableFile",
+  stage: "read",
+  path: "tasks/a.md",
+  message,
+  recoverable: true,
+});
+
+test("loaded の loadWarnings は件数の要約toastを出す", () => {
+  const harness = createEventsHarness();
+  setup(harness.value);
+  act(() => {
+    harness.emit({
+      type: "loaded",
+      path: "/proj",
+      data: {
+        ...dataOf([makeTask()]),
+        loadWarnings: [warningOf("読めません")],
+      },
+    });
+  });
+  expect(bodyText()).toContain("読み込み時の注意が 1 件あります");
+});
+
+test("同一path・同一fingerprintのwarningsは再通知しない", () => {
+  const harness = createEventsHarness();
+  setup(harness.value);
+  const warnings = [warningOf("読めません")];
+  act(() => {
+    harness.emit({ type: "load-warnings-updated", path: "/proj", warnings });
+    harness.emit({
+      type: "load-warnings-updated",
+      path: "/proj",
+      warnings: [...warnings],
+    });
+  });
+  expect(bodyText().match(/読み込み時の注意が 1 件あります/g)).toHaveLength(1);
+});
+
+test("rescanでwarningsの内容が変わると再通知し、空配列では通知しない", () => {
+  const harness = createEventsHarness();
+  setup(harness.value);
+  act(() => {
+    harness.emit({
+      type: "load-warnings-updated",
+      path: "/proj",
+      warnings: [warningOf("最初")],
+    });
+    harness.emit({
+      type: "load-warnings-updated",
+      path: "/proj",
+      warnings: [warningOf("次")],
+    });
+    harness.emit({
+      type: "load-warnings-updated",
+      path: "/proj",
+      warnings: [],
+    });
+  });
+  expect(bodyText().match(/読み込み時の注意が 1 件あります/g)).toHaveLength(2);
 });
 
 // ───────── watcher diagnostics ─────────

--- a/src/providers/ProjectNotificationsProvider/index.tsx
+++ b/src/providers/ProjectNotificationsProvider/index.tsx
@@ -1,9 +1,10 @@
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 import {
   buildTasksByNormalizedPath,
   countTasksWithBrokenLink,
 } from "@/domains/broken-link";
 import { countTasksWithParseError } from "@/domains/parse-error";
+import { ProjectLoadWarning } from "@/domains/project-load-warning";
 import {
   type ProjectEvent,
   projectErrorMessage,
@@ -12,6 +13,7 @@ import {
 } from "@/providers/ProjectProvider";
 import { useRecentProjects } from "@/providers/RecentProjectsProvider";
 import { useToastDispatch } from "@/providers/ToastProvider";
+import { projectLoadWarningMessage } from "./projectLoadWarningMessage";
 import { watcherDiagnosticMessage } from "./watcherDiagnosticMessage";
 
 /** ProjectNotificationsProvider の Props。 */
@@ -36,8 +38,28 @@ export const ProjectNotificationsProvider = ({
   const { subscribe } = useProjectEvents();
   const { showToast } = useToastDispatch();
   const { add: addRecentProject } = useRecentProjects();
+  const lastWarningToastRef = useRef<{
+    path: string;
+    fingerprint: string;
+  } | null>(null);
 
   useEffect(() => {
+    const notifyLoadWarnings = (
+      path: string,
+      warnings: ProjectLoadWarning[],
+    ): void => {
+      const fingerprint = ProjectLoadWarning.fingerprint(warnings);
+      const previous = lastWarningToastRef.current;
+      lastWarningToastRef.current = { path, fingerprint };
+      if (warnings.length === 0) {
+        return;
+      }
+      if (previous?.path === path && previous.fingerprint === fingerprint) {
+        return;
+      }
+      showToast(projectLoadWarningMessage(warnings), "warning");
+    };
+
     const handleEvent = (event: ProjectEvent): void => {
       if (event.type === "loaded") {
         addRecentProject(event.path);
@@ -53,6 +75,11 @@ export const ProjectNotificationsProvider = ({
         if (parseErrorCount >= 1) {
           showToast(`パースエラーが ${parseErrorCount} 件あります`, "warning");
         }
+        notifyLoadWarnings(event.path, event.data.loadWarnings);
+        return;
+      }
+      if (event.type === "load-warnings-updated") {
+        notifyLoadWarnings(event.path, event.warnings);
         return;
       }
       if (event.type === "watcher-diagnostic") {

--- a/src/providers/ProjectNotificationsProvider/projectLoadWarningMessage/index.ts
+++ b/src/providers/ProjectNotificationsProvider/projectLoadWarningMessage/index.ts
@@ -1,0 +1,6 @@
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
+
+/** ProjectLoadWarning の一覧を要約する warning toast 文言を返す。 */
+export const projectLoadWarningMessage = (
+  warnings: readonly ProjectLoadWarning[],
+): string => `読み込み時の注意が ${warnings.length} 件あります`;

--- a/src/providers/ProjectProvider/__tests__/ProjectProvider.contract.test.tsx
+++ b/src/providers/ProjectProvider/__tests__/ProjectProvider.contract.test.tsx
@@ -177,6 +177,7 @@ test("subscribe より前に emit されたイベントは届かない（replay 
 test("StrictMode 下で mount → remount 後も openProjectByPath が loaded に到達する", async () => {
   openProjectMock.mockResolvedValue(
     Result.ok<OpenProjectPayload>({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [
         Task.fromPayload({

--- a/src/providers/ProjectProvider/__tests__/ProjectProvider.interaction.test.tsx
+++ b/src/providers/ProjectProvider/__tests__/ProjectProvider.interaction.test.tsx
@@ -288,6 +288,7 @@ const taskB: Task = Task.fromPayload({
 });
 
 const payload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskA],
   columns: ["Todo", "Done"],
@@ -325,6 +326,7 @@ test("openProject 成功 (idle → loaded)、get_columns 成功時はその colu
       ],
       doneColumn: "Done",
       projections: new Map(),
+      loadWarnings: payload.loadWarnings,
       milestoneProjections: payload.milestoneProjections,
       openRequestId: 1,
       watcherSession: WATCHER_SESSION_FIXTURE,
@@ -413,6 +415,7 @@ test("openProject 成功 → onLoaded が path / data 付きで 1 回だけ発�
       ],
       doneColumn: "Done",
       projections: new Map(),
+      loadWarnings: payload.loadWarnings,
       milestoneProjections: payload.milestoneProjections,
       openRequestId: 1,
       watcherSession: WATCHER_SESSION_FIXTURE,
@@ -487,6 +490,7 @@ test("openProjectByPath 成功 → onLoaded が path / data 付きで発火す�
       ],
       doneColumn: "Done",
       projections: new Map(),
+      loadWarnings: payload.loadWarnings,
       milestoneProjections: payload.milestoneProjections,
       openRequestId: 1,
       watcherSession: WATCHER_SESSION_FIXTURE,
@@ -645,6 +649,7 @@ test("openProject 後勝ち: 1 回目の invoke pending 中に 2 回目が来る
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/b"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [taskB],
       columns: ["Done"],
@@ -678,6 +683,7 @@ test("openProject 後勝ち: 1 回目の invoke pending 中に 2 回目が来る
   await act(async () => {
     resolveInvokeA(
       Result.ok({
+        loadWarnings: [],
         session: WATCHER_SESSION_FIXTURE,
         tasks: [],
         columns: [],
@@ -1496,6 +1502,7 @@ test("プロジェクト切替で旧 listen が unlisten され、新 listen が
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/q"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [taskB],
       columns: ["Done"],
@@ -1575,6 +1582,7 @@ test("open-start 直後の race: loading 中に旧 callback が発火しても p
   await act(async () => {
     resolveInvoke(
       Result.ok({
+        loadWarnings: [],
         session: WATCHER_SESSION_FIXTURE,
         tasks: [taskB],
         columns: ["Done"],
@@ -1698,6 +1706,7 @@ test("プロジェクト切替で旧 task-updated unlisten + 新 listen が登�
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/q"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [taskB],
       columns: ["Done"],
@@ -1827,6 +1836,7 @@ test("open-start 直後の race: loading 中に旧 task-updated callback が発�
   await act(async () => {
     resolveInvoke(
       Result.ok({
+        loadWarnings: [],
         session: WATCHER_SESSION_FIXTURE,
         tasks: [taskB],
         columns: ["Done"],
@@ -1948,6 +1958,7 @@ test("プロジェクト切替で旧 task-deleted unlisten + 新 listen が登�
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/q"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [taskB],
       columns: ["Done"],
@@ -2019,6 +2030,7 @@ test("open-start 直後の race: loading 中に旧 task-deleted callback が発�
   await act(async () => {
     resolveInvoke(
       Result.ok({
+        loadWarnings: [],
         session: WATCHER_SESSION_FIXTURE,
         tasks: [taskB],
         columns: ["Done"],
@@ -2114,6 +2126,7 @@ test("parent あり task の filePath 削除で子の parent も未設定にな�
   openDirectoryDialogMock.mockResolvedValueOnce(Result.ok("/p"));
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [taskA, childTask],
       columns: ["Todo", "Done"],
@@ -2182,6 +2195,7 @@ test("rename シーケンス: task-deleted handler → task-created handler 連�
 // === reorderColumns ===
 
 const threeColumnPayload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [],
   columns: ["A", "B", "C"],

--- a/src/providers/ProjectProvider/__tests__/ProjectProvider.projectionSync.test.tsx
+++ b/src/providers/ProjectProvider/__tests__/ProjectProvider.projectionSync.test.tsx
@@ -100,6 +100,7 @@ const openPayload: OpenProjectPayload = {
     ],
   ]),
   milestoneProjections: new Map([["M1", initialMilestoneProjection]]),
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
 };
 
@@ -144,6 +145,7 @@ const getTasksOk = (
     tasks: [],
     projections,
     milestoneProjections,
+    loadWarnings: [],
     session: WATCHER_SESSION_FIXTURE,
   });
 
@@ -349,6 +351,7 @@ test("応答の tasks は state に反映されない（tasks の真実源は差
       tasks: [Task.fromPayload(makeTaskPayload("tasks/zzz.md", "Z"))],
       projections: new Map(),
       milestoneProjections: new Map(),
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
     }),
   );

--- a/src/providers/ProjectProvider/__tests__/ProjectProvider.state.test.ts
+++ b/src/providers/ProjectProvider/__tests__/ProjectProvider.state.test.ts
@@ -50,6 +50,7 @@ const dataA: ProjectData = {
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 };
 
 const dataB: ProjectData = {
@@ -59,6 +60,7 @@ const dataB: ProjectData = {
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 };
 
 const loadedAState: ProjectState = {
@@ -186,6 +188,7 @@ test("task-created (parent あり) → 親タスクの children に新規 filePa
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const child = makeTask({
@@ -217,6 +220,7 @@ test("task-created (parent 表記ゆれあり) → 親タスクの children に�
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const child = makeTask({
@@ -248,6 +252,7 @@ test("task-created (parent あり) で親が既に children を持っていれ�
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const child = makeTask({
@@ -323,6 +328,7 @@ test("task-deleted → 削除 filePath を他 task の links / reverseLinks か�
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   // b を削除すると、a の links と reverseLinks から tasks/b.md が消える
@@ -371,6 +377,7 @@ test("task-deleted → orphanStrategy=clear 整合: 子の parent を未設定�
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   // 親 (p) を削除した場合、子 (c) の parent と other (o) の children をクリア
@@ -417,6 +424,7 @@ test("task-deleted → parent 表記ゆれがある子の parent も未設定に
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
 
@@ -466,6 +474,7 @@ test("columns-replaced: doneColumn が rename 対象なら自動追従する", (
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const next = reducer(loaded, {
@@ -489,6 +498,7 @@ test("columns-replaced: action.doneColumn 指定時はそれが採用される (
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const next = reducer(loaded, {
@@ -512,6 +522,7 @@ test("columns-replaced: doneColumn / renames 未指定時は既存値を維持",
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const next = reducer(loaded, {
@@ -588,6 +599,7 @@ test("card-order-updated → 対象カラムの tasks が filePaths 順に並ぶ
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const next = reducer(loaded, {
@@ -617,6 +629,7 @@ test("card-order-updated → 他カラムの tasks 順序は不変", () => {
       projections: new Map(),
       milestoneProjections: new Map(),
       openRequestId: 0,
+      loadWarnings: [],
     },
   };
   const next = reducer(loaded, {
@@ -712,6 +725,7 @@ test("tasks-resynced は tasks と両 projection map を更新し columns は変
     tasks: [makeTask({ id: "z", filePath: "tasks/z.md", status: "Done" })],
     projections,
     milestoneProjections,
+    loadWarnings: [],
   });
 
   expect(next.kind).toBe("loaded");
@@ -734,6 +748,7 @@ test("state-replaced は ProjectData 全体を置き換え、tasks-resynced は 
     tasks: dataB.tasks,
     projections: dataB.projections,
     milestoneProjections: dataB.milestoneProjections,
+    loadWarnings: [],
   });
 
   const replacedData = replaced.kind === "loaded" ? replaced.data : undefined;
@@ -750,6 +765,7 @@ test("非 loaded state への tasks-resynced は無視される", () => {
     tasks: dataB.tasks,
     projections: new Map(),
     milestoneProjections: new Map(),
+    loadWarnings: [],
   });
 
   expect(next).toBe(idle);

--- a/src/providers/ProjectProvider/__tests__/ProjectProvider.watcher.test.tsx
+++ b/src/providers/ProjectProvider/__tests__/ProjectProvider.watcher.test.tsx
@@ -67,6 +67,7 @@ const taskA: Task = Task.fromPayload({
 });
 
 const payload: OpenProjectPayload = {
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
   tasks: [taskA],
   columns: ["Todo"],
@@ -246,6 +247,7 @@ test("loadedPath と異なる path の stale handler の event は無視され�
   // 別 project /other へ切替える。/p 用 handler は古い path を掴んだままになる。
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
+      loadWarnings: [],
       session: WATCHER_SESSION_FIXTURE,
       tasks: [],
       columns: ["Todo"],

--- a/src/providers/ProjectProvider/__tests__/ProjectProvider.watcherResync.test.tsx
+++ b/src/providers/ProjectProvider/__tests__/ProjectProvider.watcherResync.test.tsx
@@ -112,6 +112,7 @@ const openPayload: OpenProjectPayload = {
   columns: ["Todo"],
   projections: initialTaskProjections,
   milestoneProjections: initialMilestoneProjections,
+  loadWarnings: [],
   session: WATCHER_SESSION_FIXTURE,
 };
 
@@ -127,6 +128,7 @@ const getTasksOk = (
     tasks,
     projections,
     milestoneProjections,
+    loadWarnings: [],
     session: {
       ...WATCHER_SESSION_FIXTURE,
       revision,
@@ -509,6 +511,7 @@ test("応答の session が別世代なら dispatch されない", async () => {
       tasks: [Task.fromPayload(makeTaskPayload("tasks/other.md", "O"))],
       projections: taskProjectionMap(1, 1),
       milestoneProjections: milestoneProjectionMap(1, 1, ["tasks/other.md"]),
+      loadWarnings: [],
       session: {
         ...WATCHER_SESSION_FIXTURE,
         generation: WATCHER_SESSION_FIXTURE.generation + 1,
@@ -623,6 +626,7 @@ test("旧 project の resync が未解決でも、新 session の要求は塞が
       tasks: [],
       projections: qOpenProjections,
       milestoneProjections: qOpenMilestoneProjections,
+      loadWarnings: [],
       session: {
         ...WATCHER_SESSION_FIXTURE,
         generation: WATCHER_SESSION_FIXTURE.generation + 1,
@@ -650,6 +654,7 @@ test("旧 project の resync が未解決でも、新 session の要求は塞が
       tasks: [Task.fromPayload(makeTaskPayload("tasks/q.md", "Q"))],
       projections: qResyncProjections,
       milestoneProjections: qResyncMilestoneProjections,
+      loadWarnings: [],
       session: {
         ...WATCHER_SESSION_FIXTURE,
         generation: WATCHER_SESSION_FIXTURE.generation + 1,
@@ -784,6 +789,7 @@ test("旧 project の応答が新 session の resync より先に着地しても
   openProjectMock.mockResolvedValueOnce(
     Result.ok({
       ...openPayload,
+      loadWarnings: [],
       session: { ...WATCHER_SESSION_FIXTURE, generation: nextGeneration },
     }),
   );
@@ -842,6 +848,7 @@ test("旧 project の応答が新 session の resync より先に着地しても
         tasks: [taskA],
         projections: new Map(),
         milestoneProjections: new Map(),
+        loadWarnings: [],
         session: {
           ...WATCHER_SESSION_FIXTURE,
           generation: nextGeneration,

--- a/src/providers/ProjectProvider/__tests__/probeEventBridge.ts
+++ b/src/providers/ProjectProvider/__tests__/probeEventBridge.ts
@@ -19,7 +19,10 @@ export const bridgeProjectEvent = (
     onLoaded?.({ path: event.path, data: event.data });
     return;
   }
-  if (event.type === "watcher-diagnostic") {
+  if (
+    event.type === "watcher-diagnostic" ||
+    event.type === "load-warnings-updated"
+  ) {
     return;
   }
   onError?.(event.error);

--- a/src/providers/ProjectProvider/__tests__/useTaskWatcherEffects.lifecycle.test.tsx
+++ b/src/providers/ProjectProvider/__tests__/useTaskWatcherEffects.lifecycle.test.tsx
@@ -34,6 +34,7 @@ const loadedState: ProjectState = {
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 1,
+    loadWarnings: [],
     watcherSession: session,
   },
 };

--- a/src/providers/ProjectProvider/actions/__tests__/addLink.optimistic.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/addLink.optimistic.test.ts
@@ -67,6 +67,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/addLink.projectSwitch.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/addLink.projectSwitch.test.ts
@@ -55,6 +55,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/addLink.rollback.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/addLink.rollback.test.ts
@@ -56,6 +56,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/linkActions.concurrency.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/linkActions.concurrency.test.ts
@@ -90,6 +90,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/linkOperations.behavior.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/linkOperations.behavior.test.ts
@@ -35,6 +35,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/moveTask.behavior.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/moveTask.behavior.test.ts
@@ -61,6 +61,7 @@ const makeData = (
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/removeLink.optimistic.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/removeLink.optimistic.test.ts
@@ -92,6 +92,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/removeLink.projectSwitch.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/removeLink.projectSwitch.test.ts
@@ -70,6 +70,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/removeLink.rollback.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/removeLink.rollback.test.ts
@@ -71,6 +71,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/reorderColumns.execution.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/reorderColumns.execution.test.ts
@@ -45,6 +45,7 @@ const makeData = (): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/__tests__/reorderColumns.snapshot.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/reorderColumns.snapshot.test.ts
@@ -11,6 +11,7 @@ const dataOf = (columns: readonly Column[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 const cols = (...names: readonly string[]): readonly Column[] =>
@@ -53,6 +54,7 @@ test("from: data.columns が逆順でも表示順 [A,B,C] に sort してから�
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
   const snapshot = ReorderSnapshot.from(data, "A", "C");
   expect(snapshot.afterColumns.map((c) => c.name)).toEqual(["B", "C", "A"]);
@@ -73,6 +75,7 @@ test("from: order に gap がある [A(0), B(5), C(10)] でも from='A', to='C' 
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
   const snapshot = ReorderSnapshot.from(data, "A", "C");
   expect(snapshot.afterColumns).toEqual([
@@ -154,6 +157,7 @@ test("toCommandBuilder: current 引数を見ず snapshot.afterColumns を返す"
     projections: new Map(),
     milestoneProjections: new Map(),
     openRequestId: 0,
+    loadWarnings: [],
   };
   expect(builder(unrelatedCurrent)).toEqual({
     columns: snapshot.afterColumns,

--- a/src/providers/ProjectProvider/actions/__tests__/tasks.behavior.test.ts
+++ b/src/providers/ProjectProvider/actions/__tests__/tasks.behavior.test.ts
@@ -56,6 +56,7 @@ const makeData = (tasks: readonly Task[]): ProjectData => ({
   projections: new Map(),
   milestoneProjections: new Map(),
   openRequestId: 0,
+  loadWarnings: [],
 });
 
 type Harness = {

--- a/src/providers/ProjectProvider/actions/openProject.ts
+++ b/src/providers/ProjectProvider/actions/openProject.ts
@@ -164,6 +164,7 @@ export const openProjectAction = async ({
       doneColumn: columnsResult.value.doneColumn,
       projections: openResult.value.projections,
       milestoneProjections: openResult.value.milestoneProjections,
+      loadWarnings: openResult.value.loadWarnings,
       // この open 固有の識別子。projection 再同期が「open 直後の fresh な payload」と
       // 「open 失敗による旧 project の復元」を区別するために使う（openFail は
       // previousLoaded を同じ path のまま loaded へ戻すため path では区別できない）。

--- a/src/providers/ProjectProvider/context.ts
+++ b/src/providers/ProjectProvider/context.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
 import type { WatcherDiagnostic } from "@/domains/watcher-diagnostic";
 import type {
   CreateTaskParams,
@@ -129,6 +130,11 @@ export type ProjectColumnActionsContextValue = {
 export type ProjectEvent =
   | { type: "loaded"; path: string; data: ProjectData }
   | { type: "open-error"; error: ProjectError }
+  | {
+      type: "load-warnings-updated";
+      path: string;
+      warnings: ProjectLoadWarning[];
+    }
   // watcher backend の障害 / full rescan 失敗。state には保持せず通知だけ行う
   // （監視が壊れたことを利用者へ伝えるのが目的で、UI 状態は持たない）。
   // 型は `@/domains/watcher-diagnostic` が所有する（Provider の外へ出る契約なので

--- a/src/providers/ProjectProvider/index.tsx
+++ b/src/providers/ProjectProvider/index.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useSyncExternalStore,
 } from "react";
+import { ProjectLoadWarning } from "@/domains/project-load-warning";
 import type { WatcherDiagnostic } from "@/domains/watcher-diagnostic";
 import { addLinkAction } from "./actions/addLink";
 import type {
@@ -161,6 +162,23 @@ export const ProjectProvider = ({ children }: ProjectProviderProps) => {
   const watcherSession =
     state.kind === "loaded" ? state.data.watcherSession : null;
 
+  const lastLoadWarningsRef = useRef<{
+    path: string;
+    fingerprint: string;
+  } | null>(null);
+  const notifyLoadWarnings = useCallback(
+    (warnings: ProjectLoadWarning[], path: string): void => {
+      const fingerprint = ProjectLoadWarning.fingerprint(warnings);
+      const previous = lastLoadWarningsRef.current;
+      lastLoadWarningsRef.current = { path, fingerprint };
+      if (previous?.path === path && previous.fingerprint === fingerprint) {
+        return;
+      }
+      emit({ type: "load-warnings-updated", path, warnings });
+    },
+    [emit],
+  );
+
   const requestResync = useWatcherResyncEffect({
     loadedPath,
     gate: watcherGateRef as WatcherGateRef,
@@ -168,6 +186,7 @@ export const ProjectProvider = ({ children }: ProjectProviderProps) => {
     projectionSynced: projectionSyncedRef,
     getState: store.getState,
     dispatch: store.dispatch,
+    notifyLoadWarnings,
   });
 
   const notifyDiagnostic = useCallback(
@@ -201,6 +220,7 @@ export const ProjectProvider = ({ children }: ProjectProviderProps) => {
     synced: projectionSyncedRef,
     getState: store.getState,
     dispatch: store.dispatch,
+    notifyLoadWarnings,
   });
 
   // unmount 時は世代 bump のみ（active フラグは持たない）。in-flight command / open は
@@ -220,6 +240,7 @@ export const ProjectProvider = ({ children }: ProjectProviderProps) => {
       dispatch: store.dispatch,
       onLoaded: (event) => {
         emit({ type: "loaded", path: event.path, data: event.data });
+        notifyLoadWarnings(event.data.loadWarnings, event.path);
       },
       onError: (error) => {
         emit({ type: "open-error", error });
@@ -234,7 +255,7 @@ export const ProjectProvider = ({ children }: ProjectProviderProps) => {
         store.dispatch({ type: "reset" });
       },
     };
-  }, [store, emit]);
+  }, [store, emit, notifyLoadWarnings]);
 
   const taskActions = useMemo<ProjectTaskActionsContextValue>(
     () => ({

--- a/src/providers/ProjectProvider/reducer.ts
+++ b/src/providers/ProjectProvider/reducer.ts
@@ -4,6 +4,7 @@ import {
   ProjectData as ProjectDataDomain,
   type ProjectData as ProjectDataT,
 } from "@/domains/project-data";
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
 import type { TaskProjectionMap } from "@/domains/task-projection";
 import type { TauriError } from "@/lib/tauri";
 import type { Column } from "@/types/column";
@@ -52,7 +53,9 @@ export type ProjectAction =
       tasks: Task[];
       projections: TaskProjectionMap;
       milestoneProjections: MilestoneProjectionMap;
+      loadWarnings: ProjectLoadWarning[];
     }
+  | { type: "load-warnings-replaced"; loadWarnings: ProjectLoadWarning[] }
   | { type: "card-order-updated"; columnName: string; filePaths: string[] }
   | { type: "reset" };
 
@@ -119,7 +122,12 @@ export const reducer = (
           tasks: action.tasks,
           projections: action.projections,
           milestoneProjections: action.milestoneProjections,
+          loadWarnings: action.loadWarnings ?? data.loadWarnings,
         }),
+      );
+    case "load-warnings-replaced":
+      return ProjectState.updateData(state, (data) =>
+        ProjectDataDomain.replaceLoadWarnings(data, action.loadWarnings),
       );
     case "card-order-updated":
       return ProjectState.updateData(state, (data) =>

--- a/src/providers/ProjectProvider/useProjectionSyncEffect.ts
+++ b/src/providers/ProjectProvider/useProjectionSyncEffect.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
 import { getTasks } from "@/lib/tauri";
 import type { Column } from "@/types/column";
 import type { Task } from "@/types/task";
@@ -73,6 +74,8 @@ type ProjectionSyncDeps = SyncBasis & {
    * @param action - 反映する ProjectAction
    */
   dispatch: (action: ProjectAction) => void;
+  /** 採用したsnapshotのロード警告を通知する。 */
+  notifyLoadWarnings?: (warnings: ProjectLoadWarning[], path: string) => void;
 };
 
 /**
@@ -135,6 +138,7 @@ export const useProjectionSyncEffect = ({
   synced: syncedRef,
   getState,
   dispatch,
+  notifyLoadWarnings,
 }: ProjectionSyncDeps): void => {
   // 各再同期リクエストに採番する世代 id。最新世代の応答だけが state を確定する。
   const requestIdRef = useRef(0);
@@ -237,6 +241,11 @@ export const useProjectionSyncEffect = ({
           projections: result.value.projections,
           milestoneProjections: result.value.milestoneProjections,
         });
+        dispatch({
+          type: "load-warnings-replaced",
+          loadWarnings: result.value.loadWarnings,
+        });
+        notifyLoadWarnings?.(result.value.loadWarnings, request.path);
         syncedRef.current = {
           openRequestId,
           path: request.path,
@@ -269,6 +278,7 @@ export const useProjectionSyncEffect = ({
     syncedRef,
     getState,
     dispatch,
+    notifyLoadWarnings,
     syncTick,
   ]);
 };

--- a/src/providers/ProjectProvider/useWatcherResyncEffect.ts
+++ b/src/providers/ProjectProvider/useWatcherResyncEffect.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import type { ProjectLoadWarning } from "@/domains/project-load-warning";
 import { WatcherSession } from "@/domains/watcher-session";
 import { getTasks } from "@/lib/tauri";
 import { awaitProjectCommands, type ProjectCommandQueue } from "./concurrency";
@@ -52,6 +53,8 @@ type WatcherResyncDeps = {
    * @param action 反映する ProjectAction
    */
   dispatch: (action: ProjectAction) => void;
+  /** 採用したsnapshotのロード警告を通知する。 */
+  notifyLoadWarnings?: (warnings: ProjectLoadWarning[], path: string) => void;
 };
 
 /**
@@ -113,6 +116,7 @@ export const useWatcherResyncEffect = ({
   projectionSynced,
   getState,
   dispatch,
+  notifyLoadWarnings,
 }: WatcherResyncDeps): ((reason: WatcherResyncReason) => void) => {
   const requestIdRef = useRef(0);
   const activeRef = useRef<ActiveRequest | null>(null);
@@ -230,7 +234,12 @@ export const useWatcherResyncEffect = ({
             tasks: result.value.tasks,
             projections: result.value.projections,
             milestoneProjections: result.value.milestoneProjections,
+            loadWarnings: result.value.loadWarnings,
           });
+          const appliedState = getState();
+          if (appliedState.kind === "loaded") {
+            notifyLoadWarnings?.(result.value.loadWarnings, request.path);
+          }
           // marker は **replay を適用する前**の state で組む。replay の `task-*`
           // action は tasks だけを進めて projections は据え置くため、replay 後の
           // state を「同期済み」と記録すると、古い projections が最新扱いになって
@@ -275,6 +284,7 @@ export const useWatcherResyncEffect = ({
       projectionSynced,
       getState,
       dispatch,
+      notifyLoadWarnings,
     ],
   );
 


### PR DESCRIPTION
## 概要

Issue #458 のプロジェクト読み込み時の部分失敗を、`ProjectLoadWarning` / `loadWarnings` として Rust からUIまで伝播します。正常に読み込めたタスクは表示を継続し、ユーザーが失敗理由を確認できるようにします。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能
- [x] 🎨 UI/UX 改善
- [x] 🚨 テスト追加/修正
- [x] 📖 ドキュメント更新

### 📝 詳細な変更内容

- Rust scanner / task rebuild で per-entry、read、parse の recoverable warning を収集
- config の存在後エラーは `Config::default()` へフォールバックし、`configFallback` を返却
- `open_project` / `get_tasks` / full rescan の session payload に `loadWarnings` を追加
- ProjectData / ProjectProvider で警告を保持し、rescan 成功時に警告一覧を置換
- loaded board に展開可能な警告パネルと件数サマリー通知を追加
- unknown code/stage、null path、長文表示、project切替 isolation を考慮
- file-system / config / board-view の仕様書を更新

## 📊 システム図

```mermaid
flowchart LR
    Root[Project root] --> Scanner[Scanner]
    Config[Config loader] --> Report[ProjectLoadWarning report]
    Scanner --> Report
    Rescan[Full rescan] --> Report
    Report --> Session[ProjectSession / snapshot]
    Session --> IPC[open_project / get_tasks]
    IPC --> Domain[FE decoder]
    Domain --> State[ProjectData / Provider]
    State --> Panel[Persistent warning panel]
    State --> Toast[Summary toast]
    Fatal[Fatal boundary] --> Error[Command error / old state retained]

    classDef changed fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    Report,Session,Domain,State,Panel,Toast:::changed
```

## 📋 関連 Issue

Closes #458

## 🧪 テスト

### テスト実行方法

```bash
pnpm test:run
pnpm exec biome check src
pnpm exec oxlint src
pnpm build
cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
cargo test --manifest-path src-tauri/Cargo.toml
```

### テスト項目

- [x] 単体テスト
- [x] 統合テスト
- [x] 型チェック・lint・build
- [ ] 手動テスト（Tauri画面の起動確認は未実施）

### テスト結果

- Vitest: 310 files / 2867 tests passed
- Rust: 1265 tests passed（doc-test 2件は既存の ignore）
- Biome、Oxlint、TypeScript build、Vite build、Rust format check passed

## 🔍 レビューポイント

- recoverable warning と root / hierarchy / registry / watcher / session / lock の fatal 境界
- config fallback warning の初回openからsession、get_tasks、rescanへの保持
- full rescanでの警告置換と旧状態保持、およびfingerprintによる重複通知抑制
- unknown warning payload と project切替時のstate isolation

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている
- [x] コミットメッセージが適切な形式で書かれている
- [x] PR本文に `Closes #458` を記載している
- [x] セルフレビューを実施した
- [x] 破壊的変更がないことを確認した