### PR TITLE
VRT レポートを reg-viz 風の UI と分類に作り替える

### DIFF
--- a/.github/workflows/storybook-visual-regression.yml
+++ b/.github/workflows/storybook-visual-regression.yml
@@ -255,12 +255,12 @@ jobs:
             fi
             {
               echo "$MARKER"
-              echo "## Storybook ビジュアルリグレッション"
+              echo "## Storybook visual regression"
               echo ""
               echo "$HEADLINE"
               echo ""
               # 玉の色はレポート画面の分類アイコンと揃えてある。
-              echo "| 🔴 変更 | ⚪ 新規 | ⚫ 削除 | 🔵 差分なし |"
+              echo "| 🔴 Changed | ⚪ New | ⚫ Deleted | 🔵 Passed |"
               echo "| ---: | ---: | ---: | ---: |"
               echo "| $1 | $2 | $3 | $4 |"
               echo ""
@@ -269,7 +269,7 @@ jobs:
           else
             {
               echo "$MARKER"
-              echo "## Storybook ビジュアルリグレッション"
+              echo "## Storybook visual regression"
               echo ""
               if [ -f "$SUMMARY" ]; then
                 echo "レポートを公開できませんでした。"

--- a/.github/workflows/storybook-visual-regression.yml
+++ b/.github/workflows/storybook-visual-regression.yml
@@ -246,61 +246,34 @@ jobs:
           BODY_FILE=visual-comment.md
 
           if [ "$PUBLISH_OUTCOME" = "success" ] && [ -f "$SUMMARY" ]; then
-            # reg-suit のコメントに倣い、分類ごとの玉と内訳表を出す。
-            MARKER="$MARKER" REPORT_URL="$REPORT_URL" node --input-type=module <<'NODE' > "$BODY_FILE"
-          import { readFileSync } from "node:fs";
-
-          const summary = JSON.parse(readFileSync("visual-report/summary.json", "utf8"));
-          const categories = [
-            ["🔴", "Changed", summary.changed],
-            ["⚪", "New", summary.new],
-            ["⚫", "Deleted", summary.deleted],
-            ["🔵", "Passed", summary.passed],
-          ];
-
-          // 玉が数百個並ぶとコメントが読めなくなるので頭から50個で打ち切る(正確な件数は表にある)。
-          const MAX_BALLS = 50;
-          const allBalls = categories.flatMap(([ball, , count]) => Array.from({ length: count }, () => ball));
-          const balls = allBalls.length > MAX_BALLS ? `${allBalls.slice(0, MAX_BALLS).join("")} …` : allBalls.join("");
-
-          const headline = summary.changed > 0
-            ? "**Detected visual differences.**"
-            : "**No visual differences.**";
-          const legend = categories.map(([ball, label]) => `${ball}: ${label} items`).join(", ");
-
-          console.log(process.env.MARKER);
-          console.log("## Storybook visual regression");
-          console.log("");
-          console.log(headline);
-          console.log("");
-          console.log(`Check [this report](${process.env.REPORT_URL}), and review them.`);
-          console.log("");
-          console.log(balls || "(no stories captured)");
-          console.log("");
-          console.log("<details>");
-          console.log("<summary>What balls mean?</summary>");
-          console.log("");
-          console.log("The number of balls represents the number of images in each category.");
-          console.log("");
-          console.log(legend);
-          console.log("");
-          console.log("</details>");
-          console.log("");
-          console.log(`| ${categories.map(([ball, label]) => `${ball} ${label}`).join(" | ")} |`);
-          console.log(`| ${categories.map(() => "---:").join(" | ")} |`);
-          console.log(`| ${categories.map(([, , count]) => count).join(" | ")} |`);
-          console.log("");
-          console.log(`Threshold: ${summary.maxDiffRatio} diff ratio.`);
-          NODE
+            COUNTS=$(node -e 'const s = require("./visual-report/summary.json"); console.log(s.changed, s.new, s.deleted, s.passed)')
+            set -- $COUNTS
+            if [ "$1" -gt 0 ]; then
+              HEADLINE="Detected visual differences."
+            else
+              HEADLINE="No visual differences."
+            fi
+            {
+              echo "$MARKER"
+              echo "## Storybook visual regression"
+              echo ""
+              echo "$HEADLINE"
+              echo ""
+              echo "$REPORT_URL"
+              echo ""
+              echo "| Changed | New | Deleted | Passed |"
+              echo "| ---: | ---: | ---: | ---: |"
+              echo "| $1 | $2 | $3 | $4 |"
+            } > "$BODY_FILE"
           else
             {
               echo "$MARKER"
               echo "## Storybook visual regression"
               echo ""
               if [ -f "$SUMMARY" ]; then
-                echo "**Report could not be published.**"
+                echo "Report could not be published."
               else
-                echo "**Report is missing.**"
+                echo "Report is missing."
               fi
               echo ""
               echo "- Report not updated (compare: ${COMPARE_OUTCOME}, verify: ${VERIFY_OUTCOME}, publish: ${PUBLISH_OUTCOME})"

--- a/.github/workflows/storybook-visual-regression.yml
+++ b/.github/workflows/storybook-visual-regression.yml
@@ -259,11 +259,12 @@ jobs:
               echo ""
               echo "$HEADLINE"
               echo ""
-              echo "$REPORT_URL"
-              echo ""
-              echo "| Changed | New | Deleted | Passed |"
+              # 玉の色はレポート画面の分類アイコンと揃えてある。
+              echo "| 🔴 Changed | ⚪ New | ⚫ Deleted | 🔵 Passed |"
               echo "| ---: | ---: | ---: | ---: |"
               echo "| $1 | $2 | $3 | $4 |"
+              echo ""
+              echo "- [VRT](${REPORT_URL})"
             } > "$BODY_FILE"
           else
             {
@@ -281,9 +282,8 @@ jobs:
           fi
 
           {
-            echo ""
-            echo "- Report artifact: ${RUN_URL}"
-            echo "- Storybook preview: ${PREVIEW_URL}"
+            echo "- [Artifact](${RUN_URL})"
+            echo "- [Storybook](${PREVIEW_URL})"
           } >> "$BODY_FILE"
 
           COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \

--- a/.github/workflows/storybook-visual-regression.yml
+++ b/.github/workflows/storybook-visual-regression.yml
@@ -249,18 +249,18 @@ jobs:
             COUNTS=$(node -e 'const s = require("./visual-report/summary.json"); console.log(s.changed, s.new, s.deleted, s.passed)')
             set -- $COUNTS
             if [ "$1" -gt 0 ]; then
-              HEADLINE="Detected visual differences."
+              HEADLINE="差分が見つかりました。"
             else
-              HEADLINE="No visual differences."
+              HEADLINE="差分はありませんでした。"
             fi
             {
               echo "$MARKER"
-              echo "## Storybook visual regression"
+              echo "## Storybook ビジュアルリグレッション"
               echo ""
               echo "$HEADLINE"
               echo ""
               # 玉の色はレポート画面の分類アイコンと揃えてある。
-              echo "| 🔴 Changed | ⚪ New | ⚫ Deleted | 🔵 Passed |"
+              echo "| 🔴 変更 | ⚪ 新規 | ⚫ 削除 | 🔵 差分なし |"
               echo "| ---: | ---: | ---: | ---: |"
               echo "| $1 | $2 | $3 | $4 |"
               echo ""
@@ -269,20 +269,21 @@ jobs:
           else
             {
               echo "$MARKER"
-              echo "## Storybook visual regression"
+              echo "## Storybook ビジュアルリグレッション"
               echo ""
               if [ -f "$SUMMARY" ]; then
-                echo "Report could not be published."
+                echo "レポートを公開できませんでした。"
               else
-                echo "Report is missing."
+                echo "レポートが見つかりませんでした。"
               fi
               echo ""
-              echo "- Report not updated (compare: ${COMPARE_OUTCOME}, verify: ${VERIFY_OUTCOME}, publish: ${PUBLISH_OUTCOME})"
+              # 括弧内はワークフローの各ステップ名なので英語のままにする。
+              echo "- レポート未更新（compare: ${COMPARE_OUTCOME} / verify: ${VERIFY_OUTCOME} / publish: ${PUBLISH_OUTCOME}）"
             } > "$BODY_FILE"
           fi
 
           {
-            echo "- [Artifact](${RUN_URL})"
+            echo "- [Actions](${RUN_URL})"
             echo "- [Storybook](${PREVIEW_URL})"
           } >> "$BODY_FILE"
 

--- a/.github/workflows/storybook-visual-regression.yml
+++ b/.github/workflows/storybook-visual-regression.yml
@@ -107,18 +107,21 @@ jobs:
           REPORT_VERSION: ${{ github.event.pull_request.head.sha }}
         run: |
           test -f visual-report/index.html
-          grep -Fq 'class="nav-reveal"' visual-report/index.html
-          grep -Fq 'data-global-view-mode="overlay"' visual-report/index.html
-          grep -Fq 'data-global-view-mode="split"' visual-report/index.html
-          grep -Fq 'data-global-view-mode="slider"' visual-report/index.html
-          grep -Fq 'Visual report UI v7' visual-report/index.html
-          grep -Fq 'grid-template-columns: repeat(2, minmax(0, 1fr))' visual-report/index.html
-          grep -Fq 'mix-blend-mode: difference' visual-report/index.html
+          grep -Fq 'Visual report UI v8' visual-report/index.html
+          # reg-viz と同じ5つの比較モードが揃っていること。
+          grep -Fq 'data-view-mode="diff"' visual-report/index.html
+          grep -Fq 'data-view-mode="slide"' visual-report/index.html
+          grep -Fq 'data-view-mode="2up"' visual-report/index.html
+          grep -Fq 'data-view-mode="blend"' visual-report/index.html
+          grep -Fq 'data-view-mode="toggle"' visual-report/index.html
+          grep -Fq 'id="report-data"' visual-report/index.html
           node -e 'const summary = require("./visual-report/summary.json"); if (summary.reportVersion !== process.env.REPORT_VERSION) process.exit(1)'
+          # Changed / New / Deleted / Passed の集計がコメント生成の前提になる。
+          node -e 'const summary = require("./visual-report/summary.json"); for (const key of ["changed", "new", "deleted", "passed"]) if (typeof summary[key] !== "number") process.exit(1)'
           RESULTS=$(node -e 'console.log(require("./visual-report/summary.json").results.length)')
           if [ "$RESULTS" -gt 0 ]; then
             grep -Fq 'id="story-navigation"' visual-report/index.html
-            grep -Fq 'placeholder="Filter stories..."' visual-report/index.html
+            grep -Fq 'placeholder="Filter by file name"' visual-report/index.html
             find visual-report -mindepth 2 -maxdepth 2 -name index.html -print -quit | grep -q .
           fi
 
@@ -240,37 +243,75 @@ jobs:
           PREVIEW_URL="https://${OWNER}.github.io/${REPO_NAME}/pr-preview/pr-${PR_NUMBER}/"
           REPORT_URL="https://${OWNER}.github.io/${REPO_NAME}/visual-regression/pr-${PR_NUMBER}/?revision=${{ github.event.pull_request.head.sha }}"
           SUMMARY="visual-report/summary.json"
+          BODY_FILE=visual-comment.md
 
-          if [ "$PUBLISH_OUTCOME" != "success" ]; then
-            FAILED="unknown"
-            TOTAL="unknown"
-            STATUS="❌ report publish failed"
-          elif [ -f "$SUMMARY" ]; then
-            FAILED=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).failed)' "$SUMMARY")
-            TOTAL=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).results.length)' "$SUMMARY")
-            STATUS=$([ "$COMPARE_OUTCOME" = "success" ] && echo "✅ pass" || echo "❌ diff detected")
+          if [ "$PUBLISH_OUTCOME" = "success" ] && [ -f "$SUMMARY" ]; then
+            # reg-suit のコメントに倣い、分類ごとの玉と内訳表を出す。
+            MARKER="$MARKER" REPORT_URL="$REPORT_URL" node --input-type=module <<'NODE' > "$BODY_FILE"
+          import { readFileSync } from "node:fs";
+
+          const summary = JSON.parse(readFileSync("visual-report/summary.json", "utf8"));
+          const categories = [
+            ["🔴", "Changed", summary.changed],
+            ["⚪", "New", summary.new],
+            ["⚫", "Deleted", summary.deleted],
+            ["🔵", "Passed", summary.passed],
+          ];
+
+          // 玉が数百個並ぶとコメントが読めなくなるので頭から50個で打ち切る(正確な件数は表にある)。
+          const MAX_BALLS = 50;
+          const allBalls = categories.flatMap(([ball, , count]) => Array.from({ length: count }, () => ball));
+          const balls = allBalls.length > MAX_BALLS ? `${allBalls.slice(0, MAX_BALLS).join("")} …` : allBalls.join("");
+
+          const headline = summary.changed > 0
+            ? "**Detected visual differences.**"
+            : "**No visual differences.**";
+          const legend = categories.map(([ball, label]) => `${ball}: ${label} items`).join(", ");
+
+          console.log(process.env.MARKER);
+          console.log("## Storybook visual regression");
+          console.log("");
+          console.log(headline);
+          console.log("");
+          console.log(`Check [this report](${process.env.REPORT_URL}), and review them.`);
+          console.log("");
+          console.log(balls || "(no stories captured)");
+          console.log("");
+          console.log("<details>");
+          console.log("<summary>What balls mean?</summary>");
+          console.log("");
+          console.log("The number of balls represents the number of images in each category.");
+          console.log("");
+          console.log(legend);
+          console.log("");
+          console.log("</details>");
+          console.log("");
+          console.log(`| ${categories.map(([ball, label]) => `${ball} ${label}`).join(" | ")} |`);
+          console.log(`| ${categories.map(() => "---:").join(" | ")} |`);
+          console.log(`| ${categories.map(([, , count]) => count).join(" | ")} |`);
+          console.log("");
+          console.log(`Threshold: ${summary.maxDiffRatio} diff ratio.`);
+          NODE
           else
-            FAILED="unknown"
-            TOTAL="unknown"
-            STATUS="❌ report missing"
+            {
+              echo "$MARKER"
+              echo "## Storybook visual regression"
+              echo ""
+              if [ -f "$SUMMARY" ]; then
+                echo "**Report could not be published.**"
+              else
+                echo "**Report is missing.**"
+              fi
+              echo ""
+              echo "- Report not updated (compare: ${COMPARE_OUTCOME}, verify: ${VERIFY_OUTCOME}, publish: ${PUBLISH_OUTCOME})"
+            } > "$BODY_FILE"
           fi
 
-          BODY_FILE=visual-comment.md
           {
-            echo "$MARKER"
-            echo "## Storybook visual regression"
             echo ""
-            echo "Status: ${STATUS}"
-            echo ""
-            echo "- Changed stories over threshold: ${FAILED} / ${TOTAL}"
-            if [ "$PUBLISH_OUTCOME" = "success" ]; then
-              echo "- Rich visual diff report: ${REPORT_URL}"
-            else
-              echo "- Rich visual diff report: not updated (verify: ${VERIFY_OUTCOME}, publish: ${PUBLISH_OUTCOME})"
-            fi
             echo "- Report artifact: ${RUN_URL}"
             echo "- Storybook preview: ${PREVIEW_URL}"
-          } > "$BODY_FILE"
+          } >> "$BODY_FILE"
 
           COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id // empty")

--- a/scripts/storybook-visual-regression.mjs
+++ b/scripts/storybook-visual-regression.mjs
@@ -317,12 +317,12 @@ const compare = async (options) => {
       const diffPath = join(out, "diff", name);
       if (!existsSync(expectedPath)) {
         copy(actualPath, join(out, "actual", name));
-        results.push({ story, ...metadata, status: "added", diffPixels: 0, diffRatio: 0, hasExpected: false, hasActual: true, hasDiff: false });
+        results.push({ story, ...metadata, status: "new", reason: "no-baseline", diffPixels: 0, diffRatio: 0, hasExpected: false, hasActual: true, hasDiff: false });
         continue;
       }
       if (!existsSync(actualPath)) {
         copy(expectedPath, join(out, "expected", name));
-        results.push({ story, ...metadata, status: "removed", diffPixels: 0, diffRatio: 0, hasExpected: true, hasActual: false, hasDiff: false });
+        results.push({ story, ...metadata, status: "deleted", reason: "no-current", diffPixels: 0, diffRatio: 0, hasExpected: true, hasActual: false, hasDiff: false });
         continue;
       }
       copy(actualPath, join(out, "actual", name));
@@ -335,18 +335,21 @@ const compare = async (options) => {
         timeout: 30_000,
       });
       if (result.match) {
-        results.push({ story, ...metadata, status: "passed", diffPixels: 0, diffRatio: 0, hasExpected: true, hasActual: true, hasDiff: false });
+        results.push({ story, ...metadata, status: "passed", reason: "match", diffPixels: 0, diffRatio: 0, hasExpected: true, hasActual: true, hasDiff: false });
         continue;
       }
       if (result.reason !== "pixel-diff") {
-        results.push({ story, ...metadata, status: result.reason, diffPixels: 0, diffRatio: 1, hasExpected: true, hasActual: true, hasDiff: false });
+        // 寸法違いなどピクセル比較まで到達しなかった失敗。odiff は diff 画像を出力しない。
+        results.push({ story, ...metadata, status: "changed", reason: result.reason, diffPixels: 0, diffRatio: 1, hasExpected: true, hasActual: true, hasDiff: false });
         continue;
       }
       const diffRatio = result.diffPercentage / 100;
+      const overThreshold = diffRatio > maxDiffRatio;
       results.push({
         story,
         ...metadata,
-        status: diffRatio > maxDiffRatio ? "changed" : "passed",
+        status: overThreshold ? "changed" : "passed",
+        reason: overThreshold ? "pixel-diff" : "within-threshold",
         diffPixels: result.diffCount,
         diffRatio,
         hasExpected: true,
@@ -357,9 +360,18 @@ const compare = async (options) => {
   } finally {
     server.stop();
   }
-  const failedStatuses = new Set(["changed", "layout-diff", "file-not-exists"]);
-  const failed = results.filter((result) => failedStatuses.has(result.status));
-  const summary = { reportVersion, maxDiffRatio, failed: failed.length, results };
+  const countOf = (status) => results.filter((result) => result.status === status).length;
+  const summary = {
+    reportVersion,
+    maxDiffRatio,
+    changed: countOf("changed"),
+    new: countOf("new"),
+    deleted: countOf("deleted"),
+    passed: countOf("passed"),
+    // 新規・削除は退行ではないので失敗に数えない(reg-suit と同じ扱い)。
+    failed: countOf("changed"),
+    results,
+  };
   writeFileSync(join(out, "summary.json"), JSON.stringify(summary, null, 2));
   writeFileSync(join(out, "index.html"), renderHtml(summary));
   for (const result of results) {
@@ -367,7 +379,7 @@ const compare = async (options) => {
     mkdirSync(storyDir, { recursive: true });
     writeFileSync(join(storyDir, "index.html"), renderHtml({ ...summary, results: [result] }, { detailStory: result.story, pathPrefix: "../" }));
   }
-  if (failed.length > 0) {
+  if (summary.failed > 0) {
     process.exitCode = 1;
   }
 };
@@ -378,362 +390,585 @@ const escapeHtml = (value) => String(value)
   .replaceAll(">", "&gt;")
   .replaceAll('"', "&quot;");
 
-const comparisonPanel = (result, pathPrefix = "") => {
+// reg-viz のレポートに合わせた4分類。サイドバー・本文ともこの順で並べる。
+const CATEGORIES = [
+  { key: "changed", label: "Changed" },
+  { key: "new", label: "New" },
+  { key: "deleted", label: "Deleted" },
+  { key: "passed", label: "Passed" },
+];
+
+const REASON_LABELS = {
+  "pixel-diff": "Pixel diff",
+  "layout-diff": "Layout diff",
+  "file-not-exists": "File not exists",
+  "within-threshold": "Within threshold",
+  "no-baseline": "No baseline",
+  "no-current": "No current snapshot",
+  match: "Identical",
+};
+
+const storyLabel = (result) => {
+  if (!result.title) {
+    return result.story;
+  }
+  return result.name ? `${result.title} / ${result.name}` : result.title;
+};
+
+const storySearchText = (result) => `${result.title ?? ""} ${result.name ?? ""} ${result.story}`.toLowerCase();
+
+// カードのサムネイル。差分画像があればそれを、無ければ手元にある方のスクリーンショットを使う。
+const thumbnailKind = (result) => {
+  if (result.hasDiff) {
+    return "diff";
+  }
+  return result.hasActual ? "actual" : "expected";
+};
+
+// 詳細ページ(<story>/index.html)からは画像が1階層上、リンク先は自分自身になる。
+const assetPrefix = (options) => options.pathPrefix ?? "";
+const storyHref = (story, options) => (options.detailStory ? "./" : `${story}/`);
+
+const groupByCategory = (results) => CATEGORIES
+  .map((category) => ({ ...category, results: results.filter((result) => result.status === category.key) }))
+  .filter((group) => group.results.length > 0);
+
+// 表示順(Changed → New → Deleted → Passed)に並べ直した一覧。
+// ビューアの前後送りとカウンタはこの順序を使う。
+const orderResults = (results) => groupByCategory(results).flatMap((group) => group.results);
+
+const ball = (status) => `<span class="ball ball--${status}" aria-hidden="true"></span>`;
+
+const renderSidebar = (summary, options) => {
+  const groups = groupByCategory(summary.results);
+  const items = groups.map((group) => `<details class="group group--${group.key}" open>
+        <summary>
+          <span class="group__caret" aria-hidden="true"></span>
+          <span class="group__name">${group.label}</span>
+          <span class="group__count">${group.results.length} items</span>
+          ${ball(group.key)}
+        </summary>
+        <ul class="group__list">
+          ${group.results.map((result) => `<li data-nav-item data-search="${escapeHtml(storySearchText(result))}"><a href="${storyHref(escapeHtml(result.story), options)}" data-open="${escapeHtml(result.story)}" title="${escapeHtml(result.story)}">${escapeHtml(storyLabel(result))}</a></li>`).join("")}
+        </ul>
+      </details>`).join("");
+  return `<aside class="sidebar" id="story-navigation" aria-label="Visual regression items">
+      <div class="sidebar__search">
+        <span class="icon-search" aria-hidden="true"></span>
+        <input type="search" placeholder="Filter by file name" data-filter aria-label="Filter by file name">
+      </div>
+      <div class="sidebar__body">
+        <p class="sidebar__label">Summary</p>
+        ${items}
+        <p class="sidebar__empty" data-filter-empty hidden>No matching items</p>
+      </div>
+      <footer class="sidebar__footer">
+        <p class="sidebar__brand">Storybook Visual Regression</p>
+        <p class="sidebar__version">Visual report UI v8 · ${escapeHtml(String(summary.reportVersion ?? "local").slice(0, 7))}</p>
+      </footer>
+    </aside>`;
+};
+
+const renderCard = (result, options) => {
   const story = escapeHtml(result.story);
-  const expectedPath = `${pathPrefix}expected/${story}.png`;
-  const actualPath = `${pathPrefix}actual/${story}.png`;
-  const diffPath = `${pathPrefix}diff/${story}.png`;
-  const canCompare = result.hasExpected && result.hasActual && result.status !== "layout-diff";
-  const imageOrEmpty = (label, path, enabled) => enabled
-    ? `<figure class="comparison__pane"><figcaption>${label}</figcaption><img class="comparison__image" src="${path}" alt="${label} ${story}"></figure>`
-    : `<div class="comparison__pane comparison__pane--empty"><strong>${label}</strong><span>Not available</span></div>`;
-  // Baseline と Current を difference 合成で重ねる。一致部分は黒に沈み、差分だけが発色する。
-  // 差分ゼロだと全面が黒くなり情報量がないため、その場合は合成せず明示する。
-  const overlayPane = !canCompare
-    ? '<div class="comparison__pane comparison__pane--empty"><strong>Overlay</strong><span>Not available</span></div>'
-    : result.diffPixels > 0
-      ? `<figure class="comparison__pane">
-        <figcaption>Overlay</figcaption>
-        <div class="comparison__frame comparison__frame--pane comparison__frame--difference">
-          <img class="comparison__image" src="${expectedPath}" alt="Baseline ${story}">
-          <img class="comparison__image comparison__overlay" src="${actualPath}" alt="Current ${story}">
-        </div>
-      </figure>`
-      : '<div class="comparison__pane comparison__pane--empty"><strong>Overlay</strong><span>No visual difference</span></div>';
-  return `<div class="comparison" data-comparison>
-    <div class="comparison__view" data-view="overlay">
-      ${canCompare ? `
-      <div data-overlay>
-        <div class="comparison__frame">
-          <img class="comparison__image" src="${expectedPath}" alt="Baseline ${story}">
-          <img class="comparison__image comparison__overlay" src="${actualPath}" alt="Current ${story}" data-overlay-image style="opacity: 0.5">
-        </div>
-        <label class="comparison__control">Current opacity<input data-overlay-slider type="range" min="0" max="100" value="50" aria-label="Current opacity for ${story}"></label>
-      </div>
-      ` : '<div class="comparison__unavailable">Overlay is unavailable because this story only has one snapshot.</div>'}
+  const metrics = result.status === "changed" && result.reason === "pixel-diff"
+    ? `${(result.diffRatio * 100).toFixed(3)}% · ${result.diffPixels} px`
+    : (REASON_LABELS[result.reason] ?? result.status);
+  return `<li class="card card--${result.status}">
+          <a class="card__open" href="${storyHref(story, options)}" data-open="${story}" aria-label="Open ${story}">
+            <span class="card__thumb checker"><img loading="lazy" src="${assetPrefix(options)}${thumbnailKind(result)}/${story}.png" alt="${story}"></span>
+            <span class="card__badge">${ball(result.status)}</span>
+          </a>
+          <div class="card__meta">
+            <p class="card__name" title="${story}">${escapeHtml(storyLabel(result))}</p>
+            <p class="card__sub">${escapeHtml(metrics)}</p>
+          </div>
+        </li>`;
+};
+
+const renderSections = (summary, options) => groupByCategory(summary.results).map((group) => `<section class="section" data-section="${group.key}">
+      <h2 class="section__title">${group.label} items <span class="section__count">${group.results.length}</span></h2>
+      <ul class="cards">
+        ${group.results.map((result) => renderCard(result, options)).join("")}
+      </ul>
+    </section>`).join("");
+
+const VIEW_MODES = [
+  { key: "diff", label: "Diff" },
+  { key: "slide", label: "Slide" },
+  { key: "2up", label: "2up" },
+  { key: "blend", label: "Blend" },
+  { key: "toggle", label: "Toggle" },
+];
+
+const renderViewer = () => `<div class="viewer" data-viewer hidden>
+    <header class="viewer__bar">
+      <div class="viewer__title"><span data-viewer-ball></span><h2 data-viewer-name></h2></div>
+      <p class="viewer__counter" data-viewer-counter></p>
+      <button class="viewer__close" type="button" data-viewer-close aria-label="Close viewer">×</button>
+    </header>
+    <div class="viewer__body">
+      <button class="viewer__nav viewer__nav--prev" type="button" data-viewer-prev aria-label="Previous item">‹</button>
+      <div class="viewer__stage" data-viewer-stage></div>
+      <button class="viewer__nav viewer__nav--next" type="button" data-viewer-next aria-label="Next item">›</button>
     </div>
-    <div class="comparison__view" data-view="split" hidden>
-      <div class="comparison__split">
-        ${imageOrEmpty("Baseline", expectedPath, result.hasExpected)}
-        ${imageOrEmpty("Current", actualPath, result.hasActual)}
-        ${overlayPane}
-        ${imageOrEmpty("Diff", diffPath, result.hasDiff)}
-      </div>
-    </div>
-    <div class="comparison__view" data-view="slider" hidden>
-      ${canCompare ? `
-      <div class="comparison__frame">
-        <img class="comparison__image" src="${expectedPath}" alt="Baseline ${story}">
-        <div class="comparison__actual" data-actual style="clip-path: inset(0 0 0 50%)"><img class="comparison__image" src="${actualPath}" alt="Current ${story}"></div>
-        <div class="comparison__handle" data-handle style="left: 50%"></div>
-      </div>
-      <label class="comparison__control">Baseline / Current<input data-slider type="range" min="0" max="100" value="50" aria-label="Baseline current slider for ${story}"></label>
-      ` : '<div class="comparison__unavailable">Slider is unavailable for this story.</div>'}
-    </div>
+    <nav class="modes" aria-label="Comparison mode">
+      ${VIEW_MODES.map((mode) => `<button type="button" role="tab" data-view-mode="${mode.key}" aria-selected="false">${mode.label}</button>`).join("")}
+    </nav>
   </div>`;
-};
 
-const renderStory = (result, options = {}) => {
-  const story = escapeHtml(result.story);
-  const ratio = (result.diffRatio * 100).toFixed(4);
-  const pathPrefix = options.pathPrefix ?? "";
-  const titleHref = options.detailStory ? `${pathPrefix}index.html#${story}` : `${story}/`;
-  const storyLinkAttribute = options.detailStory ? "" : ` data-story-link="${story}"`;
-  return `<article class="story story--${result.status}" id="${story}">
-    <header class="story__header">
-      <div>
-        <p class="status">${result.status}</p>
-        <h2><a href="${titleHref}"${storyLinkAttribute}>${story}</a></h2>
-      </div>
-      <dl class="metrics">
-        <div><dt>Diff pixels</dt><dd>${result.diffPixels}</dd></div>
-        <div><dt>Diff ratio</dt><dd>${ratio}%</dd></div>
-      </dl>
-    </header>
-    ${comparisonPanel(result, pathPrefix)}
-  </article>`;
-};
+// summary.json をそのまま埋めるとレポートが重くなるので、ビューアが必要とする項目だけ渡す。
+const reportData = (summary, options) => JSON.stringify({
+  pathPrefix: options.pathPrefix ?? "",
+  initialStory: options.detailStory ?? null,
+  items: orderResults(summary.results).map((result) => ({
+    story: result.story,
+    label: storyLabel(result),
+    status: result.status,
+    reason: result.reason ?? null,
+    diffPixels: result.diffPixels,
+    diffRatio: result.diffRatio,
+    hasExpected: result.hasExpected,
+    hasActual: result.hasActual,
+    hasDiff: result.hasDiff,
+  })),
+}).replaceAll("<", "\\u003c");
 
-const formatStatusLabel = (status) => {
-  if (status === "passed") {
-    return "Clear";
-  }
-  return status.charAt(0).toUpperCase() + status.slice(1);
-};
-
-const storyTreePath = (result) => {
-  if (result.title) {
-    return result.title.split("/").filter(Boolean);
-  }
-  const componentId = result.story.split("--")[0];
-  const [root, ...rest] = componentId.split("-").filter(Boolean);
-  if (!root) {
-    return ["Other"];
-  }
-  return rest.length > 0 ? [root, rest.join("-")] : [root];
-};
-
-const renderStoryTree = (stories) => {
-  const root = { children: new Map(), stories: [] };
-  for (const result of stories) {
-    const titleParts = storyTreePath(result);
-    let node = root;
-    for (const part of titleParts) {
-      if (!node.children.has(part)) {
-        node.children.set(part, { children: new Map(), stories: [] });
-      }
-      node = node.children.get(part);
+const renderStyles = () => `
+    :root {
+      color-scheme: light;
+      --bg: #f2f5f5; --surface: #fff; --text: #0d3336; --muted: #7c8e90; --line: #dfe6e6;
+      --accent: #ff4741; --changed: #e8384f; --deleted: #2b3a3c; --passed: #1f8ceb; --new-line: #8fa2a4;
+      --checker: #e7ecec;
     }
-    node.stories.push(result);
-  }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", "Hiragino Sans", "Noto Sans JP", sans-serif; }
+    h1, h2, p, figure { margin: 0; }
+    /* 透過部分が分かるよう、reg-viz と同じ市松模様を画像の背面に敷く。 */
+    .checker { background-color: #fff; background-image: linear-gradient(45deg, var(--checker) 25%, transparent 25%), linear-gradient(-45deg, var(--checker) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, var(--checker) 75%), linear-gradient(-45deg, transparent 75%, var(--checker) 75%); background-size: 16px 16px; background-position: 0 0, 0 8px, 8px -8px, -8px 0; }
+    .ball { display: inline-block; flex: 0 0 auto; width: 12px; height: 12px; border-radius: 999px; }
+    .ball--changed { background: var(--changed); }
+    .ball--new { background: #fff; box-shadow: inset 0 0 0 2px var(--new-line); }
+    .ball--deleted { background: var(--deleted); }
+    .ball--passed { background: var(--passed); }
 
-  const renderNode = (node) => `${[...node.children.entries()].map(([label, child]) => `<li data-tree-node>
-    <details open>
-      <summary><span class="tree-icon tree-icon--folder" aria-hidden="true"></span><span>${escapeHtml(label)}</span></summary>
-      <ul>${renderNode(child)}</ul>
-    </details>
-  </li>`).join("")}${node.stories.map((result) => {
-    const story = escapeHtml(result.story);
-    const label = escapeHtml(result.name ?? result.story.split("--").at(-1) ?? result.story);
-    const searchText = escapeHtml(`${result.title ?? ""} ${result.name ?? ""} ${result.story}`.toLowerCase());
-    return `<li class="story-nav__story" data-tree-leaf data-search-text="${searchText}"><a href="#${story}" title="${story}"><span class="tree-icon tree-icon--file" aria-hidden="true"></span><span>${label}</span></a></li>`;
-  }).join("")}`;
+    .app { display: grid; grid-template-columns: 300px minmax(0, 1fr); min-height: 100vh; }
+    .sidebar { position: sticky; top: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; height: 100vh; border-right: 1px solid var(--line); background: var(--surface); }
+    .sidebar__search { display: flex; align-items: center; gap: 10px; padding: 18px 20px; border-bottom: 1px solid var(--line); }
+    .sidebar__search input { min-width: 0; width: 100%; border: 0; outline: 0; background: transparent; color: var(--text); font: inherit; font-size: 15px; }
+    .sidebar__search input::placeholder { color: var(--muted); }
+    .icon-search { position: relative; flex: 0 0 auto; width: 13px; height: 13px; border: 2px solid var(--muted); border-radius: 50%; }
+    .icon-search::after { content: ""; position: absolute; right: -6px; bottom: -4px; width: 7px; height: 2px; background: var(--muted); transform: rotate(45deg); }
+    .sidebar__body { min-height: 0; overflow: auto; padding: 20px 0 24px; }
+    .sidebar__label { padding: 0 20px 8px; color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+    .group > summary { display: flex; align-items: center; gap: 8px; padding: 10px 20px; cursor: pointer; font-size: 13px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; list-style: none; }
+    .group > summary::-webkit-details-marker { display: none; }
+    .group > summary:hover { background: #f6f9f9; }
+    .group__caret { flex: 0 0 auto; width: 0; height: 0; border-top: 5px solid var(--muted); border-right: 4px solid transparent; border-left: 4px solid transparent; transition: transform 120ms ease; }
+    .group[open] > summary .group__caret { transform: rotate(180deg); }
+    .group__name { margin-right: auto; }
+    .group__count { color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; }
+    .group__list { list-style: none; margin: 0 0 10px; padding: 0; }
+    .group__list a { display: block; overflow: hidden; padding: 7px 20px 7px 32px; color: var(--text); font-size: 13px; text-decoration: none; text-overflow: ellipsis; white-space: nowrap; }
+    .group__list a:hover { background: #f6f9f9; color: var(--accent); }
+    .sidebar__empty { padding: 24px 20px; color: var(--muted); font-size: 13px; }
+    .sidebar__footer { padding: 16px 20px; border-top: 1px solid var(--line); }
+    .sidebar__brand { font-size: 13px; font-weight: 700; }
+    .sidebar__version { margin-top: 2px; color: var(--muted); font-size: 11px; }
 
-  return `<ul class="story-nav__tree">${renderNode(root)}</ul>`;
-};
+    main { min-width: 0; padding: 44px 48px 72px; }
+    .backlink { display: inline-block; margin-bottom: 20px; color: var(--muted); font-size: 13px; font-weight: 700; text-decoration: none; }
+    .backlink:hover { color: var(--accent); }
+    h1 { font-size: 56px; font-weight: 800; letter-spacing: -0.01em; line-height: 1.05; text-transform: uppercase; overflow-wrap: anywhere; }
+    .lede { margin-top: 14px; max-width: 62ch; color: var(--muted); font-size: 14px; line-height: 1.7; }
+    .totals { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; }
+    .total { display: flex; align-items: center; gap: 8px; border: 1px solid var(--line); border-radius: 999px; padding: 8px 16px; background: var(--surface); font-size: 13px; font-weight: 700; }
+    .total span:last-child { color: var(--muted); font-weight: 600; }
+    .section { margin-top: 52px; }
+    .section__title { display: flex; align-items: center; gap: 12px; font-size: 30px; font-weight: 800; letter-spacing: -0.01em; text-transform: uppercase; }
+    .section__count { border-radius: 999px; padding: 3px 12px; background: var(--surface); border: 1px solid var(--line); font-size: 13px; font-weight: 700; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 22px; list-style: none; margin: 22px 0 0; padding: 0; }
+    .card { overflow: hidden; border-radius: 10px; background: var(--surface); box-shadow: 0 2px 10px rgb(13 51 54 / 8%); transition: transform 120ms ease, box-shadow 120ms ease; }
+    .card:hover { transform: translateY(-2px); box-shadow: 0 10px 26px rgb(13 51 54 / 14%); }
+    .card__open { position: relative; display: block; height: 200px; }
+    .card__thumb { display: block; height: 100%; }
+    .card__thumb img { display: block; width: 100%; height: 100%; object-fit: contain; }
+    .card__badge { position: absolute; top: 12px; left: 12px; display: grid; place-items: center; width: 26px; height: 26px; border-radius: 999px; background: var(--surface); box-shadow: 0 1px 4px rgb(13 51 54 / 22%); }
+    .card__meta { padding: 14px 16px 16px; border-top: 1px solid var(--line); }
+    .card__name { font-size: 13px; font-weight: 700; line-height: 1.5; overflow-wrap: anywhere; }
+    .card__sub { margin-top: 4px; color: var(--muted); font-size: 12px; }
 
-const renderSidebar = (summary, options = {}) => {
-  if (options.detailStory) {
-    return "";
-  }
-  const groups = ["changed", "layout-diff", "file-not-exists", "added", "removed", "passed"]
-    .map((status) => ({
-      status,
-      stories: summary.results.filter((result) => result.status === status),
-    }))
-    .filter((group) => group.stories.length > 0);
+    .viewer { position: fixed; inset: 0; z-index: 50; display: grid; grid-template-rows: auto minmax(0, 1fr); background: var(--bg); }
+    .viewer[hidden] { display: none; }
+    .viewer__bar { display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr); align-items: center; gap: 16px; padding: 16px 24px; border-bottom: 1px solid var(--line); background: var(--surface); }
+    .viewer__title { display: flex; align-items: center; gap: 10px; min-width: 0; }
+    .viewer__title h2 { overflow: hidden; font-size: 16px; font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
+    .viewer__counter { color: var(--muted); font-size: 14px; font-weight: 700; white-space: nowrap; }
+    .viewer__close { justify-self: end; width: 36px; height: 36px; border: 0; border-radius: 8px; background: transparent; color: var(--muted); font-size: 26px; line-height: 1; cursor: pointer; }
+    .viewer__close:hover { background: #f0f4f4; color: var(--text); }
+    .viewer__body { position: relative; min-height: 0; display: grid; grid-template-columns: 56px minmax(0, 1fr) 56px; align-items: stretch; }
+    .viewer__nav { border: 0; background: transparent; color: var(--muted); font-size: 32px; line-height: 1; cursor: pointer; }
+    .viewer__nav:hover { color: var(--text); }
+    .viewer__nav:disabled { opacity: 0.25; cursor: default; }
+    /* 下端の余白はフローティングのモード切替ぶん。スライダー等が隠れないようにする。 */
+    .viewer__stage { min-width: 0; overflow: auto; padding: 28px 8px 120px; }
 
-  if (groups.length === 0) {
-    return "";
-  }
+    /* 画像は原寸のまま上限だけ掛け、枠と操作列はその実寸に合わせて縮める。 */
+    .stagewrap { width: fit-content; max-width: 100%; margin: 0 auto; }
+    .frame { position: relative; overflow: hidden; width: fit-content; max-width: 100%; margin: 0 auto; border-radius: 8px; box-shadow: 0 2px 12px rgb(13 51 54 / 10%); }
+    .vimg { display: block; max-width: 100%; max-height: calc(100vh - 300px); user-select: none; }
+    /* 重ね合わせる側は下地と同じ矩形へ収める。寸法が違っても contain なので歪まない。 */
+    .vimg--overlay { position: absolute; inset: 0; width: 100%; height: 100%; max-height: none; object-fit: contain; }
+    .stack { position: absolute; inset: 0; overflow: hidden; }
+    .handle { position: absolute; top: 0; bottom: 0; width: 2px; background: var(--accent); pointer-events: none; }
+    .handle::after { content: ""; position: absolute; top: 50%; left: 50%; width: 30px; height: 30px; border: 2px solid var(--accent); border-radius: 999px; background: var(--surface); transform: translate(-50%, -50%); }
+    .control { display: grid; gap: 8px; margin-top: 16px; color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+    .control input[type="range"] { width: 100%; accent-color: var(--accent); }
+    .toggle-bar { display: flex; align-items: center; justify-content: center; gap: 14px; margin-top: 16px; }
+    .toggle-bar button { border: 1px solid var(--line); border-radius: 999px; padding: 7px 18px; background: var(--surface); color: var(--text); font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; }
+    .toggle-bar button:hover { border-color: var(--accent); color: var(--accent); }
+    .toggle-bar output { min-width: 72px; color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-align: center; text-transform: uppercase; }
+    .twoup { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; margin: 0 auto; max-width: 1400px; }
+    .pane { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; border-radius: 8px; background: var(--surface); box-shadow: 0 2px 12px rgb(13 51 54 / 10%); }
+    .pane figcaption { padding: 10px 14px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; }
+    .pane__body { display: grid; min-height: 220px; place-items: center; }
+    .pane__body .vimg { max-height: calc(100vh - 250px); }
+    .pane__empty { color: var(--muted); font-size: 13px; }
+    .unavailable { display: grid; min-height: 320px; max-width: 1100px; margin: 0 auto; place-items: center; border: 1px dashed var(--line); border-radius: 8px; padding: 24px; background: var(--surface); color: var(--muted); font-size: 14px; text-align: center; }
 
-  return `<aside class="story-nav" id="story-navigation" aria-label="Story result navigation">
-    <header class="story-nav__header">
-      <div class="story-nav__title"><h2>Story files</h2><span>${summary.results.length}</span></div>
-      <button class="story-nav__close" type="button" data-nav-toggle aria-label="Hide story files" aria-controls="story-navigation" aria-expanded="true">‹</button>
-      <label class="story-nav__filter"><span class="tree-icon tree-icon--search" aria-hidden="true"></span><input type="search" placeholder="Filter stories..." data-story-filter aria-label="Filter stories"></label>
-    </header>
-    <div class="story-nav__scroll" data-story-tree>
-      ${groups.map((group) => `<details class="story-nav__group story-nav__group--${group.status}" open data-status-group>
-        <summary><span>${formatStatusLabel(group.status)}</span><span class="story-nav__count">${group.stories.length}</span></summary>
-        ${renderStoryTree(group.stories)}
-      </details>`).join("")}
-      <p class="story-nav__empty" data-filter-empty hidden>No matching stories</p>
-    </div>
-  </aside>`;
-};
+    .modes { position: fixed; bottom: 26px; left: 50%; z-index: 51; display: flex; gap: 4px; padding: 6px; border-radius: 999px; background: var(--surface); box-shadow: 0 8px 28px rgb(13 51 54 / 22%); transform: translateX(-50%); }
+    .modes button { border: 0; border-radius: 999px; padding: 11px 26px; background: transparent; color: var(--text); font: inherit; font-size: 14px; font-weight: 800; cursor: pointer; }
+    .modes button:hover:not(:disabled):not(.is-active) { color: var(--accent); }
+    .modes button.is-active { background: var(--accent); color: #fff; box-shadow: 0 0 0 3px rgb(255 71 65 / 22%); }
+    .modes button:disabled { color: #c3cdcd; cursor: default; }
 
-const renderInspectorTabs = (reportVersion) => `<nav class="inspector-tabs" aria-label="Diff inspector view">
-  <span class="inspector-tabs__label">View</span>
-  <div class="inspector-tabs__list" role="tablist">
-    <button type="button" class="is-active" role="tab" data-global-view-mode="overlay" aria-selected="true">Overlay</button>
-    <button type="button" role="tab" data-global-view-mode="split" aria-selected="false">Split + Diff</button>
-    <button type="button" role="tab" data-global-view-mode="slider" aria-selected="false">Slider</button>
-  </div>
-  <span class="inspector-tabs__hint">Visual report UI v7 · ${escapeHtml(reportVersion.slice(0, 7))}</span>
-</nav>`;
+    @media (max-width: 1000px) {
+      .app { grid-template-columns: 1fr; }
+      .sidebar { position: static; height: auto; max-height: 60vh; }
+      main { padding: 28px 20px 64px; }
+      h1 { font-size: 36px; }
+      .section__title { font-size: 22px; }
+      .viewer__body { grid-template-columns: 36px minmax(0, 1fr) 36px; }
+      .twoup { grid-template-columns: 1fr; }
+      .modes { overflow-x: auto; max-width: calc(100vw - 24px); }
+      .modes button { padding: 10px 16px; font-size: 13px; }
+    }`;
 
-const renderHtml = (summary, options = {}) => `<!doctype html>
+const renderScript = () => `
+    const data = JSON.parse(document.getElementById("report-data").textContent);
+    const prefix = data.pathPrefix;
+    const items = data.items;
+    const indexOfStory = new Map(items.map((item, index) => [item.story, index]));
+    const MODE_ORDER = ["diff", "slide", "2up", "blend", "toggle"];
+
+    const filterInput = document.querySelector("[data-filter]");
+    if (filterInput) {
+      filterInput.addEventListener("input", () => {
+        const query = filterInput.value.trim().toLowerCase();
+        const navItems = [...document.querySelectorAll("[data-nav-item]")];
+        for (const navItem of navItems) navItem.hidden = !navItem.dataset.search.includes(query);
+        for (const group of document.querySelectorAll(".group")) {
+          group.hidden = !group.querySelector("[data-nav-item]:not([hidden])");
+          if (query && !group.hidden) group.open = true;
+        }
+        document.querySelector("[data-filter-empty]").hidden = navItems.some((navItem) => !navItem.hidden);
+      });
+    }
+
+    const viewer = document.querySelector("[data-viewer]");
+    const stage = viewer.querySelector("[data-viewer-stage]");
+    const nameLabel = viewer.querySelector("[data-viewer-name]");
+    const ballSlot = viewer.querySelector("[data-viewer-ball]");
+    const counter = viewer.querySelector("[data-viewer-counter]");
+    const prevButton = viewer.querySelector("[data-viewer-prev]");
+    const nextButton = viewer.querySelector("[data-viewer-next]");
+    const modeButtons = [...viewer.querySelectorAll("[data-view-mode]")];
+
+    let current = -1;
+    let mode = "diff";
+    let disposeStage = null;
+
+    const src = (kind, story) => prefix + kind + "/" + encodeURIComponent(story) + ".png";
+
+    const image = (kind, item, overlay) => {
+      const img = document.createElement("img");
+      img.className = overlay ? "vimg vimg--overlay" : "vimg";
+      img.src = src(kind, item.story);
+      img.alt = kind + " screenshot of " + item.story;
+      return img;
+    };
+
+    const unavailable = (text) => {
+      const element = document.createElement("p");
+      element.className = "unavailable";
+      element.textContent = text;
+      return element;
+    };
+
+    const pane = (label, item, kind, available) => {
+      const figure = document.createElement("figure");
+      figure.className = "pane";
+      const caption = document.createElement("figcaption");
+      caption.textContent = label;
+      const body = document.createElement("div");
+      body.className = "pane__body checker";
+      if (available) {
+        body.appendChild(image(kind, item));
+      } else {
+        const empty = document.createElement("span");
+        empty.className = "pane__empty";
+        empty.textContent = "Not available";
+        body.appendChild(empty);
+      }
+      figure.append(caption, body);
+      return figure;
+    };
+
+    const rangeControl = (label, value, onInput) => {
+      const wrapper = document.createElement("label");
+      wrapper.className = "control";
+      const text = document.createElement("span");
+      text.textContent = label;
+      const input = document.createElement("input");
+      input.type = "range";
+      input.min = "0";
+      input.max = "100";
+      input.value = String(value);
+      input.addEventListener("input", () => onInput(Number(input.value)));
+      wrapper.append(text, input);
+      onInput(value);
+      return wrapper;
+    };
+
+    const bothSides = (item) => item.hasExpected && item.hasActual;
+
+    const isModeAvailable = (item, candidate) => {
+      if (candidate === "diff") return item.hasDiff;
+      if (candidate === "2up") return true;
+      return bothSides(item);
+    };
+
+    const buildDiff = (item) => {
+      if (!item.hasDiff) {
+        const note = item.reason === "layout-diff"
+          ? "Baseline and current have different dimensions, so no pixel diff image was produced. Use 2up to compare."
+          : "No diff image for this item.";
+        return unavailable(note);
+      }
+      const frame = document.createElement("div");
+      frame.className = "frame checker";
+      frame.appendChild(image("diff", item));
+      return frame;
+    };
+
+    const buildTwoUp = (item) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "twoup";
+      wrapper.append(pane("Before", item, "expected", item.hasExpected), pane("After", item, "actual", item.hasActual));
+      return wrapper;
+    };
+
+    const buildSlide = (item) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "stagewrap";
+      const frame = document.createElement("div");
+      frame.className = "frame checker";
+      const after = document.createElement("div");
+      after.className = "stack";
+      after.appendChild(image("actual", item, true));
+      const handle = document.createElement("div");
+      handle.className = "handle";
+      frame.append(image("expected", item), after, handle);
+      const control = rangeControl("Before / After", 50, (value) => {
+        after.style.clipPath = "inset(0 0 0 " + value + "%)";
+        handle.style.left = value + "%";
+      });
+      wrapper.append(frame, control);
+      return wrapper;
+    };
+
+    const buildBlend = (item) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "stagewrap";
+      const frame = document.createElement("div");
+      frame.className = "frame checker";
+      const after = image("actual", item, true);
+      frame.append(image("expected", item), after);
+      const control = rangeControl("After opacity", 50, (value) => {
+        after.style.opacity = String(value / 100);
+      });
+      wrapper.append(frame, control);
+      return wrapper;
+    };
+
+    // 変更前後を一定間隔で入れ替えて表示する。差分の位置が残像で分かるので、
+    // 微小な移動やフォントの差を見つけるのに一番速い。
+    const buildToggle = (item) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "stagewrap";
+      const frame = document.createElement("div");
+      frame.className = "frame checker";
+      const after = image("actual", item, true);
+      frame.append(image("expected", item), after);
+
+      const bar = document.createElement("div");
+      bar.className = "toggle-bar";
+      const playButton = document.createElement("button");
+      playButton.type = "button";
+      const stepButton = document.createElement("button");
+      stepButton.type = "button";
+      stepButton.textContent = "Step";
+      const label = document.createElement("output");
+      bar.append(playButton, label, stepButton);
+
+      let showingAfter = true;
+      let timer = null;
+      const paint = () => {
+        after.style.opacity = showingAfter ? "1" : "0";
+        label.textContent = showingAfter ? "After" : "Before";
+      };
+      const flip = () => {
+        showingAfter = !showingAfter;
+        paint();
+      };
+      const stop = () => {
+        if (timer !== null) clearInterval(timer);
+        timer = null;
+        playButton.textContent = "Play";
+      };
+      const start = () => {
+        if (timer === null) timer = setInterval(flip, 600);
+        playButton.textContent = "Pause";
+      };
+      playButton.addEventListener("click", () => (timer === null ? start() : stop()));
+      stepButton.addEventListener("click", () => {
+        stop();
+        flip();
+      });
+      paint();
+      start();
+      wrapper.append(frame, bar);
+      wrapper.dispose = stop;
+      return wrapper;
+    };
+
+    const BUILDERS = { diff: buildDiff, "2up": buildTwoUp, slide: buildSlide, blend: buildBlend, toggle: buildToggle };
+
+    const renderStage = () => {
+      const item = items[current];
+      if (disposeStage) disposeStage();
+      disposeStage = null;
+      stage.replaceChildren();
+      if (!isModeAvailable(item, mode)) {
+        stage.appendChild(unavailable("This mode needs both a baseline and a current screenshot."));
+        return;
+      }
+      const content = BUILDERS[mode](item);
+      disposeStage = content.dispose ?? null;
+      stage.appendChild(content);
+    };
+
+    const syncModeButtons = () => {
+      const item = items[current];
+      for (const button of modeButtons) {
+        const key = button.dataset.viewMode;
+        const available = isModeAvailable(item, key);
+        button.disabled = !available;
+        const active = available && key === mode;
+        button.classList.toggle("is-active", active);
+        button.setAttribute("aria-selected", String(active));
+      }
+    };
+
+    const show = (index) => {
+      current = (index + items.length) % items.length;
+      const item = items[current];
+      if (!isModeAvailable(item, mode)) {
+        mode = MODE_ORDER.find((candidate) => isModeAvailable(item, candidate)) ?? "2up";
+      }
+      nameLabel.textContent = item.label;
+      nameLabel.title = item.story;
+      ballSlot.className = "ball ball--" + item.status;
+      counter.textContent = current + 1 + " / " + items.length;
+      prevButton.disabled = items.length < 2;
+      nextButton.disabled = items.length < 2;
+      syncModeButtons();
+      renderStage();
+      viewer.hidden = false;
+      document.body.style.overflow = "hidden";
+    };
+
+    const close = () => {
+      if (disposeStage) disposeStage();
+      disposeStage = null;
+      stage.replaceChildren();
+      viewer.hidden = true;
+      document.body.style.overflow = "";
+      if (window.location.hash) history.replaceState(null, "", window.location.pathname + window.location.search);
+    };
+
+    for (const button of modeButtons) {
+      button.addEventListener("click", () => {
+        mode = button.dataset.viewMode;
+        syncModeButtons();
+        renderStage();
+      });
+    }
+    prevButton.addEventListener("click", () => show(current - 1));
+    nextButton.addEventListener("click", () => show(current + 1));
+    viewer.querySelector("[data-viewer-close]").addEventListener("click", close);
+    document.addEventListener("keydown", (event) => {
+      if (viewer.hidden) return;
+      if (event.key === "Escape") close();
+      if (event.key === "ArrowLeft" && items.length > 1) show(current - 1);
+      if (event.key === "ArrowRight" && items.length > 1) show(current + 1);
+    });
+
+    for (const opener of document.querySelectorAll("[data-open]")) {
+      opener.addEventListener("click", (event) => {
+        // 修飾キー付きは別タブで詳細ページを開きたい操作なので、既定動作に任せる。
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return;
+        const index = indexOfStory.get(opener.dataset.open);
+        if (index === undefined) return;
+        event.preventDefault();
+        show(index);
+      });
+    }
+
+    const requested = data.initialStory ?? decodeURIComponent(window.location.hash.slice(1));
+    if (requested && indexOfStory.has(requested)) show(indexOfStory.get(requested));`;
+
+const renderHtml = (summary, options = {}) => {
+  const totals = CATEGORIES.map((category) => `<span class="total">${ball(category.key)}<span>${category.label}</span><span>${summary[category.key] ?? 0}</span></span>`).join("");
+  const heading = options.detailStory ? escapeHtml(options.detailStory) : "Report detail";
+  return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>${options.detailStory ? `${escapeHtml(options.detailStory)} - ` : ""}Storybook Visual Regression Report</title>
-  <style>
-    :root { color-scheme: light dark; --bg: #0f172a; --panel: #111827; --text: #e5e7eb; --muted: #9ca3af; --line: #374151; --accent: #38bdf8; --danger: #fb7185; --ok: #34d399; --warn: #fbbf24; }
-    body { margin: 0; background: var(--bg); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-    .layout { position: relative; display: grid; grid-template-columns: 320px minmax(0, 1fr); width: 100%; min-height: 100vh; transition: grid-template-columns 160ms ease; }
-    .layout--nav-hidden { grid-template-columns: 0 minmax(0, 1fr); }
-    .layout--nav-hidden .story-nav { visibility: hidden; opacity: 0; pointer-events: none; }
-    .layout--detail { display: block; width: 100%; }
-    main { min-width: 0; padding: 24px; }
-    .hero { display: flex; justify-content: space-between; gap: 24px; align-items: flex-end; margin-bottom: 24px; }
-    h1, h2, h3, p { margin: 0; }
-    h1 { font-size: 32px; }
-    a { color: inherit; }
-    .summary { color: var(--muted); margin-top: 8px; }
-    .hero__actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
-    .badge { border: 1px solid var(--line); border-radius: 999px; padding: 8px 12px; background: rgb(255 255 255 / 6%); }
-    .nav-reveal { display: none; position: sticky; top: 0; z-index: 3; align-self: start; width: 34px; height: 42px; border: 1px solid var(--line); border-left: 0; border-radius: 0 10px 10px 0; background: #1f2937; color: var(--text); cursor: pointer; }
-    .layout--nav-hidden .nav-reveal { display: block; position: absolute; left: 0; }
-    .story-nav { position: sticky; top: 0; align-self: start; display: grid; grid-template-rows: auto minmax(0, 1fr); box-sizing: border-box; height: 100vh; overflow: hidden; border-right: 1px solid var(--line); background: #18212c; transition: opacity 160ms ease; }
-    .story-nav__header { display: grid; grid-template-columns: 1fr auto; gap: 14px 8px; padding: 16px; border-bottom: 1px solid var(--line); }
-    .story-nav__title { display: flex; align-items: center; gap: 8px; min-width: 0; }
-    .story-nav__title h2 { overflow: hidden; font-size: 14px; text-overflow: ellipsis; white-space: nowrap; }
-    .story-nav__title > span, .story-nav__count { min-width: 20px; border-radius: 999px; padding: 2px 6px; background: rgb(148 163 184 / 15%); color: var(--muted); font-size: 11px; text-align: center; }
-    .story-nav__close { width: 28px; border: 0; border-radius: 6px; background: transparent; color: var(--muted); font-size: 24px; line-height: 1; cursor: pointer; }
-    .story-nav__close:hover { background: rgb(255 255 255 / 8%); color: var(--text); }
-    .story-nav__filter { grid-column: 1 / -1; display: flex; align-items: center; gap: 8px; min-width: 0; border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; background: rgb(15 23 42 / 45%); }
-    .story-nav__filter:focus-within { border-color: var(--accent); }
-    .story-nav__filter input { min-width: 0; width: 100%; border: 0; outline: 0; background: transparent; color: var(--text); font: inherit; }
-    .story-nav__scroll { min-height: 0; overflow: auto; scrollbar-gutter: stable; padding: 10px 16px 20px; }
-    .story-nav__group { margin: 6px 0 14px; }
-    .story-nav__group > summary { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 7px 4px; color: var(--muted); cursor: pointer; font-size: 11px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
-    .story-nav__group--changed > summary, .story-nav__group--layout-diff > summary, .story-nav__group--file-not-exists > summary { color: var(--danger); }
-    .story-nav__group--passed > summary { color: var(--ok); }
-    .story-nav ul { list-style: none; margin: 0; padding: 0; }
-    .story-nav__tree ul { margin-left: 10px; padding-left: 10px; border-left: 1px solid #3a4654; }
-    .story-nav__tree details > summary { display: flex; align-items: center; gap: 7px; overflow: hidden; padding: 6px 4px; cursor: pointer; color: var(--text); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
-    .story-nav__tree details > summary span:last-child { overflow: hidden; text-overflow: ellipsis; }
-    .story-nav__tree details > summary:hover { background: rgb(255 255 255 / 5%); }
-    .story-nav__story { margin: 2px 0; }
-    .story-nav a { display: flex; align-items: center; gap: 8px; overflow: hidden; border-radius: 6px; padding: 6px 5px; color: var(--text); white-space: nowrap; text-decoration: none; }
-    .story-nav a span:last-child { overflow: hidden; text-overflow: ellipsis; }
-    .story-nav a:hover { background: rgb(255 255 255 / 8%); color: var(--accent); }
-    .tree-icon { position: relative; display: inline-block; flex: 0 0 auto; width: 14px; height: 14px; color: #94a3b8; }
-    .tree-icon--folder { height: 10px; border-radius: 2px; background: currentColor; }
-    .tree-icon--folder::before { content: ""; position: absolute; top: -3px; left: 1px; width: 6px; height: 4px; border-radius: 2px 2px 0 0; background: currentColor; }
-    .tree-icon--file { box-sizing: border-box; border: 1.5px solid currentColor; border-radius: 2px; }
-    .tree-icon--file::before, .tree-icon--file::after { content: ""; position: absolute; left: 3px; right: 3px; height: 1px; background: currentColor; }
-    .tree-icon--file::before { top: 4px; } .tree-icon--file::after { top: 8px; }
-    .tree-icon--search { width: 12px; height: 12px; border: 2px solid currentColor; border-radius: 50%; }
-    .tree-icon--search::after { content: ""; position: absolute; right: -5px; bottom: -3px; width: 6px; height: 2px; background: currentColor; transform: rotate(45deg); }
-    .story-nav__empty { padding: 24px 8px; color: var(--muted); font-size: 13px; text-align: center; }
-    .story { background: var(--panel); border: 1px solid var(--line); border-radius: 18px; padding: 20px; margin-top: 18px; box-shadow: 0 18px 50px rgb(0 0 0 / 24%); }
-    .story--changed { border-color: rgb(251 113 133 / 70%); }
-    .story--layout-diff, .story--file-not-exists { border-color: rgb(251 113 133 / 70%); }
-    .story--passed { border-color: rgb(52 211 153 / 45%); }
-    .story__header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; margin-bottom: 18px; }
-    .status { display: inline-block; color: var(--bg); background: var(--warn); border-radius: 999px; padding: 3px 9px; font-size: 12px; font-weight: 700; text-transform: uppercase; margin-bottom: 8px; }
-    .story--changed .status { background: var(--danger); }
-    .story--layout-diff .status, .story--file-not-exists .status { background: var(--danger); }
-    .story--passed .status { background: var(--ok); }
-    .metrics { display: flex; gap: 12px; margin: 0; }
-    .metrics div { min-width: 110px; border: 1px solid var(--line); border-radius: 12px; padding: 10px; }
-    dt { color: var(--muted); font-size: 12px; }
-    dd { margin: 4px 0 0; font-weight: 700; }
-    .inspector-tabs { position: sticky; top: 0; z-index: 2; display: flex; align-items: center; gap: 12px; margin: -8px -24px 20px; padding: 10px 24px; border-block: 1px solid var(--line); background: rgb(15 23 42 / 94%); box-shadow: 0 8px 24px rgb(0 0 0 / 18%); backdrop-filter: blur(12px); }
-    .inspector-tabs__label, .inspector-tabs__hint { color: var(--muted); font-size: 12px; font-weight: 700; }
-    .inspector-tabs__hint { margin-left: auto; font-weight: 500; }
-    .inspector-tabs__list { display: inline-flex; padding: 3px; border: 1px solid var(--line); border-radius: 9px; background: #0b1220; }
-    .inspector-tabs button { border: 0; border-radius: 6px; padding: 8px 18px; background: transparent; color: var(--muted); font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; }
-    .inspector-tabs button:hover { color: var(--text); }
-    .inspector-tabs button.is-active { background: #334155; color: #fff; box-shadow: 0 1px 3px rgb(0 0 0 / 35%); }
-    .comparison { margin-bottom: 18px; }
-    .comparison__frame { position: relative; overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: #020617; }
-    .comparison__image { display: block; width: 100%; height: auto; user-select: none; }
-    .comparison__overlay { position: absolute; inset: 0; }
-    .comparison__split { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; align-items: stretch; }
-    .comparison__frame--pane { border: 0; border-radius: 0; }
-    /* isolation で difference 合成をこのフレーム内に閉じ込め、brightness で微小差分を持ち上げる。 */
-    .comparison__frame--difference { isolation: isolate; background: #000; filter: brightness(3); }
-    .comparison__frame--difference .comparison__overlay { mix-blend-mode: difference; }
-    .comparison__pane { min-width: 0; margin: 0; overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: #020617; }
-    .comparison__pane figcaption, .comparison__pane--empty strong { display: block; padding: 8px 12px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; font-weight: 700; }
-    .comparison__pane--empty { display: grid; min-height: 240px; align-content: start; color: var(--muted); }
-    .comparison__pane--empty span { place-self: center; margin-top: 80px; }
-    .comparison__unavailable { display: grid; min-height: 420px; place-items: center; border: 1px dashed var(--line); border-radius: 14px; color: var(--muted); background: #020617; }
-    .comparison__actual { position: absolute; inset: 0; overflow: hidden; }
-    .comparison__handle { position: absolute; top: 0; bottom: 0; width: 2px; background: var(--accent); box-shadow: 0 0 0 9999px rgb(56 189 248 / 0%); }
-    .comparison__handle::after { content: ""; position: absolute; top: 50%; left: 50%; width: 28px; height: 28px; border: 2px solid var(--accent); border-radius: 999px; background: var(--panel); transform: translate(-50%, -50%); box-shadow: 0 4px 16px rgb(0 0 0 / 35%); }
-    .comparison__control { display: grid; gap: 8px; margin-top: 10px; color: var(--muted); font-size: 13px; }
-    input[type="range"] { width: 100%; accent-color: var(--accent); }
-    @media (max-width: 900px) { .hero, .story__header { display: block; } .hero__actions { justify-content: flex-start; margin-top: 12px; } .metrics { display: grid; grid-template-columns: 1fr; } }
-    @media (max-width: 720px) { .comparison__split { grid-template-columns: 1fr; } }
-    @media (max-width: 640px) { .layout, .layout--detail, .layout--nav-hidden { display: block; width: 100%; } main { padding: 12px; } .story-nav { position: static; height: min(70vh, 620px); } .layout--nav-hidden .story-nav { display: none; } .layout--nav-hidden .nav-reveal { position: fixed; top: 0; } .inspector-tabs { overflow-x: auto; margin-inline: -12px; padding-inline: 12px; } .inspector-tabs__label, .inspector-tabs__hint { display: none; } }
+  <style>${renderStyles()}
   </style>
 </head>
 <body>
-  <div class="layout${options.detailStory ? " layout--detail" : ""}" data-layout>
-  ${renderSidebar(summary, options)}
-  ${options.detailStory ? "" : '<button class="nav-reveal" type="button" data-nav-toggle aria-label="Show story files" aria-controls="story-navigation" aria-expanded="false">›</button>'}
-  <main>
-    <section class="hero">
-      <div>
-        <h1>${options.detailStory ? escapeHtml(options.detailStory) : "Storybook Visual Regression Report"}</h1>
-        <p class="summary">${options.detailStory ? '<a href="../" data-back-link>← Back to all stories</a>' : "Switch between Overlay, Split + Diff, and Slider to inspect changes. Click a story title to open its detail page."}</p>
-      </div>
-      <div class="hero__actions">
-        <div class="badge">Failed: <strong>${summary.failed}</strong> / Threshold: ${summary.maxDiffRatio}</div>
-      </div>
-    </section>
-    ${renderInspectorTabs(summary.reportVersion ?? "local")}
-    ${summary.results.map((result) => renderStory(result, options)).join("")}
-  </main>
+  <div class="app">
+    ${renderSidebar(summary, options)}
+    <main>
+      ${options.detailStory ? '<a class="backlink" href="../">← All items</a>' : ""}
+      <h1>${heading}</h1>
+      <p class="lede">Open an item to compare it with Diff, Slide, 2up, Blend and Toggle. Threshold: ${summary.maxDiffRatio} diff ratio.</p>
+      <div class="totals">${totals}</div>
+      ${renderSections(summary, options)}
+    </main>
   </div>
-  <script>
-    const layout = document.querySelector("[data-layout]");
-    const navToggles = document.querySelectorAll("[data-nav-toggle]");
-    if (layout) {
-      for (const navToggle of navToggles) navToggle.addEventListener("click", () => {
-        const hidden = layout.classList.toggle("layout--nav-hidden");
-        for (const toggle of navToggles) toggle.setAttribute("aria-expanded", String(!hidden));
-      });
-    }
-    const storyFilter = document.querySelector("[data-story-filter]");
-    if (storyFilter) {
-      storyFilter.addEventListener("input", () => {
-        const query = storyFilter.value.trim().toLowerCase();
-        const leaves = [...document.querySelectorAll("[data-tree-leaf]")];
-        for (const leaf of leaves) leaf.hidden = !leaf.dataset.searchText.includes(query);
-        for (const node of [...document.querySelectorAll("[data-tree-node]")].reverse()) {
-          node.hidden = !node.querySelector("[data-tree-leaf]:not([hidden])");
-          if (query && !node.hidden) node.querySelector(":scope > details").open = true;
-        }
-        for (const group of document.querySelectorAll("[data-status-group]")) {
-          group.hidden = !group.querySelector("[data-tree-leaf]:not([hidden])");
-          if (query && !group.hidden) group.open = true;
-        }
-        document.querySelector("[data-filter-empty]").hidden = leaves.some((leaf) => !leaf.hidden);
-      });
-    }
-    const currentDirectory = () => window.location.pathname.endsWith("/") ? window.location.pathname : window.location.pathname + "/";
-    for (const link of document.querySelectorAll("[data-story-link]")) {
-      const story = link.getAttribute("data-story-link");
-      if (story) {
-        link.href = currentDirectory() + encodeURIComponent(story) + "/";
-      }
-    }
-    for (const link of document.querySelectorAll("[data-back-link]")) {
-      const path = window.location.pathname.endsWith("/") ? window.location.pathname.slice(0, -1) : window.location.pathname;
-      link.href = path.slice(0, path.lastIndexOf("/")) + "/";
-    }
-    const inspectorTabs = document.querySelectorAll("[data-global-view-mode]");
-    const setViewMode = (mode) => {
-      for (const tab of inspectorTabs) {
-        const active = tab.dataset.globalViewMode === mode;
-        tab.classList.toggle("is-active", active);
-        tab.setAttribute("aria-selected", String(active));
-      }
-      for (const root of document.querySelectorAll("[data-comparison]")) {
-        for (const view of root.querySelectorAll("[data-view]")) view.hidden = view.dataset.view !== mode;
-      }
-    };
-    for (const tab of inspectorTabs) tab.addEventListener("click", () => setViewMode(tab.dataset.globalViewMode));
-    for (const root of document.querySelectorAll("[data-comparison]")) {
-      for (const overlay of root.querySelectorAll("[data-overlay]")) {
-        const overlaySlider = overlay.querySelector("[data-overlay-slider]");
-        const overlayImage = overlay.querySelector("[data-overlay-image]");
-        if (overlaySlider && overlayImage) overlaySlider.addEventListener("input", () => {
-          overlayImage.style.opacity = String(Number(overlaySlider.value) / 100);
-        });
-      }
-      const slider = root.querySelector("[data-slider]");
-      const actual = root.querySelector("[data-actual]");
-      const handle = root.querySelector("[data-handle]");
-      if (slider && actual && handle) {
-        const update = () => {
-          const value = slider.value;
-          actual.style.clipPath = "inset(0 0 0 " + value + "%)";
-          handle.style.left = value + "%";
-        };
-        slider.addEventListener("input", update);
-        update();
-      }
-    }
+  ${renderViewer()}
+  <script type="application/json" id="report-data">${reportData(summary, options)}</script>
+  <script>${renderScript()}
   </script>
 </body>
 </html>`;
+};
+
 
 const { command, options } = parseArgs();
 if (command === "capture") {

--- a/scripts/storybook-visual-regression.mjs
+++ b/scripts/storybook-visual-regression.mjs
@@ -486,7 +486,8 @@ const renderCard = (result, options) => {
         </li>`;
 };
 
-const renderSections = (summary, options) => groupByCategory(summary.results).map((group) => `<section class="section" data-section="${group.key}">
+// data-count は CSS 側でカードの大きさを決めるために使う(件数が少ない分類ほど大きく見せる)。
+const renderSections = (summary, options) => groupByCategory(summary.results).map((group) => `<section class="section" data-section="${group.key}" data-count="${Math.min(group.results.length, 3)}">
       <h2 class="section__title">${group.label} items <span class="section__count">${group.results.length}</span></h2>
       <ul class="cards">
         ${group.results.map((result) => renderCard(result, options)).join("")}
@@ -588,9 +589,13 @@ const renderStyles = () => `
     .section__title { display: flex; align-items: center; gap: 12px; font-size: 30px; font-weight: 800; letter-spacing: -0.01em; text-transform: uppercase; }
     .section__count { border-radius: 999px; padding: 3px 12px; background: var(--surface); border: 1px solid var(--line); font-size: 13px; font-weight: 700; }
     .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 22px; list-style: none; margin: 22px 0 0; padding: 0; }
+    /* 1〜2件しかない分類は横に余白が余るだけなので、その分カードを大きくする。 */
+    .section[data-count="1"] .cards { grid-template-columns: minmax(0, 680px); }
+    .section[data-count="2"] .cards { grid-template-columns: repeat(2, minmax(0, 500px)); }
     .card { overflow: hidden; border-radius: 10px; background: var(--surface); box-shadow: 0 2px 10px rgb(13 51 54 / 8%); transition: transform 120ms ease, box-shadow 120ms ease; }
     .card:hover { transform: translateY(-2px); box-shadow: 0 10px 26px rgb(13 51 54 / 14%); }
-    .card__open { position: relative; display: block; height: 200px; }
+    /* 既定の撮影サイズ(1280x720)に合わせる。比が違う画像は市松模様の余白が出る。 */
+    .card__open { position: relative; display: block; aspect-ratio: 16 / 9; }
     .card__thumb { display: block; height: 100%; }
     .card__thumb img { display: block; width: 100%; height: 100%; object-fit: contain; }
     .card__badge { position: absolute; top: 12px; left: 12px; display: grid; place-items: center; width: 26px; height: 26px; border-radius: 999px; background: var(--surface); box-shadow: 0 1px 4px rgb(13 51 54 / 22%); }
@@ -615,6 +620,9 @@ const renderStyles = () => `
 
     /* 画像は原寸のまま上限だけ掛け、枠と操作列はその実寸に合わせて縮める。 */
     .stagewrap { width: fit-content; max-width: 100%; margin: 0 auto; }
+    /* 比較相手が無いぶん操作列も要らないので、その高さを画像に回す。 */
+    .stagewrap--solo .vimg { max-height: calc(100vh - 200px); }
+    .solo-label { margin-bottom: 12px; color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; }
     .frame { position: relative; overflow: hidden; width: fit-content; max-width: 100%; margin: 0 auto; border-radius: 8px; box-shadow: 0 2px 12px rgb(13 51 54 / 10%); }
     .vimg { display: block; max-width: 100%; max-height: calc(100vh - 300px); user-select: none; }
     /* 重ね合わせる側は下地と同じ矩形へ収める。寸法が違っても contain なので歪まない。 */
@@ -761,7 +769,26 @@ const renderScript = () => `
       return frame;
     };
 
+    // 片側しか無い項目(New / Deleted)は、空の "Not available" を並べても情報が無い。
+    // ある方のスクリーンショットを全幅で大きく見せる。
+    const buildSolo = (item) => {
+      const kind = item.hasActual ? "actual" : "expected";
+      const wrapper = document.createElement("div");
+      wrapper.className = "stagewrap stagewrap--solo";
+      const label = document.createElement("p");
+      label.className = "solo-label";
+      label.textContent = item.hasActual ? "After (new)" : "Before (deleted)";
+      const frame = document.createElement("div");
+      frame.className = "frame checker";
+      frame.appendChild(image(kind, item));
+      wrapper.append(label, frame);
+      return wrapper;
+    };
+
     const buildTwoUp = (item) => {
+      if (!bothSides(item)) {
+        return buildSolo(item);
+      }
       const wrapper = document.createElement("div");
       wrapper.className = "twoup";
       wrapper.append(pane("Before", item, "expected", item.hasExpected), pane("After", item, "actual", item.hasActual));


### PR DESCRIPTION
## 概要

Actions の Storybook VRT レポートを、[reg-viz / reg-suit](https://github.com/reg-viz/reg-suit) のレポートに寄せて作り替えました。4 リポジトリ（design-composer / domain-modeler / spec-board / spec-viewer）で同じ変更を入れています。

## 分類を reg-suit の語彙に揃える

判定結果の `status` を 4 分類に整理し、判定理由は `reason` へ分離しました。

| 変更前 | 変更後 |
|---|---|
| `added` | `new` |
| `removed` | `deleted` |
| `passed` | `passed` |
| `changed` / `layout-diff` / `file-not-exists` | `changed`（理由は `reason` へ） |

`summary.json` に `changed` / `new` / `deleted` / `passed` の件数を持たせています。新規・削除は退行ではないので、`failed` には `changed` だけを数えます（reg-suit と同じ扱い）。

## レポート画面

reg-viz のレイアウトに合わせて全面的に書き直しました。

- **サイドバー**: `Filter by file name` の絞り込み + 分類ごとの折りたたみ（`CHANGED 3 ITEMS` のような件数表示と分類色の玉）
- **一覧**: `CHANGED ITEMS` などの分類見出しごとにカードを並べる。カードのサムネイルは差分画像（無ければスクリーンショット）で、透過部分が分かるよう市松模様を敷く
- **ビューア**: カードを押すと全画面で開く。上部にファイル名と `n / total`、左右に前後送り、下部にモード切替のピル。`Esc` で閉じ、`←` `→` で移動
- 配色をダークから reg-viz と同じライトテーマに変更

### 比較モード

reg-viz と同じ 5 種類にしました。

| モード | 内容 |
|---|---|
| Diff | odiff が出力した差分画像 |
| Slide | 境界線を左右に動かして変更前後を切り替える |
| 2up | 変更前後を左右に並べる |
| Blend | 変更後の不透明度をスライダーで変える |
| Toggle | 変更前後を一定間隔で入れ替えて表示する（Pause / Step 付き） |

スナップショットが片側しか無い項目（New / Deleted）では、成立しないモードのボタンを disabled にしています。寸法違い（layout-diff）は差分画像が出ないため Diff だけを無効にし、2up へフォールバックします。

## PR コメント

reg-suit と同じ、分類ごとの玉 + 内訳表の形式にしました。

```
**Detected visual differences.**

Check [this report](...), and review them.

🔴🔴🔴⚪⚫🔵🔵🔵

<details><summary>What balls mean?</summary>
🔴: Changed items, ⚪: New items, ⚫: Deleted items, 🔵: Passed items
</details>

| 🔴 Changed | ⚪ New | ⚫ Deleted | 🔵 Passed |
| ---: | ---: | ---: | ---: |
| 3 | 1 | 1 | 3 |
```

玉が数百個並ぶとコメントが読めなくなるため、先頭 50 個で打ち切ります（正確な件数は表にあります）。玉は Changed から並べるので、打ち切られるのは Passed 側からです。

## 確認したこと

Changed（ピクセル差分・寸法違い）/ New / Deleted / Passed（一致・しきい値内）の 8 件を含む固定データを作り、`pnpm visual:compare` でレポートを生成して Chromium で操作を確認しました。

- 5 モードすべてで想定どおりの画像が読み込まれ、切り替わること
- サイドバーの絞り込み、前後送り、`Esc` での開閉、ハッシュ・詳細ページからの直接オープン
- 詳細ページ（`visual-report/<story>/index.html`）から画像を `../` 付きで参照できること（レビュー中に 404 になる不具合を見つけて修正しました）
- 720px 幅で横スクロールが出ないこと
- ワークフローの `Verify visual report UI` と PR コメント生成をそのまま実行し、成功・公開失敗の両経路が意図どおりになること

## ドキュメント

Actions のレポート生成にとどまる変更で、`docs/spec-board/` が扱う仕様（公開 API・データ形式・画面挙動・設定項目）には影響しないため、spec ドキュメントの更新はありません。

## 補足

`reason` に `layout-diff` などの詳細を残したので、分類を 4 つに減らしても情報は失われていません。カード下部と詳細に表示されます。

---
_Generated by [Claude Code](https://claude.ai/code/session_011FE5E8GLL6Eizwn9ydSbKa)_